### PR TITLE
Adding verification to prevent crash

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3849,10 +3849,13 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 
 			for (const auto& it : openContainers) {
 				Container* container = it.second.container;
-				if(container != nullptr){
-					if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
-						containers.push_back(container);
-					}
+				if (container == nullptr) {
+								continue;
+				}
+
+				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
+								containers.push_back(container);
+				}
 				}
 			}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3849,8 +3849,10 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 
 			for (const auto& it : openContainers) {
 				Container* container = it.second.container;
-				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
-					containers.push_back(container);
+				if(container != nullptr){
+					if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
+						containers.push_back(container);
+					}
 				}
 			}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3856,7 +3856,6 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
 								containers.push_back(container);
 				}
-				}
 			}
 
 			for (const Container* container : containers) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3850,11 +3850,11 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 			for (const auto& it : openContainers) {
 				Container* container = it.second.container;
 				if (container == nullptr) {
-								continue;
+					continue;
 				}
 
 				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
-								containers.push_back(container);
+					containers.push_back(container);
 				}
 			}
 


### PR DESCRIPTION
Adding verification to prevent crash

Details

 Thread 2 "canary" received signal SIGSEGV, Segmentation fault.
2022-12-19 15:32:19 -  [Switching to Thread 0x7ffff79ac700 (LWP 117106)]
2022-12-19 15:32:19 -  0x00005555556e888c in Player::postAddNotification (this=0x7fffb02bb680, thing=<optimized out>, oldParent=<optimized out>, index=<optimized out>, link=<optimized out>) at /home/xxx/src/creatures/players/player.cpp:3870
2022-12-19 15:32:19 -  3870					if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {