### PR TITLE
Disable install LuaJit processor ARM

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,7 +14,10 @@
     "jsoncpp",
     "libzippp",
     "protobuf",
-    "luajit",
+    {
+      "name": "luajit",
+      "platform": "!arm"
+    },
     { "name": "libmariadb",
       "features": [ "mariadbclient" ]
     },


### PR DESCRIPTION
Disabled installation of LuaJit by vcpkg.json, solving the problem of compatibility with ARM processors.
The installation of LuaJit will have to be done by apt Linux with the command:
```
sudo apt install libluajit-5.1-dev
```