### PR TITLE
[Fix Decay] Add missing duration timestamp attribute

### DIFF
--- a/src/items/item.h
+++ b/src/items/item.h
@@ -483,6 +483,7 @@ class ItemAttributes
 			checkTypes |= ITEM_ATTRIBUTE_IMBUEMENT_SLOT;
 			checkTypes |= ITEM_ATTRIBUTE_OPENCONTAINER;
 			checkTypes |= ITEM_ATTRIBUTE_QUICKLOOTCONTAINER;
+			checkTypes |= ITEM_ATTRIBUTE_DURATION_TIMESTAMP;
 			return (type & static_cast<ItemAttrTypes>(checkTypes)) != 0;
 		}
 		static bool isStrAttrType(ItemAttrTypes type) {


### PR DESCRIPTION
# Progress 
- [x] Decay attribute.

# Description

- RIngs with decay attribute was not decaying and showing 0 as decay time.
