### PR TITLE
[Bug] fixes for only monsters with valid race id can be forgeable

### DIFF
--- a/data-canary/scripts/talkactions/god/create_monster.lua
+++ b/data-canary/scripts/talkactions/god/create_monster.lua
@@ -5,16 +5,41 @@ function createMonster.onSay(player, words, param)
 		return true
 	end
 
+	-- Usage: "/m monstername, fiendish" for create a fiendish monster (/m rat, fiendish)
+	-- Usage: "/m monstername, [1-5]" for create a influenced monster with specific level (/m rat, 2)
 	if param == "" then
-		player:sendCancelMessage("Command param required.")
+		player:sendCancelMessage("Monster name param required.")
+		Spdlog.error("[createMonster.onSay] - Monster name param not found.")
 		return false
 	end
 
+	local split = param:split(",")
+	local monsterName = split[1]
+	local monsterForge = nil
+	if split[2] then
+		split[2] = split[2]:gsub("^%s*(.-)$", "%1") --Trim left
+		monsterForge = split[2]
+	end
+	-- Check dust level
+	local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(monsterForge, player)
+
 	local position = player:getPosition()
-	local monster = Game.createMonster(param, position)
+	local monster = Game.createMonster(monsterName, position)
 	if monster then
+		if not monster:isForgeable() then
+			player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
+			return false
+		end
 		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
+
+		local monsterType = monster:getType()
+		if canSetFiendish then
+			SetFiendish(monsterType, position, player, monster)
+		end
+		if canSetInfluenced then
+			SetInfluenced(monsterType, monster, player, influencedLevel)
+		end
 	else
 		player:sendCancelMessage("There is not enough room.")
 		position:sendMagicEffect(CONST_ME_POFF)

--- a/data-otservbr-global/scripts/talkactions/god/create_monster.lua
+++ b/data-otservbr-global/scripts/talkactions/god/create_monster.lua
@@ -42,13 +42,13 @@ function createMonster.onSay(player, words, param)
 	local monster = Game.createMonster(monsterName, position)
 	if monster then
 		if not monster:isForgeable() then
-			player:sendCancelMessage("Only allowed monsters can be fiendish.")
+			player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
 			return false
 		end
 		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
+		local monsterType = monster:getType()
 		if setFiendish then
-			local monsterType = monster:getType()
 			if monsterType and not monsterType:isForgeCreature() then
 				player:sendCancelMessage("Only allowed monsters can be fiendish.")
 				return false
@@ -56,6 +56,10 @@ function createMonster.onSay(player, words, param)
 			monster:setFiendish(position, player)
 		end
 		if setInfluenced then
+			if monsterType and not monsterType:isForgeCreature() then
+				player:sendCancelMessage("Only allowed monsters can be influenced.")
+				return false
+			end
 			local influencedMonster = Monster(ForgeMonster:pickInfluenced())
 			-- If it's reached the limit, we'll remove one to add the new one.
 			if ForgeMonster:exceededMaxInfluencedMonsters() then

--- a/data-otservbr-global/scripts/talkactions/god/create_monster.lua
+++ b/data-otservbr-global/scripts/talkactions/god/create_monster.lua
@@ -21,50 +21,24 @@ function createMonster.onSay(player, words, param)
 		monsterForge = split[2]
 	end
 	-- Check dust level
-	local setFiendish = false
-	local setInfluenced
-	if type(monsterForge) == "string" and monsterForge == "fiendish" then
-		setFiendish = true
-	end
-	local influencedLevel
-	if not setFiendish then
-		influencedLevel = tonumber(monsterForge)
-	end
-	if influencedLevel and influencedLevel > 0 then
-		if influencedLevel > 5 then
-			player:sendCancelMessage("Invalid influenced level.")
-			return false
-		end
-		setInfluenced = true
-	end
+	local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(monsterForge, player)
 
 	local position = player:getPosition()
 	local monster = Game.createMonster(monsterName, position)
 	if monster then
 		if not monster:isForgeable() then
-			player:sendCancelMessage("Only allowed monsters can be fiendish.")
+			player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
 			return false
 		end
 		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
-		if setFiendish then
-			local monsterType = monster:getType()
-			if monsterType and not monsterType:isForgeCreature() then
-				player:sendCancelMessage("Only allowed monsters can be fiendish.")
-				return false
-			end
-			monster:setFiendish(position, player)
+
+		local monsterType = monster:getType()
+		if canSetFiendish then
+			SetFiendish(monsterType, position, player, monster)
 		end
-		if setInfluenced then
-			local influencedMonster = Monster(ForgeMonster:pickInfluenced())
-			-- If it's reached the limit, we'll remove one to add the new one.
-			if ForgeMonster:exceededMaxInfluencedMonsters() then
-				if influencedMonster then
-					Game.removeInfluencedMonster(influencedMonster:getId())
-				end
-			end
-			Game.addInfluencedMonster(monster)
-			monster:setForgeStack(influencedLevel)
+		if canSetInfluenced then
+			SetInfluenced(monsterType, monster, player, influencedLevel)
 		end
 	else
 		player:sendCancelMessage("There is not enough room.")

--- a/data-otservbr-global/scripts/talkactions/god/create_monster.lua
+++ b/data-otservbr-global/scripts/talkactions/god/create_monster.lua
@@ -41,6 +41,10 @@ function createMonster.onSay(player, words, param)
 	local position = player:getPosition()
 	local monster = Game.createMonster(monsterName, position)
 	if monster then
