### PR TITLE
Disable the force close button (ensure a secure close)

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -21,6 +21,10 @@
 
 #include <fstream>
 
+#ifdef OS_WINDOWS
+	#include "conio.h"
+#endif
+
 #include "config/configmanager.h"
 #include "declarations.hpp"
 #include "creatures/combat/spells.h"
@@ -62,6 +66,21 @@ RSA2 g_RSA;
 std::mutex g_loaderLock;
 std::condition_variable g_loaderSignal;
 std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
+
+/**
+ *It is preferable to keep the close button off as it closes the server without saving (this can cause the player to lose items from houses and others informations, since windows automatically closes the process in five seconds, when forcing the close)
+ * Choose to use "CTROL + C" or "CTROL + BREAK" for security close
+ * To activate/desactivate window;
+ * \param MF_GRAYED Disable the "x" (force close) button
+ * \param MF_ENABLED Enable the "x" (force close) button
+*/
+void toggleForceCloseButton() {
+	#ifdef OS_WINDOWS
+	HWND hwnd = GetConsoleWindow();
+	HMENU hmenu = GetSystemMenu(hwnd, FALSE);
+	EnableMenuItem(hmenu, SC_CLOSE, MF_GRAYED);
+	#endif
+}
 
 void startupErrorMessage() {
 	SPDLOG_ERROR("The program will close after pressing the enter key...");
@@ -183,6 +202,8 @@ int main(int argc, char* argv[]) {
 #else
 	spdlog::set_pattern("[%Y-%d-%m %H:%M:%S.%e] [%^%l%$] %v ");
 #endif
+	// Toggle force close button enabled/disabled
+	toggleForceCloseButton();
 
 	// Setup bad allocation handler
 	std::set_new_handler(badAllocationHandler);

--- a/src/utils/definitions.h
+++ b/src/utils/definitions.h
@@ -46,6 +46,10 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #define NOMINMAX
 #endif
 
+#if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
+#define OS_WINDOWS
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 
 #ifdef _MSC_VER


### PR DESCRIPTION
# Description

It is preferable to keep the close button off as it closes the server without saving (this can cause the player to lose items from houses, since windows automatically closes the process in five seconds, when forcing the close)
Choose to use "CTROL + C" or "CTROL + BREAK" for security close

To activate/desactivate window
MF_GRAYED Disable the "x" (force close) button
MF_ENABLED Enable the "x" (force close) button

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
