### PR TITLE
Fixed sale in the market to create offer by stash and adjust indentation to tab 4

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7813,11 +7813,10 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 			account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
 											 "Sold on Market");
 		} else {
-			uint16_t stashmath = amount;
 			uint16_t stashminus = player->getStashItemCount(it.wareId);
-			stashmath = (amount - (amount > stashminus ? stashminus : amount));
-			std::forward_list<Item*> itemList = getMarketItemList(it.wareId, stashmath, depotLocker);
-			if (itemList.empty() && stashmath > 0) {
+			amount = (amount - (amount > stashminus ? stashminus : amount));
+			std::forward_list<Item*> itemList = getMarketItemList(it.wareId, amount, depotLocker);
+			if (itemList.empty() && amount > 0) {
 				return;
 			}
 
@@ -7826,7 +7825,7 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 			}
 
 			if (it.stackable) {
-				uint16_t tmpAmount = stashmath;
+				uint16_t tmpAmount = amount;
 				for (Item* item : itemList) {
 					uint16_t removeCount = std::min<uint16_t>(tmpAmount, item->getItemCount());
 					tmpAmount -= removeCount;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7610,8 +7610,8 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spr
 			uint16_t stashminus = player->getStashItemCount(it.wareId);
 			amount = (amount - (amount > stashminus ? stashminus : amount));
 
-			std::forward_list<Item *> itemList = getMarketItemList(it.wareId, stashmath, depotLocker);
-			if (itemList.empty() && stashmath > 0) {
+			std::forward_list<Item *> itemList = getMarketItemList(it.wareId, amount, depotLocker);
+			if (itemList.empty() && amount > 0) {
 				return;
 			}
 
@@ -7619,7 +7619,7 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spr
 				player->withdrawItem(it.wareId, (amount > stashminus ? stashminus : amount));
 			}
 
-			uint16_t tmpAmount = stashmath;
+			uint16_t tmpAmount = amount;
 			for (Item *item : itemList) {
 				if (!it.stackable) {
 					internalRemoveItem(item);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7525,9 +7525,9 @@ void Game::playerBrowseMarketOwnHistory(uint32_t playerId)
 	player->sendMarketBrowseOwnHistory(buyOffers, sellOffers);
 }
 
-void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spriteId, uint16_t amount, uint32_t price, bool anonymous) // Limit of 64k of items to create offer
+void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spriteId, uint16_t amount, uint32_t price, bool anonymous)
 {
-	// 64000 is size of the client limitation
+	// 64000 is size of the client limitation (uint16_t)
 	if (amount == 0 || amount > 64000) {
 		return;
 	}
@@ -7660,11 +7660,11 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spr
 	const MarketOfferList& sellOffers = IOMarket::getActiveOffers(MARKETACTION_SELL, it.id);
 	player->sendMarketBrowseItem(it.id, buyOffers, sellOffers);
 
-	//
-	player->updateMarketExhausted(); // Exhausted for create offert in the market
+	// Exhausted for create offert in the market
+	player->updateMarketExhausted();
 }
 
-void Game::playerCancelMarketOffer(uint32_t playerId, uint32_t timestamp, uint16_t counter) // Market cancel offer
+void Game::playerCancelMarketOffer(uint32_t playerId, uint32_t timestamp, uint16_t counter)
 {
 	Player* player = getPlayerByID(playerId);
 	if (!player) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7792,7 +7792,9 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 		}
 
 		if (!buyerPlayer) {
+			buyerPlayer = new Player(nullptr);
 			if (!IOLoginData::loadPlayerById(buyerPlayer, offer.playerId)) {
+				delete buyerPlayer;
 				return;
 			}
 		}
@@ -7809,7 +7811,7 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 
 			account.RemoveCoins(amount);
 			account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
-                                             "Sold on Market");
+											 "Sold on Market");
 		} else {
 			uint16_t stashmath = amount;
 			uint16_t stashminus = player->getStashItemCount(it.wareId);
@@ -7843,15 +7845,15 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 		player->setBankBalance(player->getBankBalance() + totalPrice);
 
 		if (it.id == ITEM_STORE_COIN) {
-      account::Account account;
-      account.LoadAccountDB(buyerPlayer->getAccount());
-      account.AddCoins(amount);
-      account.RegisterCoinsTransaction(account::COIN_ADD, amount,
-                                      "Purchased on Market");
-    }
-    else if (it.stackable)
-    {
-      uint16_t tmpAmount = amount;
+			account::Account account;
+			account.LoadAccountDB(buyerPlayer->getAccount());
+			account.AddCoins(amount);
+			account.RegisterCoinsTransaction(account::COIN_ADD, amount,
+											 "Purchased on Market");
+		}
+		else if (it.stackable)
+		{
+			uint16_t tmpAmount = amount;
 			while (tmpAmount > 0) {
 				uint16_t stackCount = std::min<uint16_t>(100, tmpAmount);
 				Item* item = Item::CreateItem(it.id, stackCount);
@@ -7862,10 +7864,10 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 
 				tmpAmount -= stackCount;
 			}
-    }
-    else
-    {
-      int32_t subType;
+		}
+		else
+		{
+			int32_t subType;
 			if (it.charges != 0) {
 				subType = it.charges;
 			} else {
@@ -7879,9 +7881,9 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 					break;
 				}
 			}
-    }
+		}
 
