### PR TITLE
Decouple config manager in true singleton

### DIFF
--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -33,7 +33,7 @@ class ConfigManager
 
 		static ConfigManager& getInstance() {
 			// Guaranteed to be destroyed
-			static ConfigManager instance;
+			inline static ConfigManager instance;
 			// Instantiated on first use
 			return instance;
 		}

--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -25,6 +25,8 @@
 class ConfigManager
 {
 	public:
+		ConfigManager() = default;
+
 		// Singleton - ensures we don't accidentally copy it
 		ConfigManager(ConfigManager const&) = delete;
 		void operator=(ConfigManager const&) = delete;
@@ -54,8 +56,6 @@ class ConfigManager
 		};
 
 	private:
-		ConfigManager() {}
-
 		std::string configFileLua = { "config.lua" };
 		std::string string[LAST_STRING_CONFIG] = {};
 		int32_t integer[LAST_INTEGER_CONFIG] = {};

--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -33,7 +33,7 @@ class ConfigManager
 
 		static ConfigManager& getInstance() {
 			// Guaranteed to be destroyed
-			inline static ConfigManager instance;
+			static ConfigManager instance;
 			// Instantiated on first use
 			return instance;
 		}

--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -25,6 +25,17 @@
 class ConfigManager
 {
 	public:
+		// Singleton - ensures we don't accidentally copy it
+		ConfigManager(ConfigManager const&) = delete;
+		void operator=(ConfigManager const&) = delete;
+
+		static ConfigManager& getInstance() {
+			// Guaranteed to be destroyed
+			static ConfigManager instance;
+			// Instantiated on first use
+			return instance;
+		}
+	
 		bool load();
 		bool reload();
 
@@ -43,6 +54,8 @@ class ConfigManager
 		};
 
 	private:
+		ConfigManager() {}
+
 		std::string configFileLua = { "config.lua" };
 		std::string string[LAST_STRING_CONFIG] = {};
 		int32_t integer[LAST_INTEGER_CONFIG] = {};
@@ -51,5 +64,7 @@ class ConfigManager
 
 		bool loaded = false;
 };
+
+constexpr auto g_configManager = &ConfigManager::getInstance;
 
 #endif  // SRC_CONFIG_CONFIGMANAGER_H_

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -21,7 +21,6 @@
 
 #include "declarations.hpp"
 #include "creatures/combat/combat.h"
-#include "config/configmanager.h"
 #include "lua/creature/events.h"
 #include "game/game.h"
 #include "io/iobestiary.h"
@@ -31,7 +30,6 @@
 
 extern Game g_game;
 extern Weapons* g_weapons;
-extern ConfigManager g_config;
 extern Events* g_events;
 extern Monsters g_monsters;
 
@@ -278,7 +276,7 @@ bool Combat::isInPvpZone(const Creature* attacker, const Creature* target)
 
 bool Combat::isProtected(const Player* attacker, const Player* target)
 {
-	uint32_t protectionLevel = g_config.getNumber(PROTECTION_LEVEL);
+	uint32_t protectionLevel = g_configManager().getNumber(PROTECTION_LEVEL);
 	if (target->getLevel() < protectionLevel || attacker->getLevel() < protectionLevel) {
 		return true;
 	}

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -19,7 +19,6 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "creatures/combat/combat.h"
 #include "creatures/combat/spells.h"
 #include "creatures/monsters/monster.h"
@@ -31,7 +30,6 @@ extern Game g_game;
 extern Spells* g_spells;
 extern Monsters g_monsters;
 extern Vocations g_vocations;
-extern ConfigManager g_config;
 extern LuaEnvironment g_luaEnvironment;
 
 Spells::Spells()
@@ -1265,7 +1263,7 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	}
 
 	postCastSpell(player);
