### PR TITLE
Fix npc get only valid direction

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -465,9 +465,9 @@ void Npc::onThinkWalk(uint32_t interval)
 		return;
 	}
 
-	Direction dir = Position::getRandomDirection();
-	if (canWalkTo(getPosition(), dir)) {
-		listWalkDir.push_front(dir);
+	Direction newDirection;
+	if (getRandomStep(newDirection)) {
+		listWalkDir.push_front(newDirection);
 		addEventWalk();
 	}
 
@@ -560,6 +560,27 @@ bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
 
 bool Npc::getNextStep(Direction& nextDirection, uint32_t& flags) {
 	return Creature::getNextStep(nextDirection, flags);
+}
+
+bool Npc::getRandomStep(Direction& moveDirection) const
+{
+	static std::vector<Direction> directionvector {
+		Direction::DIRECTION_NORTH,
+		Direction::DIRECTION_WEST,
+		Direction::DIRECTION_EAST,
+		Direction::DIRECTION_SOUTH
+	};
+	std::shuffle(directionvector.begin(), directionvector.end(), getRandomGenerator());
+
+	for (const Position& creaturePos = getPosition();
+		Direction direction : directionvector)
+	{
+		if (canWalkTo(creaturePos, direction)) {
+			moveDirection = direction;
+			return true;
+		}
+	}
+	return false;
 }
 
 void Npc::addShopPlayer(Player* player)

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -570,7 +570,7 @@ bool Npc::getRandomStep(Direction& moveDirection) const
 		Direction::DIRECTION_EAST,
 		Direction::DIRECTION_SOUTH
 	};
-	std::shuffle(directionvector.begin(), directionvector.end(), getRandomGenerator());
+	std::ranges::shuffle(directionvector, getRandomGenerator());
 
 	for (const Position& creaturePos = getPosition();
 		Direction direction : directionvector)

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -465,8 +465,9 @@ void Npc::onThinkWalk(uint32_t interval)
 		return;
 	}
 
-	Direction newDirection;
-	if (getRandomStep(newDirection)) {
+	if (Direction newDirection;
+		getRandomStep(newDirection))
+	{
 		listWalkDir.push_front(newDirection);
 		addEventWalk();
 	}

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -170,7 +170,8 @@ class Npc final : public Creature
 		void onPlacedCreature() override;
 
 		bool canWalkTo(const Position& fromPos, Direction dir) const;
-		bool getNextStep(Direction& direction, uint32_t& flags) override;
+		bool getNextStep(Direction& nextDirection, uint32_t& flags) override;
+		bool getRandomStep(Direction& moveDirection) const;
 
 		void setNormalCreatureLight() override {
 			internalLight = npcType->info.light;


### PR DESCRIPTION
# Description

Npcs were going in invalid directions, for example walls. Now they will only walk where there is free sqm.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
