### PR TITLE
Fix max network message size, solving debug client on message compression

### DIFF
--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -59,16 +59,15 @@ void NetworkMessage::addString(const std::string& value)
 {
 	size_t stringLen = value.length();
 	if (value.empty()) {
-		SPDLOG_INFO("[NetworkMessage::addBytes] - Value string is empty");
+		SPDLOG_ERROR("[NetworkMessage::addBytes] - Value string is empty");
 		return;
 	}
 	if (!canAdd(stringLen + 2)) {
-		SPDLOG_INFO("[NetworkMessage::addString] - NetworkMessage size is wrong: {}", stringLen);
+		SPDLOG_ERROR("[NetworkMessage::addString] - NetworkMessage size is wrong: {}", stringLen);
 		return;
 	}
-
 	if (stringLen > NETWORKMESSAGE_MAXSIZE) {
-		SPDLOG_INFO("[NetworkMessage::addString] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, stringLen);
+		SPDLOG_ERROR("[NetworkMessage::addString] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, stringLen);
 		return;
 	}
 
@@ -87,15 +86,15 @@ void NetworkMessage::addDouble(double value, uint8_t precision/* = 2*/)
 void NetworkMessage::addBytes(const char* bytes, size_t size)
 {
 	if (bytes == nullptr) {
-		SPDLOG_INFO("[NetworkMessage::addBytes] - Bytes is nullptr");
+		SPDLOG_ERROR("[NetworkMessage::addBytes] - Bytes is nullptr");
 		return;
 	}
 	if (!canAdd(size)) {
-		SPDLOG_INFO("[NetworkMessage::addBytes] - NetworkMessage size is wrong: {}", size);
+		SPDLOG_ERROR("[NetworkMessage::addBytes] - NetworkMessage size is wrong: {}", size);
 		return;
 	}
 	if (size > NETWORKMESSAGE_MAXSIZE) {
-		SPDLOG_INFO("[NetworkMessage::addBytes] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, size);
+		SPDLOG_ERROR("[NetworkMessage::addBytes] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, size);
 		return;
 	}
 

--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -58,7 +58,17 @@ Position NetworkMessage::getPosition()
 void NetworkMessage::addString(const std::string& value)
 {
 	size_t stringLen = value.length();
-	if (!canAdd(stringLen + 2) || stringLen > 8192) {
+	if (value.empty()) {
+		SPDLOG_INFO("[NetworkMessage::addBytes] - Value string is empty");
+		return;
+	}
+	if (!canAdd(stringLen + 2)) {
+		SPDLOG_INFO("[NetworkMessage::addString] - NetworkMessage size is wrong: {}", stringLen);
+		return;
+	}
+
+	if (stringLen > NETWORKMESSAGE_MAXSIZE) {
+		SPDLOG_INFO("[NetworkMessage::addString] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, stringLen);
 		return;
 	}
 
@@ -76,7 +86,16 @@ void NetworkMessage::addDouble(double value, uint8_t precision/* = 2*/)
 
 void NetworkMessage::addBytes(const char* bytes, size_t size)
 {
-	if (!canAdd(size) || size > 8192) {
+	if (bytes == nullptr) {
+		SPDLOG_INFO("[NetworkMessage::addBytes] - Bytes is nullptr");
+		return;
+	}
+	if (!canAdd(size)) {
+		SPDLOG_INFO("[NetworkMessage::addBytes] - NetworkMessage size is wrong: {}", size);
+		return;
+	}
+	if (size > NETWORKMESSAGE_MAXSIZE) {
+		SPDLOG_INFO("[NetworkMessage::addBytes] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, size);
 		return;
 	}
 

--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -59,8 +59,7 @@ void NetworkMessage::addString(const std::string& value)
 {
 	size_t stringLen = value.length();
 	if (value.empty()) {
-		SPDLOG_ERROR("[NetworkMessage::addBytes] - Value string is empty");
-		return;
+		SPDLOG_DEBUG("[NetworkMessage::addString] - Value string is empty");
 	}
 	if (!canAdd(stringLen + 2)) {
 		SPDLOG_ERROR("[NetworkMessage::addString] - NetworkMessage size is wrong: {}", stringLen);

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -255,7 +255,7 @@ bool Protocol::compression(OutputMessage& msg) const
 	static thread_local std::array<char, NETWORKMESSAGE_MAXSIZE> defBuffer;
 	defStream->next_in = msg.getOutputBuffer();
 	defStream->avail_in = outputMessageSize;
-	defStream->next_out = defBuffer.data();
+	defStream->next_out = (Bytef*)defBuffer.data();
 	defStream->avail_out = NETWORKMESSAGE_MAXSIZE;
 
 	if (int32_t ret = deflate(defStream.get(), Z_FINISH);

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -248,7 +248,7 @@ bool Protocol::compression(OutputMessage& msg) const
 {
 	auto outputMessageSize = msg.getLength();
 	if (outputMessageSize > NETWORKMESSAGE_MAXSIZE) {
-		SPDLOG_INFO("[NetworkMessage::compression] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, outputMessageSize);
+		SPDLOG_ERROR("[NetworkMessage::compression] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, outputMessageSize);
 		return false;
 	}
 

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -246,9 +246,15 @@ void Protocol::enableCompression()
 
 bool Protocol::compression(OutputMessage& msg) const
 {
-	static thread_local std::array<uint8_t, NETWORKMESSAGE_MAXSIZE> defBuffer;
+	auto outputMessageSize = msg.getLength();
+	if (outputMessageSize > NETWORKMESSAGE_MAXSIZE) {
+		SPDLOG_INFO("[NetworkMessage::compression] - Exceded NetworkMessage max size: {}, actually size: {}", NETWORKMESSAGE_MAXSIZE, outputMessageSize);
+		return false;
+	}
+
+	static thread_local std::array<char, NETWORKMESSAGE_MAXSIZE> defBuffer;
 	defStream->next_in = msg.getOutputBuffer();
-	defStream->avail_in = msg.getLength();
+	defStream->avail_in = outputMessageSize;
 	defStream->next_out = defBuffer.data();
 	defStream->avail_out = NETWORKMESSAGE_MAXSIZE;
 


### PR DESCRIPTION
With this change, the debug that occurs when the Packet Compression is activated, because the max NetworkMessage size was of 8192 when in fact the client currently receives a maximum of 65500

Added some logs to assist if there is a problem with the size of the size or null pointer, helping to identify the problems faster