### PR TITLE
Fixed clone depot items

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3531,7 +3531,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 int32_t Player::getThingIndex(const Thing* thing) const
 {
-	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
+	for (uint8_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		if (inventory[i] == thing) {
 			return i;
 		}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3529,9 +3529,9 @@ void Player::removeThing(Thing* thing, uint32_t count)
 	}
 }
 
-uint8_t Player::getThingIndex(const Thing* thing) const
+int32_t Player::getThingIndex(const Thing* thing) const
 {
-	for (uint8_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
+	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		if (inventory[i] == thing) {
 			return i;
 		}

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2137,7 +2137,7 @@ class Player final : public Creature, public Cylinder
 
 		void removeThing(Thing* thing, uint32_t count) override;
 
-		uint8_t getThingIndex(const Thing* thing) const override;
+		int32_t getThingIndex(const Thing* thing) const override;
 		size_t getFirstIndex() const override;
 		size_t getLastIndex() const override;
 		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override;

--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -682,9 +682,9 @@ void Container::removeThing(Thing* thing, uint32_t count)
 	}
 }
 
-uint8_t Container::getThingIndex(const Thing* thing) const
+int32_t Container::getThingIndex(const Thing* thing) const
 {
-	uint8_t index = 0;
+	int32_t index = 0;
 	for (Item* item : itemlist) {
 		if (item == thing) {
 			return index;

--- a/src/items/containers/container.h
+++ b/src/items/containers/container.h
@@ -161,7 +161,7 @@ class Container : public Item, public Cylinder
 
 		void removeThing(Thing* thing, uint32_t count) override final;
 
-		uint8_t getThingIndex(const Thing* thing) const override final;
+		int32_t getThingIndex(const Thing* thing) const override final;
 		size_t getFirstIndex() const override final;
 		size_t getLastIndex() const override final;
 		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;

--- a/src/items/cylinder.cpp
+++ b/src/items/cylinder.cpp
@@ -23,7 +23,7 @@
 
 VirtualCylinder* VirtualCylinder::virtualCylinder = new VirtualCylinder;
 
-uint8_t Cylinder::getThingIndex(const Thing*) const
+int32_t Cylinder::getThingIndex(const Thing*) const
 {
 	return -1;
 }

--- a/src/items/cylinder.h
+++ b/src/items/cylinder.h
@@ -136,7 +136,7 @@ class Cylinder : virtual public Thing
 		 * \param thing the object to get the index value from
 		 * \returns the index of the object, returns -1 if not found
 		 */
-		virtual uint8_t getThingIndex(const Thing* thing) const;
+		virtual int32_t getThingIndex(const Thing* thing) const;
 
 		/**
 		 * Returns the first index

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -873,7 +873,7 @@ class Item : virtual public Thing
 			}
 			return items[id].extraDefense;
 		}
-		int32_t getImbuementSlot() const {
+		uint8_t getImbuementSlot() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_IMBUEMENT_SLOT)) {
 				return getIntAttr(ITEM_ATTRIBUTE_IMBUEMENT_SLOT);
 			}

--- a/src/items/items.h
+++ b/src/items/items.h
@@ -225,7 +225,6 @@ class ItemType
 		int32_t defense = 0;
 		int32_t extraDefense = 0;
 		int32_t armor = 0;
-		int32_t imbuementSlot = 0;
 		int32_t rotateTo = 0;
 		int32_t runeMagLevel = 0;
 		int32_t runeLevel = 0;
@@ -260,6 +259,7 @@ class ItemType
 		uint8_t lightLevel = 0;
 		uint8_t lightColor = 0;
 		uint8_t shootRange = 1;
+		uint8_t imbuementSlot = 0;
 		int8_t hitChance = 0;
 
 		bool forceUse = false;

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1166,9 +1166,9 @@ void Tile::removeCreature(Creature* creature)
 	removeThing(creature, 0);
 }
 
-uint8_t Tile::getThingIndex(const Thing* thing) const
+int32_t Tile::getThingIndex(const Thing* thing) const
 {
-	uint8_t n = -1;
+	int32_t n = -1;
 	if (ground) {
 		if (ground == thing) {
 			return 0;

--- a/src/items/tile.h
+++ b/src/items/tile.h
@@ -221,7 +221,7 @@ class Tile : public Cylinder
 
 		void removeCreature(Creature* creature);
 
-		uint8_t getThingIndex(const Thing* thing) const override final;
+		int32_t getThingIndex(const Thing* thing) const override final;
 		size_t getFirstIndex() const override final;
 		size_t getLastIndex() const override final;
 		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;


### PR DESCRIPTION
Resolves #449

Fixes "cloning" bug of items through depot

With the wrong size, instead of getting all possible pages, it was stopping at the eighth page, which is the maximum number of items in uint8_t, so when there were more items it allowed to clone in a specific scenario, I will avoid giving examples so that they do not abuse the bug on the server of those who are not using the fix yet

Thanks @CzajaTwitch for reporting bug