### PR TITLE
fix crash invalid discord url

### DIFF
--- a/data/scripts/creaturescripts/player_death.lua
+++ b/data/scripts/creaturescripts/player_death.lua
@@ -1,4 +1,4 @@
-local playerDeath = CreatureEvent("Player Death")
+local playerDeath = CreatureEvent("PlayerDeath")
 
 local deathListEnabled = true
 local maxDeathRecords = 5

--- a/data/scripts/custom/discord_webhook.lua
+++ b/data/scripts/custom/discord_webhook.lua
@@ -3,16 +3,20 @@
 -- Leave empty if you wish to disable.
 
 announcementChannels = {
-	["serverAnnouncements"] = "https://discord.com/api/webhooks/917947825910849556/hRf4tCzjNiFFG_hlza96fQ6wgM797Mt0aHW1o8Gw-wEw39GyJsVM4WRS4HM84sTUSzSG", -- Used for an announcement channel on your discord
-	["raids"] = "https://discord.com/api/webhooks/917948005691310100/z02hFUonVSWBuRH2V1zJEUELHOKTBrMqfThJxUMrk5CovIzresLAwr_oEo65f4WQyaVv", -- Used to isolate raids on your discord
-	["player-kills"] = "https://discord.com/api/webhooks/917948118585204737/67_SpZJM6JA5SZt4kc4FNVjLSFD4ebIyGkf3v8aYnnmb74FXlKUDQRAa-L4nSYf35_IF", -- Self-explaining
+	["serverAnnouncements"] = "", -- Used for an announcement channel on your discord
+	["raids"] = "", -- Used to isolate raids on your discord
+	["player-kills"] = "", -- Self-explaining
 }
 
 --[[
 	Example of notification (After you do the config):
 	This is going to send a message into your server announcements channel
-	Webhook.specialSend("Server save", message, WEBHOOK_COLOR_WARNING,
+
+	local message = blablabla
+	local title = test
+	Webhook.send(title, message, WEBHOOK_COLOR_WARNING,
                         announcementChannels["serverAnnouncements"])
+
 	Dev Comment: This lib can be used to add special webhook channels
 	where you are going to send your messages. Webhook.specialSend was designed
 	to be used with countless possibilities.

--- a/src/server/network/webhook/webhook.cpp
+++ b/src/server/network/webhook/webhook.cpp
@@ -109,12 +109,6 @@ static std::string get_payload(std::string title, std::string message, int color
 	return out.str();
 }
 
-// Can't labmda this for some reason
-static size_t write_data(void *ptr, size_t size, size_t nmemb, void *userdata) {
-	(*static_cast<std::string *>(userdata)).append(static_cast<char *>(ptr), size * nmemb);
-	return size * nmemb;
-}
-
 static int webhook_send_message_(const char *url, const char *payload, std::string *response_body) {
 	CURL *curl = curl_easy_init();
 	if (!curl) {
@@ -125,10 +119,7 @@ static int webhook_send_message_(const char *url, const char *payload, std::stri
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload);
-
-	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &write_data);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, reinterpret_cast<void *>(&response_body));
-
 	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, "canary (https://github.com/Hydractify/canary)");
 


### PR DESCRIPTION
# Description

This PR fixed a bug that we have in the discord webhook in the project, and the bug happens when the server can't access the discord because of an invalid url or a lack of connection from the discord itself.

## Behaviour
### **Actual:**
Server crash "closes unexpectedly" if invalid url is set in "config.lua" or "data/scripts/custom/discord_webhook.lua"

### **Expected:**
The server has to work normally regardless of whether the url is correct or not and whether discord receives it or not.

## Type of change:
  - [x] Bug fix (non-breaking change which fixes an issue)