### PR TITLE
Quiver checking for ammunition level

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -243,9 +243,12 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       bool found = false;
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
-          item = ammoItem;
-          found = true;
-          break;
+			const ItemType &ammoItemType = Item::items[ammoItem->getID()];
+			if (ammoItemType.minReqLevel != 0 && level >= ammoItemType.minReqLevel) {
+				item = ammoItem;
+				found = true;
+				break;
+			}
         }
       }
       if (!found)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -243,8 +243,7 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       bool found = false;
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
-			const ItemType &ammoItemType = Item::items[ammoItem->getID()];
-			if (ammoItemType && level >= ammoItemType.minReqLevel) {
+			if (level >= Item::items[ammoItem->getID()].minReqLevel) {
 				item = ammoItem;
 				found = true;
 				break;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -243,11 +243,11 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       bool found = false;
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
-			if (level >= Item::items[ammoItem->getID()].minReqLevel) {
-				item = ammoItem;
-				found = true;
-				break;
-			}
+          if (level >= Item::items[ammoItem->getID()].minReqLevel) {
+            item = ammoItem;
+            found = true;
+            break;
+          }
         }
       }
       if (!found)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -244,7 +244,7 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
 			const ItemType &ammoItemType = Item::items[ammoItem->getID()];
-			if (ammoItemType.minReqLevel == 0 || level >= ammoItemType.minReqLevel) {
+			if (ammoItemType && level >= ammoItemType.minReqLevel) {
 				item = ammoItem;
 				found = true;
 				break;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -244,7 +244,7 @@ Item* Player::getWeapon(Slots_t slot, bool ignoreAmmo) const
       for (Item* ammoItem : container->getItemList()) {
         if (ammoItem->getAmmoType() == it.ammoType) {
 			const ItemType &ammoItemType = Item::items[ammoItem->getID()];
-			if (ammoItemType.minReqLevel != 0 && level >= ammoItemType.minReqLevel) {
+			if (ammoItemType.minReqLevel == 0 || level >= ammoItemType.minReqLevel) {
 				item = ammoItem;
 				found = true;
 				break;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -132,7 +132,10 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
     	if (container && item->getWeaponType() == WEAPON_QUIVER && player->getThing(CONST_SLOT_RIGHT) == item) {
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
-        		ammoTotal += listItem->getItemCount();
+				const ItemType &listType = Item::items[listItem->getID()];
+				if (listType.minReqLevel != 0 && player->getLevel() >= listType.minReqLevel) {
+					ammoTotal += listItem->getItemCount();
+				}
       		}
       		msg.addByte(0x01);
       		msg.add<uint32_t>(ammoTotal);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -132,9 +132,9 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
     	if (container && item->getWeaponType() == WEAPON_QUIVER && player->getThing(CONST_SLOT_RIGHT) == item) {
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
-				if (player->getLevel() >= Item::items[listItem->getID()].minReqLevel) {
-					ammoTotal += listItem->getItemCount();
-				}
+      		    if (player->getLevel() >= Item::items[listItem->getID()].minReqLevel) {
+      		        ammoTotal += listItem->getItemCount();
+      		    }
       		}
       		msg.addByte(0x01);
       		msg.add<uint32_t>(ammoTotal);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -132,8 +132,7 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
     	if (container && item->getWeaponType() == WEAPON_QUIVER && player->getThing(CONST_SLOT_RIGHT) == item) {
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
-				const ItemType &listType = Item::items[listItem->getID()];
-				if (listType && player->getLevel() >= listType.minReqLevel) {
+				if (player->getLevel() >= Item::items[listItem->getID()].minReqLevel) {
 					ammoTotal += listItem->getItemCount();
 				}
       		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -133,7 +133,7 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
 				const ItemType &listType = Item::items[listItem->getID()];
-				if (listType.minReqLevel != 0 && player->getLevel() >= listType.minReqLevel) {
+				if (listType.minReqLevel == 0 || player->getLevel() >= listType.minReqLevel) {
 					ammoTotal += listItem->getItemCount();
 				}
       		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -133,7 +133,7 @@ void ProtocolGame::AddItem(NetworkMessage &msg, const Item *item)
       		uint16_t ammoTotal = 0;
       		for (Item* listItem : container->getItemList()) {
 				const ItemType &listType = Item::items[listItem->getID()];
-				if (listType.minReqLevel == 0 || player->getLevel() >= listType.minReqLevel) {
+				if (listType && player->getLevel() >= listType.minReqLevel) {
 					ammoTotal += listItem->getItemCount();
 				}
       		}


### PR DESCRIPTION
Attempt to fix #77


# Description

Added check for minReqLevel of ammunitions in quiver both for total count of arrow as well as to select which ammunition to use

## Behaviour
### **Actual**

Quiver ignore level requirement as stated in #77 

### **Expected**

Quiver actually doesn't throw ammunitions which has higher level requirement than player level

## Fixes
#77 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
didn't tested 

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
