### PR TITLE
Rework on movements revscriptsys

### DIFF
--- a/data/scripts/movements/trap.lua
+++ b/data/scripts/movements/trap.lua
@@ -41,14 +41,14 @@ trap:register()
 trap = MoveEvent()
 trap:type("removeitem")
 
-function trap.onRemoveItem(moveitem, tileitem, position)
-	local itemPosition = moveitem:getPosition()
+function trap.onRemoveItem(item, position)
+	local itemPosition = item:getPosition()
 	if itemPosition:getDistance(position) > 0 then
-		tileitem:transform(tileitem.itemid - 1)
+		item:transform(tileitem.itemid - 1)
 		position:sendMagicEffect(CONST_ME_POFF)
 	end
 	return true
 end
 
-trap:id(2579)
+trap:id(3482)
 trap:register()

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1562,11 +1562,11 @@ void AreaCombat::setupExtArea(const std::list<uint32_t>& list, uint32_t rows)
 
 //**********************************************************//
 
-void MagicField::onStepInField(Creature* creature)
+void MagicField::onStepInField(Creature& creature)
 {
 	//remove magic walls/wild growth
 	if (id == ITEM_MAGICWALL || id == ITEM_WILDGROWTH || id == ITEM_MAGICWALL_SAFE || id == ITEM_WILDGROWTH_SAFE || isBlocking()) {
-		if (!creature->isInGhostMode()) {
+		if (!creature.isInGhostMode()) {
 			g_game().internalRemoveItem(this, 1);
 		}
 
@@ -1589,7 +1589,7 @@ void MagicField::onStepInField(Creature* creature)
 				}
 			}
 
-			Player* targetPlayer = creature->getPlayer();
+			Player* targetPlayer = creature.getPlayer();
 			if (targetPlayer) {
 				const Player* attackerPlayer = g_game().getPlayerByID(ownerId);
 				if (attackerPlayer) {
@@ -1599,11 +1599,11 @@ void MagicField::onStepInField(Creature* creature)
 				}
 			}
 
-			if (!harmfulField || (OTSYS_TIME() - createTime <= 5000) || creature->hasBeenAttacked(ownerId)) {
+			if (!harmfulField || (OTSYS_TIME() - createTime <= 5000) || creature.hasBeenAttacked(ownerId)) {
 				conditionCopy->setParam(CONDITION_PARAM_OWNER, ownerId);
 			}
 		}
 
-		creature->addCondition(conditionCopy);
+		creature.addCondition(conditionCopy);
 	}
 }

--- a/src/creatures/combat/combat.h
+++ b/src/creatures/combat/combat.h
@@ -343,7 +343,7 @@ class MagicField final : public Item
 			}
 			return 0;
 		}
-		void onStepInField(Creature* creature);
+		void onStepInField(Creature& creature);
 
 	private:
 		int64_t createTime;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1510,7 +1510,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 			Item* item = inventory[slot];
 			if (item) {
 				item->startDecaying();
-				g_moveEvents().onPlayerEquip(this, item, static_cast<Slots_t>(slot), false);
+				g_moveEvents().onPlayerEquip(*this, *item, static_cast<Slots_t>(slot), false);
 			}
 		}
 
@@ -2976,6 +2976,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 {
 	const Item* item = thing.getItem();
 	if (item == nullptr) {
+		SPDLOG_ERROR("[Player::queryAdd] - Item is nullptr");
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
@@ -3189,7 +3190,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 			return RETURNVALUE_NOTENOUGHCAPACITY;
 		}
 
-		if (!g_moveEvents().onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<Slots_t>(index), true)) {
+		if (!g_moveEvents().onPlayerEquip(const_cast<Player&>(*this), const_cast<Item&>(*item), static_cast<Slots_t>(index), true)) {
 			return RETURNVALUE_CANNOTBEDRESSED;
 		}
 	}
@@ -3795,7 +3796,7 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 {
 	if (link == LINK_OWNER) {
 		//calling movement scripts
-		g_moveEvents().onPlayerEquip(this, thing->getItem(), static_cast<Slots_t>(index), false);
+		g_moveEvents().onPlayerEquip(*this, *thing->getItem(), static_cast<Slots_t>(index), false);
 	}
 
 	bool requireListUpdate = true;
@@ -3850,7 +3851,7 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 {
 	if (link == LINK_OWNER) {
 		//calling movement scripts
-		g_moveEvents().onPlayerDeEquip(this, thing->getItem(), static_cast<Slots_t>(index));
+		g_moveEvents().onPlayerDeEquip(*this, *thing->getItem(), static_cast<Slots_t>(index));
 	}
 
 	bool requireListUpdate = true;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5392,7 +5392,7 @@ void Game::changePlayerSpeed(Player& player, int32_t varSpeedDelta)
 
 	player.setSpeed(varSpeed);
 
-	// Send to spectators
+	// Send new player speed to the spectators
 	SpectatorHashSet spectators;
 	map.getSpectators(spectators, player.getPosition(), false, true);
 	for (Creature* creatureSpectator : spectators) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2204,7 +2204,7 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 					internalRemoveItem(item);
 					return nullptr;
 				} else if (newItemId != newId) {
-					//Replacing the the old item with the new while maintaining the old position
+					// Replacing the the old item with the new while maintaining the old position
 					Item* newItem = Item::CreateItem(newItemId, 1);
 					if (newItem == nullptr) {
 						return nullptr;
@@ -5382,6 +5382,21 @@ void Game::changeSpeed(Creature* creature, int32_t varSpeedDelta)
 	map.getSpectators(spectators, creature->getPosition(), false, true);
 	for (Creature* spectator : spectators) {
 		spectator->getPlayer()->sendChangeSpeed(creature, creature->getStepSpeed());
+	}
+}
+
+void Game::changePlayerSpeed(Player& player, int32_t varSpeedDelta)
+{
+	int32_t varSpeed = player.getSpeed() - player.getBaseSpeed();
+	varSpeed += varSpeedDelta;
+
+	player.setSpeed(varSpeed);
+
+	//send to clients
+	SpectatorHashSet spectators;
+	map.getSpectators(spectators, player.getPosition(), false, true);
+	for (Creature* spectator : spectators) {
+		spectator->getPlayer()->sendChangeSpeed(&player, player.getStepSpeed());
 	}
 }
 
@@ -8617,7 +8632,7 @@ bool Game::reload(ReloadTypes_t reloadType)
 			// commented out stuff is TODO, once we approach further in revscriptsys
 			g_actions().clear(true);
 			g_creatureEvents().clear(true);
-			g_moveEvents().clear(true);
+			g_moveEvents().clear();
 			g_talkActions().clear(true);
 			g_globalEvents().clear(true);
 			g_weapons().clear(true);
@@ -8655,11 +8670,6 @@ bool Game::reload(ReloadTypes_t reloadType)
 		}
 	}
 	return true;
-}
-
-bool Game::itemidHasMoveevent(uint32_t itemid)
-{
-	return g_moveEvents().isRegistered(itemid);
 }
 
 bool Game::hasEffect(uint8_t effectId) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5392,11 +5392,22 @@ void Game::changePlayerSpeed(Player& player, int32_t varSpeedDelta)
 
 	player.setSpeed(varSpeed);
 
-	//send to clients
+	// Send to spectators
 	SpectatorHashSet spectators;
 	map.getSpectators(spectators, player.getPosition(), false, true);
-	for (Creature* spectator : spectators) {
-		spectator->getPlayer()->sendChangeSpeed(&player, player.getStepSpeed());
+	for (Creature* creatureSpectator : spectators) {
+		if (creatureSpectator == nullptr) {
+			SPDLOG_ERROR("[Game::changePlayerSpeed] - Creature spectator is nullptr");
+			continue;
+		}
+
+		const Player *playerSpectator = creatureSpectator->getPlayer();
+		if (playerSpectator == nullptr) {
+			SPDLOG_ERROR("[Game::changePlayerSpeed] - Player spectator is nullptr");
+			continue;
+		}
+
+		playerSpectator->sendChangeSpeed(&player, player.getStepSpeed());
 	}
 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -404,6 +404,7 @@ class Game
 		bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor) const;
 
 		void changeSpeed(Creature* creature, int32_t varSpeedDelta);
+		void changePlayerSpeed(Player& player, int32_t varSpeedDelta);
 		void internalCreatureChangeOutfit(Creature* creature, const Outfit_t& oufit);
 		void internalCreatureChangeVisible(Creature* creature, bool visible);
 		void changeLight(const Creature* creature);
@@ -490,7 +491,6 @@ class Game
 
 		bool reload(ReloadTypes_t reloadType);
 
-		bool itemidHasMoveevent(uint32_t itemid);
 		bool hasEffect(uint8_t effectId);
 		bool hasDistanceEffect(uint8_t effectId);
 

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1426,9 +1426,9 @@ void Tile::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t 
 
 		//calling movement scripts
 		if (creature) {
-			g_moveEvents().onCreatureMove(creature, this, MOVE_EVENT_STEP_IN);
+			g_moveEvents().onCreatureMove(*creature, *this, MOVE_EVENT_STEP_IN);
 		} else if (item) {
-			g_moveEvents().onItemMove(item, this, true);
+			g_moveEvents().onItemMove(*item, *this, true);
 		}
 	}
 
@@ -1456,11 +1456,11 @@ void Tile::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32
 	//calling movement scripts
 	Creature* creature = thing->getCreature();
 	if (creature) {
-		g_moveEvents().onCreatureMove(creature, this, MOVE_EVENT_STEP_OUT);
+		g_moveEvents().onCreatureMove(*creature, *this, MOVE_EVENT_STEP_OUT);
 	} else {
 		Item* item = thing->getItem();
 		if (item) {
-			g_moveEvents().onItemMove(item, this, false);
+			g_moveEvents().onItemMove(*item, *this, false);
 		}
 	}
 }

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -27,7 +27,6 @@
 #include "creatures/combat/spells.h"
 #include "items/containers/rewards/rewardchest.h"
 
