### PR TITLE
Fix magic wall and wild growth rune bug

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -2850,6 +2850,7 @@
 	<item id="2128" article="a" name="magic wall">
 		<attribute key="type" value="magicfield"/>
 		<attribute key="duration" value="20"/>
+		<attribute key="blocking" value="1"/>
 		<attribute key="decayTo" value="0"/>
 	</item>
 	<item id="2129" article="a" name="magic wall">

--- a/data/scripts/runes/magic_wall.lua
+++ b/data/scripts/runes/magic_wall.lua
@@ -1,18 +1,22 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
-
 function onCreateMagicWall(creature, tile)
-	local item = Game.createItem(Game.getWorldType() == WORLD_TYPE_NO_PVP and ITEM_MAGICWALL_SAFE or ITEM_MAGICWALL, 1, tile)
-	item:setAttribute(ITEM_ATTRIBUTE_DURATION, math.random(14000, 20000))
+	local magicWall
+	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
+		magicWall = ITEM_MAGICWALL_SAFE
+	else
+		magicWall = ITEM_MAGICWALL
+	end
+	local item = Game.createItem(magicWall, 1, tile)
+	item:setDuration(16, 24)
 end
 
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
 combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateMagicWall")
 
 local spell = Spell("rune")
 function spell.onCastSpell(creature, variant, isHotkey)
-    return combat:execute(creature, variant)
+	return combat:execute(creature, variant)
 end
-
 
 spell:name("Magic Wall Rune")
 spell:group("attack")

--- a/data/scripts/runes/wild_growth.lua
+++ b/data/scripts/runes/wild_growth.lua
@@ -1,16 +1,21 @@
-local combat = Combat()
-combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_EARTH)
-
-function onCreateMagicWall(creature, tile)
-	local item = Game.createItem(Game.getWorldType() == WORLD_TYPE_NO_PVP and ITEM_WILDGROWTH_SAFE or ITEM_WILDGROWTH, 1, tile)
-	item:setAttribute(ITEM_ATTRIBUTE_DURATION, math.random(38000, 45000))
+function onCreateWildGrowth(creature, tile)
+	local wildGrowth
+	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
+		wildGrowth = ITEM_WILDGROWTH_SAFE
+	else
+		wildGrowth = ITEM_WILDGROWTH
+	end
+	local item = Game.createItem(wildGrowth, 1, tile)
+	item:setDuration(30, 60)
 end
 
-combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateMagicWall")
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ENERGY)
+combat:setCallback(CALLBACK_PARAM_TARGETTILE, "onCreateWildGrowth")
 
 local spell = Spell("rune")
 function spell.onCastSpell(creature, variant, isHotkey)
-    return combat:execute(creature, variant)
+	return combat:execute(creature, variant)
 end
 
 spell:name("Wild Growth Rune")

--- a/src/items/functions/item_parse.cpp
+++ b/src/items/functions/item_parse.cpp
@@ -786,7 +786,7 @@ void ItemParse::parseWalk(const std::string& tmpStrValue, pugi::xml_attribute va
 	std::string stringValue = tmpStrValue;
 	if (stringValue == "walkstack") {
 		itemType.walkStack = valueAttribute.as_bool();
-	} else if (stringValue == "block_solid") {
+	} else if (stringValue == "blocking") {
 		itemType.blockSolid = valueAttribute.as_bool();
 	}
 }

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -799,3 +799,41 @@ int ItemFunctions::luaItemGetImbuementSlot(lua_State* L) {
 	lua_pushnumber(L, item->getImbuementSlot());
 	return 1;
 }
+
+int ItemFunctions::luaItemSetDuration(lua_State* L) {
+	// item:setDuration(minDuration, maxDuration = 0, decayTo = 0, showDuration = true)
+	// Example: item:setDuration(10000, 20000, 2129, false) = random duration from range 10000/20000
+	Item* item = getUserdata<Item>(L, 1);
+	if (!item) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	uint32_t minDuration = getNumber<uint32_t>(L, 2);
+	uint32_t maxDuration = 0;
+	if (lua_gettop(L) > 2) {
+		maxDuration = uniform_random(minDuration, getNumber<uint32_t>(L, 3));
+	}
+
+	uint16_t itemid = 0;
+	if (lua_gettop(L) > 3) {
+		itemid = getNumber<uint16_t>(L, 4);
+	}
+	bool showDuration = true;
+	if (lua_gettop(L) > 4) {
+		showDuration = getBoolean(L, 5);
+	}
+
+	ItemType& it = Item::items.getItemType(item->getID());
+	if (maxDuration == 0) {
+		it.decayTime = minDuration;
+	} else {
+		it.decayTime = maxDuration;
+	}
+	it.showDuration = showDuration;
+	it.decayTo = itemid;
+	item->startDecaying();
+	pushBoolean(L, true);
+	return 1;
+}

--- a/src/lua/functions/items/item_functions.hpp
+++ b/src/lua/functions/items/item_functions.hpp
@@ -85,6 +85,8 @@ class ItemFunctions final : LuaScriptInterface {
 			registerMethod(L, "Item", "getImbuementSlot", ItemFunctions::luaItemGetImbuementSlot);
 			registerMethod(L, "Item", "getImbuement", ItemFunctions::luaItemGetImbuement);
 
+			registerMethod(L, "Item", "setDuration", ItemFunctions::luaItemSetDuration);
+
 			ContainerFunctions::init(L);
 			ImbuementFunctions::init(L);
 			ItemTypeFunctions::init(L);
@@ -144,6 +146,8 @@ class ItemFunctions final : LuaScriptInterface {
 
 		static int luaItemGetImbuementSlot(lua_State* L);
 		static int luaItemGetImbuement(lua_State* L);
+
+		static int luaItemSetDuration(lua_State* L);
 };
 
 #endif  // SRC_LUA_FUNCTIONS_ITEMS_ITEM_FUNCTIONS_HPP_


### PR DESCRIPTION
Created a new function to set the min/max duration of an item, id to decay and whether or not to show the duration

Fixed mw being walkable, fixing a small typo in blocking parse
```cpp
item:setDuration(minduration, maxduration = 0, decayid = 0, showDuration = true)
```