### PR TITLE
Added the vocation base id and the functions to manage it instead of the "client id"

### DIFF
--- a/data/XML/vocations.xml
+++ b/data/XML/vocations.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <vocations>
-	<vocation id="0" clientid="0" name="None" description="none" magicshield="0" gaincap="10" gainhp="5" gainmana="5" gainhpticks="12" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="4.0" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="0">
+	<vocation id="0" clientid="0" baseid="0" name="None" description="none" magicshield="0" gaincap="10" gainhp="5" gainmana="5" gainhpticks="12" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="4.0" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="0">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.5" />
 		<skill id="1" multiplier="2.0" />
@@ -10,7 +10,7 @@
 		<skill id="5" multiplier="1.5" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="1" clientid="3" name="Sorcerer" description="a sorcerer" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="1">
+	<vocation id="1" clientid="3" baseid="1" name="Sorcerer" description="a sorcerer" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="1">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.5" />
 		<skill id="1" multiplier="2.0" />
@@ -20,7 +20,7 @@
 		<skill id="5" multiplier="1.5" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="2" clientid="4" name="Druid" description="a druid" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="2">
+	<vocation id="2" clientid="4" baseid="2" name="Druid" description="a druid" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="2">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.5" />
 		<skill id="1" multiplier="1.8" />
@@ -30,7 +30,7 @@
 		<skill id="5" multiplier="1.5" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="3" clientid="2" name="Paladin" description="a paladin" magicshield="0" gaincap="20" gainhp="10" gainmana="15" gainhpticks="8" gainhpamount="1" gainmanaticks="4" gainmanaamount="2" manamultiplier="1.4" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="3">
+	<vocation id="3" clientid="2" baseid="3" name="Paladin" description="a paladin" magicshield="0" gaincap="20" gainhp="10" gainmana="15" gainhpticks="8" gainhpamount="1" gainmanaticks="4" gainmanaamount="2" manamultiplier="1.4" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="3">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.2" />
 		<skill id="1" multiplier="1.2" />
@@ -40,7 +40,7 @@
 		<skill id="5" multiplier="1.1" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="4" clientid="1" name="Knight" description="a knight" magicshield="0" gaincap="25" gainhp="15" gainmana="5" gainhpticks="6" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="3.0" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="4">
+	<vocation id="4" clientid="1" baseid="4" name="Knight" description="a knight" magicshield="0" gaincap="25" gainhp="15" gainmana="5" gainhpticks="6" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="3.0" attackspeed="2000" basespeed="220" soulmax="100" gainsoulticks="120" fromvoc="4">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.1" />
 		<skill id="1" multiplier="1.1" />
@@ -50,7 +50,7 @@
 		<skill id="5" multiplier="1.1" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="5" clientid="3" name="Master Sorcerer" description="a master sorcerer" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="2" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="1">
+	<vocation id="5" clientid="13" baseid="1" name="Master Sorcerer" description="a master sorcerer" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="2" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="1">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.5" />
 		<skill id="1" multiplier="2.0" />
@@ -60,7 +60,7 @@
 		<skill id="5" multiplier="1.5" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="6" clientid="4" name="Elder Druid" description="an elder druid" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="2" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="2">
+	<vocation id="6" clientid="14" baseid="2" name="Elder Druid" description="an elder druid" magicshield="1" gaincap="10" gainhp="5" gainmana="30" gainhpticks="12" gainhpamount="1" gainmanaticks="2" gainmanaamount="2" manamultiplier="1.1" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="2">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.5" />
 		<skill id="1" multiplier="1.8" />
@@ -70,7 +70,7 @@
 		<skill id="5" multiplier="1.5" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="7" clientid="2" name="Royal Paladin" description="a royal paladin" magicshield="0" gaincap="20" gainhp="10" gainmana="15" gainhpticks="6" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.4" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="3">
+	<vocation id="7" clientid="12" baseid="3" name="Royal Paladin" description="a royal paladin" magicshield="0" gaincap="20" gainhp="10" gainmana="15" gainhpticks="6" gainhpamount="1" gainmanaticks="3" gainmanaamount="2" manamultiplier="1.4" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="3">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.2" />
 		<skill id="1" multiplier="1.2" />
