### PR TITLE
Add new map release link

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -174,7 +174,7 @@ pushWhenAttacking = false
 -- NOTE: If a map with the name already exists in the world folder, the map will not be downloaded even if the toggleDownloadMap is true
 toggleDownloadMap = true
 mapName = "otservbr"
-mapDownloadUrl = "https://github.com/opentibiabr/otservbr-global/releases/download/v1.5.0/otservbr.otbm"
+mapDownloadUrl = "https://github.com/opentibiabr/canary/releases/download/v1.5.0/otservbr.otbm"
 mapAuthor = "OpenTibiaBR"
 
 -- Party List limitations


### PR DESCRIPTION
# Description
Changing the map download link in config.lua.dist to the new link

Please delete options that are not relevant.
  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Start the executable (without having the otservbr.otbm file in the world folder) and it will download the map from the specified link

**Test Configuration**:

  - Server Version: 1291
  - Client: 1291
  - Operating System: Windows 11
