### PR TITLE
[Fix] crash related to creature death

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2771,6 +2771,9 @@ void Player::despawn()
 		}
 
 		spectator->onRemoveCreature(this, false);
+		// Remove player from spectator target list
+		spectator->setAttackedCreature(nullptr);
+		spectator->setFollowCreature(nullptr);
 	}
 
 	tile->removeCreature(this);


### PR DESCRIPTION
The crash happened in a specific scenario, when the creature was removed (and recreated) and the target reference was not removed, when it tried to target another creature, it crashed. This was apparently due to the use of onRemoveCreature, which has an "if (attackedCreature == creature", that the "attackedCreature" will not always exist.