### PR TITLE
Fix call to `configManager.getFloat` in lua

### DIFF
--- a/src/lua/functions/core/game/config_functions.cpp
+++ b/src/lua/functions/core/game/config_functions.cpp
@@ -37,3 +37,8 @@ int ConfigFunctions::luaConfigManagerGetBoolean(lua_State* L) {
 	pushBoolean(L, g_config.getBoolean(getNumber<booleanConfig_t>(L, -1)));
 	return 1;
 }
+
+int ConfigFunctions::luaConfigManagerGetFloat(lua_State* L) {
+	lua_pushnumber(L, g_configManager().getFloat(getNumber<floatingConfig_t>(L, -1)));
+	return 1;
+}

--- a/src/lua/functions/core/game/config_functions.hpp
+++ b/src/lua/functions/core/game/config_functions.hpp
@@ -31,6 +31,7 @@ class ConfigFunctions final : LuaScriptInterface {
 			registerMethod(L, "configManager", "getString", ConfigFunctions::luaConfigManagerGetString);
 			registerMethod(L, "configManager", "getNumber", ConfigFunctions::luaConfigManagerGetNumber);
 			registerMethod(L, "configManager", "getBoolean", ConfigFunctions::luaConfigManagerGetBoolean);
+			registerMethod(L, "configManager", "getFloat", ConfigFunctions::luaConfigManagerGetFloat);
 
 			#define registerEnumIn(L, tableName, value) { \
 				std::string enumName = #value; \
@@ -157,6 +158,7 @@ class ConfigFunctions final : LuaScriptInterface {
 		}
 
 	private:
+		static int luaConfigManagerGetFloat(lua_State* L);
 		static int luaConfigManagerGetBoolean(lua_State* L);
 		static int luaConfigManagerGetNumber(lua_State* L);
 		static int luaConfigManagerGetString(lua_State* L);


### PR DESCRIPTION
This fixes calls to `configManager.getFloat` in lua files.