-	if (hasCharges && item && g_config.getBoolean(REMOVE_RUNE_CHARGES)) {
+	if (hasCharges && item && g_configManager().getBoolean(REMOVE_RUNE_CHARGES)) {
 		int32_t newCount = std::max<int32_t>(0, item->getItemCount() - 1);
 		g_game.transformItem(item, item->getID(), newCount);
 		player->updateSupplyTracker(item);

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -19,7 +19,6 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "creatures/creature.h"
 #include "declarations.hpp"
 #include "game/game.h"
@@ -31,7 +30,6 @@ double Creature::speedB = 261.29;
 double Creature::speedC = -4795.01;
 
 extern Game g_game;
-extern ConfigManager g_config;
 extern CreatureEvents* g_creatureEvents;
 
 Creature::Creature()
@@ -632,7 +630,7 @@ void Creature::onDeath()
 	Creature* mostDamageCreature = nullptr;
 
 	const int64_t timeNow = OTSYS_TIME();
-	const uint32_t inFightTicks = g_config.getNumber(PZ_LOCKED);
+	const uint32_t inFightTicks = g_configManager().getNumber(PZ_LOCKED);
 	int32_t mostDamage = 0;
 	std::map<Creature*, uint64_t> experienceMap;
 	for (const auto& it : damageMap) {
@@ -747,7 +745,7 @@ bool Creature::hasBeenAttacked(uint32_t attackerId)
 	if (it == damageMap.end()) {
 		return false;
 	}
-	return (OTSYS_TIME() - it->second.ticks) <= g_config.getNumber(PZ_LOCKED);
+	return (OTSYS_TIME() - it->second.ticks) <= g_configManager().getNumber(PZ_LOCKED);
 }
 
 Item* Creature::getCorpse(Creature*, Creature*)

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -22,7 +22,6 @@
 #include "otpch.h"
 
 #include "creatures/monsters/monster.h"
-#include "config/configmanager.h"
 #include "game/game.h"
 #include "creatures/combat/spells.h"
 #include "lua/creature/events.h"
@@ -30,7 +29,6 @@
 extern Game g_game;
 extern Monsters g_monsters;
 extern Events* g_events;
-extern ConfigManager g_config;
 
 int32_t Monster::despawnRange;
 int32_t Monster::despawnRadius;
@@ -54,7 +52,7 @@ Monster::Monster(MonsterType* mType) :
 	defaultOutfit = mType->info.outfit;
 	currentOutfit = mType->info.outfit;
 	skull = mType->info.skull;
-	float multiplier = g_config.getFloat(RATE_MONSTER_HEALTH);
+	float multiplier = g_configManager().getFloat(RATE_MONSTER_HEALTH);
 	health = mType->info.health*multiplier;
 	healthMax = mType->info.healthMax*multiplier;
 	baseSpeed = mType->info.baseSpeed;
@@ -916,9 +914,9 @@ void Monster::doAttacking(uint32_t interval)
 
 				float multiplier;
 				if (maxCombatValue > 0) { //defense
-					multiplier = g_config.getFloat(RATE_MONSTER_DEFENSE);
+					multiplier = g_configManager().getFloat(RATE_MONSTER_DEFENSE);
 				} else { //attack
-					multiplier = g_config.getFloat(RATE_MONSTER_ATTACK);
+					multiplier = g_configManager().getFloat(RATE_MONSTER_ATTACK);
 				}
 
 				minCombatValue = spellBlock.minCombatValue * multiplier;
@@ -1979,9 +1977,9 @@ bool Monster::getCombatValues(int32_t& min, int32_t& max)
 
 	float multiplier;
 	if (maxCombatValue > 0) { //defense
-		multiplier = g_config.getFloat(RATE_MONSTER_DEFENSE);
+		multiplier = g_configManager().getFloat(RATE_MONSTER_DEFENSE);
 	} else { //attack
-		multiplier = g_config.getFloat(RATE_MONSTER_ATTACK);
+		multiplier = g_configManager().getFloat(RATE_MONSTER_ATTACK);
 	}
 
 	min = minCombatValue * multiplier;

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -24,7 +24,6 @@
 #include "creatures/combat/spells.h"
 #include "creatures/combat/combat.h"
 #include "items/weapons/weapons.h"
-#include "config/configmanager.h"
 #include "game/game.h"
 
 #include "utils/pugicast.h"
@@ -32,7 +31,6 @@
 extern Game g_game;
 extern Spells* g_spells;
 extern Monsters g_monsters;
-extern ConfigManager g_config;
 
 spellBlock_t::~spellBlock_t()
 {
@@ -66,7 +64,7 @@ bool Monsters::loadFromXml(bool reloading /*= false*/)
 	for (auto monsterNode : doc.child("monsters").children()) {
 		std::string name = asLowerCaseString(monsterNode.attribute("name").as_string());
 		std::string file = "data/monster/" + std::string(monsterNode.attribute("file").as_string());
-		auto forceLoad = g_config.getBoolean(FORCE_MONSTERTYPE_LOAD);
+		auto forceLoad = g_configManager().getBoolean(FORCE_MONSTERTYPE_LOAD);
 		if (forceLoad) {
 			loadMonster(file, name, true);
 			continue;

--- a/src/creatures/monsters/spawns/spawn_monster.cpp
+++ b/src/creatures/monsters/spawns/spawn_monster.cpp
@@ -22,13 +22,11 @@
 #include "creatures/monsters/spawns/spawn_monster.h"
 #include "game/game.h"
 #include "creatures/monsters/monster.h"
-#include "config/configmanager.h"
 #include "game/scheduling/scheduler.h"
 
 #include "utils/pugicast.h"
 #include "lua/creature/events.h"
 
-extern ConfigManager g_config;
 extern Monsters g_monsters;
 extern Game g_game;
 extern Events* g_events;
@@ -108,7 +106,7 @@ bool SpawnsMonster::loadFromXML(const std::string& filemonstername)
 					boostedrate = 1;
 				}
 
-				uint32_t interval = pugi::cast<uint32_t>(childMonsterNode.attribute("spawntime").value()) * 100000 / (g_config.getNumber(RATE_SPAWN) * boostedrate * eventschedule);
+				uint32_t interval = pugi::cast<uint32_t>(childMonsterNode.attribute("spawntime").value()) * 100000 / (g_configManager().getNumber(RATE_SPAWN) * boostedrate * eventschedule);
 				if (interval >= MONSTER_MINSPAWN_INTERVAL && interval <= MONSTER_MAXSPAWN_INTERVAL) {
 					spawnMonster.addMonster(nameAttribute.as_string(), pos, dir, static_cast<uint32_t>(interval));
 				} else {
@@ -259,7 +257,7 @@ void SpawnMonster::checkSpawnMonster()
 				scheduleSpawn(spawnMonsterId, sb, 3 * NONBLOCKABLE_SPAWN_MONSTER_INTERVAL);
 			}
 
-			if (++spawnMonsterCount >= static_cast<uint32_t>(g_config.getNumber(RATE_SPAWN))) {
+			if (++spawnMonsterCount >= static_cast<uint32_t>(g_configManager().getNumber(RATE_SPAWN))) {
 				break;
 			}
 		}

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -22,7 +22,6 @@
 #include "declarations.hpp"
 #include "creatures/npcs/npc.h"
 #include "creatures/npcs/npcs.h"
-#include "config/configmanager.h"
 #include "lua/callbacks/creaturecallback.h"
 #include "game/game.h"
 #include "creatures/combat/spells.h"
@@ -31,7 +30,6 @@
 extern Game g_game;
 extern Npcs g_npcs;
 extern Events* g_events;
-extern ConfigManager g_config;
 
 int32_t Npc::despawnRange;
 int32_t Npc::despawnRadius;
@@ -54,7 +52,7 @@ Npc::Npc(NpcType* npcType) :
 {
 	defaultOutfit = npcType->info.outfit;
 	currentOutfit = npcType->info.outfit;
-	float multiplier = g_config.getFloat(RATE_NPC_HEALTH);
+	float multiplier = g_configManager().getFloat(RATE_NPC_HEALTH);
 	health = npcType->info.health*multiplier;
 	healthMax = npcType->info.healthMax*multiplier;
 	baseSpeed = npcType->info.baseSpeed;

--- a/src/creatures/npcs/npcs.cpp
+++ b/src/creatures/npcs/npcs.cpp
@@ -20,7 +20,6 @@
 #include "otpch.h"
 
 #include "creatures/combat/combat.h"
-#include "config/configmanager.h"
 #include "creatures/creature.h"
 #include "declarations.hpp"
 #include "game/game.h"
@@ -34,7 +33,6 @@
 extern Game g_game;
 extern Spells* g_spells;
 extern Npcs g_npcs;
-extern ConfigManager g_config;
 
 bool NpcType::canSpawn(const Position& pos)
 {

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -22,13 +22,11 @@
 #include "creatures/npcs/spawns/spawn_npc.h"
 #include "game/game.h"
 #include "creatures/npcs/npc.h"
-#include "config/configmanager.h"
 #include "game/scheduling/scheduler.h"
 
 #include "utils/pugicast.h"
 #include "lua/creature/events.h"
 
-extern ConfigManager g_config;
 extern Npcs g_npcs;
 extern Game g_game;
 extern Events* g_events;

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -21,11 +21,9 @@
 
 #include "creatures/players/grouping/party.h"
 #include "game/game.h"
-#include "config/configmanager.h"
 #include "lua/creature/events.h"
 
 extern Game g_game;
-extern ConfigManager g_config;
 extern Events* g_events;
 
 Party::Party(Player* initLeader) : leader(initLeader)
@@ -402,7 +400,7 @@ bool Party::canUseSharedExperience(const Player* player) const
 		}
 
 		uint64_t timeDiff = OTSYS_TIME() - it->second;
-		if (timeDiff > static_cast<uint64_t>(g_config.getNumber(PZ_LOCKED))) {
+		if (timeDiff > static_cast<uint64_t>(g_configManager().getNumber(PZ_LOCKED))) {
 			return false;
 		}
 	}
@@ -477,7 +475,7 @@ void Party::showPlayerStatus(Player* player, Player* member, bool showStatus)
 
 void Party::updatePlayerStatus(Player* player)
 {
-	int32_t maxDistance = g_config.getNumber(PARTY_LIST_MAX_DISTANCE);
+	int32_t maxDistance = g_configManager().getNumber(PARTY_LIST_MAX_DISTANCE);
 	for (Player* member : memberList) {
 		bool condition = (maxDistance == 0 || (Position::getDistanceX(player->getPosition(), member->getPosition()) <= maxDistance && Position::getDistanceY(player->getPosition(), member->getPosition()) <= maxDistance));
 		if (condition) {
@@ -496,7 +494,7 @@ void Party::updatePlayerStatus(Player* player)
 
 void Party::updatePlayerStatus(Player* player, const Position& oldPos, const Position& newPos)
 {
-	int32_t maxDistance = g_config.getNumber(PARTY_LIST_MAX_DISTANCE);
+	int32_t maxDistance = g_configManager().getNumber(PARTY_LIST_MAX_DISTANCE);
 	if (maxDistance != 0) {
 		for (Player* member : memberList) {
 			bool condition1 = (Position::getDistanceX(oldPos, member->getPosition()) <= maxDistance && Position::getDistanceY(oldPos, member->getPosition()) <= maxDistance);
@@ -520,7 +518,7 @@ void Party::updatePlayerStatus(Player* player, const Position& oldPos, const Pos
 
 void Party::updatePlayerHealth(const Player* player, const Creature* target, uint8_t healthPercent)
 {
-	int32_t maxDistance = g_config.getNumber(PARTY_LIST_MAX_DISTANCE);
+	int32_t maxDistance = g_configManager().getNumber(PARTY_LIST_MAX_DISTANCE);
 	for (Player* member : memberList) {
 		bool condition = (maxDistance == 0 || (Position::getDistanceX(player->getPosition(), member->getPosition()) <= maxDistance && Position::getDistanceY(player->getPosition(), member->getPosition()) <= maxDistance));
 		if (condition) {
@@ -535,7 +533,7 @@ void Party::updatePlayerHealth(const Player* player, const Creature* target, uin
 
 void Party::updatePlayerMana(const Player* player, uint8_t manaPercent)
 {
-	int32_t maxDistance = g_config.getNumber(PARTY_LIST_MAX_DISTANCE);
+	int32_t maxDistance = g_configManager().getNumber(PARTY_LIST_MAX_DISTANCE);
 	for (Player* member : memberList) {
 		bool condition = (maxDistance == 0 || (Position::getDistanceX(player->getPosition(), member->getPosition()) <= maxDistance && Position::getDistanceY(player->getPosition(), member->getPosition()) <= maxDistance));
 		if (condition) {
@@ -550,7 +548,7 @@ void Party::updatePlayerMana(const Player* player, uint8_t manaPercent)
 
 void Party::updatePlayerVocation(const Player* player)
 {
-	int32_t maxDistance = g_config.getNumber(PARTY_LIST_MAX_DISTANCE);
+	int32_t maxDistance = g_configManager().getNumber(PARTY_LIST_MAX_DISTANCE);
 	for (Player* member : memberList) {
 		bool condition = (maxDistance == 0 || (Position::getDistanceX(player->getPosition(), member->getPosition()) <= maxDistance && Position::getDistanceY(player->getPosition(), member->getPosition()) <= maxDistance));
 		if (condition) {

--- a/src/creatures/players/imbuements/imbuements.cpp
+++ b/src/creatures/players/imbuements/imbuements.cpp
@@ -366,7 +366,7 @@ std::vector<Imbuement*> Imbuements::getImbuements(const Player* player, Item* it
 
 		// Parse the storages for each imbuement in imbuements.xml and config.lua (enable/disable storage)
 		int32_t storageValue;
-		if (g_config.getBoolean(TOGLE_IMBUEMENT_SHRINE_STORAGE)
+		if (g_configManager().getBoolean(TOGLE_IMBUEMENT_SHRINE_STORAGE)
 		&& imbuement->getStorage() != 0
 		&& !player->getStorageValue(imbuement->getStorage(), storageValue)
 		&& imbuement->getBaseID() >= 1 && imbuement->getBaseID() <= 3) {

--- a/src/creatures/players/management/waitlist.cpp
+++ b/src/creatures/players/management/waitlist.cpp
@@ -19,11 +19,9 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "game/game.h"
 #include "creatures/players/management/waitlist.h"
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 
@@ -112,7 +110,7 @@ bool WaitingList::clientLogin(const Player* player)
 		return true;
 	}
 
-	uint32_t maxPlayers = static_cast<uint32_t>(g_config.getNumber(MAX_PLAYERS));
+	uint32_t maxPlayers = static_cast<uint32_t>(g_configManager().getNumber(MAX_PLAYERS));
 	if (maxPlayers == 0 || (info->priorityWaitList.empty() && info->waitList.empty() && g_game.getPlayersOnline() < maxPlayers)) {
 		return true;
 	}

--- a/src/creatures/players/management/waitlist.cpp
+++ b/src/creatures/players/management/waitlist.cpp
@@ -110,7 +110,7 @@ bool WaitingList::clientLogin(const Player* player)
 		return true;
 	}
 
-	uint32_t maxPlayers = static_cast<uint32_t>(g_configManager().getNumber(MAX_PLAYERS));
+	auto maxPlayers = static_cast<uint32_t>(g_configManager().getNumber(MAX_PLAYERS));
 	if (maxPlayers == 0 || (info->priorityWaitList.empty() && info->waitList.empty() && g_game.getPlayersOnline() < maxPlayers)) {
 		return true;
 	}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1040,7 +1040,7 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_MARKET));
 	depotLocker->internalAddThing(inbox);
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_SUPPLY_STASH));
-	Container* depotChest = Item::CreateItemAsContainer(ITEM_DEPOT, g_configManager().getNumber(DEPOT_BOXES));
+	Container* depotChest = Item::CreateItemAsContainer(ITEM_DEPOT, static_cast<uint16_t>(g_configManager().getNumber(DEPOT_BOXES)));
 	for (uint32_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
 		DepotChest* depotBox = getDepotChest(i, true);
 		depotChest->internalAddThing(depotBox);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -25,7 +25,6 @@
 #include "items/bed.h"
 #include "creatures/interactions/chat.h"
 #include "creatures/combat/combat.h"
-#include "config/configmanager.h"
 #include "lua/creature/creatureevent.h"
 #include "lua/creature/events.h"
 #include "game/game.h"
@@ -37,7 +36,6 @@
 #include "items/weapons/weapons.h"
 #include "io/iobestiary.h"
 
-extern ConfigManager g_config;
 extern Game g_game;
 extern Chat* g_chat;
 extern Vocations g_vocations;
@@ -816,7 +814,7 @@ bool Player::canWalkthrough(const Creature* creature) const
 
 	if (player) {
 		const Tile* playerTile = player->getTile();
-		if (!playerTile || (!playerTile->hasFlag(TILESTATE_NOPVPZONE) && !playerTile->hasFlag(TILESTATE_PROTECTIONZONE) && player->getLevel() > static_cast<uint32_t>(g_config.getNumber(PROTECTION_LEVEL)) && g_game.getWorldType() != WORLD_TYPE_NO_PVP)) {
+		if (!playerTile || (!playerTile->hasFlag(TILESTATE_NOPVPZONE) && !playerTile->hasFlag(TILESTATE_PROTECTIONZONE) && player->getLevel() > static_cast<uint32_t>(g_configManager().getNumber(PROTECTION_LEVEL)) && g_game.getWorldType() != WORLD_TYPE_NO_PVP)) {
 			return false;
 		}
 
@@ -865,7 +863,7 @@ bool Player::canWalkthroughEx(const Creature* creature) const
 	const Npc* npc = creature->getNpc();
 	if (player) {
 		const Tile* playerTile = player->getTile();
-		return playerTile && (playerTile->hasFlag(TILESTATE_NOPVPZONE) || playerTile->hasFlag(TILESTATE_PROTECTIONZONE) || player->getLevel() <= static_cast<uint32_t>(g_config.getNumber(PROTECTION_LEVEL)) || g_game.getWorldType() == WORLD_TYPE_NO_PVP);
+		return playerTile && (playerTile->hasFlag(TILESTATE_NOPVPZONE) || playerTile->hasFlag(TILESTATE_PROTECTIONZONE) || player->getLevel() <= static_cast<uint32_t>(g_configManager().getNumber(PROTECTION_LEVEL)) || g_game.getWorldType() == WORLD_TYPE_NO_PVP);
 	} else if (npc) {
 		const Tile* tile = npc->getTile();
 		const HouseTile* houseTile = dynamic_cast<const HouseTile*>(tile);
@@ -1029,7 +1027,7 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	auto it = depotLockerMap.find(depotId);
 	if (it != depotLockerMap.end()) {
 		inbox->setParent(it->second);
-		for (uint8_t i = g_config.getNumber(DEPOT_BOXES); i > 0; i--) {
+		for (uint8_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
 			if (DepotChest* depotBox = getDepotChest(i, false)) {
 				depotBox->setParent(it->second->getItemByIndex(0)->getContainer());
  			}
@@ -1042,8 +1040,8 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_MARKET));
 	depotLocker->internalAddThing(inbox);
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_SUPPLY_STASH));
-	Container* depotChest = Item::CreateItemAsContainer(ITEM_DEPOT, g_config.getNumber(DEPOT_BOXES));
-	for (uint8_t i = g_config.getNumber(DEPOT_BOXES); i > 0; i--) {
+	Container* depotChest = Item::CreateItemAsContainer(ITEM_DEPOT, g_configManager().getNumber(DEPOT_BOXES));
+	for (uint8_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
 		DepotChest* depotBox = getDepotChest(i, true);
 		depotChest->internalAddThing(depotBox);
 		depotBox->setParent(depotChest);
@@ -1729,7 +1727,7 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 	}
 
 	if (teleport || oldPos.z != newPos.z) {
-		int32_t ticks = g_config.getNumber(STAIRHOP_DELAY);
+		int32_t ticks = g_configManager().getNumber(STAIRHOP_DELAY);
 		if (ticks > 0) {
 			if (Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_PACIFIED, ticks, 0)) {
 				addCondition(condition);
@@ -1879,7 +1877,7 @@ void Player::setNextActionTask(SchedulerTask* task, bool resetIdleTime /*= true 
 	}
 
 	if (!inEventMovePush)
-		if (!g_config.getBoolean(PUSH_WHEN_ATTACKING)) {
+		if (!g_configManager().getBoolean(PUSH_WHEN_ATTACKING)) {
 			cancelPush();
 		}
 
@@ -1951,7 +1949,7 @@ void Player::onThink(uint32_t interval)
 
 	if (!getTile()->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer() && !isExerciseTraining()) {
 		idleTime += interval;
-		const int32_t kickAfterMinutes = g_config.getNumber(KICK_AFTER_MINUTES);
+		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
 		if (idleTime > (kickAfterMinutes * 60000) + 60000) {
 			kickPlayer(true);
 		} else if (client && idleTime == 60000 * kickAfterMinutes) {
@@ -1988,7 +1986,7 @@ uint32_t Player::isMuted() const
 
 void Player::addMessageBuffer()
 {
-	if (MessageBufferCount > 0 && g_config.getNumber(MAX_MESSAGEBUFFER) != 0 && !hasFlag(PlayerFlag_CannotBeMuted)) {
+	if (MessageBufferCount > 0 && g_configManager().getNumber(MAX_MESSAGEBUFFER) != 0 && !hasFlag(PlayerFlag_CannotBeMuted)) {
 		--MessageBufferCount;
 	}
 }
@@ -1999,7 +1997,7 @@ void Player::removeMessageBuffer()
 		return;
 	}
 
-	const int32_t maxMessageBuffer = g_config.getNumber(MAX_MESSAGEBUFFER);
+	const int32_t maxMessageBuffer = g_configManager().getNumber(MAX_MESSAGEBUFFER);
 	if (maxMessageBuffer != 0 && MessageBufferCount <= maxMessageBuffer + 1) {
 		if (++MessageBufferCount > maxMessageBuffer) {
 			uint32_t muteCount = 1;
@@ -2670,7 +2668,7 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 		sendIcons();
 	}
 
-	Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_config.getNumber(PZ_LOCKED), 0);
+	Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_configManager().getNumber(PZ_LOCKED), 0);
 	addCondition(condition);
 }
 
@@ -2847,7 +2845,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	} else if (slotPosition & SLOTP_TWO_HAND) {
 		ret = RETURNVALUE_PUTTHISOBJECTINBOTHHANDS;
 	} else if ((slotPosition & SLOTP_RIGHT) || (slotPosition & SLOTP_LEFT)) {
-		if (!g_config.getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
+		if (!g_configManager().getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
 			ret = RETURNVALUE_CANNOTBEDRESSED;
 		} else {
 			ret = RETURNVALUE_PUTTHISOBJECTINYOURHAND;
@@ -2885,7 +2883,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 
 		case CONST_SLOT_RIGHT: {
 			if (slotPosition & SLOTP_RIGHT) {
-				if (!g_config.getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
+				if (!g_configManager().getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
           if (item->getWeaponType() != WEAPON_SHIELD && item->getWeaponType() != WEAPON_QUIVER) {
             ret = RETURNVALUE_CANNOTBEDRESSED;
           }
@@ -2938,7 +2936,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 
 		case CONST_SLOT_LEFT: {
 			if (slotPosition & SLOTP_LEFT) {
-				if (!g_config.getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
+				if (!g_configManager().getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
 					WeaponType_t type = item->getWeaponType();
 					if (type == WEAPON_NONE || type == WEAPON_SHIELD || type == WEAPON_AMMO) {
 						ret = RETURNVALUE_CANNOTBEDRESSED;
@@ -3004,7 +3002,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 		}
 
 		case CONST_SLOT_AMMO: {
-			if ((slotPosition & SLOTP_AMMO) || g_config.getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
+			if ((slotPosition & SLOTP_AMMO) || g_configManager().getBoolean(CLASSIC_EQUIPMENT_SLOTS)) {
 				ret = RETURNVALUE_NOERROR;
 			}
 			break;
@@ -3439,7 +3437,7 @@ void Player::stashContainer(StashContainerList itemDict)
 		}
 	}
 
-	if (getStashSize(stashItemDict) > g_config.getNumber(STASH_ITEMS)) {
+	if (getStashSize(stashItemDict) > g_configManager().getNumber(STASH_ITEMS)) {
 		sendCancelMessage("You don't have capacity in the Supply Stash to stow all this item.");
 		return;
 	}
@@ -3880,7 +3878,7 @@ void Player::doAttacking(uint32_t)
 		Item* tool = getWeapon();
 		const Weapon* weapon = g_weapons->getWeapon(tool);
 		uint32_t delay = getAttackSpeed();
-		bool classicSpeed = g_config.getBoolean(CLASSIC_ATTACK_SPEED);
+		bool classicSpeed = g_configManager().getBoolean(CLASSIC_ATTACK_SPEED);
 
 		if (weapon) {
 			if (!weapon->interruptSwing()) {
@@ -3909,9 +3907,9 @@ void Player::doAttacking(uint32_t)
 
 uint64_t Player::getGainedExperience(Creature* attacker) const
 {
-	if (g_config.getBoolean(EXPERIENCE_FROM_PLAYERS)) {
+	if (g_configManager().getBoolean(EXPERIENCE_FROM_PLAYERS)) {
 		Player* attackerPlayer = attacker->getPlayer();
-		if (attackerPlayer && attackerPlayer != this && skillLoss && std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <= g_config.getNumber(EXP_FROM_PLAYERS_LEVEL_RANGE)) {
+		if (attackerPlayer && attackerPlayer != this && skillLoss && std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <= g_configManager().getNumber(EXP_FROM_PLAYERS_LEVEL_RANGE)) {
 			return std::max<uint64_t>(0, std::floor(getLostExperience() * getDamageRatio(attacker) * 0.75));
 		}
 	}
@@ -4237,7 +4235,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 
 				if (lastHit && hasCondition(CONDITION_INFIGHT)) {
 					pzLocked = true;
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_config.getNumber(WHITE_SKULL_TIME), 0);
+					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_configManager().getNumber(WHITE_SKULL_TIME), 0);
 					addCondition(condition);
 				}
 			}
@@ -4552,7 +4550,7 @@ Skulls_t Player::getSkullClient(const Creature* creature) const
 	if (player && player->getSkull() == SKULL_NONE) {
 		if (player == this) {
 			for (const auto& kill : unjustifiedKills) {
-				if (kill.unavenged && (time(nullptr) - kill.time) < g_config.getNumber(ORANGE_SKULL_DURATION) * 24 * 60 * 60) {
+				if (kill.unavenged && (time(nullptr) - kill.time) < g_configManager().getNumber(ORANGE_SKULL_DURATION) * 24 * 60 * 60) {
 					return SKULL_ORANGE;
 				}
 			}
@@ -4576,7 +4574,7 @@ Skulls_t Player::getSkullClient(const Creature* creature) const
 bool Player::hasKilled(const Player* player) const
 {
 	for (const auto& kill : unjustifiedKills) {
-		if (kill.target == player->getGUID() && (time(nullptr) - kill.time) < g_config.getNumber(ORANGE_SKULL_DURATION) * 24 * 60 * 60 && kill.unavenged) {
+		if (kill.target == player->getGUID() && (time(nullptr) - kill.time) < g_configManager().getNumber(ORANGE_SKULL_DURATION) * 24 * 60 * 60 && kill.unavenged) {
 			return true;
 		}
 	}
@@ -4647,14 +4645,14 @@ void Player::addUnjustifiedDead(const Player* attacked)
 	}
 
 	if (getSkull() != SKULL_BLACK) {
-		if (dayKills >= 2 * g_config.getNumber(DAY_KILLS_TO_RED) || weekKills >= 2 * g_config.getNumber(WEEK_KILLS_TO_RED) || monthKills >= 2 * g_config.getNumber(MONTH_KILLS_TO_RED)) {
+		if (dayKills >= 2 * g_configManager().getNumber(DAY_KILLS_TO_RED) || weekKills >= 2 * g_configManager().getNumber(WEEK_KILLS_TO_RED) || monthKills >= 2 * g_configManager().getNumber(MONTH_KILLS_TO_RED)) {
 			setSkull(SKULL_BLACK);
 			//start black skull time
-			skullTicks = static_cast<int64_t>(g_config.getNumber(BLACK_SKULL_DURATION)) * 24 * 60 * 60 * 1000;
-		} else if (dayKills >= g_config.getNumber(DAY_KILLS_TO_RED) || weekKills >= g_config.getNumber(WEEK_KILLS_TO_RED) || monthKills >= g_config.getNumber(MONTH_KILLS_TO_RED)) {
+			skullTicks = static_cast<int64_t>(g_configManager().getNumber(BLACK_SKULL_DURATION)) * 24 * 60 * 60 * 1000;
+		} else if (dayKills >= g_configManager().getNumber(DAY_KILLS_TO_RED) || weekKills >= g_configManager().getNumber(WEEK_KILLS_TO_RED) || monthKills >= g_configManager().getNumber(MONTH_KILLS_TO_RED)) {
 			setSkull(SKULL_RED);
 			//reset red skull time
-			skullTicks = static_cast<int64_t>(g_config.getNumber(RED_SKULL_DURATION)) * 24 * 60 * 60 * 1000;
+			skullTicks = static_cast<int64_t>(g_configManager().getNumber(RED_SKULL_DURATION)) * 24 * 60 * 60 * 1000;
 		}
 	}
 
@@ -4691,7 +4689,7 @@ double Player::getLostPercent() const
 		}
 	}
 
-	int32_t deathLosePercent = g_config.getNumber(DEATH_LOSE_PERCENT);
+	int32_t deathLosePercent = g_configManager().getNumber(DEATH_LOSE_PERCENT);
 	if (deathLosePercent != -1) {
 		if (isPromoted()) {
 			deathLosePercent -= 3;
@@ -4769,7 +4767,7 @@ bool Player::isInWarList(uint32_t guildId) const
 
 bool Player::isPremium() const
 {
-	if (g_config.getBoolean(FREE_PREMIUM) || hasFlag(PlayerFlag_IsAlwaysPremium)) {
+	if (g_configManager().getBoolean(FREE_PREMIUM) || hasFlag(PlayerFlag_IsAlwaysPremium)) {
 		return true;
 	}
 
@@ -4944,9 +4942,9 @@ void Player::sendUnjustifiedPoints()
 
 		bool isRed = getSkull() == SKULL_RED;
 
-		auto dayMax = ((isRed ? 2 : 1) * g_config.getNumber(DAY_KILLS_TO_RED));
-		auto weekMax = ((isRed ? 2 : 1) * g_config.getNumber(WEEK_KILLS_TO_RED));
-		auto monthMax = ((isRed ? 2 : 1) * g_config.getNumber(MONTH_KILLS_TO_RED));
+		auto dayMax = ((isRed ? 2 : 1) * g_configManager().getNumber(DAY_KILLS_TO_RED));
+		auto weekMax = ((isRed ? 2 : 1) * g_configManager().getNumber(WEEK_KILLS_TO_RED));
+		auto monthMax = ((isRed ? 2 : 1) * g_configManager().getNumber(MONTH_KILLS_TO_RED));
 
 		uint8_t dayProgress = std::min(std::round(dayKills / dayMax * 100), 100.0);
 		uint8_t weekProgress = std::min(std::round(weekKills / weekMax * 100), 100.0);
@@ -5367,9 +5365,9 @@ size_t Player::getMaxDepotItems() const
 	if (group->maxDepotItems != 0) {
 		return group->maxDepotItems;
 	} else if (isPremium()) {
-		return g_config.getNumber(PREMIUM_DEPOT_LIMIT);
+		return g_configManager().getNumber(PREMIUM_DEPOT_LIMIT);
 	}
-	return g_config.getNumber(FREE_DEPOT_LIMIT);
+	return g_configManager().getNumber(FREE_DEPOT_LIMIT);
 }
 
 std::forward_list<Condition*> Player::getMuteConditions() const

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1027,7 +1027,7 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	auto it = depotLockerMap.find(depotId);
 	if (it != depotLockerMap.end()) {
 		inbox->setParent(it->second);
-		for (uint8_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
+		for (uint32_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
 			if (DepotChest* depotBox = getDepotChest(i, false)) {
 				depotBox->setParent(it->second->getItemByIndex(0)->getContainer());
  			}
@@ -1041,7 +1041,7 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	depotLocker->internalAddThing(inbox);
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_SUPPLY_STASH));
 	Container* depotChest = Item::CreateItemAsContainer(ITEM_DEPOT, g_configManager().getNumber(DEPOT_BOXES));
-	for (uint8_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
+	for (uint32_t i = g_configManager().getNumber(DEPOT_BOXES); i > 0; i--) {
 		DepotChest* depotBox = getDepotChest(i, true);
 		depotChest->internalAddThing(depotBox);
 		depotBox->setParent(depotChest);
@@ -1876,16 +1876,15 @@ void Player::setNextActionTask(SchedulerTask* task, bool resetIdleTime /*= true 
 		actionTaskEvent = 0;
 	}
 
-	if (!inEventMovePush)
-		if (!g_configManager().getBoolean(PUSH_WHEN_ATTACKING)) {
-			cancelPush();
-		}
+	if (!inEventMovePush && !g_configManager().getBoolean(PUSH_WHEN_ATTACKING)) {
+		cancelPush();
+	}
 
-		if (task) {
-			actionTaskEvent = g_scheduler.addEvent(task);
-			if (resetIdleTime) {
-				this->resetIdleTime();
-			}
+	if (task) {
+		actionTaskEvent = g_scheduler.addEvent(task);
+		if (resetIdleTime) {
+			this->resetIdleTime();
+		}
 	}
 }
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -19,12 +19,12 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "database/database.h"
+
+#include "config/configmanager.h"
 
 #include <mysql/errmsg.h>
 
-extern ConfigManager g_config;
 
 Database::~Database()
 {
@@ -47,7 +47,7 @@ bool Database::connect()
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
 	// connects to database
-	if (!mysql_real_connect(handle, g_config.getString(MYSQL_HOST).c_str(), g_config.getString(MYSQL_USER).c_str(), g_config.getString(MYSQL_PASS).c_str(), g_config.getString(MYSQL_DB).c_str(), g_config.getNumber(SQL_PORT), g_config.getString(MYSQL_SOCK).c_str(), 0)) {
+	if (!mysql_real_connect(handle, g_configManager().getString(MYSQL_HOST).c_str(), g_configManager().getString(MYSQL_USER).c_str(), g_configManager().getString(MYSQL_PASS).c_str(), g_configManager().getString(MYSQL_DB).c_str(), g_configManager().getNumber(SQL_PORT), g_configManager().getString(MYSQL_SOCK).c_str(), 0)) {
 		SPDLOG_ERROR("Message: {}", mysql_error(handle));
 		return false;
 	}

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -21,8 +21,6 @@
 
 #include "database/database.h"
 
-#include "config/configmanager.h"
-
 #include <mysql/errmsg.h>
 
 

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <iostream>
 
+#include "config/configmanager.h"
 #include "declarations.hpp"
 
 class DBResult;

--- a/src/database/databasemanager.cpp
+++ b/src/database/databasemanager.cpp
@@ -19,19 +19,19 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "database/databasemanager.h"
+
+#include "config/configmanager.h"
 #include "lua/functions/core/libs/core_libs_functions.hpp"
 #include "lua/scripts/luascript.h"
 
-extern ConfigManager g_config;
 
 bool DatabaseManager::optimizeTables()
 {
 	Database& db = Database::getInstance();
 	std::ostringstream query;
 
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(MYSQL_DB)) << " AND `DATA_FREE` > 0";
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`TABLES` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_configManager().getString(MYSQL_DB)) << " AND `DATA_FREE` > 0";
 	DBResult_ptr result = db.storeQuery(query.str());
 	if (!result) {
 		return false;
@@ -61,7 +61,7 @@ bool DatabaseManager::tableExists(const std::string& tableName)
 	Database& db = Database::getInstance();
 
 	std::ostringstream query;
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(MYSQL_DB)) << " AND `TABLE_NAME` = " << db.escapeString(tableName) << " LIMIT 1";
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_configManager().getString(MYSQL_DB)) << " AND `TABLE_NAME` = " << db.escapeString(tableName) << " LIMIT 1";
 	return db.storeQuery(query.str()).get() != nullptr;
 }
 
@@ -69,7 +69,7 @@ bool DatabaseManager::isDatabaseSetup()
 {
 	Database& db = Database::getInstance();
 	std::ostringstream query;
-	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_config.getString(MYSQL_DB));
+	query << "SELECT `TABLE_NAME` FROM `information_schema`.`tables` WHERE `TABLE_SCHEMA` = " << db.escapeString(g_configManager().getString(MYSQL_DB));
 	return db.storeQuery(query.str()).get() != nullptr;
 }
 

--- a/src/database/databasemanager.cpp
+++ b/src/database/databasemanager.cpp
@@ -21,7 +21,6 @@
 
 #include "database/databasemanager.h"
 
-#include "config/configmanager.h"
 #include "lua/functions/core/libs/core_libs_functions.hpp"
 #include "lua/scripts/luascript.h"
 

--- a/src/database/databasemanager.h
+++ b/src/database/databasemanager.h
@@ -19,6 +19,8 @@
 
 #ifndef SRC_DATABASE_DATABASEMANAGER_H_
 #define SRC_DATABASE_DATABASEMANAGER_H_
+
+#include "config/configmanager.h"
 #include "database/database.h"
 
 class DatabaseManager

--- a/src/io/iomap.h
+++ b/src/io/iomap.h
@@ -22,15 +22,15 @@
 
 #include <utility>
 
-#include "config/configmanager.h"
 #include "declarations.hpp"
+
+#include "config/configmanager.h"
 #include "map/house/house.h"
 #include "items/item.h"
 #include "map/map.h"
 #include "creatures/monsters/spawns/spawn_monster.h"
 #include "creatures/npcs/spawns/spawn_npc.h"
 
-extern ConfigManager g_config;
 
 #pragma pack(1)
 
@@ -66,7 +66,7 @@ class IOMap
 			if (map->monsterfile.empty()) {
 				// OTBM file doesn't tell us about the monsterfile,
 				// Lets guess it is mapname-monster.xml.
-				map->monsterfile = g_config.getString(MAP_NAME);
+				map->monsterfile = g_configManager().getString(MAP_NAME);
 				map->monsterfile += "-monster.xml";
 			}
 
@@ -77,7 +77,7 @@ class IOMap
 			if (map->npcfile.empty()) {
 				// OTBM file doesn't tell us about the npcfile,
 				// Lets guess it is mapname-npc.xml.
-				map->npcfile = g_config.getString(MAP_NAME);
+				map->npcfile = g_configManager().getString(MAP_NAME);
 				map->npcfile += "-npc.xml";
 			}
 
@@ -88,7 +88,7 @@ class IOMap
 			if (map->housefile.empty()) {
 				// OTBM file doesn't tell us about the housefile,
 				// Lets guess it is mapname-house.xml.
-				map->housefile = g_config.getString(MAP_NAME);
+				map->housefile = g_configManager().getString(MAP_NAME);
 				map->housefile += "-house.xml";
 			}
 

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -280,8 +280,6 @@ void IOMarket::appendHistory(uint32_t playerId, MarketAction_t type, uint16_t it
 
 bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 {
-	const int32_t marketOfferDuration = g_configManager().getNumber(MARKET_OFFER_DURATION);
-
 	Database& db = Database::getInstance();
 
 	std::ostringstream query;

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -21,13 +21,11 @@
 
 #include "io/iomarket.h"
 
-#include "config/configmanager.h"
 #include "database/databasetasks.h"
 #include "io/iologindata.h"
 #include "game/game.h"
 #include "game/scheduling/scheduler.h"
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId)
@@ -42,7 +40,7 @@ MarketOfferList IOMarket::getActiveOffers(MarketAction_t action, uint16_t itemId
 		return offerList;
 	}
 
-	const int32_t marketOfferDuration = g_config.getNumber(MARKET_OFFER_DURATION);
+	const int32_t marketOfferDuration = g_configManager().getNumber(MARKET_OFFER_DURATION);
 
 	do {
 		MarketOffer offer;
@@ -64,7 +62,7 @@ MarketOfferList IOMarket::getOwnOffers(MarketAction_t action, uint32_t playerId)
 {
 	MarketOfferList offerList;
 
-	const int32_t marketOfferDuration = g_config.getNumber(MARKET_OFFER_DURATION);
+	const int32_t marketOfferDuration = g_configManager().getNumber(MARKET_OFFER_DURATION);
 
 	std::ostringstream query;
 	query << "SELECT `id`, `amount`, `price`, `created`, `itemtype` FROM `market_offers` WHERE `player_id` = " << playerId << " AND `sale` = " << action;
@@ -193,13 +191,13 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 
 void IOMarket::checkExpiredOffers()
 {
-	const time_t lastExpireDate = time(nullptr) - g_config.getNumber(MARKET_OFFER_DURATION);
+	const time_t lastExpireDate = time(nullptr) - g_configManager().getNumber(MARKET_OFFER_DURATION);
 
 	std::ostringstream query;
 	query << "SELECT `id`, `amount`, `price`, `itemtype`, `player_id`, `sale` FROM `market_offers` WHERE `created` <= " << lastExpireDate;
 	g_databaseTasks.addTask(query.str(), IOMarket::processExpiredOffers, true);
 
-	int32_t checkExpiredMarketOffersEachMinutes = g_config.getNumber(CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES);
+	int32_t checkExpiredMarketOffersEachMinutes = g_configManager().getNumber(CHECK_EXPIRED_MARKET_OFFERS_EACH_MINUTES);
 	if (checkExpiredMarketOffersEachMinutes <= 0) {
 		return;
 	}
@@ -223,7 +221,7 @@ MarketOfferEx IOMarket::getOfferByCounter(uint32_t timestamp, uint16_t counter)
 {
 	MarketOfferEx offer;
 
-	const int32_t created = timestamp - g_config.getNumber(MARKET_OFFER_DURATION);
+	const int32_t created = timestamp - g_configManager().getNumber(MARKET_OFFER_DURATION);
 
 	std::ostringstream query;
 	query << "SELECT `id`, `sale`, `itemtype`, `amount`, `created`, `price`, `player_id`, `anonymous`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `player_name` FROM `market_offers` WHERE `created` = " << created << " AND (`id` & 65535) = " << counter << " LIMIT 1";
@@ -282,7 +280,7 @@ void IOMarket::appendHistory(uint32_t playerId, MarketAction_t type, uint16_t it
 
 bool IOMarket::moveOfferToHistory(uint32_t offerId, MarketOfferState_t state)
 {
-	const int32_t marketOfferDuration = g_config.getNumber(MARKET_OFFER_DURATION);
+	const int32_t marketOfferDuration = g_configManager().getNumber(MARKET_OFFER_DURATION);
 
 	Database& db = Database::getInstance();
 

--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -384,10 +384,10 @@ ReturnValue Container::queryAdd(int32_t addIndex, const Thing& addThing, uint32_
 	}
 
 	if (const Container* topParentContainer = getTopParentContainer()) {
-		uint32_t maxItem = static_cast<uint32_t>(g_config.getNumber(MAX_ITEM));
+		uint32_t maxItem = static_cast<uint32_t>(g_configManager().getNumber(MAX_ITEM));
 		if (const Container* addContainer = item->getContainer()) {
 			uint32_t addContainerCount = addContainer->getContainerHoldingCount() + 1;
-			uint32_t maxContainer = static_cast<uint32_t>(g_config.getNumber(MAX_CONTAINER));
+			uint32_t maxContainer = static_cast<uint32_t>(g_configManager().getNumber(MAX_CONTAINER));
 			if (addContainerCount + topParentContainer->getContainerHoldingCount() > maxContainer) {
 				return RETURNVALUE_NOTPOSSIBLE;
 			}

--- a/src/items/items.h
+++ b/src/items/items.h
@@ -24,7 +24,6 @@
 #include "declarations.hpp"
 #include "items/itemloader.h"
 #include "game/movement/position.h"
-
 struct Abilities {
 	uint32_t healthGain = 0;
 	uint32_t healthTicks = 0;

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -26,7 +26,6 @@
 #include "creatures/creature.h"
 #include "creatures/combat/combat.h"
 #include "game/game.h"
-#include "config/configmanager.h"
 #include "items/containers/mailbox/mailbox.h"
 #include "creatures/monsters/monster.h"
 #include "lua/creature/movement.h"
@@ -36,7 +35,6 @@
 #include "io/iomap.h"
 
 extern Game g_game;
-extern ConfigManager g_config;
 extern MoveEvents* g_moveEvents;
 
 StaticTile real_nullptr_tile(0xFFFF, 0xFFFF, 0xFF);
@@ -403,7 +401,7 @@ void Tile::onAddTileItem(Item* item)
 		spectator->onAddTileItem(this, cylinderMapPos);
 	}
 
-  if ((!hasFlag(TILESTATE_PROTECTIONZONE) || g_config.getBoolean(CLEAN_PROTECTION_ZONES))
+  if ((!hasFlag(TILESTATE_PROTECTIONZONE) || g_configManager().getBoolean(CLEAN_PROTECTION_ZONES))
 																							&& item->isCleanable()) {
 		if (!dynamic_cast<HouseTile*>(this)) {
 			g_game.addTileToClean(this);
@@ -476,7 +474,7 @@ void Tile::onRemoveTileItem(const SpectatorHashSet& spectators, const std::vecto
 		spectator->onRemoveTileItem(this, cylinderMapPos, iType, item);
 	}
 
-  if (!hasFlag(TILESTATE_PROTECTIONZONE) || g_config.getBoolean(CLEAN_PROTECTION_ZONES)) {
+  if (!hasFlag(TILESTATE_PROTECTIONZONE) || g_configManager().getBoolean(CLEAN_PROTECTION_ZONES)) {
 		auto items = getItemList();
 		if (!items || items->empty()) {
 			g_game.removeTileToClean(this);

--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -20,7 +20,6 @@
 #include "otpch.h"
 
 #include "creatures/combat/combat.h"
-#include "config/configmanager.h"
 #include "game/game.h"
 #include "utils/pugicast.h"
 #include "lua/creature/events.h"
@@ -28,7 +27,6 @@
 
 extern Game g_game;
 extern Vocations g_vocations;
-extern ConfigManager g_config;
 extern Weapons* g_weapons;
 extern Events* g_events;
 
@@ -194,7 +192,7 @@ bool Weapon::configureEvent(const pugi::xml_node& node)
 		premium = attr.as_bool();
 	}
 
-	if ((attr = node.attribute("breakchance")) && g_config.getBoolean(REMOVE_WEAPON_CHARGES)) {
+	if ((attr = node.attribute("breakchance")) && g_configManager().getBoolean(REMOVE_WEAPON_CHARGES)) {
 		breakChance = std::min<uint8_t>(100, pugi::cast<uint16_t>(attr.value()));
 	}
 
@@ -489,7 +487,7 @@ void Weapon::onUsedWeapon(Player* player, Item* item, Tile* destTile) const
 
 	switch (action) {
 		case WEAPONACTION_REMOVECOUNT:
-			if(g_config.getBoolean(REMOVE_WEAPON_AMMO)) {
+			if(g_configManager().getBoolean(REMOVE_WEAPON_AMMO)) {
 				Weapon::decrementItemCount(item);
 				player->updateSupplyTracker(item);
 			}
@@ -497,7 +495,7 @@ void Weapon::onUsedWeapon(Player* player, Item* item, Tile* destTile) const
 
 		case WEAPONACTION_REMOVECHARGE: {
 			uint16_t charges = item->getCharges();
-			if (charges != 0 && g_config.getBoolean(REMOVE_WEAPON_CHARGES)) {
+			if (charges != 0 && g_configManager().getBoolean(REMOVE_WEAPON_CHARGES)) {
 				g_game.transformItem(item, item->getID(), charges - 1);
 			}
 			break;

--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -494,8 +494,7 @@ void Weapon::onUsedWeapon(Player* player, Item* item, Tile* destTile) const
 			break;
 
 		case WEAPONACTION_REMOVECHARGE: {
-			uint16_t charges = item->getCharges();
-			if (charges != 0 && g_configManager().getBoolean(REMOVE_WEAPON_CHARGES)) {
+			if (uint16_t charges = item->getCharges() != 0 && g_configManager().getBoolean(REMOVE_WEAPON_CHARGES)) {
 				g_game.transformItem(item, item->getID(), charges - 1);
 			}
 			break;

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -21,7 +21,6 @@
 
 #include "lua/creature/actions.h"
 #include "items/bed.h"
-#include "config/configmanager.h"
 #include "items/containers/container.h"
 #include "game/game.h"
 #include "utils/pugicast.h"
@@ -31,7 +30,6 @@
 extern Game g_game;
 extern Spells* g_spells;
 extern Actions* g_actions;
-extern ConfigManager g_config;
 
 Actions::Actions() :
 	scriptInterface("Action Interface") {
@@ -471,9 +469,9 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* 
 			return false;
 		}
 
-		player->setNextPotionAction(OTSYS_TIME() + g_config.getNumber(ACTIONS_DELAY_INTERVAL));
+		player->setNextPotionAction(OTSYS_TIME() + g_configManager().getNumber(ACTIONS_DELAY_INTERVAL));
 	} else {
-		player->setNextAction(OTSYS_TIME() + g_config.getNumber(ACTIONS_DELAY_INTERVAL));
+		player->setNextAction(OTSYS_TIME() + g_configManager().getNumber(ACTIONS_DELAY_INTERVAL));
 	}
 
 	if (isHotkey) {
@@ -497,9 +495,9 @@ bool Actions::useItemEx(Player* player, const Position& fromPos, const Position&
 			player->sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
 			return false;
 		}
-		player->setNextPotionAction(OTSYS_TIME() + g_config.getNumber(EX_ACTIONS_DELAY_INTERVAL));
+		player->setNextPotionAction(OTSYS_TIME() + g_configManager().getNumber(EX_ACTIONS_DELAY_INTERVAL));
 	} else {
-		player->setNextAction(OTSYS_TIME() + g_config.getNumber(EX_ACTIONS_DELAY_INTERVAL));
+		player->setNextAction(OTSYS_TIME() + g_configManager().getNumber(EX_ACTIONS_DELAY_INTERVAL));
 	}
 
 	Action* action = getAction(item);

--- a/src/lua/creature/raids.cpp
+++ b/src/lua/creature/raids.cpp
@@ -24,13 +24,11 @@
 #include "utils/pugicast.h"
 
 #include "game/game.h"
-#include "config/configmanager.h"
 #include "game/scheduling/scheduler.h"
 #include "creatures/monsters/monster.h"
 #include "server/network/webhook/webhook.h"
 
 extern Game g_game;
-extern ConfigManager g_config;
 
 Raids::Raids() {
 	scriptInterface.initState();
@@ -335,7 +333,7 @@ bool AnnounceEvent::configureRaidEvent(const pugi::xml_node& eventNode) {
 }
 
 bool AnnounceEvent::executeEvent() {
-	std::string url = g_config.getString(DISCORD_WEBHOOK_URL);
+	std::string url = g_configManager().getString(DISCORD_WEBHOOK_URL);
 	g_game.broadcastMessage(message, messageType);
 	webhook_send_message("Incoming raid!", message, WEBHOOK_COLOR_RAID, url);
 	return true;

--- a/src/lua/functions/core/game/config_functions.cpp
+++ b/src/lua/functions/core/game/config_functions.cpp
@@ -21,19 +21,18 @@
 
 #include "lua/functions/core/game/config_functions.hpp"
 
-extern ConfigManager g_config;
 
 int ConfigFunctions::luaConfigManagerGetString(lua_State* L) {
-	pushString(L, g_config.getString(getNumber<stringConfig_t>(L, -1)));
+	pushString(L, g_configManager().getString(getNumber<stringConfig_t>(L, -1)));
 	return 1;
 }
 
 int ConfigFunctions::luaConfigManagerGetNumber(lua_State* L) {
-	lua_pushnumber(L, g_config.getNumber(getNumber<integerConfig_t>(L, -1)));
+	lua_pushnumber(L, g_configManager().getNumber(getNumber<integerConfig_t>(L, -1)));
 	return 1;
 }
 
 int ConfigFunctions::luaConfigManagerGetBoolean(lua_State* L) {
-	pushBoolean(L, g_config.getBoolean(getNumber<booleanConfig_t>(L, -1)));
+	pushBoolean(L, g_configManager().getBoolean(getNumber<booleanConfig_t>(L, -1)));
 	return 1;
 }

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -596,8 +596,8 @@ int GameFunctions::luaGameStartRaid(lua_State* L) {
 int GameFunctions::luaGameGetClientVersion(lua_State* L) {
 	// Game.getClientVersion()
 	lua_createtable(L, 0, 3);
-	setField(L, "version", g_config.getNumber(CLIENT_VERSION));
-	setField(L, "string", g_config.getString(CLIENT_VERSION_STR));
+	setField(L, "version", g_configManager().getNumber(CLIENT_VERSION));
+	setField(L, "string", g_configManager().getString(CLIENT_VERSION_STR));
 	return 1;
 }
 

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -21,7 +21,6 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
-#include "config/configmanager.h"
 #include "creatures/interactions/chat.h"
 #include "game/game.h"
 #include "game/scheduling/scheduler.h"
@@ -33,7 +32,6 @@
 class Creature;
 
 extern Chat* g_chat;
-extern ConfigManager g_config;
 extern Game g_game;
 extern LuaEnvironment g_luaEnvironment;
 
@@ -568,7 +566,7 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 		return 1;
 	}
 
-	if (g_config.getBoolean(WARN_UNSAFE_SCRIPTS) || g_config.getBoolean(CONVERT_UNSAFE_SCRIPTS)) {
+	if (g_configManager().getBoolean(WARN_UNSAFE_SCRIPTS) || g_configManager().getBoolean(CONVERT_UNSAFE_SCRIPTS)) {
 		std::vector<std::pair<int32_t, LuaDataType>> indexes;
 		for (int i = 3; i <= parameters; ++i) {
 			if (lua_getmetatable(globalState, i) == 0) {
@@ -584,7 +582,7 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 		}
 
 		if (!indexes.empty()) {
-			if (g_config.getBoolean(WARN_UNSAFE_SCRIPTS)) {
+			if (g_configManager().getBoolean(WARN_UNSAFE_SCRIPTS)) {
 				bool plural = indexes.size() > 1;
 
 				std::string warningString = "Argument";
@@ -613,7 +611,7 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 				reportErrorFunc(warningString);
 			}
 
-			if (g_config.getBoolean(CONVERT_UNSAFE_SCRIPTS)) {
+			if (g_configManager().getBoolean(CONVERT_UNSAFE_SCRIPTS)) {
 				for (const auto& entry : indexes) {
 					switch (entry.second) {
 						case LuaData_Item:

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -93,7 +93,7 @@ int MonsterFunctions::luaMonsterSetType(lua_State* L) {
 		monster->defaultOutfit = monsterType->info.outfit;
 		monster->currentOutfit = monsterType->info.outfit;
 		monster->skull = monsterType->info.skull;
-		float multiplier = g_config.getFloat(RATE_MONSTER_HEALTH);
+		float multiplier = g_configManager().getFloat(RATE_MONSTER_HEALTH);
 		monster->health = monsterType->info.health * multiplier;
 		monster->healthMax = monsterType->info.healthMax * multiplier;
 		monster->baseSpeed = monsterType->info.baseSpeed;

--- a/src/lua/functions/lua_functions_loader.cpp
+++ b/src/lua/functions/lua_functions_loader.cpp
@@ -19,7 +19,6 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "creatures/combat/spells.h"
 #include "creatures/interactions/chat.h"
 #include "creatures/monsters/monster.h"

--- a/src/lua/global/globalevent.cpp
+++ b/src/lua/global/globalevent.cpp
@@ -19,13 +19,11 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "lua/global/globalevent.h"
 #include "utils/tools.h"
 #include "game/scheduling/scheduler.h"
 #include "utils/pugicast.h"
 
-extern ConfigManager g_config;
 
 GlobalEvents::GlobalEvents() :
 	scriptInterface("GlobalEvent Interface") {

--- a/src/lua/scripts/scripts.cpp
+++ b/src/lua/scripts/scripts.cpp
@@ -48,7 +48,6 @@ Modules* g_modules = nullptr;
 Imbuements* g_imbuements = nullptr;
 
 extern LuaEnvironment g_luaEnvironment;
-extern ConfigManager g_config;
 
 Scripts::Scripts() :
 	scriptInterface("Scripts Interface") {
@@ -160,7 +159,7 @@ bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload) {
 		if(fs::is_regular_file(*it) && it->path().extension() == ".lua") {
 			size_t found = it->path().filename().string().find(disable);
 			if (found != std::string::npos) {
-				if (g_config.getBoolean(SCRIPTS_CONSOLE_LOGS)) {
+				if (g_configManager().getBoolean(SCRIPTS_CONSOLE_LOGS)) {
 					SPDLOG_INFO("{} [disabled]", it->path().filename().string());
 				}
 				continue;
@@ -175,7 +174,7 @@ bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload) {
 		if (!isLib) {
 			if (redir.empty() || redir != it->parent_path().string()) {
 				auto p = it->relative_path();
-				if (g_config.getBoolean(SCRIPTS_CONSOLE_LOGS)) {
+				if (g_configManager().getBoolean(SCRIPTS_CONSOLE_LOGS)) {
 					SPDLOG_INFO("[{}]", p.parent_path().filename().string());
 				}
 				redir = it->parent_path().string();
@@ -188,7 +187,7 @@ bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload) {
 			continue;
 		}
 
-		if (g_config.getBoolean(SCRIPTS_CONSOLE_LOGS)) {
+		if (g_configManager().getBoolean(SCRIPTS_CONSOLE_LOGS)) {
 			if (!reload) {
 				SPDLOG_INFO("{} [loaded]", it->filename().string());
 			} else {

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -24,10 +24,8 @@
 #include "map/house/house.h"
 #include "io/iologindata.h"
 #include "game/game.h"
-#include "config/configmanager.h"
 #include "items/bed.h"
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 House::House(uint32_t houseId) : id(houseId) {}
@@ -87,7 +85,7 @@ void House::setOwner(uint32_t guid, bool updateDatabase/* = true*/, Player* play
 			door->setAccessList("");
 		}
 	} else {
-		std::string strRentPeriod = asLowerCaseString(g_config.getString(HOUSE_RENT_PERIOD));
+		std::string strRentPeriod = asLowerCaseString(g_configManager().getString(HOUSE_RENT_PERIOD));
 		time_t currentTime = time(nullptr);
 		if (strRentPeriod == "yearly") {
            currentTime += 24 * 60 * 60 * 365;
@@ -135,7 +133,7 @@ void House::updateDoorDescription() const
 	} else {
 		ss << "It belongs to house '" << houseName << "'. Nobody owns this house.";
 
-		const int32_t housePrice = g_config.getNumber(HOUSE_PRICE);
+		const int32_t housePrice = g_configManager().getNumber(HOUSE_PRICE);
 		if (housePrice != -1) {
 			ss << " It costs " << (houseTiles.size() * housePrice) << " gold coins.";
 		}
@@ -152,7 +150,7 @@ AccessHouseLevel_t House::getHouseAccessLevel(const Player* player)
 		return HOUSE_OWNER;
 	}
 
-	if (g_config.getBoolean(HOUSE_OWNED_BY_ACCOUNT)) {
+	if (g_configManager().getBoolean(HOUSE_OWNED_BY_ACCOUNT)) {
 		if (ownerAccountId == player->getAccount()) {
 			return HOUSE_OWNER;
 		}

--- a/src/map/house/housetile.cpp
+++ b/src/map/house/housetile.cpp
@@ -24,10 +24,8 @@
 #include "map/house/housetile.h"
 #include "map/house/house.h"
 #include "game/game.h"
-#include "config/configmanager.h"
 
 extern Game g_game;
-extern ConfigManager g_config;
 
 HouseTile::HouseTile(int32_t initX, int32_t initY, int32_t initZ, House* initHouse) :
 	DynamicTile(initX, initY, initZ), house(initHouse) {}
@@ -143,7 +141,7 @@ ReturnValue HouseTile::queryRemove(const Thing& thing, uint32_t count, uint32_t 
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (actor && g_config.getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+	if (actor && g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		Player* actorPlayer = actor->getPlayer();
 		if (!house->isInvited(actorPlayer)) {
 			return RETURNVALUE_NOTPOSSIBLE;

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -19,7 +19,6 @@
 
 #include "otpch.h"
 
-#include "config/configmanager.h"
 #include "server/network/connection/connection.h"
 #include "server/network/message/outputmessage.h"
 #include "server/network/protocol/protocol.h"
@@ -27,7 +26,6 @@
 #include "game/scheduling/scheduler.h"
 #include "server/server.h"
 
-extern ConfigManager g_config;
 
 Connection_ptr ConnectionManager::createConnection(boost::asio::io_service& io_service, ConstServicePort_ptr servicePort)
 {
@@ -151,7 +149,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	}
 
 	uint32_t timePassed = std::max<uint32_t>(1, (time(nullptr) - timeConnected) + 1);
-	if ((++packetsSent / timePassed) > static_cast<uint32_t>(g_config.getNumber(MAX_PACKETS_PER_SECOND))) {
+	if ((++packetsSent / timePassed) > static_cast<uint32_t>(g_configManager().getNumber(MAX_PACKETS_PER_SECOND))) {
 			SPDLOG_INFO("{} disconnected for exceeding packet per second limit", convertIPToString(getIP()));
 			close();
 			return;
@@ -163,7 +161,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 		if (!receivedName && msgBuffer[1] == 0x00) {
 			receivedLastChar = true;
 		} else {
-			std::string serverName = g_config.getString(SERVER_NAME) + "\n";
+			std::string serverName = g_configManager().getString(SERVER_NAME) + "\n";
 
 			if (!receivedName) {
 				if (static_cast<char>(msgBuffer[0]) == serverName[0]

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6771,7 +6771,7 @@ void ProtocolGame::sendOpenStash()
 		msg.add<uint16_t>(item.first);
 		msg.add<uint32_t>(item.second);
 	}
-	msg.add<uint16_t>(g_configManager().getNumber(STASH_ITEMS) - getStashSize(list));
+	msg.add<uint16_t>(static_cast<uint16_t>(g_configManager().getNumber(STASH_ITEMS) - getStashSize(list)));
 	writeToOutputBuffer(msg);
 }
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -23,7 +23,6 @@
 
 #include "lua/creature/actions.h"
 #include "creatures/players/management/ban.h"
-#include "config/configmanager.h"
 #include "declarations.hpp"
 #include "game/game.h"
 #include "creatures/players/imbuements/imbuements.h"
@@ -41,7 +40,6 @@
 #include "items/weapons/weapons.h"
 
 extern Game g_game;
-extern ConfigManager g_config;
 extern Actions actions;
 extern CreatureEvents *g_creatureEvents;
 extern Vocations g_vocations;
@@ -209,7 +207,7 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 {
 	//dispatcher thread
 	Player *foundPlayer = g_game.getPlayerByName(name);
-	if (!foundPlayer || g_config.getBoolean(ALLOW_CLONES))
+	if (!foundPlayer || g_configManager().getBoolean(ALLOW_CLONES))
 	{
 		player = new Player(getThis());
 		player->setName(name);
@@ -241,13 +239,13 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		if (g_config.getBoolean(ONLY_PREMIUM_ACCOUNT) && !player->isPremium() && (player->getGroup()->id < account::GROUP_TYPE_GAMEMASTER || player->getAccountType() < account::ACCOUNT_TYPE_GAMEMASTER))
+		if (g_configManager().getBoolean(ONLY_PREMIUM_ACCOUNT) && !player->isPremium() && (player->getGroup()->id < account::GROUP_TYPE_GAMEMASTER || player->getAccountType() < account::ACCOUNT_TYPE_GAMEMASTER))
 		{
 			disconnectClient("Your premium time for this account is out.\n\nTo play please buy additional premium time from our website");
 			return;
 		}
 
-		if (g_config.getBoolean(ONE_PLAYER_ON_ACCOUNT) && player->getAccountType() < account::ACCOUNT_TYPE_GAMEMASTER && g_game.getPlayerByAccount(player->getAccount()))
+		if (g_configManager().getBoolean(ONE_PLAYER_ON_ACCOUNT) && player->getAccountType() < account::ACCOUNT_TYPE_GAMEMASTER && g_game.getPlayerByAccount(player->getAccount()))
 		{
 			disconnectClient("You may only login with one character\nof your account at the same time.");
 			return;
@@ -337,7 +335,7 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 	}
 	else
 	{
-		if (eventConnect != 0 || !g_config.getBoolean(REPLACE_KICK_ON_LOGIN))
+		if (eventConnect != 0 || !g_configManager().getBoolean(REPLACE_KICK_ON_LOGIN))
 		{
 			//Already trying to connect
 			disconnectClient("You are already logged in.");
@@ -502,10 +500,10 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		return;
 	}
 
-	if (clientVersion != g_config.getNumber(CLIENT_VERSION))
+	if (clientVersion != g_configManager().getNumber(CLIENT_VERSION))
 	{
 		std::ostringstream ss;
-		ss << "Only clients with protocol " << g_config.getString(CLIENT_VERSION_STR) << " allowed!";
+		ss << "Only clients with protocol " << g_configManager().getString(CLIENT_VERSION_STR) << " allowed!";
 		disconnectClient(ss.str());
 		return;
 	}
@@ -726,7 +724,7 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage msg, uint8_t recvbyt
 		case 0xE7: /* thank you */ break;
 		case 0xE8: parseDebugAssert(msg); break;
 		case 0xEE: parseGreet(msg); break;
-		case 0xEF: if (!g_config.getBoolean(STOREMODULES)) { parseCoinTransfer(msg); } break; /* premium coins transfer */
+		case 0xEF: if (!g_configManager().getBoolean(STOREMODULES)) { parseCoinTransfer(msg); } break; /* premium coins transfer */
 		case 0xF0: addGameTaskTimed(DISPATCHER_TASK_EXPIRATION, &Game::playerShowQuestLog, player->getID()); break;
 		case 0xF1: parseQuestLine(msg); break;
 		// case 0xF2: parseRuleViolationReport(msg); break;
@@ -737,9 +735,9 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage msg, uint8_t recvbyt
 		case 0xF7: parseMarketCancelOffer(msg); break;
 		case 0xF8: parseMarketAcceptOffer(msg); break;
 		case 0xF9: parseModalWindowAnswer(msg); break;
-		case 0xFA: if (!g_config.getBoolean(STOREMODULES)) { parseStoreOpen(msg); } break;
-		case 0xFB: if (!g_config.getBoolean(STOREMODULES)) { parseStoreRequestOffers(msg); } break;
-		case 0xFC: if (!g_config.getBoolean(STOREMODULES)) { parseStoreBuyOffer(msg); } break;
+		case 0xFA: if (!g_configManager().getBoolean(STOREMODULES)) { parseStoreOpen(msg); } break;
+		case 0xFB: if (!g_configManager().getBoolean(STOREMODULES)) { parseStoreRequestOffers(msg); } break;
+		case 0xFC: if (!g_configManager().getBoolean(STOREMODULES)) { parseStoreBuyOffer(msg); } break;
 //		case 0xFD: parseStoreOpenTransactionHistory(msg); break;
 //		case 0xFE: parseStoreRequestTransactionHistory(msg); break;
 
@@ -1591,8 +1589,8 @@ void ProtocolGame::sendHighscores(const std::vector<HighscoreCharacter> &charact
 	msg.addByte(0x00); // No data available
 
 	msg.addByte(1); // Worlds
-	msg.addString(g_config.getString(SERVER_NAME)); // First World
-	msg.addString(g_config.getString(SERVER_NAME)); // Selected World
+	msg.addString(g_configManager().getString(SERVER_NAME)); // First World
+	msg.addString(g_configManager().getString(SERVER_NAME)); // Selected World
 
 	msg.addByte(0); // Game World Category: 0xFF(-1) - Selected World
 	msg.addByte(0); // BattlEye World Type
@@ -1657,7 +1655,7 @@ void ProtocolGame::sendHighscores(const std::vector<HighscoreCharacter> &charact
 		msg.addString(character.name); // Character Name
 		msg.addString(""); // Probably Character Title(not visible in window)
 		msg.addByte(character.vocation); // Vocation Id
-		msg.addString(g_config.getString(SERVER_NAME)); // World
+		msg.addString(g_configManager().getString(SERVER_NAME)); // World
 		msg.add<uint16_t>(character.level); // Level
 		msg.addByte((player->getGUID() == character.id)); // Player Indicator Boolean
 		msg.add<uint64_t>(character.points); // Points
@@ -3488,7 +3486,7 @@ void ProtocolGame::sendStoreHighlight()
 
 void ProtocolGame::sendPremiumTrigger()
 {
-	if (!g_config.getBoolean(FREE_PREMIUM))
+	if (!g_configManager().getBoolean(FREE_PREMIUM))
 	{
 		NetworkMessage msg;
 		msg.addByte(0x9E);
@@ -5229,8 +5227,8 @@ void ProtocolGame::sendAddCreature(const Creature *creature, const Position &pos
 	msg.addByte(0x00); // can change pvp framing option
 	msg.addByte(0x00); // expert mode button enabled
 
-	msg.addString(g_config.getString(STORE_IMAGES_URL));
-	msg.add<uint16_t>(static_cast<uint16_t>(g_config.getNumber(STORE_COIN_PACKET)));
+	msg.addString(g_configManager().getString(STORE_IMAGES_URL));
+	msg.add<uint16_t>(static_cast<uint16_t>(g_configManager().getNumber(STORE_COIN_PACKET)));
 
 	msg.addByte(shouldAddExivaRestrictions ? 0x01 : 0x00); // exiva button enabled
 	msg.addByte(0x00); // Tournament button
@@ -6773,7 +6771,7 @@ void ProtocolGame::sendOpenStash()
 		msg.add<uint16_t>(item.first);
 		msg.add<uint32_t>(item.second);
 	}
-	msg.add<uint16_t>(g_config.getNumber(STASH_ITEMS) - getStashSize(list));
+	msg.add<uint16_t>(g_configManager().getNumber(STASH_ITEMS) - getStashSize(list));
 	writeToOutputBuffer(msg);
 }
 

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -40,7 +40,6 @@ class Quest;
 class ProtocolGame;
 using ProtocolGame_ptr = std::shared_ptr<ProtocolGame>;
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 struct TextMessage
@@ -460,7 +459,7 @@ private:
 
 	uint32_t eventConnect = 0;
 	uint32_t challengeTimestamp = 0;
-	uint32_t version = g_config.getNumber(CLIENT_VERSION);
+	uint32_t version = g_configManager().getNumber(CLIENT_VERSION);
 	int32_t clientVersion = 0;
 
 	uint8_t challengeRandom = 0;

--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -25,7 +25,6 @@
 #include "security/rsa.h"
 #include "game/scheduling/tasks.h"
 #include "creatures/players/account/account.hpp"
-#include "config/configmanager.h"
 #include "io/iologindata.h"
 #include "creatures/players/management/ban.h"
 #include "game/game.h"
@@ -34,7 +33,6 @@
 #include <limits>
 #include <vector>
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 void ProtocolLogin::disconnectClient(const std::string& message, uint16_t version)
@@ -60,7 +58,7 @@ void ProtocolLogin::getCharacterList(const std::string& email, const std::string
 	Game::updatePremium(account);
 
 	auto output = OutputMessagePool::getOutputMessage();
-	const std::string& motd = g_config.getString(MOTD);
+	const std::string& motd = g_configManager().getString(MOTD);
 	if (!motd.empty()) {
 		// Add MOTD
 		output->addByte(0x14);
@@ -82,10 +80,10 @@ void ProtocolLogin::getCharacterList(const std::string& email, const std::string
 	output->addByte(1);  // number of worlds
 
 	output->addByte(0);  // world id
-	output->addString(g_config.getString(SERVER_NAME));
-	output->addString(g_config.getString(IP));
+	output->addString(g_configManager().getString(SERVER_NAME));
+	output->addString(g_configManager().getString(IP));
 
-	output->add<uint16_t>(g_config.getShortNumber(GAME_PORT));
+	output->add<uint16_t>(g_configManager().getShortNumber(GAME_PORT));
 
 	output->addByte(0);
 
@@ -99,7 +97,7 @@ void ProtocolLogin::getCharacterList(const std::string& email, const std::string
 
 	// Add premium days
 	output->addByte(0);
-	if (g_config.getBoolean(FREE_PREMIUM)) {
+	if (g_configManager().getBoolean(FREE_PREMIUM)) {
 		output->addByte(1);
 		output->add<uint32_t>(0);
 	} else {

--- a/src/server/network/protocol/protocolstatus.cpp
+++ b/src/server/network/protocol/protocolstatus.cpp
@@ -22,11 +22,9 @@
 #include "otpch.h"
 
 #include "server/network/protocol/protocolstatus.h"
-#include "config/configmanager.h"
 #include "game/game.h"
 #include "server/network/message/outputmessage.h"
 
-extern ConfigManager g_config;
 extern Game g_game;
 
 std::map<uint32_t, int64_t> ProtocolStatus::ipConnectMap;
@@ -37,9 +35,9 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 	uint32_t ip = getIP();
 	if (ip != 0x0100007F) {
 		std::string ipStr = convertIPToString(ip);
-		if (ipStr != g_config.getString(IP)) {
+		if (ipStr != g_configManager().getString(IP)) {
 			std::map<uint32_t, int64_t>::const_iterator it = ipConnectMap.find(ip);
-			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_config.getNumber(STATUSQUERY_TIMEOUT)))) {
+			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT)))) {
 				disconnect();
 				return;
 			}
@@ -96,18 +94,18 @@ void ProtocolStatus::sendStatusString()
 	pugi::xml_node serverinfo = tsqp.append_child("serverinfo");
 	uint64_t uptime = (OTSYS_TIME() - ProtocolStatus::start) / 1000;
 	serverinfo.append_attribute("uptime") = std::to_string(uptime).c_str();
-	serverinfo.append_attribute("ip") = g_config.getString(IP).c_str();
-	serverinfo.append_attribute("servername") = g_config.getString(SERVER_NAME).c_str();
-	serverinfo.append_attribute("port") = std::to_string(g_config.getNumber(LOGIN_PORT)).c_str();
-	serverinfo.append_attribute("location") = g_config.getString(LOCATION).c_str();
-	serverinfo.append_attribute("url") = g_config.getString(URL).c_str();
+	serverinfo.append_attribute("ip") = g_configManager().getString(IP).c_str();
+	serverinfo.append_attribute("servername") = g_configManager().getString(SERVER_NAME).c_str();
+	serverinfo.append_attribute("port") = std::to_string(g_configManager().getNumber(LOGIN_PORT)).c_str();
+	serverinfo.append_attribute("location") = g_configManager().getString(LOCATION).c_str();
+	serverinfo.append_attribute("url") = g_configManager().getString(URL).c_str();
 	serverinfo.append_attribute("server") = STATUS_SERVER_NAME;
 	serverinfo.append_attribute("version") = STATUS_SERVER_VERSION;
-	serverinfo.append_attribute("client") = g_config.getString(CLIENT_VERSION_STR).c_str();
+	serverinfo.append_attribute("client") = g_configManager().getString(CLIENT_VERSION_STR).c_str();
 
 	pugi::xml_node owner = tsqp.append_child("owner");
-	owner.append_attribute("name") = g_config.getString(OWNER_NAME).c_str();
-	owner.append_attribute("email") = g_config.getString(OWNER_EMAIL).c_str();
+	owner.append_attribute("name") = g_configManager().getString(OWNER_NAME).c_str();
+	owner.append_attribute("email") = g_configManager().getString(OWNER_EMAIL).c_str();
 
 	pugi::xml_node players = tsqp.append_child("players");
 	uint32_t real = 0;
@@ -127,7 +125,7 @@ void ProtocolStatus::sendStatusString()
 		}
 	}
 	players.append_attribute("online") = std::to_string(real).c_str();
-	players.append_attribute("max") = std::to_string(g_config.getNumber(MAX_PLAYERS)).c_str();
+	players.append_attribute("max") = std::to_string(g_configManager().getNumber(MAX_PLAYERS)).c_str();
 	players.append_attribute("peak") = std::to_string(g_game.getPlayersRecord()).c_str();
 
 	pugi::xml_node monsters = tsqp.append_child("monsters");
@@ -137,15 +135,15 @@ void ProtocolStatus::sendStatusString()
 	npcs.append_attribute("total") = std::to_string(g_game.getNpcsOnline()).c_str();
 
 	pugi::xml_node rates = tsqp.append_child("rates");
-	rates.append_attribute("experience") = std::to_string(g_config.getNumber(RATE_EXPERIENCE)).c_str();
-	rates.append_attribute("skill") = std::to_string(g_config.getNumber(RATE_SKILL)).c_str();
-	rates.append_attribute("loot") = std::to_string(g_config.getNumber(RATE_LOOT)).c_str();
-	rates.append_attribute("magic") = std::to_string(g_config.getNumber(RATE_MAGIC)).c_str();
-	rates.append_attribute("spawn") = std::to_string(g_config.getNumber(RATE_SPAWN)).c_str();
+	rates.append_attribute("experience") = std::to_string(g_configManager().getNumber(RATE_EXPERIENCE)).c_str();
+	rates.append_attribute("skill") = std::to_string(g_configManager().getNumber(RATE_SKILL)).c_str();
+	rates.append_attribute("loot") = std::to_string(g_configManager().getNumber(RATE_LOOT)).c_str();
+	rates.append_attribute("magic") = std::to_string(g_configManager().getNumber(RATE_MAGIC)).c_str();
+	rates.append_attribute("spawn") = std::to_string(g_configManager().getNumber(RATE_SPAWN)).c_str();
 
 	pugi::xml_node map = tsqp.append_child("map");
-	map.append_attribute("name") = g_config.getString(MAP_NAME).c_str();
-	map.append_attribute("author") = g_config.getString(MAP_AUTHOR).c_str();
+	map.append_attribute("name") = g_configManager().getString(MAP_NAME).c_str();
+	map.append_attribute("author") = g_configManager().getString(MAP_AUTHOR).c_str();
 
 	uint32_t mapWidth, mapHeight;
 	g_game.getMapDimensions(mapWidth, mapHeight);
@@ -153,7 +151,7 @@ void ProtocolStatus::sendStatusString()
 	map.append_attribute("height") = std::to_string(mapHeight).c_str();
 
 	pugi::xml_node motd = tsqp.append_child("motd");
-	motd.text() = g_config.getString(MOTD).c_str();
+	motd.text() = g_configManager().getString(MOTD).c_str();
 
 	std::ostringstream ss;
 	doc.save(ss, "", pugi::format_raw);
@@ -170,36 +168,36 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);
-		output->addString(g_config.getString(SERVER_NAME));
-		output->addString(g_config.getString(IP));
-		output->addString(std::to_string(g_config.getNumber(LOGIN_PORT)));
+		output->addString(g_configManager().getString(SERVER_NAME));
+		output->addString(g_configManager().getString(IP));
+		output->addString(std::to_string(g_configManager().getNumber(LOGIN_PORT)));
 	}
 
 	if (requestedInfo & REQUEST_OWNER_SERVER_INFO) {
 		output->addByte(0x11);
-		output->addString(g_config.getString(OWNER_NAME));
-		output->addString(g_config.getString(OWNER_EMAIL));
+		output->addString(g_configManager().getString(OWNER_NAME));
+		output->addString(g_configManager().getString(OWNER_EMAIL));
 	}
 
 	if (requestedInfo & REQUEST_MISC_SERVER_INFO) {
 		output->addByte(0x12);
-		output->addString(g_config.getString(MOTD));
-		output->addString(g_config.getString(LOCATION));
-		output->addString(g_config.getString(URL));
+		output->addString(g_configManager().getString(MOTD));
+		output->addString(g_configManager().getString(LOCATION));
+		output->addString(g_configManager().getString(URL));
 		output->add<uint64_t>((OTSYS_TIME() - ProtocolStatus::start) / 1000);
 	}
 
 	if (requestedInfo & REQUEST_PLAYERS_INFO) {
 		output->addByte(0x20);
 		output->add<uint32_t>(g_game.getPlayersOnline());
-		output->add<uint32_t>(g_config.getNumber(MAX_PLAYERS));
+		output->add<uint32_t>(g_configManager().getNumber(MAX_PLAYERS));
 		output->add<uint32_t>(g_game.getPlayersRecord());
 	}
 
 	if (requestedInfo & REQUEST_MAP_INFO) {
 		output->addByte(0x30);
-		output->addString(g_config.getString(MAP_NAME));
-		output->addString(g_config.getString(MAP_AUTHOR));
+		output->addString(g_configManager().getString(MAP_NAME));
+		output->addString(g_configManager().getString(MAP_AUTHOR));
 		uint32_t mapWidth, mapHeight;
 		g_game.getMapDimensions(mapWidth, mapHeight);
 		output->add<uint16_t>(mapWidth);
@@ -230,7 +228,7 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 		output->addByte(0x23); // server software info
 		output->addString(STATUS_SERVER_NAME);
 		output->addString(STATUS_SERVER_VERSION);
-		output->addString(g_config.getString(CLIENT_VERSION_STR));
+		output->addString(g_configManager().getString(CLIENT_VERSION_STR));
 	}
 	send(output);
 	disconnect();

--- a/src/server/network/webhook/webhook.cpp
+++ b/src/server/network/webhook/webhook.cpp
@@ -9,10 +9,6 @@
 #include <iostream>
 #include <memory>
 
-#include "config/configmanager.h"
-
-extern ConfigManager g_config;
-
 // Tread no further, adventurer!
 // Go back while you still can.
 
@@ -82,8 +78,8 @@ static std::string get_payload(std::string title, std::string message, int color
 
 	std::stringstream footer_text;
 	footer_text
-			<< g_config.getString(IP) << ":"
-			<< g_config.getNumber(GAME_PORT) << " | "
+			<< g_configManager().getString(IP) << ":"
+			<< g_configManager().getNumber(GAME_PORT) << " | "
 			<< time_buf << " UTC";
 
 	Json::Value footer(Json::objectValue);

--- a/src/server/network/webhook/webhook.h
+++ b/src/server/network/webhook/webhook.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "config/configmanager.h"
+
 void webhook_init();
 
 void webhook_send_message(std::string title, std::string message, int color, std::string url);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -22,10 +22,8 @@
 #include "server/network/message/outputmessage.h"
 #include "server/server.h"
 #include "game/scheduling/scheduler.h"
-#include "config/configmanager.h"
 #include "creatures/players/management/ban.h"
 
-extern ConfigManager g_config;
 Ban g_bans;
 
 ServiceManager::~ServiceManager()
@@ -169,12 +167,12 @@ void ServicePort::open(uint16_t port)
 	pendingStart = false;
 
 	try {
-		if (g_config.getBoolean(BIND_ONLY_GLOBAL_ADDRESS)) {
+		if (g_configManager().getBoolean(BIND_ONLY_GLOBAL_ADDRESS)) {
 			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_service,
                            boost::asio::ip::tcp::endpoint(
                            boost::asio::ip::address(
                            boost::asio::ip::address_v4::from_string(
-                           g_config.getString(IP))), serverPort)));
+                           g_configManager().getString(IP))), serverPort)));
 		} else {
 			acceptor.reset(new boost::asio::ip::tcp::acceptor(io_service,
                            boost::asio::ip::tcp::endpoint(

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -21,6 +21,7 @@
 #define SRC_SERVER_SERVER_H_
 
 #include "server/network/connection/connection.h"
+#include "config/configmanager.h"
 #include "server/signals.h"
 #include <memory>
 

--- a/src/server/signals.cpp
+++ b/src/server/signals.cpp
@@ -20,7 +20,6 @@
 #include "otpch.h"
 #include <csignal>
 
-#include "config/configmanager.h"
 #include "creatures/appearance/mounts/mounts.h"
 #include "creatures/combat/spells.h"
 #include "creatures/monsters/monster.h"
@@ -40,7 +39,6 @@ extern Scheduler g_scheduler;
 extern DatabaseTasks g_databaseTasks;
 extern Dispatcher g_dispatcher;
 
-extern ConfigManager g_config;
 extern Actions* g_actions;
 extern Monsters g_monsters;
 extern TalkActions* g_talkActions;
@@ -144,7 +142,7 @@ void Signals::sighupHandler()
 	//Dispatcher thread
 	SPDLOG_INFO("SIGHUP received, reloading config files...");
 
-	g_config.reload();
+	g_configManager().reload();
 	SPDLOG_INFO("Reloaded config");
 
 	g_game.raids.reload();

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -20,9 +20,7 @@
 #include "otpch.h"
 
 #include "utils/tools.h"
-#include "config/configmanager.h"
 
-extern ConfigManager g_config;
 
 void printXMLError(const std::string& where, const std::string& fileName, const pugi::xml_parse_result& result)
 {


### PR DESCRIPTION
ConfigManager class decoupled in a true singleton, thus allowing direct calls without needing to instantiate in each file.

Modification required for pull request: #32
This is optional, just to solve a sonar check issue.

Thanks @lgrossi for made the decouple logic.