### PR TITLE
Fix summons and familiars bug

### DIFF
--- a/data/scripts/talkactions/god/create_summon.lua
+++ b/data/scripts/talkactions/god/create_summon.lua
@@ -11,10 +11,8 @@ function createSummon.onSay(player, words, param)
 	end
 
 	local position = player:getPosition()
-	local monster = Game.createMonster(param, position)
+	local monster = Game.createMonster(param, position, true, false, player)
 	if monster then
-		player:addSummon(monster)
-		monster:reload()
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
 	else
 		player:sendCancelMessage("There is not enough room.")

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -16,7 +16,6 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <algorithm>
 
 #include "otpch.h"
 
@@ -144,21 +143,9 @@ void Creature::onThink(uint32_t interval)
 		blockCount = std::min<uint32_t>(blockCount + 1, 2);
 		blockTicks = 0;
 	}
-	if (returnToMasterInterval > 0) {
-		returnToMasterInterval -= interval;
-		int32_t distX = Position::getDistanceX(master->getPosition(), getPosition());
-		int32_t distY = Position::getDistanceY(master->getPosition(), getPosition());
-		if (returnToMasterInterval <= 0 || (distX + distY <= 2)) {
-			returnToMasterInterval = 0;
-			if (master)
-				setAttackedCreature(master->getAttackedCreature());
-		}
-	}
-
 
 	if (followCreature) {
 		walkUpdateTicks += interval;
-
 		if (forceUpdateFollowPath || walkUpdateTicks >= 2000) {
 			walkUpdateTicks = 0;
 			forceUpdateFollowPath = false;
@@ -221,18 +208,6 @@ void Creature::onCreatureWalk()
 			}
 
 			stopEventWalk();
-		}
-	}
-
-	if(isSummon() && followCreature && followCreature != master && master->getPosition().z == getPosition().z) {
-		int32_t distX = Position::getDistanceX(master->getPosition(), getPosition());
-		int32_t distY = Position::getDistanceY(master->getPosition(), getPosition());
-		if (distX >= Map::maxClientViewportX || distY >= Map::maxClientViewportY) {
-			stopEventWalk();
-			followCreature = master;
-			forceUpdateFollowPath = true;
-			attackedCreature = nullptr;
-			returnToMasterInterval = 2000;
 		}
 	}
 
