### PR TITLE
Add check for check if pointer from "Weapons::clear" is nullptr

### DIFF
--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -58,7 +58,7 @@ const Weapon* Weapons::getWeapon(const Item* item) const
 void Weapons::clear(bool fromLua)
 {
 	for (auto it = weapons.begin(); it != weapons.end(); ) {
-		if (fromLua == it->second->fromLua) {
+		if (it->second && fromLua == it->second->fromLua) {
 			it = weapons.erase(it);
 		} else {
 			++it;


### PR DESCRIPTION
# Description

Fixed weapons crash problem.

**GDB raport**
![image](https://user-images.githubusercontent.com/67392692/134767542-f25640e9-b927-4227-9d42-2fc1846e64bd.png)

`#2 #3 #4` (screen)

This is a fix to that

  - [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: 12.64
  - Client: 12.64
  - Operating System: **Linux**

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works

** Fix #60

**Author:** @Costallat 