### PR TITLE
Stop commiting changes in savePlayer function to keep the data consistent

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -529,6 +529,9 @@ void Game::saveGameState()
 
 	SPDLOG_INFO("Saving server...");
 
+	DBTransaction transaction;
+	transaction.begin();
+
 	for (const auto& it : players) {
 		it.second->loginPosition = it.second->getPosition();
 		IOLoginData::savePlayer(it.second);
@@ -539,6 +542,8 @@ void Game::saveGameState()
 	}
 
 	Map::save();
+
+	transaction.commit();
 
 	g_databaseTasks().flush();
 

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -829,6 +829,8 @@ bool IOLoginData::savePlayer(Player* player)
   }
   Database& db = Database::getInstance();
 
+  db.executeQuery("set autocommit = 0;");
+
   std::ostringstream query;
   query << "SELECT `save` FROM `players` WHERE `id` = " << player->getGUID();
   DBResult_ptr result = db.storeQuery(query.str());

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -969,11 +969,6 @@ bool IOLoginData::savePlayer(Player* player)
   }
   query << " WHERE `id` = " << player->getGUID();
 
-  DBTransaction transaction;
-  if (!transaction.begin()) {
-    return false;
-  }
-
   if (!db.executeQuery(query.str())) {
     return false;
   }
@@ -1273,8 +1268,7 @@ bool IOLoginData::savePlayer(Player* player)
     return false;
   }
 
-  //End the transaction
-  return transaction.commit();
+  return true;
 }
 
 std::string IOLoginData::getNameByGuid(uint32_t guid)


### PR DESCRIPTION
# Description
This change will prevent breaking the Consistency/Isolation of database access, thus preventing certain item duplication.

Side effect is: now, the only way for player to save and commit his character data is to wait for server save. Logging off will save data into database, but not commit it. Thus any progress made between server save and crash will be lost, regardless whether player relogged/died/went to sleep etc. 

The main concern of this pull is whether u want to have database commits on logut (which in my opinion should never be the desirable case), or to prevent item dupe by crash. 
## Fixes
#468 

## Type of change
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested
I tried to replicate bugs from #468, but none of them worked. Also I tried to check if my code didnt break engine in other way. Normal server save was working as intended - it saved and commited changes to database.


**Test Configuration**:

  - Server Version: 1.4.0
  - Client: tibia-client-12.86.11871
  - Operating System: win10
  - Server Protocol: 12.86
  - MySQL Version: 10.5.5