### PR TITLE
Fix event scheduler folder

### DIFF
--- a/src/lua/scripts/scripts.cpp
+++ b/src/lua/scripts/scripts.cpp
@@ -36,9 +36,10 @@ Scripts::~Scripts() {
 bool Scripts::loadEventSchedulerScripts(const std::string& fileName) {
 	namespace fs = boost::filesystem;
 
-	const auto dir = fs::current_path() / "core" / "events" / "scripts" / "scheduler";
+	auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
+	const auto dir = fs::current_path() / coreFolder / "events" / "scripts" / "scheduler";
 	if(!fs::exists(dir) || !fs::is_directory(dir)) {
-		SPDLOG_WARN("{} - Can not load folder 'scheduler' on core/events/scripts'", __FUNCTION__);
+		SPDLOG_WARN("{} - Can not load folder 'scheduler' on {}/events/scripts'", __FUNCTION__, coreFolder);
 		return false;
 	}
 


### PR DESCRIPTION
# Description

There was a location that is not pulling from the "core" folder set in config.lua, generating a problem when loading events
Fix this error: 
![image](https://user-images.githubusercontent.com/8551443/204424322-10a2c095-62b2-4d8e-8fd3-7f948a9b164d.png)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
