### PR TITLE
Add option for enable or disable emoted spells for each player

### DIFF
--- a/data/scripts/talkactions/player/emote_spell.lua
+++ b/data/scripts/talkactions/player/emote_spell.lua
@@ -1,0 +1,19 @@
+local emoteSpell = TalkAction("!emote")
+
+function emoteSpell.onSay(player, words, param)
+	if param == "" then
+		player:sendCancelMessage("You need to specify on/off param.")
+		return false
+	end
+	if param == "on" then
+		player:setStorageValue(STORAGEVALUE_EMOTE, 1)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You activated emoted spells")
+	elseif param == "off" then
+		player:setStorageValue(STORAGEVALUE_EMOTE, 0)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "You desactivated emoted spells")
+	end
+	return true
+end
+
+emoteSpell:separator(" ")
+emoteSpell:register()

--- a/data/scripts/talkactions/player/emote_spell.lua
+++ b/data/scripts/talkactions/player/emote_spell.lua
@@ -1,3 +1,4 @@
+-- Usage talkaction: "!emote on" or "!emote off"
 local emoteSpell = TalkAction("!emote")
 
 function emoteSpell.onSay(player, words, param)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6211,7 +6211,7 @@ bool Player::saySpell(
 {
 	if (text.empty()) {
 		SPDLOG_DEBUG("{} - Spell text is empty for player {}", __FUNCTION__, getName());
-		return;
+		return false;
 	}
 
 	if (!pos) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6202,6 +6202,70 @@ std::pair<std::vector<Item*>, std::map<uint16_t, uint32_t>> Player::requestLocke
 	return std::make_pair(itemVector, marketItems);
 }
 
+bool Player::saySpell(
+	SpeakClasses type,
+	const std::string& text,
+	bool ghostMode,
+	SpectatorHashSet* spectatorsPtr/* = nullptr*/,
+	const Position* pos/* = nullptr*/)
+{
+	if (text.empty()) {
+		SPDLOG_DEBUG("{} - Spell text is empty for player {}", __FUNCTION__, getName());
+		return;
+	}
+
+	if (!pos) {
+		pos = &getPosition();
+	}
+
+	SpectatorHashSet spectators;
+
+	if (!spectatorsPtr || spectatorsPtr->empty()) {
+		// This somewhat complex construct ensures that the cached SpectatorHashSet
+		// is used if available and if it can be used, else a local vector is
+		// used (hopefully the compiler will optimize away the construction of
+		// the temporary when it's not used).
+		if (type != TALKTYPE_YELL && type != TALKTYPE_MONSTER_YELL) {
+			g_game().map.getSpectators(spectators, *pos, false, false,
+                           Map::maxClientViewportX, Map::maxClientViewportX,
+                           Map::maxClientViewportY, Map::maxClientViewportY);
+		} else {
+			g_game().map.getSpectators(spectators, *pos, true, false, 18, 18, 14, 14);
+		}
+	} else {
+		spectators = (*spectatorsPtr);
+	}
+
+	int32_t valueEmote = 0;
+	// Send to client 
+	for (Creature* spectator : spectators) {
+		if (Player* tmpPlayer = spectator->getPlayer()) {
+			tmpPlayer->getStorageValue(STORAGEVALUE_EMOTE, valueEmote);
+			if (!ghostMode || tmpPlayer->canSeeCreature(this)) {
+				if (valueEmote == 1) {
+					tmpPlayer->sendCreatureSay(this, TALKTYPE_MONSTER_SAY, text, pos);
+				} else {
+					tmpPlayer->sendCreatureSay(this, TALKTYPE_SPELL_USE, text, pos);
+				}
+			}
+		}
+	}
+
+	// Execute lua event method
+	for (Creature* spectator : spectators) {
+		auto tmpPlayer = spectator->getPlayer();
+		if (!tmpPlayer) {
+			continue;
+		}
+
+		tmpPlayer->onCreatureSay(this, type, text);
+		if (this != tmpPlayer) {
+			g_events().eventCreatureOnHear(tmpPlayer, this, text, type);
+		}
+	}
+	return true;
+}
+
 /*******************************************************************************
  * Interfaces
  ******************************************************************************/
@@ -6219,4 +6283,3 @@ error_t Player::GetAccountInterface(account::Account* account) {
 	account = account_;
 	return account::ERROR_NO;
 }
-

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2090,6 +2090,14 @@ class Player final : public Creature, public Cylinder
 
 		std::pair<std::vector<Item*>, std::map<uint16_t, uint32_t>> requestLockerItems(DepotLocker *depotLocker) const;
 
+		bool saySpell(
+			SpeakClasses type,
+			const std::string& text,
+			bool ghostMode,
+			SpectatorHashSet* spectatorsPtr = nullptr,
+			const Position* pos = nullptr
+		);
+
 	private:
 		std::forward_list<Condition*> getMuteConditions() const;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5260,10 +5260,10 @@ bool Game::playerSaySpell(Player* player, SpeakClasses type, const std::string& 
 			player->cancelPush();
 		}
 
-		if (!g_configManager().getBoolean(EMOTE_SPELLS)) {
-			return internalCreatureSay(player, TALKTYPE_SPELL_USE, words, false);
-		} else {
+		if (g_configManager().getBoolean(EMOTE_SPELLS)) {
 			return internalCreatureSay(player, TALKTYPE_MONSTER_SAY, words, false);
+		} else {
+			return player->saySpell(type, words, false);
 		}
 
 	} else if (result == TALKACTION_FAILED) {

--- a/src/lua/functions/core/game/lua_enums.hpp
+++ b/src/lua/functions/core/game/lua_enums.hpp
@@ -1038,6 +1038,7 @@ class LuaEnums final : LuaScriptInterface {
 			registerEnum(L, LIGHT_STATE_NIGHT);
 			registerEnum(L, LIGHT_STATE_SUNSET);
 			registerEnum(L, LIGHT_STATE_SUNRISE);
+			registerEnum(L, STORAGEVALUE_EMOTE);
 
 			// Webhook default colors
 			registerEnum(L, WEBHOOK_COLOR_ONLINE);


### PR DESCRIPTION
Option is used with talkaction, but can be customized to be per item, store, etc.
To use, just activate with talkaction ```!emote on``` or ```!emote off```