### PR TITLE
Better handling of the Game::checkCreatures function

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5328,23 +5328,27 @@ void Game::checkCreatures(size_t index)
 	g_scheduler.addEvent(createSchedulerTask(EVENT_CHECK_CREATURE_INTERVAL, std::bind(&Game::checkCreatures, this, (index + 1) % EVENT_CREATURECOUNT)));
 
 	auto& checkCreatureList = checkCreatureLists[index];
-	auto it = checkCreatureList.begin(), end = checkCreatureList.end();
-	while (it != end) {
-		Creature* creature = *it;
-		if (creature->creatureCheck) {
+	size_t it = 0, end = checkCreatureList.size();
+	while (it < end) {
+		Creature* creature = checkCreatureList[it];
+		if (creature && creature->creatureCheck) {
 			if (creature->getHealth() > 0) {
 				creature->onThink(EVENT_CREATURE_THINK_INTERVAL);
 				creature->onAttacking(EVENT_CREATURE_THINK_INTERVAL);
 				creature->executeConditions(EVENT_CREATURE_THINK_INTERVAL);
+			} else {
+				creature->onDeath();
 			}
 			++it;
 		} else {
 			creature->inCheckCreaturesVector = false;
-			it = checkCreatureList.erase(it);
 			ReleaseCreature(creature);
+
+			checkCreatureList[it] = checkCreatureList.back();
+			checkCreatureList.pop_back();
+			--end;
 		}
 	}
-
 	cleanup();
 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -536,7 +536,6 @@ class Game
 		std::map<uint32_t, uint32_t> stages;
 
 		std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];
-		std::list<Creature*> checkCreatureLists[EVENT_CREATURECOUNT];
 
 		std::list<Item*> imbuedItems[EVENT_IMBUEMENT_BUCKETS];
 
@@ -545,6 +544,7 @@ class Game
 
 		std::vector<Charm*> CharmList;
 		std::vector<Creature*> ToReleaseCreatures;
+		std::vector<Creature*> checkCreatureLists[EVENT_CREATURECOUNT];
 		std::vector<Item*> ToReleaseItems;
 
 		size_t lastBucket = 0;


### PR DESCRIPTION
Credits to @saiyansking

Co-Authored-By: Jakub @saiyansking <jakubkubina@hotmail.com>

# Description

In some scenario that I couldn't identify, I had a crash related to this function, I solved it using SaiyansKing's server function (optimized_forgottenserver), hope he can comment on this here.

## Behaviour
### **Actual**

```cpp
  canary.exe!Monster::doAttacking(unsigned int interval) Line 920 C++
  canary.exe!Creature::onAttacking(unsigned int interval) Line 180 C++
  canary.exe!Game::checkCreatures(unsigned __int64 index) Line 5330 C++
  [Embedded Frame] canary.exe!std::_Func_class<void>::operator()() Line 968 C++
  [Embedded Frame] canary.exe!Task::operator()() Line 41 C++
  canary.exe!Dispatcher::threadMain() Line 62 C++
  [External Code]
  ```

### **Expected**

No crash!

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
