### PR TITLE
[Fix] Non-unique item name registration

### DIFF
--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -266,8 +266,8 @@ void Items::parseItemNode(const pugi::xml_node & itemNode, uint16_t id) {
 		return;
 	}
 
-	std::string xmlName = itemNode.attribute("name").as_string();
-	if (!xmlName.empty() && itemType.name != xmlName) {
+	if (std::string xmlName = itemNode.attribute("name").as_string();
+			!xmlName.empty() && itemType.name != xmlName) {
 		if (!itemType.name.empty()) {
 			if (auto it = std::find_if(nameToItems.begin(), nameToItems.end(), [id](const auto nameMapIt) {
 					return nameMapIt.second == id;

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -266,25 +266,24 @@ void Items::parseItemNode(const pugi::xml_node & itemNode, uint16_t id) {
 		return;
 	}
 
-	bool isNameRegistered = !itemType.name.empty();
-	if (isNameRegistered && itemType.name != itemNode.attribute("name").as_string()) {
-		if (auto result = nameToItems.find(asLowerCaseString(itemType.name)); 
-			result != nameToItems.end()) {
-			nameToItems.erase(result);
-			isNameRegistered = false;
+	std::string xmlName = itemNode.attribute("name").as_string();
+	if (!xmlName.empty() && itemType.name != xmlName) {
+		if (!itemType.name.empty()) {
+			if (auto it = std::find_if(nameToItems.begin(), nameToItems.end(), [id](const auto nameMapIt) {
+					return nameMapIt.second == id;
+				}); it != nameToItems.end()) {
+				nameToItems.erase(it);
+			}
 		}
-	}
 
-	itemType.loaded = true;
-	itemType.name = itemNode.attribute("name").as_string();
-
-	if (!isNameRegistered) {
+		itemType.name = xmlName;
 		nameToItems.insert({
 			asLowerCaseString(itemType.name),
 			id
 		});
 	}
 
+	itemType.loaded = true;
 	pugi::xml_attribute articleAttribute = itemNode.attribute("article");
 	if (articleAttribute) {
 		itemType.article = articleAttribute.as_string();


### PR DESCRIPTION
# Description
Fix an issue related to items that have a non-unique name on the register. This problem was breaking some monster's loot.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
 
## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
