### PR TITLE
[Bug] fixes the same name conflict of function and global variable

### DIFF
--- a/data-canary/scripts/lib/register_monster_type.lua
+++ b/data-canary/scripts/lib/register_monster_type.lua
@@ -274,7 +274,7 @@ registerMonsterType.events = function(mtype, mask)
 	end
 end
 
-function sortLootByChance(loot)
+function SortLootByChance(loot)
 	if not configManager.getBoolean(configKeys.SORT_LOOT_BY_CHANCE) then
 		return
 	end
@@ -290,7 +290,7 @@ end
 
 registerMonsterType.loot = function(mtype, mask)
 	if type(mask.loot) == "table" then
-		sortLootByChance(mask.loot)
+		SortLootByChance(mask.loot)
 		local lootError = false
 		for _, loot in pairs(mask.loot) do
 			local parent = Loot()
@@ -352,7 +352,7 @@ registerMonsterType.loot = function(mtype, mask)
 				parent:setUnique(loot.unique)
 			end
 			if loot.child then
-				sortLootByChance(loot.child)
+				SortLootByChance(loot.child)
 				for _, children in pairs(loot.child) do
 					local child = Loot()
 					if children.name then

--- a/data-otservbr-global/scripts/lib/register_monster_type.lua
+++ b/data-otservbr-global/scripts/lib/register_monster_type.lua
@@ -275,7 +275,7 @@ registerMonsterType.events = function(mtype, mask)
 	end
 end
 
-function sortLootByChance(loot)
+function SortLootByChance(loot)
 	if not configManager.getBoolean(configKeys.SORT_LOOT_BY_CHANCE) then
 		return
 	end
@@ -291,7 +291,7 @@ end
 
 registerMonsterType.loot = function(mtype, mask)
 	if type(mask.loot) == "table" then
-		sortLootByChance(mask.loot)
+		SortLootByChance(mask.loot)
 		local lootError = false
 		for _, loot in pairs(mask.loot) do
 			local parent = Loot()
@@ -353,7 +353,7 @@ registerMonsterType.loot = function(mtype, mask)
 				parent:setUnique(loot.unique)
 			end
 			if loot.child then
-				sortLootByChance(loot.child)
+				SortLootByChance(loot.child)
 				for _, children in pairs(loot.child) do
 					local child = Loot()
 					if children.name then


### PR DESCRIPTION
The variable of the same name is found in config.lua, which conflicts with the global function and causes problems after using "/reload" command.