### PR TITLE
Fixing summon searching player target and icons update

### DIFF
--- a/data/lib/core/functions/creature.lua
+++ b/data/lib/core/functions/creature.lua
@@ -98,18 +98,13 @@ function Creature:setItemOutfit(item, time)
 	return true
 end
 
-function Creature:addSummon(monster)
+function Creature:setSummon(monster)
 	local summon = Monster(monster)
 	if not summon then
 		return false
 	end
 
-	summon:setTarget(nil)
-	summon:setFollowCreature(nil)
-	summon:setDropLoot(false)
-	summon:setSkillLoss(false)
-	summon:setMaster(self)
-
+	summon:setMaster(self, true)
 	return true
 end
 

--- a/data/scripts/actions/other/music.lua
+++ b/data/scripts/actions/other/music.lua
@@ -44,7 +44,7 @@ function music.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		if instrument.monster and chance then
 			local monster = Game.createMonster(instrument.monster, player:getPosition(), true)
 			if monster then
-				player:addSummon(monster)
+				player:setSummon(monster)
 			end
 		elseif instrument.itemId and chance then
 			player:addItem(instrument.itemId, instrument.itemCount)

--- a/data/scripts/runes/animate_dead_rune.lua
+++ b/data/scripts/runes/animate_dead_rune.lua
@@ -12,7 +12,7 @@ function rune.onCastSpell(player, variant)
 					local summon = Game.createMonster("Skeleton", position, true, true)
 					if summon then
 						corpse:remove()
-						player:addSummon(summon)
+						player:setSummon(summon)
 						position:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 						return true
 					end

--- a/data/scripts/runes/convince_creature.lua
+++ b/data/scripts/runes/convince_creature.lua
@@ -32,7 +32,7 @@ function rune.onCastSpell(creature, variant, isHotkey)
 
 	creature:addMana(-manaCost)
 	creature:addManaSpent(manaCost)