@@ -969,9 +944,6 @@ void Creature::goToFollowCreature()
 bool Creature::setFollowCreature(Creature* creature)
 {
 	if (creature) {
-		if (returnToMasterInterval > 0 && master && creature != master)
-			return false;
-
 		if (followCreature == creature) {
 			return true;
 		}
@@ -1600,12 +1572,7 @@ bool FrozenPathingConditionCall::operator()(const Position& startPos, const Posi
 		return false;
 	}
 
-	int32_t testDist;
-	if(fpp.absoluteDist)
-		testDist = Position::getDistanceX(targetPos, testPos) + Position::getDistanceY(targetPos, testPos);
-	else
-		testDist = std::max<int32_t>(Position::getDistanceX(targetPos, testPos), Position::getDistanceY(targetPos, testPos));
-
+	int32_t testDist = std::max<int32_t>(Position::getDistanceX(targetPos, testPos), Position::getDistanceY(targetPos, testPos));
 	if (fpp.maxTargetDist == 1) {
 		if (testDist < fpp.minTargetDist || testDist > fpp.maxTargetDist) {
 			return false;
@@ -1614,8 +1581,8 @@ bool FrozenPathingConditionCall::operator()(const Position& startPos, const Posi
 	} else if (testDist <= fpp.maxTargetDist) {
 		if (testDist < fpp.minTargetDist) {
 			return false;
-		} else if (testDist == fpp.maxTargetDist && (!fpp.preferDiagonal ||
-						Position::getDistanceX(targetPos, testPos) == Position::getDistanceY(targetPos, testPos))) {
+		}
+		if (testDist == fpp.maxTargetDist) {
 			bestMatchDist = 0;
 			return true;
 		} else if (testDist > bestMatchDist) {

--- a/src/creatures/creature.h
+++ b/src/creatures/creature.h
@@ -532,7 +532,6 @@ class Creature : virtual public Thing
 		uint32_t scriptEventsBitField = 0;
 		uint32_t eventWalk = 0;
 		uint32_t walkUpdateTicks = 0;
-		int32_t returnToMasterInterval = 0;
 		uint32_t lastHitCreatureId = 0;
 		uint32_t blockCount = 0;
 		uint32_t blockTicks = 0;

--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -385,8 +385,7 @@ enum CreatureType_t : uint8_t {
 	CREATURETYPE_PLAYER = 0,
 	CREATURETYPE_MONSTER = 1,
 	CREATURETYPE_NPC = 2,
-	CREATURETYPE_SUMMONPLAYER = 3,
-	CREATURETYPE_SUMMON_OWN = 3,
+	CREATURETYPE_SUMMON_PLAYER = 3,
 	CREATURETYPE_SUMMON_OTHERS = 4,
 	CREATURETYPE_HIDDEN = 5,
 };
@@ -639,8 +638,6 @@ struct FindPathParams {
 	bool clearSight = true;
 	bool allowDiagonal = true;
 	bool keepDistance = false;
-	bool absoluteDist = false;
-	bool preferDiagonal = false;
 	int32_t maxSearchDist = 0;
 	int32_t minTargetDist = -1;
 	int32_t maxTargetDist = -1;

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -722,7 +722,7 @@ bool Monster::isTarget(const Creature* creature) const
 
 bool Monster::selectTarget(Creature* creature)
 {
-	if (!isTarget(creature) || returnToMasterInterval > 0) {
+	if (!isTarget(creature)) {
 		return false;
 	}
 
@@ -2119,10 +2119,6 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 
 	if (isSummon()) {
 		if (getMaster() == creature) {
-			int32_t distX = Position::getDistanceX(getPosition(), creature->getPosition());
-			int32_t distY = Position::getDistanceY(getPosition(), creature->getPosition());
-			fpp.absoluteDist = true;
-			fpp.preferDiagonal = !(distX >= 2 && distY == 0 || distY >= 2 && distX == 0);
 			fpp.maxTargetDist = 2;
 			fpp.fullPathSearch = true;
 		} else if (targetDistance <= 1) {

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -184,8 +184,8 @@ bool SpawnNpc::spawnNpc(uint32_t spawnId, NpcType* npcType, const Position& pos,
 {
 	std::unique_ptr<Npc> npc_ptr(new Npc(npcType));
 	if (startup) {
-		//No need to send out events to the surrounding since there is no one out there to listen!
-		if (!g_game.internalPlaceCreature(npc_ptr.get(), pos, true, false)) {
+		// No need to send out events to the surrounding since there is no one out there to listen!
+		if (!g_game.internalPlaceCreature(npc_ptr.get(), pos, true, false, true)) {
 			return false;
 		}
 	} else {

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -185,7 +185,7 @@ bool SpawnNpc::spawnNpc(uint32_t spawnId, NpcType* npcType, const Position& pos,
 	std::unique_ptr<Npc> npc_ptr(new Npc(npcType));
 	if (startup) {
 		//No need to send out events to the surrounding since there is no one out there to listen!
-		if (!g_game.internalPlaceCreature(npc_ptr.get(), pos, true, false, true)) {
+		if (!g_game.internalPlaceCreature(npc_ptr.get(), pos, true, false)) {
 			return false;
 		}
 	} else {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -990,7 +990,7 @@ Player* Game::getPlayerByAccount(uint32_t acc)
 	return nullptr;
 }
 
-bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/)
+bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos /*=false*/, bool forced /*= false*/, bool creatureCheck /*= false*/)
 {
 	if (creature->getParent() != nullptr) {
 		return false;
@@ -1003,6 +1003,12 @@ bool Game::internalPlaceCreature(Creature* creature, const Position& pos, bool e
 	creature->incrementReferenceCounter();
 	creature->setID();
 	creature->addList();
+
+	if (creatureCheck) {
+		addCreatureCheck(creature);
+		creature->onPlacedCreature();
+	}
+
 	return true;
 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -118,7 +118,7 @@ class Game
 
 		Player* getPlayerByAccount(uint32_t acc);
 
-		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false);
+		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, bool creatureCheck = false);
 
 		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool force = false);
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -118,7 +118,7 @@ class Game
 
 		Player* getPlayerByAccount(uint32_t acc);
 
-		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, bool creatureCheck = false);
+		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false);
 
 		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool force = false);
 

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -430,11 +430,22 @@ int GameFunctions::luaGameCreateContainer(lua_State* L) {
 }
 
 int GameFunctions::luaGameCreateMonster(lua_State* L) {
-	// Game.createMonster(monsterName, position[, extended = false[, force = false]])
+	// Game.createMonster(monsterName, position[, extended = false[, force = false[, master = nil]]])
 	Monster* monster = Monster::createMonster(getString(L, 1));
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
+	}
+
+	bool isSummon = false;
+	if (lua_gettop(L) >= 5) {
+		Creature* master = getCreature(L, 5);
+		if (master) {
+			monster->setMaster(master);
+			monster->setDropLoot(false);
+			monster->setSkillLoss(false);
+			isSummon = true;
+		}
 	}
 
 	const Position& position = getPosition(L, 2);
@@ -444,7 +455,11 @@ int GameFunctions::luaGameCreateMonster(lua_State* L) {
 		pushUserdata<Monster>(L, monster);
 		setMetatable(L, -1, "Monster");
 	} else {
-		delete monster;
+		if (isSummon) {
+			monster->setMaster(nullptr);
+		} else {
+			delete monster;
+		}
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/lua/functions/core/game/lua_enums.hpp
+++ b/src/lua/functions/core/game/lua_enums.hpp
@@ -462,8 +462,7 @@ class LuaEnums final : LuaScriptInterface {
 			registerEnum(L, CREATURETYPE_PLAYER)
 			registerEnum(L, CREATURETYPE_MONSTER)
 			registerEnum(L, CREATURETYPE_NPC)
-			registerEnum(L, CREATURETYPE_SUMMONPLAYER)
-			registerEnum(L, CREATURETYPE_SUMMON_OWN)
+			registerEnum(L, CREATURETYPE_SUMMON_PLAYER)
 			registerEnum(L, CREATURETYPE_SUMMON_OTHERS)
 			registerEnum(L, CREATURETYPE_HIDDEN)
 

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -291,27 +291,6 @@ int CreatureFunctions::luaCreatureSetMaster(lua_State* L) {
 	return 1;
 }
 
-int CreatureFunctions::luaCreatureReload(lua_State* L) {
-	// creature:reload()
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (!creature) {
-		lua_pushnil(L);
-		return 1;
-	}
-
-	const Position& position = creature->getPosition();
-	SpectatorHashSet spectators;
-	g_game.map.getSpectators(spectators, position, false, true); // 3 parâmetro é multifloor, ver se há necessidade de usar.
-	for (Creature* spectator : spectators) {
-		Player* tmpPlayer = spectator->getPlayer();
-		if (tmpPlayer) {
-			tmpPlayer->reloadCreature(creature);
-		}
-	}
-
-	return 1;
-}
-
 int CreatureFunctions::luaCreatureGetLight(lua_State* L) {
 	// creature:getLight()
 	const Creature* creature = getUserdata<const Creature>(L, 1);

--- a/src/lua/functions/creatures/creature_functions.hpp
+++ b/src/lua/functions/creatures/creature_functions.hpp
@@ -52,7 +52,6 @@ class CreatureFunctions final : LuaScriptInterface {
 			registerMethod(L, "Creature", "setFollowCreature", CreatureFunctions::luaCreatureSetFollowCreature);
 			registerMethod(L, "Creature", "getMaster", CreatureFunctions::luaCreatureGetMaster);
 			registerMethod(L, "Creature", "setMaster", CreatureFunctions::luaCreatureSetMaster);
-			registerMethod(L, "Creature", "reload", CreatureFunctions::luaCreatureReload);
 			registerMethod(L, "Creature", "getLight", CreatureFunctions::luaCreatureGetLight);
 			registerMethod(L, "Creature", "setLight", CreatureFunctions::luaCreatureSetLight);
 			registerMethod(L, "Creature", "getSpeed", CreatureFunctions::luaCreatureGetSpeed);
@@ -126,8 +125,6 @@ class CreatureFunctions final : LuaScriptInterface {
 
 		static int luaCreatureGetMaster(lua_State* L);
 		static int luaCreatureSetMaster(lua_State* L);
-
-		static int luaCreatureReload(lua_State* L);
 
 		static int luaCreatureGetLight(lua_State* L);
 		static int luaCreatureSetLight(lua_State* L);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2748,19 +2748,16 @@ void ProtocolGame::sendCreatureType(const Creature *creature, uint8_t creatureTy
 	NetworkMessage msg;
 	msg.addByte(0x95);
 	msg.add<uint32_t>(creature->getID());
-	msg.addByte(creatureType);
-
-	if (player->getOperatingSystem() == CLIENTOS_WINDOWS)
-	{
-		msg.addByte(creatureType); // type or any byte idk
+	if (creatureType == CREATURETYPE_SUMMON_OTHERS) {
+		creatureType = CREATURETYPE_SUMMON_PLAYER;
 	}
-
-	if (creatureType == CREATURETYPE_SUMMONPLAYER)
-	{
-		const Creature *master = creature->getMaster();
-		if (master)
-		{
+	msg.addByte(creatureType); // type or any byte idk
+	if (creatureType == CREATURETYPE_SUMMON_PLAYER) {
+		const Creature* master = creature->getMaster();
+		if (master) {
 			msg.add<uint32_t>(master->getID());
+		} else {
+			msg.add<uint32_t>(0);
 		}
 	}
 
@@ -6042,7 +6039,7 @@ void ProtocolGame::AddCreature(NetworkMessage &msg, const Creature *creature, bo
 			msg.addByte(creatureType);
 		}
 
-		if (creatureType == CREATURETYPE_SUMMONPLAYER)
+		if (creatureType == CREATURETYPE_SUMMON_PLAYER)
 		{
 			const Creature *master = creature->getMaster();
 			if (master)
@@ -6124,7 +6121,7 @@ void ProtocolGame::AddCreature(NetworkMessage &msg, const Creature *creature, bo
 			const Player *masterPlayer = master->getPlayer();
 			if (masterPlayer)
 			{
-				creatureType = CREATURETYPE_SUMMONPLAYER;
+				creatureType = CREATURETYPE_SUMMON_PLAYER;
 			}
 		}
 	}
@@ -6138,7 +6135,7 @@ void ProtocolGame::AddCreature(NetworkMessage &msg, const Creature *creature, bo
 		msg.addByte(creatureType); // Type (for summons)
 	}
 
-	if (creatureType == CREATURETYPE_SUMMONPLAYER)
+	if (creatureType == CREATURETYPE_SUMMON_PLAYER)
 	{
 		const Creature *master = creature->getMaster();
 		if (master)


### PR DESCRIPTION
# Description

The familiars kept following the glued players, the summon icon didn't appear properly.
I reverted most of the changes related to summons and family members, because the code was wrong, the master is passed in Game.createMonster() and not in creature:addSummon(), this second is only used with summons from monsters and in the convince creature.

## Behaviour
### **Actual**
![image](https://user-images.githubusercontent.com/8551443/132115804-1a6ff22e-bc21-4cc5-a437-922255d7976c.png)

### **Expected**
![image](https://user-images.githubusercontent.com/8551443/132115810-a8e0978f-272b-44c4-a058-4d283190ca3f.png)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Create a summon with the icon (shield)
  - [x] Create a summon and this is following with a distance of 1 sqm.

**Test Configuration**:

  - Server Version: 12.64
  - Client: 12.64
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