+		if not monster:isForgeable() then
+			player:sendCancelMessage("Only allowed monsters can be fiendish.")
+			return false
+		end
 		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		position:sendMagicEffect(CONST_ME_MAGIC_RED)
 		if setFiendish then

--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -909,3 +909,47 @@ function Player:doCheckBossRoom(bossName, fromPos, toPos)
 	end
 	return true
 end
+
+function CheckDustLevel(monsterForge, player)
+	local canSetFiendish = false
+	local canSetInfluenced
+	if type(monsterForge) == "string" and monsterForge == "fiendish" then
+		canSetFiendish = true
+	end
+	local influencedLevel
+	if not canSetFiendish then
+		influencedLevel = tonumber(monsterForge)
+	end
+	if influencedLevel and influencedLevel > 0 then
+		if influencedLevel > 5 then
+			player:sendCancelMessage("Invalid influenced level.")
+			return false
+		end
+		canSetInfluenced = true
+	end
+	return canSetFiendish, canSetInfluenced, influencedLevel
+end
+
+function SetFiendish(monsterType, position, player, monster)
+	if monsterType and not monsterType:isForgeCreature() then
+		player:sendCancelMessage("Only allowed monsters can be fiendish.")
+		return false
+	end
+	monster:setFiendish(position, player)
+end
+
+function SetInfluenced(monsterType, monster, player, influencedLevel)
+	if monsterType and not monsterType:isForgeCreature() then
+		player:sendCancelMessage("Only allowed monsters can be influenced.")
+		return false
+	end
+	local influencedMonster = Monster(ForgeMonster:pickInfluenced())
+	-- If it's reached the limit, we'll remove one to add the new one.
+	if ForgeMonster:exceededMaxInfluencedMonsters() then
+		if influencedMonster then
+			Game.removeInfluencedMonster(influencedMonster:getId())
+		end
+	end
+	Game.addInfluencedMonster(monster)
+	monster:setForgeStack(influencedLevel)
+end

--- a/data/libs/functions/monster.lua
+++ b/data/libs/functions/monster.lua
@@ -117,7 +117,7 @@ function Monster.onReceivDamageSL(self, damage, tp, killer)
 end
 
 function Monster.setFiendish(self, position, player)
-	if not self then
+	if not self or not self:isForgeable() then
 		player:sendCancelMessage("Only allowed monsters can be fiendish.")
 		return false
 	end

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -280,7 +280,7 @@ class Monster final : public Creature
 		void configureForgeSystem();
 
 		bool canBeForgeMonster() const {
-			return getForgeStack() == 0 && !isSummon() && !isRewardBoss() && canDropLoot() && isForgeCreature();
+			return getForgeStack() == 0 && !isSummon() && !isRewardBoss() && canDropLoot() && isForgeCreature() && getRaceId() > 0;
 		}
 
 		

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -501,7 +501,7 @@ int MonsterFunctions::luaMonsterClearFiendishStatus(lua_State *L) {
 
 int MonsterFunctions::luaMonsterIsForgeable(lua_State *L) {
 	// monster:isForgeable()
-	Monster *monster = getUserdata<Monster>(L, 1);
+	const Monster *monster = getUserdata<Monster>(L, 1);
 	if (!monster) {
 		reportErrorFunc(getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		pushBoolean(L, false);

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -498,3 +498,16 @@ int MonsterFunctions::luaMonsterClearFiendishStatus(lua_State *L) {
 	monster->clearFiendishStatus();
 	return 1;
 }
+
+int MonsterFunctions::luaMonsterIsForgeable(lua_State *L) {
+	// monster:isForgeable()
+	Monster *monster = getUserdata<Monster>(L, 1);
+	if (!monster) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
+		pushBoolean(L, false);
+		return 0;
+	}
+
+	pushBoolean(L, monster->canBeForgeMonster());
+	return 1;
+}

--- a/src/lua/functions/creatures/monster/monster_functions.hpp
+++ b/src/lua/functions/creatures/monster/monster_functions.hpp
@@ -63,6 +63,7 @@ class MonsterFunctions final : LuaScriptInterface {
 				registerMethod(L, "Monster", "setForgeStack", MonsterFunctions::luaMonsterSetForgeStack);
 				registerMethod(L, "Monster", "configureForgeSystem", MonsterFunctions::luaMonsterConfigureForgeSystem);
 				registerMethod(L, "Monster", "clearFiendishStatus", MonsterFunctions::luaMonsterClearFiendishStatus);
+				registerMethod(L, "Monster", "isForgeable", MonsterFunctions::luaMonsterIsForgeable);
 
 				CharmFunctions::init(L);
 				LootFunctions::init(L);
@@ -113,6 +114,7 @@ class MonsterFunctions final : LuaScriptInterface {
 		static int luaMonsterSetForgeStack(lua_State *L);
 		static int luaMonsterConfigureForgeSystem(lua_State *L);
 		static int luaMonsterClearFiendishStatus(lua_State *L);
+		static int luaMonsterIsForgeable(lua_State *L);
 
 		friend class CreatureFunctions;
 };


### PR DESCRIPTION
# Description

Some monsters that didn't have a "raceId" could be forgeable, which resulted in unexpected behaviour and a error in the distro

## Behaviour
### **Actual**

It was possible to set as fiendish or influenced bosses and other monsters that don't have raceId, which generated a loop in the distro or error.

### **Expected**

![image](https://user-images.githubusercontent.com/8551443/208485048-bc947061-a901-425f-b351-141e22783a53.png)

## Fixes #702

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
