### PR TITLE
Fixed buying more than 1 item with only one free slot

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -222,20 +222,20 @@ void Npc::onThink(uint32_t interval)
 void Npc::onPlayerBuyItem(Player* player, uint16_t itemId,
                           uint8_t subType, uint8_t amount, bool ignore, bool inBackpacks)
 {
-	if (!player) {
+	if (player == nullptr) {
+		SPDLOG_ERROR("[Npc::onPlayerBuyItem] - Player is nullptr");
 		return;
 	}
 
-	// Check if the player not have empty slots
-	if (player->getFreeBackpackSlots() == 0) {
+	const ItemType& itemType = Item::items[itemId];
+	if (!itemType.stackable && amount > 1 && player->getFreeBackpackSlots() == 1 || player->getFreeBackpackSlots() == 0) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		return;
 	}
 
 	uint32_t buyPrice = 0;
-	const ItemType& itemType = Item::items[itemId];
-	const std::vector<ShopBlock> &shopVector = getShopItemVector();
-	for (ShopBlock shopBlock : shopVector)
+	for (const std::vector<ShopBlock> &shopVector = getShopItemVector();
+	ShopBlock shopBlock : shopVector)
 	{
 		if (itemType.id == shopBlock.itemId && shopBlock.itemBuyPrice != 0)
 		{

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -234,8 +234,8 @@ void Npc::onPlayerBuyItem(Player* player, uint16_t itemId,
 	}
 
 	uint32_t buyPrice = 0;
-	for (const std::vector<ShopBlock> &shopVector = getShopItemVector();
-	ShopBlock shopBlock : shopVector)
+	const std::vector<ShopBlock> &shopVector = getShopItemVector();
+	for (ShopBlock shopBlock : shopVector)
 	{
 		if (itemType.id == shopBlock.itemId && shopBlock.itemBuyPrice != 0)
 		{

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -228,7 +228,7 @@ void Npc::onPlayerBuyItem(Player* player, uint16_t itemId,
 	}
 
 	const ItemType& itemType = Item::items[itemId];
-	if (!itemType.stackable && amount > 1 && player->getFreeBackpackSlots() == 1 || player->getFreeBackpackSlots() == 0) {
+	if (!itemType.stackable && player->getFreeBackpackSlots() != amount || player->getFreeBackpackSlots() == 0) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		return;
 	}

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -228,7 +228,7 @@ void Npc::onPlayerBuyItem(Player* player, uint16_t itemId,
 	}
 
 	const ItemType& itemType = Item::items[itemId];
-	if (!itemType.stackable && player->getFreeBackpackSlots() != amount || player->getFreeBackpackSlots() == 0) {
+	if (!itemType.stackable && player->getFreeBackpackSlots() < amount || player->getFreeBackpackSlots() == 0) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		return;
 	}


### PR DESCRIPTION
Example: when trying to buy 100 non-stackable items with a free slot, it would remove the money from 100 but only deliver one item