### PR TITLE
Fixed potion mana amount heals, remove wrong parameter from doTargetCombatMana on potions.lua

### DIFF
--- a/data/scripts/actions/other/potions.lua
+++ b/data/scripts/actions/other/potions.lua
@@ -178,7 +178,7 @@ function potions.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		end
 
 		if potion.mana then
-			doTargetCombatMana(0, target, COMBAT_MANADRAIN, potion.mana[1], potion.mana[2])
+			doTargetCombatMana(0, target, potion.mana[1], potion.mana[2])
 		end
 
 		if potion.antidote then


### PR DESCRIPTION
# Description

was being passed an extra parameter in the "doTargetCombatMana" function, this function randomizes the amount of mana a potion heals. With this parameter, the minimum "6" was always passed, which is the value of the constant "COMBAT_MANADRAIN", thus making an "ultimate mana potion", for example, heal 80, 100, 130... however, it should cure between 425 and 575.

here the function that is called and where the parameter is used
https://github.com/opentibiabr/canary/blob/0e43691c78bd3421dad2972c7dde866804dda14c/src/lua/functions/core/game/global_functions.cpp#L391

See on Line 413. The minimum and maximum parameters are in order 3 and 4.
https://github.com/opentibiabr/canary/blob/0e43691c78bd3421dad2972c7dde866804dda14c/src/lua/functions/core/game/global_functions.cpp#L413

and the effect type is already applied on line 412.
https://github.com/opentibiabr/canary/blob/0e43691c78bd3421dad2972c7dde866804dda14c/src/lua/functions/core/game/global_functions.cpp#L412

## Behaviour
### **Actual**
 an "ultimate mana potion", for example, heal 80, 100, 130...

### **Expected**
 an "ultimate mana potion", for example, heal between 425 - 575

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Tests were done in-game

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
