### PR TITLE
Exposed `vocation->getBaseAttackSpeed`

### DIFF
--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -222,6 +222,17 @@ int VocationFunctions::luaVocationGetSoulGainTicks(lua_State* L) {
 	return 1;
 }
 
+int VocationFunctions::luaVocationGetBaseAttackSpeed(lua_State* L) {
+	// vocation:getBaseAttackSpeed()
+	Vocation* vocation = getUserdata<Vocation>(L, 1);
+	if (vocation) {
+		lua_pushnumber(L, vocation->getBaseAttackSpeed());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int VocationFunctions::luaVocationGetAttackSpeed(lua_State* L) {
 	// vocation:getAttackSpeed()
 	Vocation* vocation = getUserdata<Vocation>(L, 1);

--- a/src/lua/functions/creatures/player/vocation_functions.hpp
+++ b/src/lua/functions/creatures/player/vocation_functions.hpp
@@ -50,6 +50,7 @@ class VocationFunctions final : LuaScriptInterface {
 			registerMethod(L, "Vocation", "getMaxSoul", VocationFunctions::luaVocationGetMaxSoul);
 			registerMethod(L, "Vocation", "getSoulGainTicks", VocationFunctions::luaVocationGetSoulGainTicks);
 
+			registerMethod(L, "Vocation", "getBaseAttackSpeed", VocationFunctions::luaVocationGetBaseAttackSpeed);
 			registerMethod(L, "Vocation", "getAttackSpeed", VocationFunctions::luaVocationGetAttackSpeed);
 			registerMethod(L, "Vocation", "getBaseSpeed", VocationFunctions::luaVocationGetBaseSpeed);
 
@@ -82,6 +83,7 @@ class VocationFunctions final : LuaScriptInterface {
 		static int luaVocationGetMaxSoul(lua_State* L);
 		static int luaVocationGetSoulGainTicks(lua_State* L);
 
+		static int luaVocationGetBaseAttackSpeed(lua_State* L);
 		static int luaVocationGetAttackSpeed(lua_State* L);
 		static int luaVocationGetBaseSpeed(lua_State* L);
 


### PR DESCRIPTION
This fixes `/data/scripts/creaturescripts/others/offline_training.lua` and `/data/lib/tables/exercise_training.lua`.