### PR TITLE
Fix function name: getAttackSpeed

### DIFF
--- a/data/lib/tables/exercise_training.lua
+++ b/data/lib/tables/exercise_training.lua
@@ -130,6 +130,6 @@ function exerciseEvent(playerId, tilePosition, weaponId, dummyId)
 	end
 
 	local vocation = player:getVocation()
-	onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getBaseAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
+	onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed() / configManager.getFloat(configKeys.RATE_EXERCISE_TRAINING_SPEED), playerId, tilePosition, weaponId, dummyId)
 	return
 end


### PR DESCRIPTION
Fix function name in exercise training, from `getBaseAttackSpeed` to `getAttackSpeed`.