### PR TITLE
Set windows default build as release

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,16 +7,21 @@
   },
   "configurePresets": [
     {
-      "name": "windows-default",
-      "displayName": "Windows Default",
-      "description": "Sets Ninja generator, compilers and build",
+      "name": "windows-release",
+      "displayName": "Windows - Release",
+      "description": "Sets Ninja generator, compilers, build and install directory and set build type as release",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": {
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
            "type": "FILEPATH"
-        }
+        },
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -30,16 +35,17 @@
       }
     },
     {
-      "name": "linux-default",
-      "displayName": "Linux Default",
-      "description": "Sets Ninja generator, compilers, build and install directory, debug build type",
+      "name": "linux-release",
+      "displayName": "Linux - Release",
+      "description": "Sets Ninja generator, compilers, build and install directory and set build type as release",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": {
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
            "type": "FILEPATH"
-        }
+        },
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },
       "condition": {
         "type": "equals",
@@ -48,22 +54,9 @@
       }
     },
     {
-      "name": "windows-release",
-      "inherits": "windows-default",
-      "displayName": "Windows - Release Build",
-      "description": "Build Release Mode",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      },
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      }
-    },
-    {
       "name": "windows-debug",
-      "inherits": "windows-default",
-      "displayName": "Windows - Debug Build",
+      "inherits": "windows-release",
+      "displayName": "Windows - Debug",
       "description": "Build Debug Mode",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -76,17 +69,8 @@
       }
     },
     {
-      "name": "linux-release",
-      "inherits": "linux-default",
-      "displayName": "Linux - Release Build",
-      "description": "Build Release Mode",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
       "name": "linux-debug",
-      "inherits": "linux-default",
+      "inherits": "linux-release",
       "displayName": "Linux - Debug Build",
       "description": "Build Debug Mode",
       "cacheVariables": {


### PR DESCRIPTION
Refactor cmake presets to keep windows release as the default preset to
help newcomers.

Signed-off-by: Renato Foot <renato@foot.br>