### PR TITLE
Allow stacking items with custom attributes

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -240,12 +240,30 @@ bool Item::equals(const Item* otherItem) const
 					return false;
 				}
 			}
-		} else {
+		} else if (ItemAttributes::isIntAttrType(attribute.type)) {
 			for (const auto& otherAttribute : otherAttributeList) {
 				if (attribute.type == otherAttribute.type && attribute.value.integer != otherAttribute.value.integer) {
 					return false;
 				}
 			}
+		} else if (ItemAttributes::isCustomAttrType(attribute.type)) {
+			for (const auto& otherAttribute : otherAttributeList) {
+				if (attribute.type == otherAttribute.type) {
+					if (attribute.value.custom->size() != otherAttribute.value.custom->size()) {
+						return false;
+					}
+
+					for (auto it = attribute.value.custom->begin(); it != attribute.value.custom->end(); it++) {
+						if (otherAttribute.value.custom->find(it->first) == otherAttribute.value.custom->end()) {
+							return false;
+						} else if (otherAttribute.value.custom->at(it->first).value != it->second.value) {
+							return false;
+						}
+					}
+				}
+			}
+		} else {
+			return false;
 		}
 	}
 	return true;


### PR DESCRIPTION
# Description
**steps to reproduce:**
1. create 100 bolts
2. set custom attribute
3. split them
4. try stacking

**expected:** items stack
**observed:** can't stack

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
splitting and trying to mix following items:
```
-- upgraded bolts
i = Player("Administrator"):addItem("bolt", 100)
i:setCustomAttribute("test1", 1)
i = Player("Administrator"):addItem("bolt", 100)
i:setCustomAttribute("test1", 2)
i = Player("Administrator"):addItem("bolt", 100)
i:setCustomAttribute("test2", 1)
-- control stack
i = Player("Administrator"):addItem("bolt", 100)
```
(items with same attributes mix, items with different: don't)

**Test Configuration**:
  - Server Version: my fork of tfs, but the function is identical so I expect it to work on canary as well
  - Client: 12.71 QT
  - Operating System: Windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
