### PR TITLE
Sort loot of monsters to try most rare itens first

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -152,6 +152,13 @@ serverSaveCleanMap = false
 serverSaveClose = false
 serverSaveShutdown = true
 
+-- Sort loot by chance, most rare items drop first
+-- it is good to be setted when you have a higher
+-- rateLoot to avoid losing all rare items when
+-- the corpse size is less than the total of loots
+-- the monster can drop
+sortLootByChance = false
+
 -- Rates
 -- NOTE: rateExp, rateSkill and rateMagic is used as a fallback only
 -- To configure rates see file data/stages.lua

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -273,8 +273,24 @@ registerMonsterType.events = function(mtype, mask)
 		end
 	end
 end
+
+function sortLootByChance(loot)
+	if not configManager.getBoolean(configKeys.SORT_LOOT_BY_CHANCE) then
+		return
+	end
+
+	table.sort(loot, function(loot1, loot2)
+		if not loot1.chance or not loot2.chance then
+			return 0
+		end
+
+		return loot1.chance < loot2.chance
+	end)
+end
+
 registerMonsterType.loot = function(mtype, mask)
 	if type(mask.loot) == "table" then
+		sortLootByChance(mask.loot)
 		local lootError = false
 		for _, loot in pairs(mask.loot) do
 			local parent = Loot()
@@ -336,6 +352,7 @@ registerMonsterType.loot = function(mtype, mask)
 				parent:setUnique(loot.unique)
 			end
 			if loot.child then
+				sortLootByChance(loot.child)
 				for _, children in pairs(loot.child) do
 					local child = Loot()
 					if children.name then

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - 7171:7171
       - 7172:7172
+    volumes:
+      - ../data:/otbr/data
     depends_on:
       - mysql
       - website

--- a/src/config/config_definitions.hpp
+++ b/src/config/config_definitions.hpp
@@ -63,6 +63,8 @@ enum booleanConfig_t {
 	STAMINA_PZ,
 	PUSH_WHEN_ATTACKING,
 
+	SORT_LOOT_BY_CHANCE,
+
 	LAST_BOOLEAN_CONFIG
 	};
 

--- a/src/config/configmanager.cpp
+++ b/src/config/configmanager.cpp
@@ -181,6 +181,7 @@ bool ConfigManager::load()
 	boolean[FREE_QUESTS] = getGlobalBoolean(L, "freeQuests", false);
 	boolean[STAMINA_TRAINER] = getGlobalBoolean(L, "staminaTrainer", false);
 	boolean[STAMINA_PZ] = getGlobalBoolean(L, "staminaPz", false);
+	boolean[SORT_LOOT_BY_CHANCE] = getGlobalBoolean(L, "sortLootByChance", false);
 
 	boolean[ONLY_PREMIUM_ACCOUNT] = getGlobalBoolean(L, "onlyPremiumAccount", false);
 

--- a/src/lua/functions/core/game/config_functions.hpp
+++ b/src/lua/functions/core/game/config_functions.hpp
@@ -143,6 +143,7 @@ class ConfigFunctions final : LuaScriptInterface {
 			registerEnumIn(L, "configKeys", STAMINA_TRAINER_DELAY)
 			registerEnumIn(L, "configKeys", STAMINA_PZ_GAIN)
 			registerEnumIn(L, "configKeys", STAMINA_TRAINER_GAIN)
+			registerEnumIn(L, "configKeys", SORT_LOOT_BY_CHANCE)
 
 			registerEnumIn(L, "configKeys", PUSH_WHEN_ATTACKING)
 


### PR DESCRIPTION
BASED PR: https://github.com/opentibiabr/otservbr-global/pull/2690

# Description

- Sort the loot by chance before register it

## Behaviour
### **Actual**

- If you change your `rateLoot` to bigger values, some monsters which have a small container size will most of the time just drop the items in the order they are inserted into the monster.loot, and most of the time this means that rare items don't will drop

### **Expected**

- It should give a chance first for rare items to drop

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Change your `rateLoot` to a big value like 500 and kill an demon, it should drop items with lowest chance of drop (mostly of the times, they are the rare items)

**Test Configuration**:

  - Server Version: 12.64
  - Client: 12.64
  - Operating System: Ubuntu 18.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