-	creature:addSummon(target)
+	creature:setSummon(target)
 	creature:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	return true
 end

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -912,7 +912,7 @@ BlockType_t Creature::blockHit(Creature* attacker, CombatType_t combatType, int3
 bool Creature::setAttackedCreature(Creature* creature)
 {
 	if (creature) {
-		if (this->getMonster() && this->getMonster()->isFamiliar() && this->getTile()->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		if (this->getMonster() && this->getMonster()->isFamiliar() && this->getTile() && this->getTile()->hasFlag(TILESTATE_PROTECTIONZONE)) {
 			return false;
 		}
 
@@ -1193,7 +1193,7 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 	}
 }
 
-bool Creature::setMaster(Creature* newMaster) {
+bool Creature::setMaster(Creature* newMaster, bool reloadCreature/* = false*/) {
 	// Persists if this creature has ever been a summon
 	this->summoned = true;
 
@@ -1201,6 +1201,13 @@ bool Creature::setMaster(Creature* newMaster) {
 		return false;
 	}
 
+	// Reloading summon icon/knownCreature and reset informations (follow/dropLoot/skillLoss)
+	if (reloadCreature) {
+		setFollowCreature(nullptr);
+		setDropLoot(false);
+		setSkillLoss(false);
+		g_game().reloadCreature(this);
+	}
 	if (newMaster) {
 		incrementReferenceCounter();
 		newMaster->summons.push_back(this);

--- a/src/creatures/creature.h
+++ b/src/creatures/creature.h
@@ -284,7 +284,7 @@ class Creature : virtual public Thing
 		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
                                     bool checkDefense = false, bool checkArmor = false, bool field = false);
 
-		bool setMaster(Creature* newMaster);
+		bool setMaster(Creature* newMaster, bool reloadCreature = false);
 
 		void removeMaster() {
 			if (master) {

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -714,7 +714,7 @@ bool Monster::isTarget(const Creature* creature) const
 		return false;
 	}
 	Faction_t targetFaction = creature->getFaction();
-	if (getFaction() != FACTION_DEFAULT && master->getMonster()) {
+	if (getFaction() != FACTION_DEFAULT && master && master->getMonster()) {
 		return isEnemyFaction(targetFaction);
 	}
 	return true;

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -714,7 +714,7 @@ bool Monster::isTarget(const Creature* creature) const
 		return false;
 	}
 	Faction_t targetFaction = creature->getFaction();
-	if (getFaction() != FACTION_DEFAULT) {
+	if (getFaction() != FACTION_DEFAULT && master->getMonster()) {
 		return isEnemyFaction(targetFaction);
 	}
 	return true;
@@ -733,7 +733,7 @@ bool Monster::selectTarget(Creature* creature)
 	}
 
 	if (isHostile() || isSummon()) {
-		if (setAttackedCreature(creature) && !isSummon()) {
+		if (setAttackedCreature(creature)) {
 			g_dispatcher().addTask(createTask(std::bind(&Game::checkCreatureAttack, &g_game(), getID())));
 		}
 	}
@@ -1091,9 +1091,7 @@ void Monster::onThinkDefense(uint32_t interval)
 			Monster* summon = Monster::createMonster(summonBlock.name);
 			if (summon) {
 				if (g_game().placeCreature(summon, getPosition(), false, summonBlock.force)) {
-					summon->setDropLoot(false);
-					summon->setSkillLoss(false);
-					summon->setMaster(this);
+					summon->setMaster(this, true);
 					g_game().addMagicEffect(getPosition(), CONST_ME_MAGIC_BLUE);
 					g_game().addMagicEffect(summon->getPosition(), CONST_ME_TELEPORT);
 				} else {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5521,6 +5521,19 @@ void Game::updateCreatureIcon(const Creature* creature)
 	}
 }
 
+void Game::reloadCreature(const Creature* creature)
+{
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, creature->getPosition(), false, true);
+	for (Creature* spectator : spectators) {
+		Player* tmpPlayer = spectator->getPlayer();
+		if (!tmpPlayer) {
+			continue;
+		}
+		tmpPlayer->reloadCreature(creature);
+	}
+}
+
 bool Game::combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* target, bool checkDefense, bool checkArmor, bool field)
 {
 	if (damage.primary.type == COMBAT_NONE && damage.secondary.type == COMBAT_NONE) {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -410,6 +410,7 @@ class Game
 		void internalCreatureChangeVisible(Creature* creature, bool visible);
 		void changeLight(const Creature* creature);
 		void updateCreatureIcon(const Creature* creature);
+		void reloadCreature(const Creature* creature);
 		void updateCreatureSkull(const Creature* player);
 		void updatePlayerShield(Player* player);
 		void updateCreatureType(Creature* creature);

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -429,9 +429,7 @@ int GameFunctions::luaGameCreateMonster(lua_State* L) {
 	if (lua_gettop(L) >= 5) {
 		Creature* master = getCreature(L, 5);
 		if (master) {
-			monster->setMaster(master);
-			monster->setDropLoot(false);
-			monster->setSkillLoss(false);
+			monster->setMaster(master, true);
 			isSummon = true;
 		}
 	}

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -278,6 +278,20 @@ int CreatureFunctions::luaCreatureGetMaster(lua_State* L) {
 	return 1;
 }
 
+int CreatureFunctions::luaCreatureReload(lua_State* L)
+{
+	// creature:reload()
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	g_game().reloadCreature(creature);
+	pushBoolean(L, true);
+	return 1;
+}
+
 int CreatureFunctions::luaCreatureSetMaster(lua_State* L) {
 	// creature:setMaster(master)
 	Creature* creature = getUserdata<Creature>(L, 1);
@@ -286,8 +300,9 @@ int CreatureFunctions::luaCreatureSetMaster(lua_State* L) {
 		return 1;
 	}
 
-	pushBoolean(L, creature->setMaster(getCreature(L, 2)));
-	g_game().updateCreatureType(creature);
+	pushBoolean(L, creature->setMaster(getCreature(L, 2), true));
+	// Reloading creature icon/knownCreature
+	CreatureFunctions::luaCreatureReload(L);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/creature_functions.hpp
+++ b/src/lua/functions/creatures/creature_functions.hpp
@@ -50,6 +50,7 @@ class CreatureFunctions final : LuaScriptInterface {
 			registerMethod(L, "Creature", "setTarget", CreatureFunctions::luaCreatureSetTarget);
 			registerMethod(L, "Creature", "getFollowCreature", CreatureFunctions::luaCreatureGetFollowCreature);
 			registerMethod(L, "Creature", "setFollowCreature", CreatureFunctions::luaCreatureSetFollowCreature);
+			registerMethod(L, "Creature", "reload", CreatureFunctions::luaCreatureReload);
 			registerMethod(L, "Creature", "getMaster", CreatureFunctions::luaCreatureGetMaster);
 			registerMethod(L, "Creature", "setMaster", CreatureFunctions::luaCreatureSetMaster);
 			registerMethod(L, "Creature", "getLight", CreatureFunctions::luaCreatureGetLight);
@@ -122,6 +123,8 @@ class CreatureFunctions final : LuaScriptInterface {
 
 		static int luaCreatureGetFollowCreature(lua_State* L);
 		static int luaCreatureSetFollowCreature(lua_State* L);
+
+		static int luaCreatureReload(lua_State* L);
 
 		static int luaCreatureGetMaster(lua_State* L);
 		static int luaCreatureSetMaster(lua_State* L);


### PR DESCRIPTION
Fixed the bug when the player was attacking a creature and summoned, the summon would not attack the creature until the player stopped attacking and attacked again.

Fixed the icon of creatures that use the "creature:addSummon" function
Added Game::reloadCreature functions
Rework on function "Creature::setMaster", somes functions were centralized within the setMaster, avoiding repetitions:
```cpp
Creature::setTarget
Creature::setFollowCreature
Creature::setDropLoot
Creature::setSkillLoss
```