### PR TITLE
[Bug] fixes reward chest unique loot

### DIFF
--- a/data-canary/scripts/reward_chest/boss_death.lua
+++ b/data-canary/scripts/reward_chest/boss_death.lua
@@ -1,13 +1,8 @@
 local bossDeath = CreatureEvent("BossDeath")
 
 function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUnjustified, mostDamageUnjustified)
-	-- player
-	if not creature then
-		return true
-	end
-
 	-- Deny summons and players
-	if creature:isPlayer() or creature:getMaster() then
+	if not creature or creature:isPlayer() or creature:getMaster() then
 		return true
 	end
 

--- a/data/libs/reward_boss/monster.lua
+++ b/data/libs/reward_boss/monster.lua
@@ -82,7 +82,7 @@ function MonsterType.getBossReward(self, lootFactor, topScore)
 			local lootBlock = loot[i]
 			if lootBlock then
 				if lootBlock.unique and not topScore then
-					--continue
+					-- Ignore loot with unique
 				else
 					self:createLootItem(lootBlock, lootFactor, result)
 				end

--- a/data/libs/reward_boss/monster.lua
+++ b/data/libs/reward_boss/monster.lua
@@ -81,9 +81,7 @@ function MonsterType.getBossReward(self, lootFactor, topScore)
 		for i = #loot, 0, -1 do
 			local lootBlock = loot[i]
 			if lootBlock then
-				if lootBlock.unique and not topScore then
-					-- Ignore loot with unique
-				else
+				if not lootBlock.unique or topScore then
 					self:createLootItem(lootBlock, lootFactor, result)
 				end
 			end

--- a/data/libs/reward_boss/monster.lua
+++ b/data/libs/reward_boss/monster.lua
@@ -82,7 +82,7 @@ function MonsterType.getBossReward(self, lootFactor, topScore)
 			local lootBlock = loot[i]
 			if lootBlock then
 				if lootBlock.unique and not topScore then
-					return
+					--continue
 				else
 					self:createLootItem(lootBlock, lootFactor, result)
 				end


### PR DESCRIPTION
# Description

When two players kill a boss that has unique loot, it gives an error and one of them does not receive loot.

## Behaviour
### **Actual**
Player not receive loot and receive console error

### **Expected**
Player receive loot and not receive console error

## Fixes #711, #699

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
With two players (they cannot be from the god account) kill a boss that has unique loot, for example "Ocyakao" (put the unique loot at 100000 to make it easier to test)

**Test Configuration**:

  - Server Version: 1291
  - Client: 1291
  - Operating System: Windows 11
