### PR TITLE
add note to the reload.lua script

### DIFF
--- a/data/scripts/talkactions/god/reload.lua
+++ b/data/scripts/talkactions/god/reload.lua
@@ -1,3 +1,10 @@
+-- NOTE: Using this script might cause unwanted changes.
+-- This script forces a reload in the entire server, this means
+-- that everything that is stored in memory might stop to work
+-- properly and/or completely.
+--
+-- This script should be used in test environments only.
+
 local reloadTypes = {
 	["all"] = RELOAD_TYPE_ALL,
 


### PR DESCRIPTION
It seems like a common error to use the `/reload` command in a production environment.
Knowing that this could cause bugs, I think it should be documented to only use the reload command on test environments.
