### PR TITLE
Fix docker-compose: add env to correct mysql host

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - login
     links:
       - mysql
+    environment:
+      - SERVER_DB_HOST=mysql
 
   mysql:
     build:


### PR DESCRIPTION
Added a env to service _server_ with correct database host