### PR TITLE
Fixed addition of money to player on selling item to one npc

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -340,14 +340,14 @@ void Npc::onPlayerSellItem(Player* player, uint16_t itemId,
 		}
 	}
 
-	uint64_t totalCost = 0;
 	// We will only add the money if any item has been removed from the player, to ensure that there is no possibility of cloning money
 	if (removedItems == 0) {
 		SPDLOG_ERROR("[Npc::onPlayerSellItem] - Player {} have a problem for remove items from id {} on shop for npc {}", player->getName(), itemId, getName());
 		return;
 	}
 
-	totalCost = static_cast<uint64_t>(sellPrice * removedItems);
+	uint64_t totalCost = 0;
+	totalCost = static_cast<uint64_t>(sellPrice * amount);
 	g_game().addMoney(player, totalCost);
 
 	// npc:onSellItem(player, itemId, subType, amount, ignore, itemName, totalCost)

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -346,8 +346,7 @@ void Npc::onPlayerSellItem(Player* player, uint16_t itemId,
 		return;
 	}
 
-	uint64_t totalCost = 0;
-	totalCost = static_cast<uint64_t>(sellPrice * amount);
+	auto totalCost = static_cast<uint64_t>(sellPrice * amount);
 	g_game().addMoney(player, totalCost);
 
 	// npc:onSellItem(player, itemId, subType, amount, ignore, itemName, totalCost)


### PR DESCRIPTION
# Description
It solves a small problem added, by mistake, in the pr of the tier, which is to sell stackable item and receive only the money of a one item.
Example: sell 100 mushrooms and receive money for only 1 item.

## Fixes #577

\# (issue)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Sell a stackavel item, you will only receive money from a one count.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:
