### PR TITLE
Added name for no longer unknown inspection type

### DIFF
--- a/src/server/server_definitions.hpp
+++ b/src/server/server_definitions.hpp
@@ -83,7 +83,7 @@ enum Resource_t : uint8_t{
 enum InspectObjectTypes : uint8_t {
 	INSPECT_NORMALOBJECT = 0,
 	INSPECT_NPCTRADE = 1,
-	INSPECT_UNKNOWN = 2,
+	INSPECT_PLAYERTRADE = 2,
 	INSPECT_CYCLOPEDIA = 3
 };
 


### PR DESCRIPTION
# Description
While working on my own implementation on inspection, I've discovered what the missing enum does.
As far as vs code search is telling me, this isn't used anywhere else in the code so it's safe to change.

## Type of change
  - Bug fix (non-breaking change which fixes an issue)
  - New feature (non-breaking change which adds functionality)

## How Has This Been Tested
I printed header packet and first byte when clicking inspect in trade window and the output was 205, 2 (header + byte)
