### PR TITLE
improve: upgrade curl to use TLS version 1.2

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -57,8 +57,8 @@ bool Map::loadMap(const std::string& identifier,
 			FILE *otbm = fopen(identifier.c_str(), "wb");
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 			curl_easy_setopt(curl, CURLOPT_URL, mapDownloadUrl.c_str());
-			curl_easy_setopt(curl, CURLOPT_WRITEDATA, otbm);
 			curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+			curl_easy_setopt(curl, CURLOPT_WRITEDATA, otbm);
 			curl_easy_perform(curl);
 			curl_easy_cleanup(curl);
 			fclose(otbm);

--- a/src/server/network/webhook/webhook.cpp
+++ b/src/server/network/webhook/webhook.cpp
@@ -130,6 +130,7 @@ static int webhook_send_message_(const char *url, const char *payload, std::stri
 	}
 
 	curl_easy_setopt(curl, CURLOPT_URL, url);
+	curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 	curl_easy_setopt(curl, CURLOPT_POST, 1L);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, reinterpret_cast<void *>(&response_body));
@@ -143,7 +144,7 @@ static int webhook_send_message_(const char *url, const char *payload, std::stri
 		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
 	} else {
 		SPDLOG_ERROR("Failed to send webhook message with the error: {}",
-                     curl_easy_strerror(res));
+						curl_easy_strerror(res));
 	}
 
 	curl_easy_cleanup(curl);


### PR DESCRIPTION
This pull request updates the version of curl used in the project to version 7.64.0 or above, which includes support for Transport Layer Security (TLS) version 1.2. This update ensures that the project is using the most secure version of the protocol and is in compliance with industry security standards.