@@ -80,7 +80,7 @@
 		<skill id="5" multiplier="1.1" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="8" clientid="1" name="Elite Knight" description="an elite knight" magicshield="0" gaincap="25" gainhp="15" gainmana="5" gainhpticks="4" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="3.0" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="4">
+	<vocation id="8" clientid="11" baseid="4" name="Elite Knight" description="an elite knight" magicshield="0" gaincap="25" gainhp="15" gainmana="5" gainhpticks="4" gainhpamount="1" gainmanaticks="6" gainmanaamount="2" manamultiplier="3.0" attackspeed="2000" basespeed="220" soulmax="200" gainsoulticks="15" fromvoc="4">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<skill id="0" multiplier="1.1" />
 		<skill id="1" multiplier="1.1" />

--- a/data/lib/tables/vocation.lua
+++ b/data/lib/tables/vocation.lua
@@ -15,6 +15,17 @@ VOCATION = {
 		KNIGHT = 1,
 		PALADIN = 2,
 		SORCERER = 3,
-		DRUID = 4
+		DRUID = 4,
+		ELITE_KNIGHT = 11,
+		ROYAL_PALADIN = 12,
+		MASTER_SORCERER = 13,
+		ELDER_DRUID = 14
+	},
+	BASE_ID = {
+        NONE = 0,
+        SORCERER = 1,
+        DRUID = 2,
+        PALADIN = 3,
+        KNIGHT = 4
 	}
 }

