### PR TITLE
[FIX] - Bestiary kill counter lag

### DIFF
--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -138,7 +138,7 @@ class Player final : public Creature, public Cylinder
 		{
 			uint32_t oldCount = getBestiaryKillCount(raceid);
 			uint32_t key = STORAGEVALUE_BESTIARYKILLCOUNT + raceid;
-			addStorageValue(key, static_cast<int32_t>(oldCount + amount));
+			addStorageValue(key, static_cast<int32_t>(oldCount + amount), true);
 		}
 		uint32_t getBestiaryKillCount(uint16_t raceid) const
 		{


### PR DESCRIPTION
# Description
Using storage as bestiary kill counter result on the problem that, when updating the storage value, it will call a tree of functions that lead us to a LUA function, which iterate into the quests systems tables. This happens because the server tries to identify if that storage key is related to a quest, then updating the quest log and sending the message to the player. On the bestiary system, it's useless calling that tree of function, which can cause a unnecessary stress and takes time on main thread.

## Fixes

Resolves #551

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Kill a huge amount of creatures at the same time and see the server freezing. Then apply this changes and test it again.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings