### PR TITLE
Quiver checking for ammunition level

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -243,9 +243,12 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       bool found = false;
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
-          item = ammoItem;
-          found = true;
-          break;
+			const ItemType &ammoItemType = Item::items[ammoItem->getID()];
+			if (ammoItemType.minReqLevel != 0 && level >= ammoItemType.minReqLevel) {
+				item = ammoItem;
+				found = true;
+				break;
+			}
         }
       }
       if (!found)

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -132,7 +132,10 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
     	if (container && item->getWeaponType() == WEAPON_QUIVER && player->getThing(CONST_SLOT_RIGHT) == item) {
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
-        		ammoTotal += listItem->getItemCount();
+				const ItemType &listType = Item::items[listItem->getID()];
+				if (listType.minReqLevel != 0 && player->getLevel() >= listType.minReqLevel) {
+					ammoTotal += listItem->getItemCount();
+				}
       		}
       		msg.addByte(0x01);
       		msg.add<uint32_t>(ammoTotal);


### PR DESCRIPTION
Attempt to fix #77


# Description

Added check for minReqLevel of ammunitions in quiver both for total count of arrow as well as to select which ammunition to use

## Behaviour
### **Actual**

Quiver ignore level requirement as stated in #77 

### **Expected**

Quiver actually doesn't throw ammunitions which has higher level requirement than player level

## Fixes
#77 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
didn't tested 

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