-
 Actions::Actions() :
 	scriptInterface("Action Interface") {
 	scriptInterface.initState();

--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -274,7 +274,6 @@ uint32_t MoveEvents::onPlayerEquip(Player& player, Item& item, Slots_t slot, boo
 	if (!moveEvent) {
 		return 1;
 	}
-
 	return moveEvent->fireEquip(player, item, slot, isCheck);
 }
 

--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -27,271 +27,137 @@
 #include "lua/creature/movement.h"
 #include "creatures/players/imbuements/imbuements.h"
 
-
-MoveEvents::MoveEvents() :
-	scriptInterface("MoveEvents Interface") {
-	scriptInterface.initState();
-}
-
-MoveEvents::~MoveEvents() {
-	clear(false);
-}
-
-void MoveEvents::clearMap(MoveListMap& map, bool fromLua) {
-	for (auto it = map.begin(); it != map.end(); ++it) {
-		for (int eventType = MOVE_EVENT_STEP_IN; eventType < MOVE_EVENT_LAST; ++eventType) {
-			auto& moveEvents = it->second.moveEvent[eventType];
-			for (auto find = moveEvents.begin(); find != moveEvents.end(); ) {
-				if (fromLua == find->fromLua) {
-					find = moveEvents.erase(find);
-				} else {
-					++find;
-				}
-			}
-		}
-	}
-}
-
-void MoveEvents::clearPosMap(MovePosListMap& map, bool fromLua) {
-	for (auto it = map.begin(); it != map.end(); ++it) {
-		for (int eventType = MOVE_EVENT_STEP_IN; eventType < MOVE_EVENT_LAST; ++eventType) {
-			auto& moveEvents = it->second.moveEvent[eventType];
-			for (auto find = moveEvents.begin(); find != moveEvents.end(); ) {
-				if (fromLua == find->fromLua) {
-					find = moveEvents.erase(find);
-				} else {
-					++find;
-				}
-			}
-		}
-	}
-}
-
-void MoveEvents::clear(bool fromLua) {
-	clearMap(itemIdMap, fromLua);
-	clearMap(actionIdMap, fromLua);
-	clearMap(uniqueIdMap, fromLua);
-	clearPosMap(positionMap, fromLua);
-
-	reInitState(fromLua);
-}
-
-LuaScriptInterface& MoveEvents::getScriptInterface() {
-	return scriptInterface;
-}
-
-std::string MoveEvents::getScriptBaseName() const {
-	return "movements";
+void MoveEvents::clear() {
+	uniqueIdMap.clear();
+	actionIdMap.clear();
+	itemIdMap.clear();
+	positionsMap.clear();
 }
 
 Event_ptr MoveEvents::getEvent(const std::string& nodeName) {
-	if (strcasecmp(nodeName.c_str(), "movevent") != 0) {
-		return nullptr;
-	}
 	return Event_ptr(new MoveEvent(&scriptInterface));
 }
 
-bool MoveEvents::isRegistered(uint32_t itemid) {
-	auto it = itemIdMap.find(itemid);
-	return it != itemIdMap.end();
-}
-
-bool MoveEvents::registerEvent(Event_ptr event, const pugi::xml_node& node) {
-	MoveEvent_ptr moveEvent{static_cast<MoveEvent*>(event.release())}; //event is guaranteed to be a MoveEvent
-
-	const MoveEvent_t eventType = moveEvent->getEventType();
-	if (eventType == MOVE_EVENT_ADD_ITEM || eventType == MOVE_EVENT_REMOVE_ITEM) {
-		pugi::xml_attribute tileItemAttribute = node.attribute("tileitem");
-		if (tileItemAttribute && pugi::cast<uint16_t>(tileItemAttribute.value()) == 1) {
-			switch (eventType) {
-				case MOVE_EVENT_ADD_ITEM:
-					moveEvent->setEventType(MOVE_EVENT_ADD_ITEM_ITEMTILE);
-					break;
-				case MOVE_EVENT_REMOVE_ITEM:
-					moveEvent->setEventType(MOVE_EVENT_REMOVE_ITEM_ITEMTILE);
-					break;
-				default:
-					break;
-			}
-		}
-	}
-
-	pugi::xml_attribute attr;
-	if ((attr = node.attribute("itemid"))) {
-		int32_t id = pugi::cast<int32_t>(attr.value());
-		if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-			ItemType& it = Item::items.getItemType(id);
-			it.wieldInfo = moveEvent->getWieldInfo();
-			it.minReqLevel = moveEvent->getReqLevel();
-			it.minReqMagicLevel = moveEvent->getReqMagLv();
-			it.vocationString = moveEvent->getVocationString();
-		}
-		addEvent(std::move(*moveEvent), id, itemIdMap);
-	} else if ((attr = node.attribute("fromid"))) {
-		uint32_t id = pugi::cast<uint32_t>(attr.value());
-		uint32_t endId = pugi::cast<uint32_t>(node.attribute("toid").value());
-
-		addEvent(*moveEvent, id, itemIdMap);
-
-		if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-			ItemType& it = Item::items.getItemType(id);
-			it.wieldInfo = moveEvent->getWieldInfo();
-			it.minReqLevel = moveEvent->getReqLevel();
-			it.minReqMagicLevel = moveEvent->getReqMagLv();
-			it.vocationString = moveEvent->getVocationString();
-
-			while (++id <= endId) {
-				addEvent(*moveEvent, id, itemIdMap);
-
-				ItemType& tit = Item::items.getItemType(id);
-				tit.wieldInfo = moveEvent->getWieldInfo();
-				tit.minReqLevel = moveEvent->getReqLevel();
-				tit.minReqMagicLevel = moveEvent->getReqMagLv();
-				tit.vocationString = moveEvent->getVocationString();
-			}
-		} else {
-			while (++id <= endId) {
-				addEvent(*moveEvent, id, itemIdMap);
-			}
-		}
-	} else if ((attr = node.attribute("uniqueid"))) {
-		addEvent(std::move(*moveEvent), pugi::cast<int32_t>(attr.value()), uniqueIdMap);
-	} else if ((attr = node.attribute("fromuid"))) {
-		uint32_t id = pugi::cast<uint32_t>(attr.value());
-		uint32_t endId = pugi::cast<uint32_t>(node.attribute("touid").value());
-		addEvent(*moveEvent, id, uniqueIdMap);
-		while (++id <= endId) {
-			addEvent(*moveEvent, id, uniqueIdMap);
-		}
-	} else if ((attr = node.attribute("actionid"))) {
-		addEvent(std::move(*moveEvent), pugi::cast<int32_t>(attr.value()), actionIdMap);
-	} else if ((attr = node.attribute("fromaid"))) {
-		uint32_t id = pugi::cast<uint32_t>(attr.value());
-		uint32_t endId = pugi::cast<uint32_t>(node.attribute("toaid").value());
-		addEvent(*moveEvent, id, actionIdMap);
-		while (++id <= endId) {
-			addEvent(*moveEvent, id, actionIdMap);
-		}
-	} else if ((attr = node.attribute("pos"))) {
-		std::vector<int32_t> posList = vectorAtoi(explodeString(attr.as_string(), ";"));
-		if (posList.size() < 3) {
-			return false;
-		}
-
-		Position pos(posList[0], posList[1], posList[2]);
-		addEvent(std::move(*moveEvent), pos, positionMap);
-	} else {
-		return false;
-	}
-	return true;
-}
-
-bool MoveEvents::registerLuaFunction(MoveEvent* event) {
-	MoveEvent_ptr moveEvent{ event };
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
-			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-				ItemType& it = Item::items.getItemType(id);
-				it.wieldInfo = moveEvent->getWieldInfo();
-				it.minReqLevel = moveEvent->getReqLevel();
-				it.minReqMagicLevel = moveEvent->getReqMagLv();
-				it.vocationString = moveEvent->getVocationString();
-			}
-		} else {
-			uint32_t iterId = 0;
-			while (++iterId < moveEvent->getItemIdRange().size()) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(moveEvent->getItemIdRange().at(iterId));
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, moveEvent->getItemIdRange().at(iterId), itemIdMap);
-			}
-		}
-	} else {
-		return false;
-	}
-	return true;
-}
-
-bool MoveEvents::registerLuaEvent(MoveEvent* event) {
-	MoveEvent_ptr moveEvent{ event };
-	if (moveEvent->getItemIdRange().size() > 0) {
-		if (moveEvent->getItemIdRange().size() == 1) {
-			uint32_t id = moveEvent->getItemIdRange().at(0);
-			addEvent(*moveEvent, id, itemIdMap);
-			if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-				ItemType& it = Item::items.getItemType(id);
-				it.wieldInfo = moveEvent->getWieldInfo();
-				it.minReqLevel = moveEvent->getReqLevel();
-				it.minReqMagicLevel = moveEvent->getReqMagLv();
-				it.vocationString = moveEvent->getVocationString();
-			}
-		} else {
-			auto v = moveEvent->getItemIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				if (moveEvent->getEventType() == MOVE_EVENT_EQUIP) {
-					ItemType& it = Item::items.getItemType(*i);
-					it.wieldInfo = moveEvent->getWieldInfo();
-					it.minReqLevel = moveEvent->getReqLevel();
-					it.minReqMagicLevel = moveEvent->getReqMagLv();
-					it.vocationString = moveEvent->getVocationString();
-				}
-				addEvent(*moveEvent, *i, itemIdMap);
-			}
-		}
-	} else if (moveEvent->getActionIdRange().size() > 0) {
-		if (moveEvent->getActionIdRange().size() == 1) {
-			int32_t id = moveEvent->getActionIdRange().at(0);
-			addEvent(*moveEvent, id, actionIdMap);
-		} else {
-			auto v = moveEvent->getActionIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, actionIdMap);
-			}
-		}
-	} else if (moveEvent->getUniqueIdRange().size() > 0) {
-		if (moveEvent->getUniqueIdRange().size() == 1) {
-			int32_t id = moveEvent->getUniqueIdRange().at(0);
-			addEvent(*moveEvent, id, uniqueIdMap);
-		} else {
-			auto v = moveEvent->getUniqueIdRange();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, uniqueIdMap);
-			}
-		}
-	} else if (moveEvent->getPosList().size() > 0) {
-		if (moveEvent->getPosList().size() == 1) {
-			Position pos = moveEvent->getPosList().at(0);
-			addEvent(*moveEvent, pos, positionMap);
-		} else {
-			auto v = moveEvent->getPosList();
-			for (auto i = v.begin(); i != v.end(); i++) {
-				addEvent(*moveEvent, *i, positionMap);
-			}
-		}
-	} else {
+bool MoveEvents::registerLuaFunction(MoveEvent& moveEvent) {
+	auto itemIdVector = moveEvent.getItemIdsVector();
+	if (itemIdVector.empty()) {
 		return false;
 	}
 
+	std::for_each(itemIdVector.begin(), itemIdVector.end(), [this, &moveEvent](uint32_t &itemId) {
+		registerEvent(moveEvent, itemId, itemIdMap);
+		if (moveEvent.getEventType() == MOVE_EVENT_EQUIP) {
+			ItemType& it = Item::items.getItemType(itemId);
+			it.wieldInfo = moveEvent.getWieldInfo();
+			it.minReqLevel = moveEvent.getReqLevel();
+			it.minReqMagicLevel = moveEvent.getReqMagLv();
+			it.vocationString = moveEvent.getVocationString();
+		}
+		return true;
+	});
+	itemIdVector.clear();
+	itemIdVector.shrink_to_fit();
 	return true;
 }
 
-void MoveEvents::addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map) {
-	auto it = map.find(id);
-	if (it == map.end()) {
+bool MoveEvents::registerLuaItemEvent(MoveEvent& moveEvent) {
+	auto itemIdVector = moveEvent.getItemIdsVector();
+	if (itemIdVector.empty()) {
+		return false;
+	}
+
+	std::for_each(itemIdVector.begin(), itemIdVector.end(), [this, &moveEvent](uint32_t &itemId) {
+		registerEvent(moveEvent, itemId, itemIdMap);
+		if (moveEvent.getEventType() == MOVE_EVENT_EQUIP) {
+			ItemType& it = Item::items.getItemType(itemId);
+			it.wieldInfo = moveEvent.getWieldInfo();
+			it.minReqLevel = moveEvent.getReqLevel();
+			it.minReqMagicLevel = moveEvent.getReqMagLv();
+			it.vocationString = moveEvent.getVocationString();
+		}
+		return true;
+	});
+	itemIdVector.clear();
+	itemIdVector.shrink_to_fit();
+	return true;
+}
+
+bool MoveEvents::registerLuaActionEvent(MoveEvent& moveEvent) {
+	auto actionIdVector = moveEvent.getActionIdsVector();
+	if (actionIdVector.empty()) {
+		return false;
+	}
+
+	std::for_each(actionIdVector.begin(), actionIdVector.end(), [this, &moveEvent](uint32_t &actionId) {
+		registerEvent(moveEvent, actionId, actionIdMap);
+		return true;
+	});
+
+	actionIdVector.clear();
+	actionIdVector.shrink_to_fit();
+	return true;
+}
+
+bool MoveEvents::registerLuaUniqueEvent(MoveEvent& moveEvent) {
+	auto uniqueIdVector = moveEvent.getUniqueIdsVector();
+	if (uniqueIdVector.empty()) {
+		return false;
+	}
+
+	std::for_each(uniqueIdVector.begin(), uniqueIdVector.end(), [this, &moveEvent](uint32_t &uniqueId) {
+		registerEvent(moveEvent, uniqueId, uniqueIdMap);
+		return true;
+	});
+
+	uniqueIdVector.clear();
+	uniqueIdVector.shrink_to_fit();
+	return true;
+}
+
+bool MoveEvents::registerLuaPositionEvent(MoveEvent& moveEvent) {
+	auto positionVector = moveEvent.getPositionsVector();
+	if (positionVector.empty()) {
+		return false;
+	}
+
+	std::for_each(positionVector.begin(), positionVector.end(), [this, &moveEvent](Position &position) {
+		registerEvent(moveEvent, position, positionsMap);
+		return true;
+	});
+
+	positionVector.clear();
+	positionVector.shrink_to_fit();
+	return true;
+}
+
+bool MoveEvents::registerLuaEvent(MoveEvent& moveEvent) {
+	// Check if event is correct
+	if (registerLuaItemEvent(moveEvent)
+	|| registerLuaUniqueEvent(moveEvent)
+	|| registerLuaActionEvent(moveEvent)
+	|| registerLuaPositionEvent(moveEvent))
+	{
+		return true;
+	} else {
+		SPDLOG_WARN("[MoveEvents::registerLuaEvent] - "
+				"Missing id, aid, uid or position");
+		return false;
+	}
+	SPDLOG_DEBUG("[MoveEvents::registerLuaEvent] - Missing or incorrect event for some script");
+	return false;
+}
+
+void MoveEvents::registerEvent(MoveEvent& moveEvent, int32_t id, MoveListMap& moveListMap) {
+	auto it = moveListMap.find(id);
+	if (it == moveListMap.end()) {
 		MoveEventList moveEventList;
 		moveEventList.moveEvent[moveEvent.getEventType()].push_back(std::move(moveEvent));
-		map[id] = moveEventList;
+		moveListMap[id] = moveEventList;
 	} else {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[moveEvent.getEventType()];
 		for (MoveEvent& existingMoveEvent : moveEventList) {
 			if (existingMoveEvent.getSlot() == moveEvent.getSlot()) {
-				SPDLOG_WARN("[MoveEvents::addEvent] - "
+				SPDLOG_WARN("[MoveEvents::registerEvent] - "
 							"Duplicate move event found: {}", id);
 			}
 		}
@@ -299,7 +165,7 @@ void MoveEvents::addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map) {
 	}
 }
 
-MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, Slots_t slot) {
+MoveEvent* MoveEvents::getEvent(Item& item, MoveEvent_t eventType, Slots_t slot) {
 	uint32_t slotp;
 	switch (slot) {
 		case CONST_SLOT_HEAD: slotp = SLOTP_HEAD; break;
@@ -315,8 +181,8 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, Slots_t slot)
 		default: slotp = 0; break;
 	}
 
-  if (item->hasAttribute(ITEM_ATTRIBUTE_ACTIONID)) {
-		MoveListMap::iterator it = actionIdMap.find(item->getActionId());
+	if (item.hasAttribute(ITEM_ATTRIBUTE_ACTIONID)) {
+		MoveListMap::iterator it = actionIdMap.find(item.getActionId());
 		if (it != actionIdMap.end()) {
 			std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 			for (MoveEvent& moveEvent : moveEventList) {
@@ -327,7 +193,7 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, Slots_t slot)
 		}
 	}
 
-	auto it = itemIdMap.find(item->getID());
+	auto it = itemIdMap.find(item.getID());
 	if (it != itemIdMap.end()) {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 		for (MoveEvent& moveEvent : moveEventList) {
@@ -339,11 +205,10 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, Slots_t slot)
 	return nullptr;
 }
 
-MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType) {
+MoveEvent* MoveEvents::getEvent(Item& item, MoveEvent_t eventType) {
 	MoveListMap::iterator it;
-
-	if (item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
-		it = uniqueIdMap.find(item->getUniqueId());
+	if (item.hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
+		it = uniqueIdMap.find(item.getUniqueId());
 		if (it != uniqueIdMap.end()) {
 			std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 			if (!moveEventList.empty()) {
@@ -352,8 +217,8 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType) {
 		}
 	}
 
-	if (item->hasAttribute(ITEM_ATTRIBUTE_ACTIONID)) {
-		it = actionIdMap.find(item->getActionId());
+	if (item.hasAttribute(ITEM_ATTRIBUTE_ACTIONID)) {
+		it = actionIdMap.find(item.getActionId());
 		if (it != actionIdMap.end()) {
 			std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 			if (!moveEventList.empty()) {
@@ -362,7 +227,7 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType) {
 		}
 	}
 
-	it = itemIdMap.find(item->getID());
+	it = itemIdMap.find(item.getID());
 	if (it != itemIdMap.end()) {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 		if (!moveEventList.empty()) {
@@ -372,26 +237,26 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType) {
 	return nullptr;
 }
 
-void MoveEvents::addEvent(MoveEvent moveEvent, const Position& pos, MovePosListMap& map) {
-	auto it = map.find(pos);
-	if (it == map.end()) {
+void MoveEvents::registerEvent(MoveEvent& moveEvent, const Position& position, MovePosListMap& moveListMap) {
+	auto it = moveListMap.find(position);
+	if (it == moveListMap.end()) {
 		MoveEventList moveEventList;
 		moveEventList.moveEvent[moveEvent.getEventType()].push_back(std::move(moveEvent));
-		map[pos] = moveEventList;
+		moveListMap[position] = moveEventList;
 	} else {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[moveEvent.getEventType()];
 		if (!moveEventList.empty()) {
-			SPDLOG_WARN("[MoveEvents::addEvent] - "
-						"Duplicate move event found: {}", pos.toString());
+			SPDLOG_WARN("[MoveEvents::registerEvent] - "
+						"Duplicate move event found: {}", position.toString());
 		}
 
 		moveEventList.push_back(std::move(moveEvent));
 	}
 }
 
-MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType) {
-	auto it = positionMap.find(tile->getPosition());
-	if (it != positionMap.end()) {
+MoveEvent* MoveEvents::getEvent(Tile& tile, MoveEvent_t eventType) {
+	auto it = positionsMap.find(tile.getPosition());
+	if (it != positionsMap.end()) {
 		std::list<MoveEvent>& moveEventList = it->second.moveEvent[eventType];
 		if (!moveEventList.empty()) {
 			return &(*moveEventList.begin());
@@ -400,18 +265,18 @@ MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType) {
 	return nullptr;
 }
 
-uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEvent_t eventType) {
-	const Position& pos = tile->getPosition();
+uint32_t MoveEvents::onCreatureMove(Creature& creature, Tile& tile, MoveEvent_t eventType) {
+	const Position& pos = tile.getPosition();
 
 	uint32_t ret = 1;
 
 	MoveEvent* moveEvent = getEvent(tile, eventType);
 	if (moveEvent) {
-		ret &= moveEvent->fireStepEvent(creature, nullptr, pos);
+		ret &= moveEvent->fireStepEvent(creature, pos);
 	}
 
-	for (size_t i = tile->getFirstIndex(), j = tile->getLastIndex(); i < j; ++i) {
-		Thing* thing = tile->getThing(i);
+	for (size_t i = tile.getFirstIndex(), j = tile.getLastIndex(); i < j; ++i) {
+		Thing* thing = tile.getThing(i);
 		if (!thing) {
 			continue;
 		}
@@ -421,23 +286,24 @@ uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEv
 			continue;
 		}
 
-		moveEvent = getEvent(tileItem, eventType);
+		moveEvent = getEvent(*tileItem, eventType);
 		if (moveEvent) {
-			ret &= moveEvent->fireStepEvent(creature, tileItem, pos);
+			ret &= moveEvent->fireStepEvent(creature, *tileItem, pos);
 		}
 	}
 	return ret;
 }
 
-uint32_t MoveEvents::onPlayerEquip(Player* player, Item* item, Slots_t slot, bool isCheck) {
+uint32_t MoveEvents::onPlayerEquip(Player& player, Item& item, Slots_t slot, bool isCheck) {
 	MoveEvent* moveEvent = getEvent(item, MOVE_EVENT_EQUIP, slot);
 	if (!moveEvent) {
 		return 1;
 	}
+
 	return moveEvent->fireEquip(player, item, slot, isCheck);
 }
 
-uint32_t MoveEvents::onPlayerDeEquip(Player* player, Item* item, Slots_t slot) {
+uint32_t MoveEvents::onPlayerDeEquip(Player& player, Item& item, Slots_t slot) {
 	MoveEvent* moveEvent = getEvent(item, MOVE_EVENT_DEEQUIP, slot);
 	if (!moveEvent) {
 		return 1;
@@ -445,7 +311,7 @@ uint32_t MoveEvents::onPlayerDeEquip(Player* player, Item* item, Slots_t slot) {
 	return moveEvent->fireEquip(player, item, slot, false);
 }
 
-uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd) {
+uint32_t MoveEvents::onItemMove(Item& item, Tile& tile, bool isAdd) {
 	MoveEvent_t eventType1, eventType2;
 	if (isAdd) {
 		eventType1 = MOVE_EVENT_ADD_ITEM;
@@ -458,28 +324,30 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd) {
 	uint32_t ret = 1;
 	MoveEvent* moveEvent = getEvent(tile, eventType1);
 	if (moveEvent) {
-		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
+		// No tile item
+		ret &= moveEvent->fireAddRemItem(item, tile.getPosition());
 	}
 
 	moveEvent = getEvent(item, eventType1);
 	if (moveEvent) {
-		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
+		// No tile item
+		ret &= moveEvent->fireAddRemItem(item, tile.getPosition());
 	}
 
-	for (size_t i = tile->getFirstIndex(), j = tile->getLastIndex(); i < j; ++i) {
-		Thing* thing = tile->getThing(i);
+	for (size_t i = tile.getFirstIndex(), j = tile.getLastIndex(); i < j; ++i) {
+		Thing* thing = tile.getThing(i);
 		if (!thing) {
 			continue;
 		}
 
 		Item* tileItem = thing->getItem();
-		if (!tileItem || tileItem == item) {
+		if (!tileItem) {
 			continue;
 		}
 
-		moveEvent = getEvent(tileItem, eventType2);
+		moveEvent = getEvent(*tileItem, eventType2);
 		if (moveEvent) {
-			ret &= moveEvent->fireAddRemItem(item, tileItem, tile->getPosition());
+			ret &= moveEvent->fireAddRemItem(item, *tileItem, tile.getPosition());
 		}
 	}
 	return ret;
@@ -487,146 +355,20 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd) {
 
 MoveEvent::MoveEvent(LuaScriptInterface* interface) : Event(interface) {}
 
-std::string MoveEvent::getScriptEventName() const {
-	switch (eventType) {
-		case MOVE_EVENT_STEP_IN: return "onStepIn";
-		case MOVE_EVENT_STEP_OUT: return "onStepOut";
-		case MOVE_EVENT_EQUIP: return "onEquip";
-		case MOVE_EVENT_DEEQUIP: return "onDeEquip";
-		case MOVE_EVENT_ADD_ITEM: return "onAddItem";
-		case MOVE_EVENT_REMOVE_ITEM: return "onRemoveItem";
-		default:
-			SPDLOG_ERROR("[MoveEvent::getScriptEventName] - Invalid event type");
-			return std::string();
-	}
-}
-
-bool MoveEvent::configureEvent(const pugi::xml_node& node) {
-	pugi::xml_attribute eventAttr = node.attribute("event");
-	if (!eventAttr) {
-		SPDLOG_ERROR("[MoveEvent::configureMoveEvent] - Missing event");
-		return false;
-	}
-
-	std::string tmpStr = asLowerCaseString(eventAttr.as_string());
-	if (tmpStr == "stepin") {
-		eventType = MOVE_EVENT_STEP_IN;
-	} else if (tmpStr == "stepout") {
-		eventType = MOVE_EVENT_STEP_OUT;
-	} else if (tmpStr == "equip") {
-		eventType = MOVE_EVENT_EQUIP;
-	} else if (tmpStr == "deequip") {
-		eventType = MOVE_EVENT_DEEQUIP;
-	} else if (tmpStr == "additem") {
-		eventType = MOVE_EVENT_ADD_ITEM;
-	} else if (tmpStr == "removeitem") {
-		eventType = MOVE_EVENT_REMOVE_ITEM;
-	} else {
-		SPDLOG_ERROR("[MoveEvent::configureMoveEvent] - "
-                    "No valid event name {}", eventAttr.as_string());
-		return false;
-	}
-
-	if (eventType == MOVE_EVENT_EQUIP || eventType == MOVE_EVENT_DEEQUIP) {
-		pugi::xml_attribute slotAttribute = node.attribute("slot");
-		if (slotAttribute) {
-			tmpStr = asLowerCaseString(slotAttribute.as_string());
-			if (tmpStr == "head") {
-				slot = SLOTP_HEAD;
-			} else if (tmpStr == "necklace") {
-				slot = SLOTP_NECKLACE;
-			} else if (tmpStr == "backpack") {
-				slot = SLOTP_BACKPACK;
-			} else if (tmpStr == "armor") {
-				slot = SLOTP_ARMOR;
-			} else if (tmpStr == "right-hand") {
-				slot = SLOTP_RIGHT;
-			} else if (tmpStr == "left-hand") {
-				slot = SLOTP_LEFT;
-			} else if (tmpStr == "hand" || tmpStr == "shield") {
-				slot = SLOTP_RIGHT | SLOTP_LEFT;
-			} else if (tmpStr == "legs") {
-				slot = SLOTP_LEGS;
-			} else if (tmpStr == "feet") {
-				slot = SLOTP_FEET;
-			} else if (tmpStr == "ring") {
-				slot = SLOTP_RING;
-			} else if (tmpStr == "ammo") {
-				slot = SLOTP_AMMO;
-			} else {
-				SPDLOG_WARN("[MoveEvent::configureMoveEvent] - "
-							"Unknown slot type: {}", slotAttribute.as_string());
-			}
-		}
-
-		wieldInfo = 0;
-
-		pugi::xml_attribute levelAttribute = node.attribute("level");
-		if (levelAttribute) {
-			reqLevel = pugi::cast<uint32_t>(levelAttribute.value());
-			if (reqLevel > 0) {
-				wieldInfo |= WIELDINFO_LEVEL;
-			}
-		}
-
-		pugi::xml_attribute magLevelAttribute = node.attribute("maglevel");
-		if (magLevelAttribute) {
-			reqMagLevel = pugi::cast<uint32_t>(magLevelAttribute.value());
-			if (reqMagLevel > 0) {
-				wieldInfo |= WIELDINFO_MAGLV;
-			}
-		}
-
-		pugi::xml_attribute premiumAttribute = node.attribute("premium");
-		if (premiumAttribute) {
-			premium = premiumAttribute.as_bool();
-			if (premium) {
-				wieldInfo |= WIELDINFO_PREMIUM;
-			}
-		}
-
-		//Gather vocation information
-		std::list<std::string> vocStringList;
-		for (auto vocationNode : node.children()) {
-			pugi::xml_attribute vocationNameAttribute = vocationNode.attribute("name");
-			if (!vocationNameAttribute) {
-				continue;
-			}
-
-			int32_t vocationId = g_vocations().getVocationId(vocationNameAttribute.as_string());
-			if (vocationId != -1) {
-				vocEquipMap[vocationId] = true;
-				if (vocationNode.attribute("showInDescription").as_bool(true)) {
-					vocStringList.push_back(asLowerCaseString(vocationNameAttribute.as_string()));
-				}
-			}
-		}
-
-		if (!vocEquipMap.empty()) {
-			wieldInfo |= WIELDINFO_VOCREQ;
-		}
-
-		for (const std::string& str : vocStringList) {
-			if (!vocationString.empty()) {
-				if (str != vocStringList.back()) {
-					vocationString.push_back(',');
-					vocationString.push_back(' ');
-				} else {
-					vocationString += " and ";
-				}
-			}
-
-			vocationString += str;
-			vocationString.push_back('s');
-		}
-	}
-	return true;
-}
-
 uint32_t MoveEvent::StepInField(Creature* creature, Item* item, const Position&) {
+	if (!creature) {
+		SPDLOG_ERROR("[MoveEvent::StepInField] - Creature is nullptr");
+		return 0;
+	}
+
+	if (!item) {
+		SPDLOG_ERROR("[MoveEvent::StepInField] - Item is nullptr");
+		return 0;
+	}
+
 	MagicField* field = item->getMagicField();
 	if (field) {
-		field->onStepInField(creature);
+		field->onStepInField(*creature);
 		return 1;
 	}
 
@@ -638,11 +380,18 @@ uint32_t MoveEvent::StepOutField(Creature*, Item*, const Position&) {
 }
 
 uint32_t MoveEvent::AddItemField(Item* item, Item*, const Position&) {
-	if (MagicField* field = item->getMagicField()) {
-		Tile* tile = item->getTile();
-		if (CreatureVector* creatures = tile->getCreatures()) {
+	if (!item) {
+		SPDLOG_ERROR("[MoveEvent::AddItemField] - Item is nullptr");
+		return 0;
+	}
+
+	if (MagicField* field = item->getMagicField())
+	{
+		if (Tile* tile = item->getTile();
+		CreatureVector* creatures = tile->getCreatures())
+		{
 			for (Creature* creature : *creatures) {
-				field->onStepInField(creature);
+				field->onStepInField(*creature);
 			}
 		}
 		return 1;
@@ -655,6 +404,16 @@ uint32_t MoveEvent::RemoveItemField(Item*, Item*, const Position&) {
 }
 
 uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, Slots_t slot, bool isCheck) {
+	if (!player) {
+		SPDLOG_ERROR("[MoveEvent::EquipItem] - Creature is nullptr");
+		return 0;
+	}
+
+	if (!item) {
+		SPDLOG_ERROR("[MoveEvent::EquipItem] - Item is nullptr");
+		return 0;
+	}
+
 	if (player->isItemAbilityEnabled(slot)) {
 		return 1;
 	}
@@ -668,7 +427,7 @@ uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, 
 			return 0;
 		}
 
-		const VocEquipMap& vocEquipMap = moveEvent->getVocEquipMap();
+		const std::map<uint16_t, bool>& vocEquipMap = moveEvent->getVocEquipMap();
 		if (!vocEquipMap.empty() && vocEquipMap.find(player->getVocationId()) == vocEquipMap.end()) {
 			return 0;
 		}
@@ -710,7 +469,7 @@ uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, 
 	}
 
 	if (it.abilities->speed != 0) {
-		g_game().changeSpeed(player, it.abilities->speed);
+		g_game().changePlayerSpeed(*player, it.abilities->speed);
 	}
 
 	if (it.abilities->conditionSuppressions != 0) {
@@ -771,6 +530,16 @@ uint32_t MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, 
 }
 
 uint32_t MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, Slots_t slot, bool) {
+	if (!player) {
+		SPDLOG_ERROR("[MoveEvent::EquipItem] - Creature is nullptr");
+		return 0;
+	}
+
+	if (!item) {
+		SPDLOG_ERROR("[MoveEvent::EquipItem] - Item is nullptr");
+		return 0;
+	}
+
 	if (!player->isItemAbilityEnabled(slot)) {
 		return 1;
 	}
@@ -805,7 +574,7 @@ uint32_t MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, Slots_t 
 	}
 
 	if (it.abilities->speed != 0) {
-		g_game().changeSpeed(player, -it.abilities->speed);
+		g_game().changePlayerSpeed(*player, -it.abilities->speed);
 	}
 
 	if (it.abilities->conditionSuppressions != 0) {
@@ -847,35 +616,6 @@ uint32_t MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, Slots_t 
 	return 1;
 }
 
-// TODO (EDUARDO): Move this functions for revscriptsys interface
-bool MoveEvent::loadFunction(const pugi::xml_attribute& attr, bool isScripted) {
-	const char* functionName = attr.as_string();
-	if (strcasecmp(functionName, "onstepinfield") == 0) {
-		stepFunction = StepInField;
-	} else if (strcasecmp(functionName, "onstepoutfield") == 0) {
-		stepFunction = StepOutField;
-	} else if (strcasecmp(functionName, "onaddfield") == 0) {
-		moveFunction = AddItemField;
-	} else if (strcasecmp(functionName, "onremovefield") == 0) {
-		moveFunction = RemoveItemField;
-	} else if (strcasecmp(functionName, "onequipitem") == 0) {
-		equipFunction = EquipItem;
-	} else if (strcasecmp(functionName, "ondeequipitem") == 0) {
-		equipFunction = DeEquipItem;
-	} else {
-		if (!isScripted) {
-			SPDLOG_WARN("[MoveEvent::loadFunction] - "
-						"Function {} does not exist", functionName);
-			return false;
-		}
-	}
-
-	if (!isScripted) {
-		scripted = false;
-	}
-	return true;
-}
-
 MoveEvent_t MoveEvent::getEventType() const {
 	return eventType;
 }
@@ -884,21 +624,21 @@ void MoveEvent::setEventType(MoveEvent_t type) {
 	eventType = type;
 }
 
-uint32_t MoveEvent::fireStepEvent(Creature* creature, Item* item, const Position& pos) {
-	if (scripted) {
+uint32_t MoveEvent::fireStepEvent(Creature& creature, Item& item, const Position& pos) {
+	if (isScripted()) {
 		return executeStep(creature, item, pos);
 	} else {
-		return stepFunction(creature, item, pos);
+		return stepFunction(&creature, &item, pos);
 	}
 }
 
-bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos) {
+bool MoveEvent::executeStep(Creature& creature, Item& item, const Position& pos) {
 	//onStepIn(creature, item, pos, fromPosition)
 	//onStepOut(creature, item, pos, fromPosition)
 	if (!scriptInterface->reserveScriptEnv()) {
 		SPDLOG_ERROR("[MoveEvent::executeStep - Creature {} item {}] "
                     "Call stack overflow. Too many lua script calls being nested.",
-                    creature->getName(), item->getName());
+                    creature.getName(), item.getName());
 		return false;
 	}
 
@@ -908,35 +648,67 @@ bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(scriptId);
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
-	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
-	LuaScriptInterface::pushThing(L, item);
+	LuaScriptInterface::pushUserdata<Creature>(L, &creature);
+	LuaScriptInterface::setCreatureMetatable(L, -1, &creature);
+	LuaScriptInterface::pushThing(L, &item);
 	LuaScriptInterface::pushPosition(L, pos);
-	LuaScriptInterface::pushPosition(L, creature->getLastPosition());
+	LuaScriptInterface::pushPosition(L, creature.getLastPosition());
 
 	return scriptInterface->callFunction(4);
 }
 
-uint32_t MoveEvent::fireEquip(Player* player, Item* item, Slots_t toSlot, bool isCheck) {
-	if (scripted) {
-		if (!equipFunction || equipFunction(this, player, item, toSlot, isCheck) == 1) {
+uint32_t MoveEvent::fireStepEvent(Creature& creature, const Position& pos) {
+	if (isScripted()) {
+		return executeStep(creature, pos);
+	} else {
+		return stepFunction(&creature, nullptr, pos);
+	}
+}
+
+bool MoveEvent::executeStep(Creature& creature, const Position& pos) {
+	//onStepIn(creature, pos, fromPosition)
+	//onStepOut(creature, pos, fromPosition)
+	if (!scriptInterface->reserveScriptEnv()) {
+		SPDLOG_ERROR("[MoveEvent::executeStep - Creature {}] "
+                    "Call stack overflow. Too many lua script calls being nested.",
+                    creature.getName());
+		return false;
+	}
+
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
+
+	lua_State* L = scriptInterface->getLuaState();
+
+	scriptInterface->pushFunction(scriptId);
+	LuaScriptInterface::pushUserdata<Creature>(L, &creature);
+	LuaScriptInterface::setCreatureMetatable(L, -1, &creature);
+	LuaScriptInterface::pushPosition(L, pos);
+	LuaScriptInterface::pushPosition(L, creature.getLastPosition());
+
+	return scriptInterface->callFunction(3);
+}
+
+uint32_t MoveEvent::fireEquip(Player& player, Item& item, Slots_t toSlot, bool isCheck) {
+	if (isScripted()) {
+		if (!equipFunction || equipFunction(this, &player, &item, toSlot, isCheck) == 1) {
 			if (executeEquip(player, item, toSlot, isCheck)) {
 				return 1;
 			}
 		}
 		return 0;
 	} else {
-		return equipFunction(this, player, item, toSlot, isCheck);
+		return equipFunction(this, &player, &item, toSlot, isCheck);
 	}
 }
 
-bool MoveEvent::executeEquip(Player* player, Item* item, Slots_t onSlot, bool isCheck) {
+bool MoveEvent::executeEquip(Player& player, Item& item, Slots_t onSlot, bool isCheck) {
 	//onEquip(player, item, slot, isCheck)
 	//onDeEquip(player, item, slot, isCheck)
 	if (!scriptInterface->reserveScriptEnv()) {
 		SPDLOG_ERROR("[MoveEvent::executeEquip - Player {} item {}] "
                     "Call stack overflow. Too many lua script calls being nested.",
-                    player->getName(), item->getName());
+                    player.getName(), item.getName());
 		return false;
 	}
 
@@ -946,31 +718,31 @@ bool MoveEvent::executeEquip(Player* player, Item* item, Slots_t onSlot, bool is
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(scriptId);
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushUserdata<Player>(L, &player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
-	LuaScriptInterface::pushThing(L, item);
+	LuaScriptInterface::pushThing(L, &item);
 	lua_pushnumber(L, onSlot);
 	LuaScriptInterface::pushBoolean(L, isCheck);
 
 	return scriptInterface->callFunction(4);
 }
 
-uint32_t MoveEvent::fireAddRemItem(Item* item, Item* fromTile, const Position& pos) {
-	if (scripted) {
+uint32_t MoveEvent::fireAddRemItem(Item& item, Item& fromTile, const Position& pos) {
+	if (isScripted()) {
 		return executeAddRemItem(item, fromTile, pos);
 	} else {
-		return moveFunction(item, fromTile, pos);
+		return moveFunction(&item, &fromTile, pos);
 	}
 }
 
-bool MoveEvent::executeAddRemItem(Item* item, Item* fromTile, const Position& pos) {
-	//onaddItem(moveitem, tileitem, pos)
+bool MoveEvent::executeAddRemItem(Item& item, Item& fromTile, const Position& pos) {
+	//onAddItem(moveitem, tileitem, pos)
 	//onRemoveItem(moveitem, tileitem, pos)
 	if (!scriptInterface->reserveScriptEnv()) {
 		SPDLOG_ERROR("[MoveEvent::executeAddRemItem - "
                     "Item {} item on tile x: {} y: {} z: {}] "
                     "Call stack overflow. Too many lua script calls being nested.",
-                    item->getName(),
+                    item.getName(),
                     pos.getX(), pos.getY(), pos.getZ());
 		return false;
 	}
@@ -981,9 +753,41 @@ bool MoveEvent::executeAddRemItem(Item* item, Item* fromTile, const Position& po
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(scriptId);
-	LuaScriptInterface::pushThing(L, item);
-	LuaScriptInterface::pushThing(L, fromTile);
+	LuaScriptInterface::pushThing(L, &item);
+	LuaScriptInterface::pushThing(L, &fromTile);
 	LuaScriptInterface::pushPosition(L, pos);
 
 	return scriptInterface->callFunction(3);
+}
+
+uint32_t MoveEvent::fireAddRemItem(Item& item, const Position& pos) {
+	if (isScripted()) {
+		return executeAddRemItem(item, pos);
+	} else {
+		return moveFunction(&item, nullptr, pos);
+	}
+}
+
+bool MoveEvent::executeAddRemItem(Item& item, const Position& pos) {
+	//onaddItem(moveitem, pos)
+	//onRemoveItem(moveitem, pos)
+	if (!scriptInterface->reserveScriptEnv()) {
+		SPDLOG_ERROR("[MoveEvent::executeAddRemItem - "
+                    "Item {} item on tile x: {} y: {} z: {}] "
+                    "Call stack overflow. Too many lua script calls being nested.",
+                    item.getName(),
+                    pos.getX(), pos.getY(), pos.getZ());
+		return false;
+	}
+
+	ScriptEnvironment* env = scriptInterface->getScriptEnv();
+	env->setScriptId(scriptId, scriptInterface);
+
+	lua_State* L = scriptInterface->getLuaState();
+
+	scriptInterface->pushFunction(scriptId);
+	LuaScriptInterface::pushThing(L, &item);
+	LuaScriptInterface::pushPosition(L, pos);
+
+	return scriptInterface->callFunction(2);
 }

--- a/src/lua/creature/movement.h
+++ b/src/lua/creature/movement.h
@@ -26,20 +26,16 @@
 #include "lua/functions/events/move_event_functions.hpp"
 #include "creatures/players/vocations/vocation.h"
 
-
 class MoveEvent;
-using MoveEvent_ptr = std::unique_ptr<MoveEvent>;
 
 struct MoveEventList {
 	std::list<MoveEvent> moveEvent[MOVE_EVENT_LAST];
 };
 
-using VocEquipMap = std::map<uint16_t, bool>;
-
 class MoveEvents final : public BaseEvents {
 	public:
-		MoveEvents();
-		~MoveEvents();
+		MoveEvents() = default;
+		~MoveEvents() = default;
 
 		// non-copyable
 		MoveEvents(const MoveEvents&) = delete;
@@ -52,18 +48,92 @@ class MoveEvents final : public BaseEvents {
 			return instance;
 		}
 
-		uint32_t onCreatureMove(Creature* creature, const Tile* tile, MoveEvent_t eventType);
-		uint32_t onPlayerEquip(Player* player, Item* item, Slots_t slot, bool isCheck);
-		uint32_t onPlayerDeEquip(Player* player, Item* item, Slots_t slot);
-		uint32_t onItemMove(Item* item, Tile* tile, bool isAdd);
+		uint32_t onCreatureMove(Creature& creature, Tile& tile, MoveEvent_t eventType);
+		uint32_t onPlayerEquip(Player& player, Item& item, Slots_t slot, bool isCheck);
+		uint32_t onPlayerDeEquip(Player& player, Item& item, Slots_t slot);
+		uint32_t onItemMove(Item& item, Tile& tile, bool isAdd);
 
-		MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
+		void clear(bool fromLua) override final {
+			fromLua = false;
+		}
 
-		bool isRegistered(uint32_t itemid);
+		std::map<Position, MoveEventList> getPositionsMap() const {
+			return positionsMap;
+		}
 
-		bool registerLuaEvent(MoveEvent* event);
-		bool registerLuaFunction(MoveEvent* event);
-		void clear(bool fromLua) override final;
+		bool hasPosition(Position position) const {
+			if (auto it = positionsMap.find(position);
+			it != positionsMap.end())
+			{
+				return true;
+			}
+			return false;
+		}
+
+		void setPosition(Position position, MoveEventList moveEventList) {
+			positionsMap.try_emplace(position, moveEventList);
+		}
+
+		std::map<int32_t, MoveEventList> getItemIdMap() const {
+			return itemIdMap;
+		}
+
+		bool hasItemId(int32_t itemId) const {
+			if (auto it = itemIdMap.find(itemId);
+			it != itemIdMap.end())
+			{
+				return true;
+			}
+			return false;
+		}
+
+		void setItemId(int32_t itemId, MoveEventList moveEventList) {
+			itemIdMap.try_emplace(itemId, moveEventList);
+		}
+
+		std::map<int32_t, MoveEventList> getUniqueIdMap() const {
+			return uniqueIdMap;
+		}
+
+		bool hasUniqueId(int32_t uniqueId) const {
+			if (auto it = uniqueIdMap.find(uniqueId);
+			it != uniqueIdMap.end())
+			{
+				return true;
+			}
+			return false;
+		}
+
+		void setUniqueId(int32_t uniqueId, MoveEventList moveEventList) {
+			uniqueIdMap.try_emplace(uniqueId, moveEventList);
+		}
+
+		std::map<int32_t, MoveEventList> getActionIdMap() const {
+			return actionIdMap;
+		}
+
+		bool hasActionId(int32_t actionId) const {
+			if (auto it = actionIdMap.find(actionId);
+			it != actionIdMap.end())
+			{
+				return true;
+			}
+			return false;
+		}
+
+		void setActionId(int32_t actionId, MoveEventList moveEventList) {
+			actionIdMap.try_emplace(actionId, moveEventList);
+		}
+
+		MoveEvent* getEvent(Item& item, MoveEvent_t eventType);
+
+		bool registerLuaFunction(MoveEvent& moveEvent);
+		bool registerLuaItemEvent(MoveEvent& moveEvent);
+		bool registerLuaActionEvent(MoveEvent& moveEvent);
+		bool registerLuaUniqueEvent(MoveEvent& moveEvent);
+		bool registerLuaPositionEvent(MoveEvent& moveEvent);
+		bool registerLuaEvent(MoveEvent& event);
+		void clear();
 
 	private:
 		using MoveListMap = std::map<int32_t, MoveEventList>;
@@ -71,24 +141,29 @@ class MoveEvents final : public BaseEvents {
 		void clearMap(MoveListMap& map, bool fromLua);
 		void clearPosMap(MovePosListMap& map, bool fromLua);
 
-		LuaScriptInterface& getScriptInterface() override;
-		std::string getScriptBaseName() const override;
+		LuaScriptInterface& getScriptInterface() override {
+			return scriptInterface;
+		}
+		std::string getScriptBaseName() const override {
+			return "";
+		}
 		Event_ptr getEvent(const std::string& nodeName) override;
-		bool registerEvent(Event_ptr event, const pugi::xml_node& node) override;
+		bool registerEvent([[maybe_unused]] Event_ptr event, [[maybe_unused]] const pugi::xml_node& node) override {
+			return false;
+		}
 
-		void addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map);
+		void registerEvent(MoveEvent& moveEvent, int32_t id, MoveListMap& moveListMap);
+		void registerEvent(MoveEvent& moveEvent, const Position& position, MovePosListMap& moveListMap);
+		MoveEvent* getEvent(Tile& tile, MoveEvent_t eventType);
 
-		void addEvent(MoveEvent moveEvent, const Position& pos, MovePosListMap& map);
-		MoveEvent* getEvent(const Tile* tile, MoveEvent_t eventType);
-
-		MoveEvent* getEvent(Item* item, MoveEvent_t eventType, Slots_t slot);
+		MoveEvent* getEvent(Item& item, MoveEvent_t eventType, Slots_t slot);
 
 		MoveListMap uniqueIdMap;
 		MoveListMap actionIdMap;
 		MoveListMap itemIdMap;
-		MovePosListMap positionMap;
+		MovePosListMap positionsMap;
 
-		LuaScriptInterface scriptInterface;
+		LuaScriptInterface scriptInterface {"MoveEvent interface"};
 };
 
 constexpr auto g_moveEvents = &MoveEvents::getInstance;
@@ -104,21 +179,32 @@ class MoveEvent final : public Event {
 		MoveEvent_t getEventType() const;
 		void setEventType(MoveEvent_t type);
 
-		bool configureEvent(const pugi::xml_node& node) override;
-		bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override;
+		bool configureEvent([[maybe_unused]] const pugi::xml_node& node) override {
+			return false;
+		}
+		bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override {
+			return Event::loadFunction(attr, isScripted);
+		}
 
-		uint32_t fireStepEvent(Creature* creature, Item* item, const Position& pos);
-		uint32_t fireAddRemItem(Item* item, Item* tileItem, const Position& pos);
-		uint32_t fireEquip(Player* player, Item* item, Slots_t slot, bool isCheck);
+		uint32_t fireStepEvent(Creature& creature, Item& item, const Position& pos);
+		// No have item
+		uint32_t fireStepEvent(Creature& creature, const Position& pos);
+		uint32_t fireAddRemItem(Item& item, Item& tileItem, const Position& pos);
+		uint32_t fireAddRemItem(Item& item, const Position& pos);
+		uint32_t fireEquip(Player& player, Item& item, Slots_t slot, bool isCheck);
 
 		uint32_t getSlot() const {
 			return slot;
 		}
 
-		//scripting
-		bool executeStep(Creature* creature, Item* item, const Position& pos);
-		bool executeEquip(Player* player, Item* item, Slots_t slot, bool isCheck);
-		bool executeAddRemItem(Item* item, Item* tileItem, const Position& pos);
+		// Scripting to lua interface
+		bool executeStep(Creature& creature, Item& item, const Position& pos);
+		// No have item
+		bool executeStep(Creature& creature, const Position& pos);
+		bool executeEquip(Player& player, Item& item, Slots_t slot, bool isCheck);
+		bool executeAddRemItem(Item& item, Item& tileItem, const Position& pos);
+		// No have tile item
+		bool executeAddRemItem(Item& item, const Position& pos);
 		//
 
 		//onEquip information
@@ -140,7 +226,7 @@ class MoveEvent final : public Event {
 		uint32_t getWieldInfo() const {
 			return wieldInfo;
 		}
-		const VocEquipMap& getVocEquipMap() const {
+		const std::map<uint16_t, bool>& getVocEquipMap() const {
 			return vocEquipMap;
 		}
 		void addVocEquipMap(std::string vocName) {
@@ -155,29 +241,29 @@ class MoveEvent final : public Event {
 		void setTileItem(bool b) {
 			tileItem = b;
 		}
-		std::vector<uint32_t> getItemIdRange() {
-			return itemIdRange;
+		std::vector<uint32_t> getItemIdsVector() {
+			return itemIdVector;
 		}
-		void addItemId(uint32_t id) {
-			itemIdRange.emplace_back(id);
+		void setItemId(uint32_t id) {
+			itemIdVector.emplace_back(id);
 		}
-		std::vector<uint32_t> getActionIdRange() {
-			return actionIdRange;
+		std::vector<uint32_t> getActionIdsVector() {
+			return actionIdVector;
 		}
-		void addActionId(uint32_t id) {
-			actionIdRange.emplace_back(id);
+		void setActionId(uint32_t id) {
+			actionIdVector.emplace_back(id);
 		}
-		std::vector<uint32_t> getUniqueIdRange() {
-			return uniqueIdRange;
+		std::vector<uint32_t> getUniqueIdsVector() {
+			return uniqueIdVector;
 		}
-		void addUniqueId(uint32_t id) {
-			uniqueIdRange.emplace_back(id);
+		void setUniqueId(uint32_t id) {
+			uniqueIdVector.emplace_back(id);
 		}
-		std::vector<Position> getPosList() {
-			return posList;
+		std::vector<Position> getPositionsVector() {
+			return positionVector;
 		}
-		void addPosList(Position pos) {
-			posList.emplace_back(pos);
+		void setPosition(Position pos) {
+			positionVector.emplace_back(pos);
 		}
 		void setSlot(uint32_t s) {
 			slot = s;
@@ -222,7 +308,9 @@ class MoveEvent final : public Event {
 		EquipFunction equipFunction;
 
 	private:
-		std::string getScriptEventName() const override;
+		std::string getScriptEventName() const override {
+			return "";
+		}
 
 		uint32_t slot = SLOTP_WHEREEVER;
 
@@ -232,13 +320,13 @@ class MoveEvent final : public Event {
 		bool premium = false;
 		std::string vocationString;
 		uint32_t wieldInfo = 0;
-		VocEquipMap vocEquipMap;
+		std::map<uint16_t, bool> vocEquipMap;
 		bool tileItem = false;
 
-		std::vector<uint32_t> itemIdRange;
-		std::vector<uint32_t> actionIdRange;
-		std::vector<uint32_t> uniqueIdRange;
-		std::vector<Position> posList;
+		std::vector<uint32_t> itemIdVector;
+		std::vector<uint32_t> actionIdVector;
+		std::vector<uint32_t> uniqueIdVector;
+		std::vector<Position> positionVector;
 };
 
 #endif  // SRC_LUA_CREATURE_MOVEMENT_H_

--- a/src/lua/creature/movement.h
+++ b/src/lua/creature/movement.h
@@ -35,7 +35,7 @@ struct MoveEventList {
 class MoveEvents final : public BaseEvents {
 	public:
 		MoveEvents() = default;
-		~MoveEvents() = default;
+		~MoveEvents() override = default;
 
 		// non-copyable
 		MoveEvents(const MoveEvents&) = delete;
@@ -53,7 +53,7 @@ class MoveEvents final : public BaseEvents {
 		uint32_t onPlayerDeEquip(Player& player, Item& item, Slots_t slot);
 		uint32_t onItemMove(Item& item, Tile& tile, bool isAdd);
 
-		void clear(bool fromLua) override final {
+		void clear(bool fromLua) override {
 			fromLua = false;
 		}
 
@@ -127,7 +127,6 @@ class MoveEvents final : public BaseEvents {
 
 		MoveEvent* getEvent(Item& item, MoveEvent_t eventType);
 
-		bool registerLuaFunction(MoveEvent& moveEvent);
 		bool registerLuaItemEvent(MoveEvent& moveEvent);
 		bool registerLuaActionEvent(MoveEvent& moveEvent);
 		bool registerLuaUniqueEvent(MoveEvent& moveEvent);
@@ -150,8 +149,8 @@ class MoveEvents final : public BaseEvents {
 			return false;
 		}
 
-		void registerEvent(MoveEvent& moveEvent, int32_t id, std::map<int32_t, MoveEventList>& moveListMap);
-		void registerEvent(MoveEvent& moveEvent, const Position& position, std::map<Position, MoveEventList>& moveListMap);
+		void registerEvent(MoveEvent& moveEvent, int32_t id, std::map<int32_t, MoveEventList>& moveListMap) const;
+		void registerEvent(MoveEvent& moveEvent, const Position& position, std::map<Position, MoveEventList>& moveListMap) const;
 		MoveEvent* getEvent(Tile& tile, MoveEvent_t eventType);
 
 		MoveEvent* getEvent(Item& item, MoveEvent_t eventType, Slots_t slot);
@@ -175,9 +174,6 @@ class MoveEvent final : public Event {
 
 		bool configureEvent([[maybe_unused]] const pugi::xml_node& node) override {
 			return false;
-		}
-		bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override {
-			return Event::loadFunction(attr, isScripted);
 		}
 
 		uint32_t fireStepEvent(Creature& creature, Item& item, const Position& pos);
@@ -235,25 +231,25 @@ class MoveEvent final : public Event {
 		void setTileItem(bool b) {
 			tileItem = b;
 		}
-		std::vector<uint32_t> getItemIdsVector() {
+		std::vector<uint32_t> getItemIdsVector() const {
 			return itemIdVector;
 		}
 		void setItemId(uint32_t id) {
 			itemIdVector.emplace_back(id);
 		}
-		std::vector<uint32_t> getActionIdsVector() {
+		std::vector<uint32_t> getActionIdsVector() const {
 			return actionIdVector;
 		}
 		void setActionId(uint32_t id) {
 			actionIdVector.emplace_back(id);
 		}
-		std::vector<uint32_t> getUniqueIdsVector() {
+		std::vector<uint32_t> getUniqueIdsVector() const {
 			return uniqueIdVector;
 		}
 		void setUniqueId(uint32_t id) {
 			uniqueIdVector.emplace_back(id);
 		}
-		std::vector<Position> getPositionsVector() {
+		std::vector<Position> getPositionsVector() const {
 			return positionVector;
 		}
 		void setPosition(Position pos) {

--- a/src/lua/creature/movement.h
+++ b/src/lua/creature/movement.h
@@ -136,10 +136,8 @@ class MoveEvents final : public BaseEvents {
 		void clear();
 
 	private:
-		using MoveListMap = std::map<int32_t, MoveEventList>;
-		using MovePosListMap = std::map<Position, MoveEventList>;
-		void clearMap(MoveListMap& map, bool fromLua);
-		void clearPosMap(MovePosListMap& map, bool fromLua);
+		void clearMap(std::map<int32_t, MoveEventList>& map, bool fromLua);
+		void clearPosMap(std::map<Position, MoveEventList>& map, bool fromLua);
 
 		LuaScriptInterface& getScriptInterface() override {
 			return scriptInterface;
@@ -152,25 +150,21 @@ class MoveEvents final : public BaseEvents {
 			return false;
 		}
 
-		void registerEvent(MoveEvent& moveEvent, int32_t id, MoveListMap& moveListMap);
-		void registerEvent(MoveEvent& moveEvent, const Position& position, MovePosListMap& moveListMap);
+		void registerEvent(MoveEvent& moveEvent, int32_t id, std::map<int32_t, MoveEventList>& moveListMap);
+		void registerEvent(MoveEvent& moveEvent, const Position& position, std::map<Position, MoveEventList>& moveListMap);
 		MoveEvent* getEvent(Tile& tile, MoveEvent_t eventType);
 
 		MoveEvent* getEvent(Item& item, MoveEvent_t eventType, Slots_t slot);
 
-		MoveListMap uniqueIdMap;
-		MoveListMap actionIdMap;
-		MoveListMap itemIdMap;
-		MovePosListMap positionsMap;
+		std::map<int32_t, MoveEventList> uniqueIdMap;
+		std::map<int32_t, MoveEventList> actionIdMap;
+		std::map<int32_t, MoveEventList> itemIdMap;
+		std::map<Position, MoveEventList> positionsMap;
 
 		LuaScriptInterface scriptInterface {"MoveEvent interface"};
 };
 
 constexpr auto g_moveEvents = &MoveEvents::getInstance;
-
-using StepFunction = std::function<uint32_t(Creature* creature, Item* item, const Position& pos)>;
-using MoveFunction = std::function<uint32_t(Item* item, Item* tileItem, const Position& pos)>;
-using EquipFunction = std::function<uint32_t(MoveEvent* moveEvent, Player* player, Item* item, Slots_t slot, bool boolean)>;
 
 class MoveEvent final : public Event {
 	public:
@@ -303,9 +297,26 @@ class MoveEvent final : public Event {
 		static uint32_t DeEquipItem(MoveEvent* moveEvent, Player* player, Item* item, Slots_t slot, bool boolean);
 
 		MoveEvent_t eventType = MOVE_EVENT_NONE;
-		StepFunction stepFunction;
-		MoveFunction moveFunction;
-		EquipFunction equipFunction;
+		// Step function structure
+		std::function<uint32_t(
+			Creature* creature,
+			Item* item,
+			const Position& pos
+		)>stepFunction;
+		// Move function structure
+		std::function<uint32_t(
+			Item* item,
+			Item* tileItem,
+			const Position& pos
+		)> moveFunction;
+		// Equip function structure
+		std::function<uint32_t(
+			MoveEvent* moveEvent,
+			Player* player,
+			Item* item,
+			Slots_t slot,
+			bool boolean
+		)> equipFunction;
 
 	private:
 		std::string getScriptEventName() const override {

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -590,13 +590,6 @@ int GameFunctions::luaGameReload(lua_State* L) {
 	return 1;
 }
 
-int GameFunctions::luaGameItemidHasMoveevent(lua_State* L) {
-	// Game.itemidHasMoveevent(itemid)
-	uint32_t itemid = getNumber<uint32_t>(L, 1);
-	pushBoolean(L, g_game().itemidHasMoveevent(itemid));
-	return 1;
-}
-
 int GameFunctions::luaGameHasEffect(lua_State* L) {
 	// Game.hasEffect(effectId)
 	uint8_t effectId = getNumber<uint8_t>(L, 1);

--- a/src/lua/functions/core/game/game_functions.hpp
+++ b/src/lua/functions/core/game/game_functions.hpp
@@ -74,7 +74,6 @@ class GameFunctions final : LuaScriptInterface {
 
 				registerMethod(L, "Game", "reload", GameFunctions::luaGameReload);
 
-				registerMethod(L, "Game", "itemidHasMoveevent", GameFunctions::luaGameItemidHasMoveevent);
 				registerMethod(L, "Game", "hasDistanceEffect", GameFunctions::luaGameHasDistanceEffect);
 				registerMethod(L, "Game", "hasEffect", GameFunctions::luaGameHasEffect);
 				registerMethod(L, "Game", "getOfflinePlayer", GameFunctions::luaGameGetOfflinePlayer);
@@ -127,7 +126,6 @@ class GameFunctions final : LuaScriptInterface {
 			static int luaGameReload(lua_State* L);
 
 			static int luaGameGetOfflinePlayer(lua_State* L);
-			static int luaGameItemidHasMoveevent(lua_State* L);
 			static int luaGameHasEffect(lua_State* L);
 			static int luaGameHasDistanceEffect(lua_State* L);
 };

--- a/src/lua/functions/events/move_event_functions.cpp
+++ b/src/lua/functions/events/move_event_functions.cpp
@@ -77,8 +77,10 @@ int MoveEventFunctions::luaMoveEventRegister(lua_State* L) {
 	// moveevent:register()
 	MoveEvent* moveevent = getUserdata<MoveEvent>(L, 1);
 	if (moveevent) {
+		// If not scripted, register item event
+		// Example: unscripted_equipments.lua
 		if (!moveevent->isScripted()) {
-			pushBoolean(L, g_moveEvents().registerLuaFunction(*moveevent));
+			pushBoolean(L, g_moveEvents().registerLuaItemEvent(*moveevent));
 			return 1;
 		}
 

--- a/src/lua/functions/events/move_event_functions.cpp
+++ b/src/lua/functions/events/move_event_functions.cpp
@@ -78,14 +78,11 @@ int MoveEventFunctions::luaMoveEventRegister(lua_State* L) {
 	MoveEvent* moveevent = getUserdata<MoveEvent>(L, 1);
 	if (moveevent) {
 		if (!moveevent->isScripted()) {
-			pushBoolean(L, g_moveEvents().registerLuaFunction(moveevent));
+			pushBoolean(L, g_moveEvents().registerLuaFunction(*moveevent));
 			return 1;
 		}
-		pushBoolean(L, g_moveEvents().registerLuaEvent(moveevent));
-		moveevent->getItemIdRange().clear();
-		moveevent->getActionIdRange().clear();
-		moveevent->getUniqueIdRange().clear();
-		moveevent->getPosList().clear();
+
+		pushBoolean(L, g_moveEvents().registerLuaEvent(*moveevent));
 	} else {
 		lua_pushnil(L);
 	}
@@ -100,6 +97,7 @@ int MoveEventFunctions::luaMoveEventOnCallback(lua_State* L) {
 			pushBoolean(L, false);
 			return 1;
 		}
+
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);
@@ -236,10 +234,10 @@ int MoveEventFunctions::luaMoveEventItemId(lua_State* L) {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addItemId(getNumber<uint32_t>(L, 2 + i));
+				moveevent->setItemId(getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addItemId(getNumber<uint32_t>(L, 2));
+			moveevent->setItemId(getNumber<uint32_t>(L, 2));
 		}
 		pushBoolean(L, true);
 	} else {
@@ -255,10 +253,10 @@ int MoveEventFunctions::luaMoveEventActionId(lua_State* L) {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addActionId(getNumber<uint32_t>(L, 2 + i));
+				moveevent->setActionId(getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addActionId(getNumber<uint32_t>(L, 2));
+			moveevent->setActionId(getNumber<uint32_t>(L, 2));
 		}
 		pushBoolean(L, true);
 	} else {
@@ -274,10 +272,10 @@ int MoveEventFunctions::luaMoveEventUniqueId(lua_State* L) {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addUniqueId(getNumber<uint32_t>(L, 2 + i));
+				moveevent->setUniqueId(getNumber<uint32_t>(L, 2 + i));
 			}
 		} else {
-			moveevent->addUniqueId(getNumber<uint32_t>(L, 2));
+			moveevent->setUniqueId(getNumber<uint32_t>(L, 2));
 		}
 	pushBoolean(L, true);
 	} else {
@@ -293,10 +291,10 @@ int MoveEventFunctions::luaMoveEventPosition(lua_State* L) {
 		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
 			for (int i = 0; i < parameters; ++i) {
-				moveevent->addPosList(getPosition(L, 2 + i));
+				moveevent->setPosition(getPosition(L, 2 + i));
 			}
 		} else {
-			moveevent->addPosList(getPosition(L, 2));
+			moveevent->setPosition(getPosition(L, 2));
 		}
 		pushBoolean(L, true);
 	} else {

--- a/src/lua/global/baseevents.h
+++ b/src/lua/global/baseevents.h
@@ -167,6 +167,8 @@ class BaseEvents {
 		virtual void clear(bool) = 0;
 
 		bool loaded = false;
+
+		friend class MoveEvents;
 };
 
 /**


### PR DESCRIPTION
Movements completely redone to remove a memory leak related to the registration of movements, in the luaMoveEventRegister function, where the memory was fread and then used. We also added some pointer sanity checks, preventing future crashes and fixing some known ones.

* Removed old XML load
* Passed some objects as a reference, to avoid nullpointer
* Added nullpointer checks in some places and the code was redone to work better
* Added some logs to help in case of errors
* Fixed crash related to replaceable magic fields

Notes: MoveEvent::onRemoveItem function from now on it will no longer have the "tileitem" argument