### PR TITLE
Added "if" check to verify if tables are null on reload talkaction 

### DIFF
--- a/data/global.lua
+++ b/data/global.lua
@@ -56,13 +56,19 @@ specialRopeSpots = {12935}
 updateInterval = 2
 -- Healing
 -- Global table to insert data
-healingImpact = {}
+if healingImpact == nil then
+	healingImpact = {}
+end
 -- Damage
 -- Global table to insert data
-damageImpact = {}
+if damageImpact == nil then
+	damageImpact = {}
+end
 
 -- New prey => preyTimeLeft
-nextPreyTime = {}
+if nextPreyTime == nil then
+	nextPreyTime = {}
+end
 
 do -- Event Schedule rates
 	local lootRate = Game.getEventSLoot()


### PR DESCRIPTION
# Description

When reloading, the tables were cleaned, causing some server behavior to bug.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
