### PR TITLE
fix: upload artifacts in GHA from Ubuntu

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -68,6 +68,6 @@ jobs:
       - name: Create and Upload Artifact
         uses: actions/upload-artifact@main
         with:
-          name: canary-${{ matrix.buildtype }}-${{ github.sha }}
+          name: canary-${{ matrix.os }}-${{ matrix.buildtype }}-${{ github.sha }}
           path: |
             ${{ github.workspace }}/build/${{ matrix.buildtype }}/bin/


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/61994374/210022571-67c88f01-3862-40ac-8a6a-411988b3cd59.png)

## Now:
![image](https://user-images.githubusercontent.com/61994374/210022601-17c88b17-924a-47d4-97da-53a3c07697db.png)
