### PR TITLE
[Fix] Removing unnecessary warn on item creation when id equal 0

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -78,7 +78,7 @@ Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
 		}
 
 		newItem->incrementReferenceCounter();
-	} else {
+	} else if (type != 0) {
 		SPDLOG_WARN("[Item::CreateItem] Item with id '{}' is not registered and cannot be created.", type);
 	}
 


### PR DESCRIPTION
# Description
Add a check on the spdlog::warn to prevent when itemID is equal 0. This happens a lot when slain a creature that has no body registered. (Regular creatures/summons/boss)
![image](https://user-images.githubusercontent.com/66353315/166161726-5ccddbe2-4a9e-4563-b5fe-a57fbe6ec204.png)


# Note
You may notice that there is already a check if the itemtype ID is equal 0 or not. But this is not necessary the same check because when we try to create an item that is not registered on the item protobuf binary file and on items.xml, then the itemtype will return with id == 0 but type != 0.