### PR TITLE
Fixed daily reward serverTimeThreshold

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -71,7 +71,7 @@ local DailyRewardItems = {
 
 DailyReward = {
 	testMode = false,
-	serverTimeThreshold = (24 * 60 * 60), -- Counting down 24hours from last server save
+	serverTimeThreshold = (25 * 60 * 60), -- Counting down 24hours from last server save
 
 	storages = {
 		-- Player


### PR DESCRIPTION
# Description

Due to the time interval that the save server starts and ends, sometimes the player loses the reward

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)