### PR TITLE
[Fix] Reverting item tier to 0 + Market/Cyclopedia item tier

### DIFF
--- a/data/scripts/item_classification/item_tiers.lua
+++ b/data/scripts/item_classification/item_tiers.lua
@@ -2,33 +2,33 @@ local itemTierClassifications = {
 	-- Upgrade classification 1
 	[1] = {
 		-- Update tier 0
-		[0] = {price = 25000}
+		[1] = {price = 25000}
 	},
 	-- Upgrade classification 2
 	[2] = {
 		-- Update tier 0
-		[0] = {price = 750000},
+		[1] = {price = 750000},
 		-- Update tier 1
-		[1] = {price = 5000000}
+		[2] = {price = 5000000}
 	},
 	-- Upgrade classification 3
 	[3] = {
-		[0] = {price = 4000000},
-		[1] = {price = 10000000},
-		[2] = {price = 20000000}
+		[1] = {price = 4000000},
+		[2] = {price = 10000000},
+		[3] = {price = 20000000}
 	},
 	-- Upgrade classification 4
 	[4] = {
-		[0] = {price = 8000000},
-		[1] = {price = 20000000},
-		[2] = {price = 40000000},
-		[3] = {price = 65000000},
-		[4] = {price = 100000000},
-		[5] = {price = 250000000},
-		[6] = {price = 750000000},
-		[7] = {price = 2500000000},
-		[8] = {price = 8000000000},
-		[9] = {price = 15000000000}
+		[1] = {price = 8000000},
+		[2] = {price = 20000000},
+		[3] = {price = 40000000},
+		[4] = {price = 65000000},
+		[5] = {price = 100000000},
+		[6] = {price = 250000000},
+		[7] = {price = 750000000},
+		[8] = {price = 2500000000},
+		[9] = {price = 8000000000},
+		[10] = {price = 15000000000}
 	}
 }
 
@@ -40,7 +40,7 @@ for classificationId, classificationTable in ipairs(itemTierClassifications) do
 	classification.Upgrades = {}
 	for tierId, tierTable in ipairs(classificationTable) do
 		if tierId and tierTable.price then
-			table.insert(classification.Upgrades, {TierId = tierId, Price = tierTable.price})
+			table.insert(classification.Upgrades, {TierId = tierId - 1, Price = tierTable.price})
 		end
 	end
 	-- Create item classification and register classification table

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6499,7 +6499,7 @@ void ProtocolGame::openImbuementWindow(Item *item)
 	msg.addByte(item->getImbuementSlot());
 
 	// Send imbuement time
-	for (uint8_t slotid = 0; slotid < item->getImbuementSlot(); slotid++)
+	for (uint8_t slotid = 0; slotid < static_cast<uint8_t>(item->getImbuementSlot()); slotid++)
 	{
 		ImbuementInfo imbuementInfo;
 		if (!item->getImbuementInfo(slotid, &imbuementInfo))

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -76,7 +76,7 @@ void ProtocolGame::AddItem(NetworkMessage &msg, uint16_t id, uint8_t count)
 		msg.addByte(0x01);
 	}
 	if (it.upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 }
 
@@ -191,7 +191,7 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
 		msg.addByte(podiumVisible ? static_cast<uint8_t>(boost::get<int64_t>(podiumVisible->value)) : 0x01);
 	}
 	if (it.upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 }
 
@@ -4046,7 +4046,7 @@ void ProtocolGame::sendMarketEnter(uint32_t depotId)
 		msg.add<uint16_t>(it->first);
 		if (Item::items[it->first].upgradeClassification > 0)
 		{
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(std::min<uint32_t>(0xFFFF, it->second));
 	}
