### PR TITLE
Fix remove imbuing from item

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6594,6 +6594,7 @@ void Game::checkImbuements()
 			int32_t newDuration = std::max(0, (duration - (EVENT_IMBUEMENTINTERVAL * EVENT_IMBUEMENT_BUCKETS) / 690));
 			if (duration > 0 && newDuration == 0) {
 				needUpdate = true;
+				item->setImbuement(slot, 0);
 			}
 		}
 
@@ -6604,9 +6605,6 @@ void Game::checkImbuements()
 			player->postRemoveNotification(item, player, index);
 			ReleaseItem(item);
 			it = imbuedItems[bucket].erase(it);
-			for (uint8_t slot = 0; slot < slots; slot++) {
-				item->setImbuement(slot, 0);
-			}
 		}
 
 		for (uint8_t slot = 0; slot < slots; slot++) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6569,6 +6569,9 @@ void Game::checkImbuements()
 	auto it = imbuedItems[bucket].begin(), end = imbuedItems[bucket].end();
 	while (it != end) {
 		Item* item = *it;
+		if (!item) {
+			continue;
+		}
 
 		if (item->isRemoved() || !item->getParent()->getCreature()) {
 			ReleaseItem(item);
@@ -6578,7 +6581,7 @@ void Game::checkImbuements()
 
 		Player* player = item->getParent()->getCreature()->getPlayer();
 		const ItemType& itemType = Item::items[item->getID()];
-		if (!player->hasCondition(CONDITION_INFIGHT) && !itemType.isContainer()) {
+		if (!player|| !player->hasCondition(CONDITION_INFIGHT) && !itemType.isContainer()) {
 			it++;
 			continue;
 		}


### PR DESCRIPTION
# Description

Fix remove imbuing from item

## Behaviour
### **Actual**

When one imbuing end, all imbuing from item will be removed

### **Expected**

Only one imbuing removed

## Fixes

https://github.com/opentibiabr/otservbr-global-archived/issues/2649

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update