### PR TITLE
Fix prey loot message

### DIFF
--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -32,9 +32,9 @@ function Monster:onDropLoot(corpse)
 				Spdlog.warn(string.format("[2][Monster:onDropLoot] - Could not add loot item to monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
 			end
 		end
-		local preyLootActive = false
-		-- Runs the loot again if the player gets a chance to loot in the prey
+
 		if player then
+			-- Runs the loot again if the player gets a chance to loot in the prey
 			local preyLootPercent = player:getPreyLootPercentage(mType:raceId())
 			if preyLootPercent > 0 then
 				local probability = math.random(0, 100)
@@ -43,22 +43,18 @@ function Monster:onDropLoot(corpse)
 						local item = corpse:createLootItem(monsterLoot[i], charmBonus)
 						if not item then
 							Spdlog.warn(string.format("[3][Monster:onDropLoot] - Could not add loot item to monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
-						else
-							preyLootActive = true
 						end
 					end
 				end
 			end
-		end
 
-		if player then
 			local text = {}
 			if self:getName():lower() == (Game.getBoostedCreature()):lower() then
 				 text = ("Loot of %s: %s (boosted loot)"):format(mType:getNameDescription(), corpse:getContentDescription())
 			else
 				 text = ("Loot of %s: %s"):format(mType:getNameDescription(), corpse:getContentDescription())
 			end
-			if preyLootActive then
+			if preyLootPercent > 0 then
 				text = text .. " (active prey bonus)"
 			end
 			if charmBonus then


### PR DESCRIPTION
# Description

Prey message should appear on the monster that is with loot prey regardless of whether it was activated or not.

Need PR #684 to work correctly

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] My changes generate no new warnings
