### PR TITLE
[Fix] Item name register from appearances protobuf

### DIFF
--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -170,6 +170,13 @@ void Items::loadFromProtobuf()
 		iType.lookThrough = object.flags().ignore_look();
 		iType.stackable = object.flags().cumulative();
 		iType.isPodium = object.flags().show_off_socket();
+
+		if (!iType.name.empty()) {
+			nameToItems.insert({
+				asLowerCaseString(iType.name),
+				iType.id
+			});
+		}
 	}
 
 	items.shrink_to_fit();
@@ -259,13 +266,24 @@ void Items::parseItemNode(const pugi::xml_node & itemNode, uint16_t id) {
 		return;
 	}
 
+	bool isNameRegistered = !itemType.name.empty();
+	if (isNameRegistered && itemType.name != itemNode.attribute("name").as_string()) {
+		if (auto result = nameToItems.find(asLowerCaseString(itemType.name)); 
+			result != nameToItems.end()) {
+			nameToItems.erase(result);
+			isNameRegistered = false;
+		}
+	}
+
 	itemType.loaded = true;
 	itemType.name = itemNode.attribute("name").as_string();
 
-	nameToItems.insert({
-		asLowerCaseString(itemType.name),
-		id
-	});
+	if (!isNameRegistered) {
+		nameToItems.insert({
+			asLowerCaseString(itemType.name),
+			id
+		});
+	}
 
 	pugi::xml_attribute articleAttribute = itemNode.attribute("article");
 	if (articleAttribute) {


### PR DESCRIPTION
# Description

It was missing the item name register on the function _**void Items::loadFromProtobuf()**_ on the _Items_ map. This map is used to identify a item by it's name instead of ID. This is largely used on the **SRC** and **LUA** environments.

This wrong behavior on the items name register was affecting only items who had their names on the appearances.dat protobuf file but was not registered on the items.xml file.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

1. On the actual SRC (Without this PR), go to the items.xml file. 
2. Remove the entire register from any item that have it's name registered on the appearances.dat. (Try the fire sword only for tests)
3. Run the server and try to _/i fire sword_ and see that the server is unable to identify and create the item by it's name.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
