### PR TITLE
[Bug] prevent player move item with the imbuement window opened

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -876,6 +876,10 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos,
 	if (!player) {
 		return;
 	}
+	
+	if (player->hasImbuingItem()) {
+        return;
+    }
 
 	uint8_t fromIndex = 0;
 	if (fromPos.x == 0xFFFF) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -877,6 +877,7 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos,
 		return;
 	}
 	
+	// Prevent the player from being able to move the item within the imbuement window
 	if (player->hasImbuingItem()) {
         return;
     }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -880,7 +880,7 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos,
 	// Prevent the player from being able to move the item within the imbuement window
 	if (player->hasImbuingItem()) {
         return;
-    }
+	}
 
 	uint8_t fromIndex = 0;
 	if (fromPos.x == 0xFFFF) {


### PR DESCRIPTION
Fix movement when use imbuement shrine