### PR TITLE
[Fix] Client debug on depot search (255+ items)

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6012,10 +6012,14 @@ void Player::requestDepotSearchItem(uint16_t itemId, uint8_t tier)
 			}
 
 			if (c->isInbox()) {
-				inboxItems.push_back(item);
+				if (inboxItems.size() < 255) {
+					inboxItems.push_back(item);
+				}
 				inboxCount += Item::countByType(item, -1);
 			} else {
-				depotItems.push_back(item);
+				if (depotItems.size() < 255) {
+					depotItems.push_back(item);
+				}
 				depotCount += Item::countByType(item, -1);
 			}
 		}


### PR DESCRIPTION
# Description

There is a debug on client when you search for an item that has more than 255 slots. For example, if you search for a 'mace' and you have 256 mace on your depot and you click on search, the client will debug.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
