### PR TITLE
Fixing monster type name overriding and somes improvements

### DIFF
--- a/src/creatures/creature.h
+++ b/src/creatures/creature.h
@@ -103,6 +103,8 @@ class Creature : virtual public Thing
 		}
 
 		virtual const std::string& getName() const = 0;
+		// Real creature name, set on creature creation "createNpcType(typeName) and createMonsterType(typeName)"
+		virtual const std::string& getTypeName() const = 0;
 		virtual const std::string& getNameDescription() const = 0;
 
 		virtual CreatureType_t getType() const = 0;

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -65,7 +65,7 @@ class Monster final : public Creature
 			return mType->name;
 		}
 		// Real monster name, set on monster creation "createMonsterType(typeName)"
-		const std::string& getTypeName() const {
+		const std::string& getTypeName() const override {
 			return mType->typeName;
 		}
 		const std::string& getNameDescription() const override {

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -64,6 +64,10 @@ class Monster final : public Creature
 		const std::string& getName() const override {
 			return mType->name;
 		}
+		// Real monster name, set on monster creation "createMonsterType(typeName)"
+		const std::string& getTypeName() const {
+			return mType->typeName;
+		}
 		const std::string& getNameDescription() const override {
 			return mType->nameDescription;
 		}

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -1453,13 +1453,11 @@ MonsterType* Monsters::getMonsterType(const std::string& name)
 {
 	std::string lowerCaseName = asLowerCaseString(name);
 	if (auto it = monsters.find(lowerCaseName);
-	it != monsters.end())
+	it != monsters.end()
+	// We will only return the MonsterType if it match the exact name of the monster
+	&& it->first.find(lowerCaseName) != it->first.npos)
 	{
-		// We will only return the MonsterType if it match the exact name of the monster
-		if ((it->first.find(lowerCaseName)) != it->first.npos)
-		{
-			return it->second;
-		}
+		return it->second;
 	}
 	SPDLOG_ERROR("[Monsters::getMonsterType] - Monster with name {} not exist", lowerCaseName);
 	return nullptr;

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -1456,8 +1456,7 @@ MonsterType* Monsters::getMonsterType(const std::string& name)
 	it != monsters.end())
 	{
 		// We will only return the MonsterType if it match the exact name of the monster
-		int found;
-		if ((found = it->first.find(lowerCaseName)) != it->first.npos)
+		if ((it->first.find(lowerCaseName)) != it->first.npos)
 		{
 			return it->second;
 		}

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -759,13 +759,13 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 	if (reloading) {
 		auto it = monsters.find(asLowerCaseString(monsterName));
 		if (it != monsters.end()) {
-			mType = &it->second;
+			mType = it->second;
 			mType->info = {};
 		}
 	}
 
 	if (!mType) {
-		mType = &monsters[asLowerCaseString(monsterName)];
+		mType = monsters[asLowerCaseString(monsterName)];
 	}
 
 	mType->name = attr.as_string();

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -1452,17 +1452,18 @@ void Monsters::loadLootContainer(const pugi::xml_node& node, LootBlock& lBlock)
 MonsterType* Monsters::getMonsterType(const std::string& name)
 {
 	std::string lowerCaseName = asLowerCaseString(name);
-
-	auto it = monsters.find(lowerCaseName);
-	if (it == monsters.end()) {
-		auto it2 = unloadedMonsters.find(lowerCaseName);
-		if (it2 == unloadedMonsters.end()) {
-			return nullptr;
+	if (auto it = monsters.find(lowerCaseName);
+	it != monsters.end())
+	{
+		// We will only return the MonsterType if it match the exact name of the monster
+		int found;
+		if ((found = it->first.find(lowerCaseName)) != it->first.npos)
+		{
+			return it->second;
 		}
-
-		return loadMonster(it2->second, name);
 	}
-	return &it->second;
+	SPDLOG_ERROR("[Monsters::getMonsterType] - Monster with name {} not exist", lowerCaseName);
+	return nullptr;
 }
 
 MonsterType* Monsters::getMonsterTypeByRaceId(uint16_t thisrace) {
@@ -1477,8 +1478,6 @@ MonsterType* Monsters::getMonsterTypeByRaceId(uint16_t thisrace) {
 
 void Monsters::addMonsterType(const std::string& name, MonsterType* mType)
 {
-	// Suppress [-Werror=unused-but-set-parameter]
-	// https://stackoverflow.com/questions/1486904/how-do-i-best-silence-a-warning-about-unused-variables
-	(void) mType;
-	mType = &monsters[asLowerCaseString(name)];
+	std::string lowerName = asLowerCaseString(name);
+	monsters[lowerName] = mType;
 }

--- a/src/creatures/monsters/monsters.h
+++ b/src/creatures/monsters/monsters.h
@@ -154,6 +154,11 @@ class MonsterType
 
 	public:
 		MonsterType() = default;
+		MonsterType(std::string initName) : name(initName) {
+			typeName = initName;
+			nameDescription = initName;
+		};
+
 
 		// non-copyable
 		MonsterType(const MonsterType&) = delete;
@@ -162,6 +167,7 @@ class MonsterType
 		bool loadCallback(LuaScriptInterface* scriptInterface);
 
 		std::string name;
+		std::string typeName;
 		std::string nameDescription;
 
 		MonsterInfo info;
@@ -244,7 +250,7 @@ class Monsters
 		bool deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std::string& description = "");
 
 		std::unique_ptr<LuaScriptInterface> scriptInterface;
-		std::map<std::string, MonsterType> monsters;
+		std::map<std::string, MonsterType*> monsters;
 
 	private:
 		ConditionDamage* getDamageCondition(ConditionType_t conditionType,

--- a/src/creatures/monsters/monsters.h
+++ b/src/creatures/monsters/monsters.h
@@ -154,11 +154,7 @@ class MonsterType
 
 	public:
 		MonsterType() = default;
-		MonsterType(std::string initName) : name(initName) {
-			typeName = initName;
-			nameDescription = initName;
-		};
-
+		explicit MonsterType(const std::string initName) : name(initName), typeName(initName), nameDescription(initName) {};
 
 		// non-copyable
 		MonsterType(const MonsterType&) = delete;

--- a/src/creatures/monsters/monsters.h
+++ b/src/creatures/monsters/monsters.h
@@ -154,7 +154,7 @@ class MonsterType
 
 	public:
 		MonsterType() = default;
-		explicit MonsterType(const std::string initName) : name(initName), typeName(initName), nameDescription(initName) {};
+		explicit MonsterType(const std::string &initName) : name(initName), typeName(initName), nameDescription(initName) {};
 
 		// non-copyable
 		MonsterType(const MonsterType&) = delete;

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -71,6 +71,10 @@ class Npc final : public Creature
 		const std::string& getName() const override {
 			return npcType->name;
 		}
+		// Real npc name, set on npc creation "createNpcType(typeName)"
+		const std::string& getTypeName() const override {
+			return npcType->typeName;
+		}
 		const std::string& getNameDescription() const override {
 			return npcType->nameDescription;
 		}

--- a/src/creatures/npcs/npcs.h
+++ b/src/creatures/npcs/npcs.h
@@ -81,7 +81,7 @@ class NpcType
 
 	public:
 		NpcType() = default;
-		explicit NpcType(const std::string initName) : name(initName), typeName(initName), nameDescription(initName) {};
+		explicit NpcType(const std::string &initName) : name(initName), typeName(initName), nameDescription(initName) {};
 
 		// non-copyable
 		NpcType(const NpcType&) = delete;

--- a/src/creatures/npcs/npcs.h
+++ b/src/creatures/npcs/npcs.h
@@ -81,13 +81,14 @@ class NpcType
 
 	public:
 		NpcType() = default;
-		NpcType(std::string name) : name(name), nameDescription(name) {};
+		explicit NpcType(const std::string initName) : name(initName), typeName(initName), nameDescription(initName) {};
 
 		// non-copyable
 		NpcType(const NpcType&) = delete;
 		NpcType& operator=(const NpcType&) = delete;
 
 		std::string name;
+		std::string typeName;
 		std::string nameDescription;
 		NpcInfo info;
 

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -100,6 +100,9 @@ class Player final : public Creature, public Cylinder
 		void setName(std::string newName) {
 			this->name = std::move(newName);
 		}
+		const std::string& getTypeName() const override {
+			return name;
+		}
 		const std::string& getNameDescription() const override {
 			return name;
 		}

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -35,7 +35,7 @@ int GameFunctions::luaGameCreateMonsterType(lua_State* L) {
 	// Game.createMonsterType(name)
 	if (isString(L, 1)) {
 		std::string name = getString(L, 1);
-		MonsterType *monsterType = new MonsterType(name);
+		auto monsterType = new MonsterType(name);
 		g_monsters().addMonsterType(name, monsterType);
 		if (!monsterType) {
 			reportErrorFunc("MonsterType is nullptr");

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -33,25 +33,17 @@
 // Game
 int GameFunctions::luaGameCreateMonsterType(lua_State* L) {
 	// Game.createMonsterType(name)
-	if (getScriptEnv()->getScriptInterface() != &g_scripts().getScriptInterface()) {
-		reportErrorFunc("MonsterTypes can only be registered in the Scripts interface.");
-		lua_pushnil(L);
-		return 1;
-	}
-
-	MonsterType* monsterType = g_monsters().getMonsterType(getString(L, 1));
-	if (monsterType) {
-		monsterType->info.lootItems.clear();
-		monsterType->info.attackSpells.clear();
-		monsterType->info.defenseSpells.clear();
-		pushUserdata<MonsterType>(L, monsterType);
-		setMetatable(L, -1, "MonsterType");
-	} else if (isString(L, 1)) {
-		monsterType = new MonsterType();
+	if (isString(L, 1)) {
 		std::string name = getString(L, 1);
+		MonsterType *monsterType = new MonsterType(name);
 		g_monsters().addMonsterType(name, monsterType);
-		monsterType = g_monsters().getMonsterType(getString(L, 1));
-		monsterType->name = name;
+		if (!monsterType) {
+			reportErrorFunc("MonsterType is nullptr");
+			pushBoolean(L, false);
+			delete monsterType;
+			return 1;
+		}
+
 		monsterType->nameDescription = "a " + name;
 		pushUserdata<MonsterType>(L, monsterType);
 		setMetatable(L, -1, "MonsterType");
@@ -213,7 +205,7 @@ int GameFunctions::luaGameGetMonsterTypes(lua_State* L) {
 	lua_createtable(L, type.size(), 0);
 
 	for (auto& mType : type) {
-		pushUserdata<MonsterType>(L, &mType.second);
+		pushUserdata<MonsterType>(L, mType.second);
 		setMetatable(L, -1, "MonsterType");
 		lua_setfield(L, -2, mType.first.c_str());
 	}

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -189,10 +189,21 @@ int CreatureFunctions::luaCreatureGetId(lua_State* L) {
 }
 
 int CreatureFunctions::luaCreatureGetName(lua_State* L) {
-	// creature:getName()
+	// creature:getTypeName()
 	const Creature* creature = getUserdata<const Creature>(L, 1);
 	if (creature) {
 		pushString(L, creature->getName());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int CreatureFunctions::luaCreatureGetTypeName(lua_State* L) {
+	// creature:getName()
+	const Creature* creature = getUserdata<const Creature>(L, 1);
+	if (creature) {
+		pushString(L, creature->getTypeName());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/creature_functions.hpp
+++ b/src/lua/functions/creatures/creature_functions.hpp
@@ -46,6 +46,7 @@ class CreatureFunctions final : LuaScriptInterface {
 			registerMethod(L, "Creature", "getParent", CreatureFunctions::luaCreatureGetParent);
 			registerMethod(L, "Creature", "getId", CreatureFunctions::luaCreatureGetId);
 			registerMethod(L, "Creature", "getName", CreatureFunctions::luaCreatureGetName);
+			registerMethod(L, "Creature", "getTypeName", CreatureFunctions::luaCreatureGetTypeName);
 			registerMethod(L, "Creature", "getTarget", CreatureFunctions::luaCreatureGetTarget);
 			registerMethod(L, "Creature", "setTarget", CreatureFunctions::luaCreatureSetTarget);
 			registerMethod(L, "Creature", "getFollowCreature", CreatureFunctions::luaCreatureGetFollowCreature);
@@ -116,6 +117,7 @@ class CreatureFunctions final : LuaScriptInterface {
 
 		static int luaCreatureGetId(lua_State* L);
 		static int luaCreatureGetName(lua_State* L);
+		static int luaCreatureGetTypeName(lua_State* L);
 
 		static int luaCreatureGetTarget(lua_State* L);
 		static int luaCreatureSetTarget(lua_State* L);

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -817,6 +817,17 @@ int MonsterTypeFunctions::luaMonsterTypeGetDefenseList(lua_State* L) {
 	return 1;
 }
 
+int MonsterTypeFunctions::luaMonsterTypeGetTypeName(lua_State* L) {
+	// monsterType:getTypeName()
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (!monsterType) {
+		return 1;
+	}
+
+	pushString(L, monsterType->typeName);
+	return 1;
+}
+
 int MonsterTypeFunctions::luaMonsterTypeAddDefense(lua_State* L) {
 	// monsterType:addDefense(monsterspell)
 	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -819,7 +819,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetDefenseList(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetTypeName(lua_State* L) {
 	// monsterType:getTypeName()
-	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	const MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
 	if (!monsterType) {
 		return 1;
 	}

--- a/src/lua/functions/creatures/monster/monster_type_functions.hpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.hpp
@@ -81,6 +81,8 @@ class MonsterTypeFunctions final : LuaScriptInterface {
 				registerMethod(L, "MonsterType", "getDefenseList", MonsterTypeFunctions::luaMonsterTypeGetDefenseList);
 				registerMethod(L, "MonsterType", "addDefense", MonsterTypeFunctions::luaMonsterTypeAddDefense);
 
+				registerMethod(L, "MonsterType", "getTypeName", MonsterTypeFunctions::luaMonsterTypeGetTypeName);
+
 				registerMethod(L, "MonsterType", "getElementList", MonsterTypeFunctions::luaMonsterTypeGetElementList);
 				registerMethod(L, "MonsterType", "addElement", MonsterTypeFunctions::luaMonsterTypeAddElement);
 
@@ -200,6 +202,8 @@ class MonsterTypeFunctions final : LuaScriptInterface {
 
 		static int luaMonsterTypeGetDefenseList(lua_State* L);
 		static int luaMonsterTypeAddDefense(lua_State* L);
+
+		static int luaMonsterTypeGetTypeName(lua_State* L);
 
 		static int luaMonsterTypeGetElementList(lua_State* L);
 		static int luaMonsterTypeAddElement(lua_State* L);

--- a/src/protobuf/appearances.pb.cc
+++ b/src/protobuf/appearances.pb.cc
@@ -923,8 +923,8 @@ const char descriptor_table_protodef_appearances_2eproto[] PROTOBUF_SECTION_VARI
   "earance\022\n\n\002id\030\001 \001(\r\022<\n\013frame_group\030\002 \003(\013"
   "2\'.Canary.protobuf.appearances.FrameGrou"
   "p\022;\n\005flags\030\003 \001(\0132,.Canary.protobuf.appea"
-  "rances.AppearanceFlags\022\014\n\004name\030\004 \001(\t\022\023\n\013"
-  "description\030\005 \001(\t\"\335\r\n\017AppearanceFlags\022=\n"
+  "rances.AppearanceFlags\022\014\n\004name\030\004 \001(\014\022\023\n\013"
+  "description\030\005 \001(\014\"\335\r\n\017AppearanceFlags\022=\n"
   "\004bank\030\001 \001(\0132/.Canary.protobuf.appearance"
   "s.AppearanceFlagBank\022\014\n\004clip\030\002 \001(\010\022\016\n\006bo"
   "ttom\030\003 \001(\010\022\013\n\003top\030\004 \001(\010\022\021\n\tcontainer\030\005 \001"
@@ -987,11 +987,11 @@ const char descriptor_table_protodef_appearances_2eproto[] PROTOBUF_SECTION_VARI
   "ect_id\030\003 \001(\r\022N\n\026restrict_to_profession\030\005"
   " \003(\0162..Canary.protobuf.appearances.PLAYE"
   "R_PROFESSION\022\025\n\rminimum_level\030\006 \001(\r\"\245\001\n\021"
-  "AppearanceFlagNPC\022\014\n\004name\030\001 \001(\t\022\020\n\010locat"
-  "ion\030\002 \001(\t\022\022\n\nsale_price\030\003 \001(\r\022\021\n\tbuy_pri"
+  "AppearanceFlagNPC\022\014\n\004name\030\001 \001(\014\022\020\n\010locat"
+  "ion\030\002 \001(\014\022\022\n\nsale_price\030\003 \001(\r\022\021\n\tbuy_pri"
   "ce\030\004 \001(\r\022\037\n\027currency_object_type_id\030\005 \001("
   "\r\022(\n currency_quest_flag_display_name\030\006 "
-  "\001(\t\"&\n\025AppearanceFlagAutomap\022\r\n\005color\030\001 "
+  "\001(\014\"&\n\025AppearanceFlagAutomap\022\r\n\005color\030\001 "
   "\001(\r\"O\n\022AppearanceFlagHook\0229\n\tdirection\030\001"
   " \001(\0162&.Canary.protobuf.appearances.HOOK_"
   "TYPE\"$\n\026AppearanceFlagLenshelp\022\n\n\002id\030\001 \001"
@@ -3565,26 +3565,20 @@ const char* Appearance::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID:
         } else
           goto handle_unusual;
         continue;
-      // optional string name = 4;
+      // optional bytes name = 4;
       case 4:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
           auto str = _internal_mutable_name();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          #ifndef NDEBUG
-          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "Canary.protobuf.appearances.Appearance.name");
-          #endif  // !NDEBUG
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // optional string description = 5;
+      // optional bytes description = 5;
       case 5:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 42)) {
           auto str = _internal_mutable_description();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          #ifndef NDEBUG
-          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "Canary.protobuf.appearances.Appearance.description");
-          #endif  // !NDEBUG
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -3642,23 +3636,15 @@ uint8_t* Appearance::_InternalSerialize(
         3, _Internal::flags(this), target, stream);
   }
 
-  // optional string name = 4;
+  // optional bytes name = 4;
   if (cached_has_bits & 0x00000001u) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->_internal_name().data(), static_cast<int>(this->_internal_name().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
-      "Canary.protobuf.appearances.Appearance.name");
-    target = stream->WriteStringMaybeAliased(
+    target = stream->WriteBytesMaybeAliased(
         4, this->_internal_name(), target);
   }
 
-  // optional string description = 5;
+  // optional bytes description = 5;
   if (cached_has_bits & 0x00000002u) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->_internal_description().data(), static_cast<int>(this->_internal_description().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
-      "Canary.protobuf.appearances.Appearance.description");
-    target = stream->WriteStringMaybeAliased(
+    target = stream->WriteBytesMaybeAliased(
         5, this->_internal_description(), target);
   }
 
@@ -3687,17 +3673,17 @@ size_t Appearance::ByteSizeLong() const {
 
   cached_has_bits = _has_bits_[0];
   if (cached_has_bits & 0x0000000fu) {
-    // optional string name = 4;
+    // optional bytes name = 4;
     if (cached_has_bits & 0x00000001u) {
       total_size += 1 +
-        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
           this->_internal_name());
     }
 
-    // optional string description = 5;
+    // optional bytes description = 5;
     if (cached_has_bits & 0x00000002u) {
       total_size += 1 +
-        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
           this->_internal_description());
     }
 
@@ -7864,26 +7850,20 @@ const char* AppearanceFlagNPC::_InternalParse(const char* ptr, ::PROTOBUF_NAMESP
     uint32_t tag;
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // optional string name = 1;
+      // optional bytes name = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
           auto str = _internal_mutable_name();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          #ifndef NDEBUG
-          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "Canary.protobuf.appearances.AppearanceFlagNPC.name");
-          #endif  // !NDEBUG
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // optional string location = 2;
+      // optional bytes location = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
           auto str = _internal_mutable_location();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          #ifndef NDEBUG
-          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "Canary.protobuf.appearances.AppearanceFlagNPC.location");
-          #endif  // !NDEBUG
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -7915,14 +7895,11 @@ const char* AppearanceFlagNPC::_InternalParse(const char* ptr, ::PROTOBUF_NAMESP
         } else
           goto handle_unusual;
         continue;
-      // optional string currency_quest_flag_display_name = 6;
+      // optional bytes currency_quest_flag_display_name = 6;
       case 6:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 50)) {
           auto str = _internal_mutable_currency_quest_flag_display_name();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
-          #ifndef NDEBUG
-          ::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "Canary.protobuf.appearances.AppearanceFlagNPC.currency_quest_flag_display_name");
-          #endif  // !NDEBUG
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -7958,23 +7935,15 @@ uint8_t* AppearanceFlagNPC::_InternalSerialize(
   (void) cached_has_bits;
 
   cached_has_bits = _has_bits_[0];
-  // optional string name = 1;
+  // optional bytes name = 1;
   if (cached_has_bits & 0x00000001u) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->_internal_name().data(), static_cast<int>(this->_internal_name().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
-      "Canary.protobuf.appearances.AppearanceFlagNPC.name");
-    target = stream->WriteStringMaybeAliased(
+    target = stream->WriteBytesMaybeAliased(
         1, this->_internal_name(), target);
   }
 
-  // optional string location = 2;
+  // optional bytes location = 2;
   if (cached_has_bits & 0x00000002u) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->_internal_location().data(), static_cast<int>(this->_internal_location().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
-      "Canary.protobuf.appearances.AppearanceFlagNPC.location");
-    target = stream->WriteStringMaybeAliased(
+    target = stream->WriteBytesMaybeAliased(
         2, this->_internal_location(), target);
   }
 
@@ -7996,13 +7965,9 @@ uint8_t* AppearanceFlagNPC::_InternalSerialize(
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(5, this->_internal_currency_object_type_id(), target);
   }
 
-  // optional string currency_quest_flag_display_name = 6;
+  // optional bytes currency_quest_flag_display_name = 6;
   if (cached_has_bits & 0x00000004u) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::VerifyUTF8StringNamedField(
-      this->_internal_currency_quest_flag_display_name().data(), static_cast<int>(this->_internal_currency_quest_flag_display_name().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::SERIALIZE,
-      "Canary.protobuf.appearances.AppearanceFlagNPC.currency_quest_flag_display_name");
-    target = stream->WriteStringMaybeAliased(
+    target = stream->WriteBytesMaybeAliased(
         6, this->_internal_currency_quest_flag_display_name(), target);
   }
 
@@ -8024,24 +7989,24 @@ size_t AppearanceFlagNPC::ByteSizeLong() const {
 
   cached_has_bits = _has_bits_[0];
   if (cached_has_bits & 0x0000003fu) {
-    // optional string name = 1;
+    // optional bytes name = 1;
     if (cached_has_bits & 0x00000001u) {
       total_size += 1 +
-        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
           this->_internal_name());
     }
 
-    // optional string location = 2;
+    // optional bytes location = 2;
     if (cached_has_bits & 0x00000002u) {
       total_size += 1 +
-        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
           this->_internal_location());
     }
 
-    // optional string currency_quest_flag_display_name = 6;
+    // optional bytes currency_quest_flag_display_name = 6;
     if (cached_has_bits & 0x00000004u) {
       total_size += 1 +
-        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
           this->_internal_currency_quest_flag_display_name());
     }
 

--- a/src/protobuf/appearances.pb.h
+++ b/src/protobuf/appearances.pb.h
@@ -2031,7 +2031,7 @@ class Appearance final :
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Canary::protobuf::appearances::FrameGroup >&
       frame_group() const;
 
-  // optional string name = 4;
+  // optional bytes name = 4;
   bool has_name() const;
   private:
   bool _internal_has_name() const;
@@ -2049,7 +2049,7 @@ class Appearance final :
   std::string* _internal_mutable_name();
   public:
 
-  // optional string description = 5;
+  // optional bytes description = 5;
   bool has_description() const;
   private:
   bool _internal_has_description() const;
@@ -4869,7 +4869,7 @@ class AppearanceFlagNPC final :
     kBuyPriceFieldNumber = 4,
     kCurrencyObjectTypeIdFieldNumber = 5,
   };
-  // optional string name = 1;
+  // optional bytes name = 1;
   bool has_name() const;
   private:
   bool _internal_has_name() const;
@@ -4887,7 +4887,7 @@ class AppearanceFlagNPC final :
   std::string* _internal_mutable_name();
   public:
 
-  // optional string location = 2;
+  // optional bytes location = 2;
   bool has_location() const;
   private:
   bool _internal_has_location() const;
@@ -4905,7 +4905,7 @@ class AppearanceFlagNPC final :
   std::string* _internal_mutable_location();
   public:
 
-  // optional string currency_quest_flag_display_name = 6;
+  // optional bytes currency_quest_flag_display_name = 6;
   bool has_currency_quest_flag_display_name() const;
   private:
   bool _internal_has_currency_quest_flag_display_name() const;
@@ -7374,7 +7374,7 @@ inline void Appearance::set_allocated_flags(::Canary::protobuf::appearances::App
   // @@protoc_insertion_point(field_set_allocated:Canary.protobuf.appearances.Appearance.flags)
 }
 
-// optional string name = 4;
+// optional bytes name = 4;
 inline bool Appearance::_internal_has_name() const {
   bool value = (_has_bits_[0] & 0x00000001u) != 0;
   return value;
@@ -7394,7 +7394,7 @@ template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
 void Appearance::set_name(ArgT0&& arg0, ArgT... args) {
  _has_bits_[0] |= 0x00000001u;
- name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+ name_.SetBytes(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.Appearance.name)
 }
 inline std::string* Appearance::mutable_name() {
@@ -7443,7 +7443,7 @@ inline void Appearance::set_allocated_name(std::string* name) {
   // @@protoc_insertion_point(field_set_allocated:Canary.protobuf.appearances.Appearance.name)
 }
 
-// optional string description = 5;
+// optional bytes description = 5;
 inline bool Appearance::_internal_has_description() const {
   bool value = (_has_bits_[0] & 0x00000002u) != 0;
   return value;
@@ -7463,7 +7463,7 @@ template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
 void Appearance::set_description(ArgT0&& arg0, ArgT... args) {
  _has_bits_[0] |= 0x00000002u;
- description_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+ description_.SetBytes(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.Appearance.description)
 }
 inline std::string* Appearance::mutable_description() {
@@ -10313,7 +10313,7 @@ inline void AppearanceFlagMarket::set_minimum_level(uint32_t value) {
 
 // AppearanceFlagNPC
 
-// optional string name = 1;
+// optional bytes name = 1;
 inline bool AppearanceFlagNPC::_internal_has_name() const {
   bool value = (_has_bits_[0] & 0x00000001u) != 0;
   return value;
@@ -10333,7 +10333,7 @@ template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
 void AppearanceFlagNPC::set_name(ArgT0&& arg0, ArgT... args) {
  _has_bits_[0] |= 0x00000001u;
- name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+ name_.SetBytes(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.AppearanceFlagNPC.name)
 }
 inline std::string* AppearanceFlagNPC::mutable_name() {
@@ -10382,7 +10382,7 @@ inline void AppearanceFlagNPC::set_allocated_name(std::string* name) {
   // @@protoc_insertion_point(field_set_allocated:Canary.protobuf.appearances.AppearanceFlagNPC.name)
 }
 
-// optional string location = 2;
+// optional bytes location = 2;
 inline bool AppearanceFlagNPC::_internal_has_location() const {
   bool value = (_has_bits_[0] & 0x00000002u) != 0;
   return value;
@@ -10402,7 +10402,7 @@ template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
 void AppearanceFlagNPC::set_location(ArgT0&& arg0, ArgT... args) {
  _has_bits_[0] |= 0x00000002u;
- location_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+ location_.SetBytes(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.AppearanceFlagNPC.location)
 }
 inline std::string* AppearanceFlagNPC::mutable_location() {
@@ -10535,7 +10535,7 @@ inline void AppearanceFlagNPC::set_currency_object_type_id(uint32_t value) {
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.AppearanceFlagNPC.currency_object_type_id)
 }
 
-// optional string currency_quest_flag_display_name = 6;
+// optional bytes currency_quest_flag_display_name = 6;
 inline bool AppearanceFlagNPC::_internal_has_currency_quest_flag_display_name() const {
   bool value = (_has_bits_[0] & 0x00000004u) != 0;
   return value;
@@ -10555,7 +10555,7 @@ template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
 void AppearanceFlagNPC::set_currency_quest_flag_display_name(ArgT0&& arg0, ArgT... args) {
  _has_bits_[0] |= 0x00000004u;
- currency_quest_flag_display_name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+ currency_quest_flag_display_name_.SetBytes(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
   // @@protoc_insertion_point(field_set:Canary.protobuf.appearances.AppearanceFlagNPC.currency_quest_flag_display_name)
 }
 inline std::string* AppearanceFlagNPC::mutable_currency_quest_flag_display_name() {


### PR DESCRIPTION
The real name of the monster was replaced by the name of the look, generating unexpected behavior and in a very specific scenario a crash (when two different monsters had the same "name")
Some improvements related to the creation of monsters and the verification of the monster name in getMonsterType, also preventing any unexpected behavior