### PR TITLE
[Fix] Bestiary tracker list loader

### DIFF
--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -522,15 +522,14 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	PropStream propBestStream;
 	propBestStream.init(Bestattr, attrBestSize);
 
-	for (int i = 0; i <= propBestStream.size(); i++) {
-     uint16_t raceid_t;
-     if (propBestStream.read<uint16_t>(raceid_t)) {
-      MonsterType* tmp_tt = g_monsters.getMonsterTypeByRaceId(raceid_t);
-      if (tmp_tt) {
-       player->addBestiaryTrackerList(tmp_tt);
-      }
-     }
-	}
+  uint16_t raceid_t;
+  while (propBestStream.read<uint16_t>(raceid_t)) {
+    MonsterType* tmp_tt = g_monsters.getMonsterTypeByRaceId(raceid_t);
+    if (tmp_tt) {
+      player->addBestiaryTrackerList(tmp_tt);
+    }
+  }
+
 
   } else {
 	query.str(std::string());


### PR DESCRIPTION
# Description

Change on iologindata to fix an issue related to not loading properly the right amount of creatures on bestiary tracker.

## Behaviour
### **Actual**

Saving more than 3 monsters on bestiary tracker is not working properly when relogging the character. It's removing the last one creature until it's left only 3.

### **Expected**

Save and load any amount of creatures as the player wish.

## Fixes

Resolves #80

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Add 10 creatures on bestiary tracker, relog and see that the bestiary tracker list is not with all of the 10. With the changes on this PR, after relogging with 10 creatures on tracker, you will find all of then there on the list.

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
