### PR TITLE
[Fix] runes being used only if they are on the tile

### DIFF
--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -385,19 +385,20 @@ Action* Actions::getAction(const Item* item) {
 		return &it->second;
 	}
 
-	if (const Tile * tile = item->getTile();
-	tile)
-	{
-		if (const Player* player = item->getHoldingPlayer();
-		player && item->getTopParent() == player)
-		{
-			SPDLOG_DEBUG("[Actions::getAction] - The position only is valid for use item in the map, player name {}", player->getName());
-			return nullptr;
-		}
 
-		if (auto iteratePositions = actionPositionMap.find(tile->getPosition());
-		iteratePositions != actionPositionMap.end())
+	if (auto iteratePositions = actionPositionMap.find(item->getPosition());
+	iteratePositions != actionPositionMap.end())
+	{
+		if (const Tile * tile = item->getTile();
+		tile)
 		{
+			if (const Player* player = item->getHoldingPlayer();
+			player && item->getTopParent() == player)
+			{
+				SPDLOG_DEBUG("[Actions::getAction] - The position only is valid for use item in the map, player name {}", player->getName());
+				return nullptr;
+			}
+
 			return &iteratePositions->second;
 		}
 	}

--- a/src/lua/functions/events/action_functions.cpp
+++ b/src/lua/functions/events/action_functions.cpp
@@ -183,8 +183,10 @@ int ActionFunctions::luaActionPosition(lua_State* L) {
 			return 1;
 		}
 
-		if (Item::items.getItemType(itemId).moveable == true) {
-			SPDLOG_WARN("[ActionFunctions::luaActionPosition] - Item with id {}, registered on script position {} is moveable, being created on the map, the item can be moved or removed by a player", itemId, position.toString());
+		// If it is an item that can be removed, then it will be set as non-movable.
+		ItemType &itemType = Item::items.getItemType(itemId);
+		if (itemType.moveable == true) {
+			itemType.moveable = false;
 		}
 
 		g_game().setCreateLuaItems(position, itemId);


### PR DESCRIPTION
Moved the check inside the iterator, making the rune no longer access the tile check and can be used inside the backpack
Modified so if the item set to be crafted is a moveable item, then the script will set the unmovable flag to prevent any player from moving the item.