### PR TITLE
Rework of checkCreatureAsKnown and fix of client debug

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -936,7 +936,8 @@ void ProtocolGame::GetFloorDescription(NetworkMessage &msg, int32_t x, int32_t y
 
 void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool &known, uint32_t &removedKnown)
 {
-    if (known = !knownCreatureSet.insert(id).second) {
+	known = !knownCreatureSet.insert(id).second;
+    if (known) {
         return;
     }
 
@@ -956,7 +957,7 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool &known, uint32_t &remo
             continue;
         }
 
-        Player* checkPlayer = creature->getPlayer();
+        const Player* checkPlayer = creature->getPlayer();
 
         if (!checkPlayer) {
             removedKnown = *it;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -936,49 +936,44 @@ void ProtocolGame::GetFloorDescription(NetworkMessage &msg, int32_t x, int32_t y
 
 void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool &known, uint32_t &removedKnown)
 {
-	auto result = knownCreatureSet.insert(id);
-	if (!result.second)
-	{
-		known = true;
-		return;
-	}
+    if (known = !knownCreatureSet.insert(id).second) {
+        return;
+    }
 
-	known = false;
+    if (knownCreatureSet.size() < 1300) {
+        removedKnown = 0;
+        return;
+    }
 
-	if (knownCreatureSet.size() > 1300)
-	{
-		// Look for a creature to remove
-		for (auto it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
-			// We need to protect party players from removing
-			Creature* creature = g_game.getCreatureByID(*it);
-			Player* checkPlayer;
-			if (creature && (checkPlayer = creature->getPlayer()) != nullptr) {
-				if (player->getParty() != checkPlayer->getParty() && !canSee(creature)) {
-					removedKnown = *it;
-					knownCreatureSet.erase(it);
-					return;
-				}
-			} else if (!canSee(creature)) {
-				removedKnown = *it;
-				knownCreatureSet.erase(it);
-				return;
-			}
-		}
+    // Look for a creature to remove
+    for (auto it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
+        if (*it == id) {
+            continue;
+        }
 
-		// Bad situation. Let's just remove anyone.
-		auto it = knownCreatureSet.begin();
-		if (*it == id)
-		{
-			++it;
-		}
+        Creature* creature = g_game.getCreatureByID(*it);
+        if (!creature || canSee(creature)) continue;
 
-		removedKnown = *it;
-		knownCreatureSet.erase(it);
-	}
-	else
-	{
-		removedKnown = 0;
-	}
+        Player* checkPlayer = creature->getPlayer();
+
+        if (!checkPlayer) {
+            removedKnown = *it;
+            knownCreatureSet.erase(it);
+            return;
+        }
+
+        // We need to protect party players from removing
+        if (checkPlayer && player->getParty() != checkPlayer->getParty()) {
+            removedKnown = *it;
+            knownCreatureSet.erase(it);
+            return;
+        }
+
+        removedKnown = *it;
+    }
+
+    /* Bad situation. Let's just remove the last valid one. */
+    knownCreatureSet.erase(removedKnown);
 }
 
 bool ProtocolGame::canSee(const Creature *c) const

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -936,7 +936,7 @@ void ProtocolGame::GetFloorDescription(NetworkMessage &msg, int32_t x, int32_t y
 
 void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool &known, uint32_t &removedKnown)
 {
-	known = !knownCreatureSet.insert(id).second;
+    known = !knownCreatureSet.insert(id).second;
     if (known) {
         return;
     }

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -952,7 +952,9 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool &known, uint32_t &remo
         }
 
         Creature* creature = g_game.getCreatureByID(*it);
-        if (!creature || canSee(creature)) continue;
+        if (!creature || canSee(creature)) {
+            continue;
+        }
 
         Player* checkPlayer = creature->getPlayer();
 


### PR DESCRIPTION
# Description
Before, if you moved with the char diagonally for a while or even normally at a certain time, the debug client "closes unexpectedly" with this fix it doesn't happen anymore.

Note: walking diagonally forces the client to debug faster.

## Credits fix code: ##
Discord: mrianura#8150

## Credits rework code: ##
@lgrossi

## Credits for discussing the problem and testing: ##
@andersonfaaria
@Beats-Dh 
@dudantas
@gccris 
@lgrossi 
@marcosvf132
@omeranha
 
## Fixes Issue:
- [x] #83
 
## It was tested as follows:
An area with many "81k" monsters was created and we passed these monsters walking only diagonally and we had no more client debug.

## Change type
    - [x] Bug fix (non-stop change that fixes an issue)