### PR TITLE
Update server dockerfile to pull vcpkg from opentibiabr fork

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: docker.io
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: docker/server/Dockerfile
-          tags: docker.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
+          tags: ghcr.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
@@ -62,7 +62,7 @@ jobs:
         with:
           file: docker/server/Dockerfile
           push: true
-          tags: docker.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
+          tags: ghcr.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: docker.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: docker/server/Dockerfile
-          tags: ghcr.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
+          tags: docker.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
@@ -62,7 +62,7 @@ jobs:
         with:
           file: docker/server/Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
+          tags: docker.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 

--- a/docker/data/download-myaac.sh
+++ b/docker/data/download-myaac.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-wget https://github.com/slawkens/myaac/archive/master.zip -O myaac.zip
+wget https://github.com/opentibiabr/myaac/archive/refs/heads/main.zip -O myaac.zip
 unzip -o myaac.zip -d .
 
 mv myaac-master/* ./web
 rm myaac.zip myaac-master -rf
 
-wget https://github.com/opentibiabr/myaac-tibia12-login/archive/refs/heads/develop.zip -O myaac-otbr-plugin.zip
-unzip -o myaac-otbr-plugin.zip -d .
+wget https://github.com/opentibiabr/myaac-tibia12-login/archive/refs/heads/main.zip -O myaac-otbr-plugin.zip
+unzip -o myaac-otbr-plugin.zip -d myaac-tibia12-login-main/
 
-cp -r myaac-tibia12-login-develop/* ./web
-rm -rf myaac-otbr-plugin.zip myaac-tibia12-login-develop
+cp -r myaac-tibia12-login-main/* ./web
+rm -rf myaac-otbr-plugin.zip myaac-tibia12-login-main

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - mysql
       - website
-      - login
+      - login-server
     links:
       - mysql
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ../
       dockerfile: docker/server/Dockerfile
+    restart: always
     ports:
       - 7171:7171
       - 7172:7172
@@ -46,24 +47,27 @@ services:
     depends_on:
       - mysql
 
-  login:
-    image: opentibiabr/login-server:latest
+  login-server:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
-      - 80:8080
+      - 80:80
+      - 9090:9090
     depends_on:
       - mysql
     environment:
-      - DB_DATABASE=canary
-      - DB_HOSTNAME=mysql
-      - DB_PORT=3306
-      - DB_PASSWORD=canary
-      - DB_USERNAME=canary
-      - ENV_LOG_LEVEL=verbose
-      - ENV_TYPE=dev
-      - LOGIN_PORT=8080
+      - LOGIN_HTTP_PORT=80
+      - LOGIN_GRPC_PORT=9090
+      - MYSQL_HOST=mysql
+      - MYSQL_PORT=3306
+      - MYSQL_DBNAME=canary
+      - MYSQL_USER=canary
+      - MYSQL_PASS=canary
       - SERVER_NAME=Canary
-      - SERVER_LOCATION=Bra
       - SERVER_IP=127.0.0.1
       - SERVER_PORT=7172
-#      - VOCATIONS -- map your custom vocations here, if needed, comma separated
+      - SERVER_LOCATION=NL
+      - RATE_LIMITER_RATE=3000000000000
+      - RATE_LIMITER_BURST=53000000000000

--- a/docker/login/Dockerfile
+++ b/docker/login/Dockerfile
@@ -1,3 +1,3 @@
-FROM lucasggrossi/otbr_login:go-login1.0
+FROM opentibiabr/login-server:latest
 
-ENTRYPOINT ["/login-server/loginserver-linux-x64"]
+ENTRYPOINT ["/bin/login-server"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends cmake git \
 	&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
-RUN git clone https://github.com/microsoft/vcpkg --depth=1
+RUN git clone https://github.com/opentibiabr/vcpkg --depth=1
 RUN ./vcpkg/bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Download all dependencies
 FROM ubuntu:22.04 AS dependencies
 
-RUN apt-get update && apt-get install -y --no-install-recommends cmake git \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends cmake git \
 	unzip build-essential ca-certificates curl zip unzip tar \
 	pkg-config ninja-build autoconf automake libtool \
 	&& apt-get clean \

--- a/docker/server/start.sh
+++ b/docker/server/start.sh
@@ -27,6 +27,20 @@ echo "================================"
 echo ""
 
 echo ""
+echo "===== Wait for the DB to be Up ====="
+echo ""
+
+until mysql -u "$DB_USER" -p"$DB_PASSWORD" -h "$DB_HOST" --port="$DB_PORT" -e "SHOW DATABASES;"
+do
+	echo "DB offline, trying again"
+	sleep 5s
+done
+
+echo ""
+echo "================================"
+echo ""
+
+echo ""
 echo "===== Create Database and Import schema ====="
 echo ""
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,10 +14,7 @@
     "jsoncpp",
     "protobuf",
     "parallel-hashmap",
-    {
-      "name": "luajit",
-      "platform": "!arm"
-    },
+    "luajit",
     { "name": "libmariadb",
       "features": [ "mariadbclient" ]
     },


### PR DESCRIPTION
# Description

This PR is a baseline correction of the server Dockerfile in the canary repository, which pulled the vcpkg repo from Microsoft directly, and not from the opentibiabr fork.

Correction of issue https://github.com/opentibiabr/canary/issues/494

## Behaviour
### **Actual**

Clone the repository main branch and run
`docker-compose up`
The docker CLI will break the command after a few minutes, with an error when building the libmaria package.

### **Expected**

Clone the repository main branch and run
`docker-compose up`
The docker CLI will continuously build all the packages and create the container for the canary server.

## Fixes

\# VCPKG repository appointment.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
