### PR TITLE
Fix experience rate stages

### DIFF
--- a/data-canary/scripts/creaturescripts/advance_save.lua
+++ b/data-canary/scripts/creaturescripts/advance_save.lua
@@ -25,11 +25,7 @@ function advanceSave.onAdvance(player, skill, oldLevel, newLevel)
 	end
 
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		local baseRate = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
-		-- Event scheduler
-		if SCHEDULE_EXP_RATE ~= 100 then
-			baseRate = math.max(0, (baseRate * SCHEDULE_EXP_RATE)/100)
-		end
+		local baseRate = player:getFinalBaseRateExperience()
 		player:setBaseXpGain(baseRate * 100)
 	end
 

--- a/data-canary/scripts/creaturescripts/login.lua
+++ b/data-canary/scripts/creaturescripts/login.lua
@@ -91,15 +91,10 @@ function login.onLogin(player)
 	nextUseXpStamina[playerId] = 1
 
 	-- Set Client XP Gain Rate --
-	local rateExp = 1
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		rateExp = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
-		if SCHEDULE_EXP_RATE ~= 100 then
-			rateExp = math.max(0, (rateExp * SCHEDULE_EXP_RATE)/100)
-		end
+		local baseRate = player:getFinalBaseRateExperience()
+		player:setBaseXpGain(baseRate * 100)
 	end
-
-	player:setBaseXpGain(rateExp * 100)
 
 	return true
 end

--- a/data-otservbr-global/scripts/creaturescripts/others/advance_save.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/advance_save.lua
@@ -25,11 +25,7 @@ function advanceSave.onAdvance(player, skill, oldLevel, newLevel)
 	end
 
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		local baseRate = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
-		-- Event scheduler
-		if SCHEDULE_EXP_RATE ~= 100 then
-			baseRate = math.max(0, (baseRate * SCHEDULE_EXP_RATE)/100)
-		end
+		local baseRate = player:getFinalBaseRateExperience()
 		player:setBaseXpGain(baseRate * 100)
 	end
 

--- a/data-otservbr-global/scripts/creaturescripts/others/login.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/login.lua
@@ -217,20 +217,16 @@ function playerLogin.onLogin(player)
 	end
 
 	-- Set Client XP Gain Rate --
-	local rateExp = 1
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		rateExp = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
-
-		if SCHEDULE_EXP_RATE ~= 100 then
-			rateExp = math.max(0, (rateExp * SCHEDULE_EXP_RATE)/100)
-		end
+		local baseRate = player:getFinalBaseRateExperience()
+		print(baseRate)
+		player:setBaseXpGain(baseRate * 100)
 	end
 
 	local staminaMinutes = player:getStamina()
 	local staminaBonus = (staminaMinutes > 2340) and 150 or ((staminaMinutes < 840) and 50 or 100)
 
 	player:setStaminaXpBoost(staminaBonus)
-	player:setBaseXpGain(rateExp * 100)
 
 	if onExerciseTraining[player:getId()] then -- onLogin & onLogout
 		stopEvent(onExerciseTraining[player:getId()].event)

--- a/data-otservbr-global/scripts/creaturescripts/others/login.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/login.lua
@@ -219,7 +219,6 @@ function playerLogin.onLogin(player)
 	-- Set Client XP Gain Rate --
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
 		local baseRate = player:getFinalBaseRateExperience()
-		print(baseRate)
 		player:setBaseXpGain(baseRate * 100)
 	end
 

--- a/data-otservbr-global/scripts/talkactions/player/server_info.lua
+++ b/data-otservbr-global/scripts/talkactions/player/server_info.lua
@@ -2,8 +2,9 @@ local serverInfo = TalkAction("!serverinfo")
 
 function serverInfo.onSay(player, words, param)
 	local configRateSkill =  configManager.getNumber(configKeys.RATE_SKILL)
+	local baseRate = player:getFinalBaseRateExperience()
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Server Info:"
-	.. "\nExp rate: " .. getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
+	.. "\nExp rate: " .. baseRate
 	.. "\nSword Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_SWORD), configRateSkill)
 	.. "\nClub Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_CLUB), configRateSkill)
 	.. "\nAxe Skill rate: " .. getRateFromTable(skillsStages, player:getSkillLevel(SKILL_AXE), configRateSkill)

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -680,14 +680,6 @@ function Player:onGainExperience(target, exp, rawExp)
 		self:addCondition(soulCondition)
 	end
 
-	-- Experience Stage Multiplier
-	local expStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXPERIENCE))
-
-	-- Event scheduler
-	if SCHEDULE_EXP_RATE ~= 100 then
-		expStage = math.max(0, (expStage * SCHEDULE_EXP_RATE)/100)
-	end
-
 	-- Store Bonus
 	useStaminaXpBoost(self) -- Use store boost stamina
 
@@ -723,7 +715,15 @@ function Player:onGainExperience(target, exp, rawExp)
 		end
 	end
 
-	return math.max((exp * expStage + (exp * (storeXpBoostAmount/100))) * staminaBoost)
+	local baseRate = self:getFinalBaseRateExperience()
+	local finalExperience
+	if configManager.getBoolean(configKeys.RATE_USE_STAGES) then
+		finalExperience = (exp * baseRate + (exp * (storeXpBoostAmount/100))) * staminaBoost
+	else 
+		finalExperience = (exp + (exp * (storeXpBoostAmount/100))) * staminaBoost
+	end
+
+	return math.max(finalExperience)
 end
 
 function Player:onLoseExperience(exp)

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -719,7 +719,7 @@ function Player:onGainExperience(target, exp, rawExp)
 	local finalExperience
 	if configManager.getBoolean(configKeys.RATE_USE_STAGES) then
 		finalExperience = (exp * baseRate + (exp * (storeXpBoostAmount/100))) * staminaBoost
-	else 
+	else
 		finalExperience = (exp + (exp * (storeXpBoostAmount/100))) * staminaBoost
 	end
 

--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -439,3 +439,19 @@ function Player:CreateFamiliarSpell()
 	end
 	return true
 end
+
+function Player.getFinalBaseRateExperience(self)
+	-- Experience Stage Multiplier
+	local baseRate
+	local rateExperience = configManager.getNumber(configKeys.RATE_EXPERIENCE)
+	if configManager.getBoolean(configKeys.RATE_USE_STAGES) then
+		baseRate = getRateFromTable(experienceStages, self:getLevel(), rateExperience)
+	else 
+		baseRate = rateExperience
+	end
+	-- Event scheduler
+	if SCHEDULE_EXP_RATE ~= 100 then
+		baseRate = math.max(0, (baseRate * SCHEDULE_EXP_RATE) / 100)
+	end
+	return baseRate
+end


### PR DESCRIPTION
# Description

Fix for use callback rateUseStages = false/true

## Behaviour
### **Actual**

Changing the "rateUseStages" does not influence anything, as the stages continue to be used

### **Expected**

When setting "rateUseStages" to false, experience stages stop working

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Already specified in the Behaviour

**Test Configuration**:

  - Server Version: 1291
  - Client: 1291
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
