### PR TITLE
Fix guest house kick bug

### DIFF
--- a/data-canary/scripts/spells/house/kick.lua
+++ b/data-canary/scripts/spells/house/kick.lua
@@ -8,7 +8,7 @@ function spell.onCastSpell(player, variant)
 		if not owner:canEditAccessList(GUEST_LIST, player) then
 			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 			player:getPosition():sendMagicEffect(CONST_ME_POFF)
-		return false
+			return false
 		end
 	end
 

--- a/data-canary/scripts/spells/house/kick.lua
+++ b/data-canary/scripts/spells/house/kick.lua
@@ -4,6 +4,14 @@ function spell.onCastSpell(player, variant)
 	local targetPlayer = Player(variant:getString()) or player
 	local guest = targetPlayer:getTile():getHouse()
 	local owner =  player:getTile():getHouse()
+	if targetPlayer ~= player then
+		if not owner:canEditAccessList(GUEST_LIST, player) then
+			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+			player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+		end
+	end
+
 	if not owner or not guest or not guest:kickPlayer(player, targetPlayer) then
 		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)


### PR DESCRIPTION
Resolves #637

# Description

Fixes guests being able to kick others from houses, after this change, guests can only kick themselves from the house (to not get trapped somehow)

Owners/Sub-owners can still kick others from house.

## Behaviour
### **Actual**

Guests are able to kick other players from house, then being able to abuse (pk them if they were afk training)

### **Expected**

Guest should not be able to kick others, so they cannot abuse other players, only owners and sub-owners can kick.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)