### PR TITLE
[Feature] Experience tracker

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2186,7 +2186,6 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		levelPercent = 0;
 	}
 	sendStats();
-
 	sendExperienceTracker(rawExp, exp);
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2186,6 +2186,8 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		levelPercent = 0;
 	}
 	sendStats();
+
+	sendExperienceTracker(rawExp, exp);
 }
 
 void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2273,6 +2273,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		levelPercent = 0;
 	}
 	sendStats();
+	sendExperienceTracker(0, -exp);
 }
 
 double_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2272,7 +2272,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		levelPercent = 0;
 	}
 	sendStats();
-	sendExperienceTracker(0, -exp);
+	sendExperienceTracker(0, -static_cast<int64_t>(exp));
 }
 
 double_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -1379,7 +1379,7 @@ class Player final : public Creature, public Cylinder
 				client->sendOpenPrivateChannel(receiver);
 			}
 		}
-		void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp) {
+		void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp) const {
 			if (client) {
 				client->sendExperienceTracker(rawExp, finalExp);
 			}

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -1379,7 +1379,7 @@ class Player final : public Creature, public Cylinder
 				client->sendOpenPrivateChannel(receiver);
 			}
 		}
-		void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp) const {
+		void sendExperienceTracker(int64_t rawExp, int64_t finalExp) const {
 			if (client) {
 				client->sendExperienceTracker(rawExp, finalExp);
 			}

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -1379,6 +1379,11 @@ class Player final : public Creature, public Cylinder
 				client->sendOpenPrivateChannel(receiver);
 			}
 		}
+		void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp) {
+			if (client) {
+				client->sendExperienceTracker(rawExp, finalExp);
+			}
+		}
 		void sendOutfitWindow() {
 			if (client) {
 				client->sendOutfitWindow();

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2656,6 +2656,15 @@ void ProtocolGame::sendOpenPrivateChannel(const std::string &receiver)
 	writeToOutputBuffer(msg);
 }
 
+void ProtocolGame::sendExperienceTracker(uint64_t rawExp, uint64_t finalExp)
+{
+	NetworkMessage msg;
+	msg.addByte(0xAF);
+	msg.add<uint64_t>(rawExp);
+	msg.add<uint64_t>(finalExp);
+	writeToOutputBuffer(msg);
+}
+
 void ProtocolGame::sendChannelEvent(uint16_t channelId, const std::string &playerName, ChannelEvent_t channelEvent)
 {
 	NetworkMessage msg;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2656,12 +2656,12 @@ void ProtocolGame::sendOpenPrivateChannel(const std::string &receiver)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendExperienceTracker(uint64_t rawExp, uint64_t finalExp)
+void ProtocolGame::sendExperienceTracker(int64_t rawExp, int64_t finalExp)
 {
 	NetworkMessage msg;
 	msg.addByte(0xAF);
-	msg.add<uint64_t>(rawExp);
-	msg.add<uint64_t>(finalExp);
+	msg.add<int64_t>(rawExp);
+	msg.add<int64_t>(finalExp);
 	writeToOutputBuffer(msg);
 }
 

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -236,6 +236,7 @@ private:
 	void sendChannelsDialog();
 	void sendChannel(uint16_t channelId, const std::string &channelName, const UsersMap *channelUsers, const InvitedMap *invitedUsers);
 	void sendOpenPrivateChannel(const std::string &receiver);
+	void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp);
 	void sendToChannel(const Creature *creature, SpeakClasses type, const std::string &text, uint16_t channelId);
 	void sendPrivateMessage(const Player *speaker, SpeakClasses type, const std::string &text);
 	void sendIcons(uint32_t icons);

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -236,7 +236,7 @@ private:
 	void sendChannelsDialog();
 	void sendChannel(uint16_t channelId, const std::string &channelName, const UsersMap *channelUsers, const InvitedMap *invitedUsers);
 	void sendOpenPrivateChannel(const std::string &receiver);
-	void sendExperienceTracker(uint64_t rawExp, uint64_t finalExp);
+	void sendExperienceTracker(int64_t rawExp, int64_t finalExp);
 	void sendToChannel(const Creature *creature, SpeakClasses type, const std::string &text, uint16_t channelId);
 	void sendPrivateMessage(const Player *speaker, SpeakClasses type, const std::string &text);
 	void sendIcons(uint32_t icons);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66353315/155828622-81bc5d00-325e-457f-8aa4-af025512053e.png)
![image](https://user-images.githubusercontent.com/66353315/155829023-1cabb18d-fa98-466e-adfb-ae9b66461f66.png)

# Description

On the oldest protocols, the client was handling the experience changes by it's own, now on the new protorocol (12.72+), we need to send to the client the right amount of experience that the player has gainned so it can update it's tracker.

## Behaviour
### **Actual**

Gaining/losing experience is not updating the XP analyzer.

### **Expected**

Show the right amount of the gained/losted experience so the client can track the incoming exp and calculate xp/h etc.

## Fixes

Resolves #229

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