-    if (buyerPlayer->isOffline()) {
+		if (buyerPlayer->isOffline()) {
 			IOLoginData::savePlayer(buyerPlayer);
 			delete buyerPlayer;
 		}
@@ -7910,11 +7912,11 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 		}
 
 		if (it.id == ITEM_STORE_COIN) {
-      account::Account account;
-      account.LoadAccountDB(player->getAccount());
-      account.AddCoins(amount);
-      account.RegisterCoinsTransaction(account::COIN_ADD, amount,
-                                      "Purchased on Market");
+			account::Account account;
+			account.LoadAccountDB(player->getAccount());
+			account.AddCoins(amount);
+			account.RegisterCoinsTransaction(account::COIN_ADD, amount,
+											 "Purchased on Market");
 		} else if (it.stackable) {
 			uint16_t tmpAmount = amount;
 			while (tmpAmount > 0) {
@@ -7947,28 +7949,29 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 		if (sellerPlayer) {
 			sellerPlayer->setBankBalance(sellerPlayer->getBankBalance() + totalPrice);
 			if (it.id == ITEM_STORE_COIN) {
-        account::Account account;
-        account.LoadAccountDB(sellerPlayer->getAccount());
-        account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
-                                        "Sold on Market");
-      }
+				account::Account account;
+				account.LoadAccountDB(sellerPlayer->getAccount());
+				account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
+												 "Sold on Market");
+			}
 		} else {
 			IOLoginData::increaseBankBalance(offer.playerId, totalPrice);
 			if (it.id == ITEM_STORE_COIN) {
 				sellerPlayer = new Player(nullptr);
 
 				if (IOLoginData::loadPlayerById(sellerPlayer, offer.playerId)) {
-          account::Account account;
-          account.LoadAccountDB(sellerPlayer->getAccount());
-          account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
-                                          "Sold on Market");
-		}
+					account::Account account;
+					account.LoadAccountDB(sellerPlayer->getAccount());
+					account.RegisterCoinsTransaction(account::COIN_REMOVE, amount,
+													 "Sold on Market");
+				}
 
 				delete sellerPlayer;
 			}
 		}
+
 		if (it.id != ITEM_STORE_COIN) {
-		player->onReceiveMail();
+			player->onReceiveMail();
 		}
 	}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7697,11 +7697,10 @@ void Game::playerCancelMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 		}
 
 		if (it.id == ITEM_STORE_COIN) {
-      account::Account account;
-      account.LoadAccountDB(player->getAccount());
-      account.AddCoins(offer.amount);
-    }
-		else if (it.stackable) {
+			account::Account account;
+			account.LoadAccountDB(player->getAccount());
+			account.AddCoins(offer.amount);
+		} else if (it.stackable) {
 			uint16_t tmpAmount = offer.amount;
 			while (tmpAmount > 0) {
 				int32_t stackCount = std::min<int32_t>(100, tmpAmount);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7888,8 +7888,7 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 			IOLoginData::savePlayer(buyerPlayer);
 			delete buyerPlayer;
 		}
-	// MARKETACTION_SELL
-	} else {
+	} else if (offer.type == MARKETACTION_SELL) {
 		Player* sellerPlayer = getPlayerByGUID(offer.playerId);
 		if (player == sellerPlayer) {
 			player->sendFYIBox("You cannot accept your own offer.");

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7607,9 +7607,8 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t spr
 
 			account.RemoveCoins(static_cast<uint32_t>(amount));
 		} else {
-			uint16_t stashmath = amount;
 			uint16_t stashminus = player->getStashItemCount(it.wareId);
-			stashmath = (amount - (amount > stashminus ? stashminus : amount));
+			amount = (amount - (amount > stashminus ? stashminus : amount));
 
 			std::forward_list<Item *> itemList = getMarketItemList(it.wareId, stashmath, depotLocker);
 			if (itemList.empty() && stashmath > 0) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7735,11 +7735,13 @@ void Game::playerCancelMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 	offer.timestamp += g_config.getNumber(MARKET_OFFER_DURATION);
 	player->sendMarketCancelOffer(offer);
 	player->sendMarketEnter(player->getLastDepotId());
-	player->updateMarketExhausted(); // Exhausted for cancel offer in the market
+	// Exhausted for cancel offer in the market
+	player->updateMarketExhausted();
 }
 
-void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16_t counter, uint16_t amount) // Limit of 64k of items to create offer
+void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16_t counter, uint16_t amount)
 {
+	// Limit of 64k of items to create offer
 	if (amount == 0 || amount > 64000) {
 		return;
 	}
@@ -7886,7 +7888,8 @@ void Game::playerAcceptMarketOffer(uint32_t playerId, uint32_t timestamp, uint16
 			IOLoginData::savePlayer(buyerPlayer);
 			delete buyerPlayer;
 		}
-	} else {//MARKETACTION_SELL
+	// MARKETACTION_SELL
+	} else {
 		Player* sellerPlayer = getPlayerByGUID(offer.playerId);
 		if (player == sellerPlayer) {
 			player->sendFYIBox("You cannot accept your own offer.");

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -300,7 +300,7 @@ bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 		return false;
 	}
 
-	appendHistory(result->getNumber<uint32_t>("player_id"), static_cast<MarketAction_t>(result->getNumber<uint16_t>("sale")), result->getNumber<uint16_t>("itemtype"), result->getNumber<uint16_t>("amount"), result->getNumber<uint32_t>("price"), result->getNumber<uint32_t>("created") + marketOfferDuration, state);
+	appendHistory(result->getNumber<uint32_t>("player_id"), static_cast<MarketAction_t>(result->getNumber<uint16_t>("sale")), result->getNumber<uint16_t>("itemtype"), result->getNumber<uint16_t>("amount"), result->getNumber<uint32_t>("price"), time(nullptr), state);
 	return true;
 }
 


### PR DESCRIPTION
# Description

When creating an offer with the item in the stash, it removed the item but did not create the offer.
Fixed the date when an item goes into history.
Thanks @gccris for the fixes.

Fixed indentation of functions:
playerCreateMarketOffer
playerCancelMarketOffer
playerAcceptMarketOffer

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
