### PR TITLE
Fixed for not send log of internalDecayItem failed

### DIFF
--- a/src/items/decay/decay.cpp
+++ b/src/items/decay/decay.cpp
@@ -190,6 +190,10 @@ void Decay::internalDecayItem(Item* item)
 		}
 		g_game().transformItem(item, static_cast<uint16_t>(it.decayTo));
 	} else {
+		if (item->getLoadedFromMap()) {
+			return;
+		}
+
 		ReturnValue ret = g_game().internalRemoveItem(item);
 		if (ret != RETURNVALUE_NOERROR) {
 			SPDLOG_ERROR("[Decay::internalDecayItem] - internalDecayItem failed, "


### PR DESCRIPTION
# Description

This disables the log being sent when trying to remove items that have decay and are created by rme

## Behaviour
### **Actual**

![image](https://user-images.githubusercontent.com/8551443/205472305-ca52701c-a02e-4d7a-b159-4615e64ec372.png)

### **Expected**

No error

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