--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -63,10 +63,10 @@ local DAILY_REWARD_STATUS_PREMIUM = 1
 
 local DailyRewardItems = {
 	[0] = {7618, 7620}, -- God/no vocation character
-	[VOCATION.CLIENT_ID.PALADIN] = {7618, 7588, 7620, 7589, 8472, 26030, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
-	[VOCATION.CLIENT_ID.DRUID] = {7618, 7620, 7589, 7590, 26029, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2269, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
-	[VOCATION.CLIENT_ID.SORCERER] = {7618, 7620, 7589, 7590, 26029, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
-	[VOCATION.CLIENT_ID.KNIGHT] = {7618, 7588, 7591, 8473, 26031, 7620, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
+	[VOCATION.BASE_ID.PALADIN] = {7618, 7588, 7620, 7589, 8472, 26030, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
+	[VOCATION.BASE_ID.DRUID] = {7618, 7620, 7589, 7590, 26029, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2269, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
+	[VOCATION.BASE_ID.SORCERER] = {7618, 7620, 7589, 7590, 26029, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
+	[VOCATION.BASE_ID.KNIGHT] = {7618, 7588, 7591, 8473, 26031, 7620, 2316, 2274, 2291, 2266, 2310, 2262, 2277, 2313, 2305, 2301, 2303, 2302, 2304, 2271, 2265, 2293, 2286, 2289, 2308, 2288, 2268, 2315},
 }
 
 DailyReward = {
@@ -283,7 +283,7 @@ end
 
 function Player.iterateTest(self)
 	local dailyTable = DailyReward.rewards[5]
-	local reward = DailyRewardItems[self:getVocation():getClientId()]
+	local reward = DailyRewardItems[self:getVocation():getBaseId()]
 
 	if not(reward) then
 		reward = {}
@@ -572,10 +572,10 @@ function Player.readDailyReward(self, msg, currentDay, state)
 	else
 		if systemType == 1 then
 			if (state == DAILY_REWARD_STATUS_FREE) then
-				rewards = DailyRewardItems[self:getVocation():getClientId()]
+				rewards = DailyRewardItems[self:getVocation():getBaseId()]
 				itemsToPick = dailyTable.freeAccount
 			else
-				rewards = DailyRewardItems[self:getVocation():getClientId()]
+				rewards = DailyRewardItems[self:getVocation():getBaseId()]
 				itemsToPick = dailyTable.premiumAccount
 			end
 

--- a/data/scripts/actions/other/potions.lua
+++ b/data/scripts/actions/other/potions.lua
@@ -18,28 +18,40 @@ bullseye:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 local setting = {
 	[236] = {
 		health = {250, 350},
-		vocations = {3, 4, 7, 8},
+		vocations = {
+			VOCATION.BASE_ID.KNIGHT,
+			VOCATION.BASE_ID.PALADIN
+		},
 		level = 50,
 		flask = 283,
 		description = "Only knights and paladins of level 50 or above may drink this fluid."
 	},
 	[237] = {
 		mana = {115, 185},
-		vocations = {1, 2, 3, 5, 6, 7},
+		vocations = {
+			VOCATION.BASE_ID.SORCERER,
+			VOCATION.BASE_ID.DRUID,
+			VOCATION.BASE_ID.PALADIN
+		},
 		level = 50,
 		flask = 283,
 		description = "Only sorcerers, druids and paladins of level 50 or above may drink this fluid."
 	},
 	[238] = {
 		mana = {150, 250},
-		vocations = {1, 2, 5, 6},
+		vocations = {
+			VOCATION.BASE_ID.SORCERER,
+			VOCATION.BASE_ID.DRUID
+		},
 		level = 80,
 		flask = 284,
 		description = "Only druids and sorcerers of level 80 or above may drink this fluid."
 	},
 	[239] = {
 		health = {425, 575},
-		vocations = {4, 8},
+		vocations = {
+			VOCATION.BASE_ID.KNIGHT
+		},
 		level = 80,
 		flask = 284,
 		description = "Only knights of level 80 or above may drink this fluid."
@@ -60,32 +72,43 @@ local setting = {
 	},
 	[7439] = {
 		condition = berserk,
-		vocations = {4, 8},
+		vocations = {
+			VOCATION.BASE_ID.KNIGHT
+		},
 		effect = CONST_ME_MAGIC_RED,
 		description = "Only knights may drink this potion.", text = "You feel stronger."
 	},
 	[7440] = {
 		condition = mastermind,
-		vocations = {1, 2, 5, 6},
+		vocations = {
+			VOCATION.BASE_ID.SORCERER,
+			VOCATION.BASE_ID.DRUID
+		},
 		effect = CONST_ME_MAGIC_BLUE,
 		description = "Only sorcerers and druids may drink this potion.", text = "You feel smarter."
 	},
 	[7443] = {
 		condition = bullseye,
-		vocations = {3, 7},
+		vocations = {
+			VOCATION.BASE_ID.PALADIN
+		},
 		effect = CONST_ME_MAGIC_GREEN,
 		description = "Only paladins may drink this potion.", text = "You feel more accurate."
 	},
 	[7642] = {
 		health = {250, 350}, mana = {100, 200},
-		vocations = {3, 7},
+		vocations = {
+			VOCATION.BASE_ID.PALADIN
+		},
 		level = 80,
 		flask = 284,
 		description = "Only paladins of level 80 or above may drink this fluid."
 	},
 	[7643] = {
 		health = {650, 850},
-		vocations = {4, 8},
+		vocations = {
+			VOCATION.BASE_ID.KNIGHT
+		},
 		level = 130,
 		flask = 284,
 		description = "Only knights of level 130 or above may drink this fluid."
@@ -100,21 +123,28 @@ local setting = {
 	},
 	[23373] = {
 		mana = {425, 575},
-		vocations = {1, 2, 5, 6},
+		vocations = {
+			VOCATION.BASE_ID.SORCERER,
+			VOCATION.BASE_ID.DRUID
+		},
 		level = 130,
 		flask = 284,
 		description = "Only druids and sorcerers of level 130 or above may drink this fluid."
 	},
 	[23374] = {
 		health = {420, 580}, mana = {250, 350},
-		vocations = {3, 7},
+		vocations = {
+			VOCATION.BASE_ID.PALADIN
+		},
 		level = 130,
 		flask = 284,
 		description = "Only paladins of level 130 or above may drink this fluid."
 	},
 	[23375] = {
 		health = {875, 1125},
-		vocations = {4, 8},
+		vocations = {
+			VOCATION.BASE_ID.KNIGHT
+		},
 		level = 200,
 		flask = 284,
 		description = "Only knights of level 200 or above may drink this fluid."
@@ -129,7 +159,7 @@ function potions.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 
 	local potion = setting[item:getId()]
-	if potion.level and player:getLevel() < potion.level or potion.vocations and not table.contains(potion.vocations, player:getVocation():getId()) then
+	if potion.level and player:getLevel() < potion.level or potion.vocations and not table.contains(potion.vocations, player:getVocation():getBaseId()) then
 		player:say(potion.description, TALKTYPE_MONSTER_SAY)
 		return true
 	end
@@ -144,11 +174,11 @@ function potions.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	else
 		if potion.health then
-			doTargetCombat(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
+			doTargetCombatHealth(0, target, COMBAT_HEALING, potion.health[1], potion.health[2])
 		end
 
 		if potion.mana then
-			doTargetCombat(0, target, COMBAT_MANADRAIN, potion.mana[1], potion.mana[2])
+			doTargetCombatMana(0, target, COMBAT_MANADRAIN, potion.mana[1], potion.mana[2])
 		end
 
 		if potion.antidote then

--- a/src/creatures/players/vocations/vocation.cpp
+++ b/src/creatures/players/vocations/vocation.cpp
@@ -54,6 +54,10 @@ bool Vocations::loadFromXml()
 			voc.clientId = pugi::cast<uint16_t>(attr.value());
 		}
 
+		if ((attr = vocationNode.attribute("baseid"))) {
+			voc.baseId = pugi::cast<uint16_t>(attr.value());
+		}
+		
 		if ((attr = vocationNode.attribute("description"))) {
 			voc.description = attr.as_string();
 		}

--- a/src/creatures/players/vocations/vocation.h
+++ b/src/creatures/players/vocations/vocation.h
@@ -45,6 +45,10 @@ class Vocation
 			return clientId;
 		}
 
+		uint8_t getBaseId() const {
+			return baseId;
+		}
+
 		uint32_t getHPGain() const {
 			return gainHP;
 		}
@@ -125,6 +129,7 @@ class Vocation
 
 		uint8_t soulMax = 100;
 		uint8_t clientId = 0;
+		uint8_t baseId = 0;
 
 		static uint32_t skillBase[SKILL_LAST + 1];
 };

--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -65,6 +65,17 @@ int VocationFunctions::luaVocationGetClientId(lua_State* L) {
 	return 1;
 }
 
+int VocationFunctions::luaVocationGetBaseId(lua_State* L) {
+	// vocation:getBaseId()
+	Vocation* vocation = getUserdata<Vocation>(L, 1);
+	if (vocation) {
+		lua_pushnumber(L, vocation->getBaseId());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int VocationFunctions::luaVocationGetName(lua_State* L) {
 	// vocation:getName()
 	Vocation* vocation = getUserdata<Vocation>(L, 1);

--- a/src/lua/functions/creatures/player/vocation_functions.hpp
+++ b/src/lua/functions/creatures/player/vocation_functions.hpp
@@ -30,6 +30,7 @@ class VocationFunctions final : LuaScriptInterface {
 
 			registerMethod(L, "Vocation", "getId", VocationFunctions::luaVocationGetId);
 			registerMethod(L, "Vocation", "getClientId", VocationFunctions::luaVocationGetClientId);
+			registerMethod(L, "Vocation", "getBaseId", VocationFunctions::luaVocationGetBaseId);
 			registerMethod(L, "Vocation", "getName", VocationFunctions::luaVocationGetName);
 			registerMethod(L, "Vocation", "getDescription", VocationFunctions::luaVocationGetDescription);
 
@@ -61,6 +62,7 @@ class VocationFunctions final : LuaScriptInterface {
 
 		static int luaVocationGetId(lua_State* L);
 		static int luaVocationGetClientId(lua_State* L);
+		static int luaVocationGetBaseId(lua_State* L);
 		static int luaVocationGetName(lua_State* L);
 		static int luaVocationGetDescription(lua_State* L);
 


### PR DESCRIPTION
New lua function: vocation:getBaseId()
New c++ function vocation->getBaseId()

The idea of the base id is that the "promotions" have the same id as the base vocation, so that it is not necessary to have repetitions of ifs and if a new vocation is added, it will also not be necessary to register them in the scripts that call the vocations , because the id is the same. This function should only be used in scripts that will be used by all base vocations.

For example, if a spell can be buy by the "knight" or "elite knight", then you can use vocation:getBaseId()
It is always preferable to use vocation:getBaseId() when possible.