@@ -4121,7 +4121,7 @@ void ProtocolGame::sendMarketBrowseItem(uint16_t itemId, const MarketOfferList &
 	msg.addByte(MARKETREQUEST_ITEM_BROWSE);
 	msg.addItemId(itemId);
 	if (Item::items[itemId].upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 
 	msg.add<uint32_t>(buyOffers.size());
@@ -4155,7 +4155,7 @@ void ProtocolGame::sendMarketAcceptOffer(const MarketOfferEx &offer)
 	msg.addByte(MARKETREQUEST_ITEM_BROWSE);
 	msg.addItemId(offer.itemId);
 	if (Item::items[offer.itemId].upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 
 	if (offer.type == MARKETACTION_BUY)
@@ -4195,7 +4195,7 @@ void ProtocolGame::sendMarketBrowseOwnOffers(const MarketOfferList &buyOffers, c
 		msg.add<uint16_t>(offer.counter);
 		msg.addItemId(offer.itemId);
 		if (Item::items[offer.itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(offer.amount);
 		msg.add<uint64_t>(offer.price);
@@ -4208,7 +4208,7 @@ void ProtocolGame::sendMarketBrowseOwnOffers(const MarketOfferList &buyOffers, c
 		msg.add<uint16_t>(offer.counter);
 		msg.addItemId(offer.itemId);
 		if (Item::items[offer.itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(offer.amount);
 		msg.add<uint64_t>(offer.price);
@@ -4230,7 +4230,7 @@ void ProtocolGame::sendMarketCancelOffer(const MarketOfferEx &offer)
 		msg.add<uint16_t>(offer.counter);
 		msg.addItemId(offer.itemId);
 		if (Item::items[offer.itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(offer.amount);
 		msg.add<uint64_t>(offer.price);
@@ -4244,7 +4244,7 @@ void ProtocolGame::sendMarketCancelOffer(const MarketOfferEx &offer)
 		msg.add<uint16_t>(offer.counter);
 		msg.addItemId(offer.itemId);
 		if (Item::items[offer.itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(offer.amount);
 		msg.add<uint64_t>(offer.price);
@@ -4271,7 +4271,7 @@ void ProtocolGame::sendMarketBrowseOwnHistory(const HistoryMarketOfferList &buyO
 		msg.add<uint16_t>(counterMap[it->timestamp]++);
 		msg.addItemId(it->itemId);
 		if (Item::items[it->itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(it->amount);
 		msg.add<uint64_t>(it->price);
@@ -4288,7 +4288,7 @@ void ProtocolGame::sendMarketBrowseOwnHistory(const HistoryMarketOfferList &buyO
 		msg.add<uint16_t>(counterMap[it->timestamp]++);
 		msg.addItemId(it->itemId);
 		if (Item::items[it->itemId].upgradeClassification > 0) {
-			msg.addByte(1);
+			msg.addByte(0);
 		}
 		msg.add<uint16_t>(it->amount);
 		msg.add<uint64_t>(it->price);
@@ -4332,7 +4332,7 @@ void ProtocolGame::sendMarketDetail(uint16_t itemId)
 	const ItemType &it = Item::items[itemId];
 
 	if (it.upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 
 	if (it.armor != 0)
@@ -6494,12 +6494,12 @@ void ProtocolGame::openImbuementWindow(Item *item)
 	msg.addByte(0xEB);
 	msg.addItemId(item->getID());
 	if (Item::items[item->getID()].upgradeClassification > 0) {
-		msg.addByte(1);
+		msg.addByte(0);
 	}
 	msg.addByte(item->getImbuementSlot());
 
 	// Send imbuement time
-	for (uint8_t slotid = 0; slotid < static_cast<uint8_t>(item->getImbuementSlot()); slotid++)
+	for (uint8_t slotid = 0; slotid < item->getImbuementSlot(); slotid++)
 	{
 		ImbuementInfo imbuementInfo;
 		if (!item->getImbuementInfo(slotid, &imbuementInfo))
@@ -6853,7 +6853,7 @@ void ProtocolGame::sendItemsPrice()
 			msg.addItemId(it.first);
 			if (Item::items[it.first].upgradeClassification > 0)
 			{
-				msg.addByte(1);
+				msg.addByte(0);
 			}
 			msg.add<uint32_t>(it.second);
 			msg.add<uint32_t>(0);


### PR DESCRIPTION
# Description

Reverting the commit that was making all items tier 1 (Only visual) and fixing the market/cyclopedia issue that was not showing some items on market list.

