### PR TITLE
[Fix] - Add check for prevent message type parameter nil or wrong

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3629,6 +3629,12 @@ void ProtocolGame::sendPreyData(PreySlotNum_t slot, PreyState_t slotState)
 
 void ProtocolGame::sendTextMessage(const TextMessage &message)
 {
+	if (message.type == MESSAGE_NONE) {
+		SPDLOG_ERROR("[ProtocolGame::sendTextMessage] - Message type is wrong, missing or invalid for player with name {}, on position {}", player->getName(), player->getPosition().toString());
+		player->sendTextMessage(MESSAGE_ADMINISTRADOR, "There was a problem requesting your message, please contact the administrator");
+		return;
+	}
+
 	NetworkMessage msg;
 	msg.addByte(0xB4);
 	msg.addByte(message.type);

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -43,6 +43,9 @@ using ProtocolGame_ptr = std::shared_ptr<ProtocolGame>;
 
 struct TextMessage
 {
+	TextMessage() = default;
+	TextMessage(MessageClasses initType, std::string initText) : type(initType), text(std::move(initText)) {}
+
 	MessageClasses type = MESSAGE_STATUS;
 	std::string text;
 	Position position;
@@ -52,9 +55,6 @@ struct TextMessage
 		int32_t value = 0;
 		TextColor_t color;
 	} primary, secondary;
-
-	TextMessage() = default;
-	TextMessage(MessageClasses initType, std::string initText) : type(initType), text(std::move(initText)) {}
 };
 
 class ProtocolGame final : public Protocol


### PR DESCRIPTION
How to test: Add a message with a wrong, none, or nil parameter, such as
```lua
player:sendTextMessage(MESSAGE_NONE, "Message")
```
Without this correction, the message simply is not sent to the player, but without passing any information that went wrong.