### PR TITLE
Added parse resource balance byte

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -800,6 +800,7 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage msg, uint8_t recvbyt
 		case 0xE7: /* thank you */ break;
 		case 0xE8: parseDebugAssert(msg); break;
 		case 0xEB: parsePreyAction(msg); break;
+		case 0xED: parseSendResourceBalance(msg); break;
 		case 0xEE: parseGreet(msg); break;
 		// Premium coins transfer
 		// case 0xEF: parseCoinTransfer(msg); break;
@@ -2577,6 +2578,15 @@ void ProtocolGame::parsePreyAction(NetworkMessage &msg)
 	}
 
 	addGameTask(&Game::playerPreyAction, player->getID(), slot, action, option, index, raceId);
+}
+
+void ProtocolGame::parseSendResourceBalance(NetworkMessage &msg) {
+	sendResourcesBalance(
+		player->getMoney(),
+		player->getBankBalance(),
+		player->getPreyCards(),
+		player->getTaskHuntingPoints()
+	);
 }
 
 void ProtocolGame::parseInviteToParty(NetworkMessage &msg)

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2580,7 +2580,8 @@ void ProtocolGame::parsePreyAction(NetworkMessage &msg)
 	addGameTask(&Game::playerPreyAction, player->getID(), slot, action, option, index, raceId);
 }
 
-void ProtocolGame::parseSendResourceBalance() {
+void ProtocolGame::parseSendResourceBalance()
+{
 	sendResourcesBalance(
 		player->getMoney(),
 		player->getBankBalance(),

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -800,7 +800,7 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage msg, uint8_t recvbyt
 		case 0xE7: /* thank you */ break;
 		case 0xE8: parseDebugAssert(msg); break;
 		case 0xEB: parsePreyAction(msg); break;
-		case 0xED: parseSendResourceBalance(msg); break;
+		case 0xED: parseSendResourceBalance(); break;
 		case 0xEE: parseGreet(msg); break;
 		// Premium coins transfer
 		// case 0xEF: parseCoinTransfer(msg); break;
@@ -2580,7 +2580,7 @@ void ProtocolGame::parsePreyAction(NetworkMessage &msg)
 	addGameTask(&Game::playerPreyAction, player->getID(), slot, action, option, index, raceId);
 }
 
-void ProtocolGame::parseSendResourceBalance(NetworkMessage &msg) {
+void ProtocolGame::parseSendResourceBalance() {
 	sendResourcesBalance(
 		player->getMoney(),
 		player->getBankBalance(),

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -159,6 +159,7 @@ private:
 	void parseBugReport(NetworkMessage &msg);
 	void parseDebugAssert(NetworkMessage &msg);
 	void parsePreyAction(NetworkMessage &msg);
+	void parseSendResourceBalance();
 	void parseRuleViolationReport(NetworkMessage &msg);
 
 	void parseBestiarysendRaces();


### PR DESCRIPTION
# Description

When opening the prey window, for example, the money that the player got after logging in was not updated. Only when rerolling a monster or interacting with a window button (or after relog).
This way we will update the resource balance by the client's request, client side

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Log in the char, add some money, for example 1kk, open the prey window. Money will not appear in the prey window, unless the player interacts with any of the prey buttons, such as reroll.

**Test Configuration**:

  - Server Version: 1291
  - Client: 1291
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
