### PR TITLE
fix: global result table to Result

### DIFF
--- a/data-canary/scripts/creaturescripts/player_death.lua
+++ b/data-canary/scripts/creaturescripts/player_death.lua
@@ -49,12 +49,12 @@ function playerDeath.onDeath(player, corpse, killer, mostDamageKiller, unjustifi
 	local deathRecords = 0
 	local tmpResultId = resultId
 	while tmpResultId ~= false do
-		tmpResultId = result.next(resultId)
+		tmpResultId = Result.next(resultId)
 		deathRecords = deathRecords + 1
 	end
 
 	if resultId ~= false then
-		result.free(resultId)
+		Result.free(resultId)
 	end
 
 	local limit = deathRecords - maxDeathRecords
@@ -72,8 +72,8 @@ function playerDeath.onDeath(player, corpse, killer, mostDamageKiller, unjustifi
 				local warId = false
 				resultId = db.storeQuery("SELECT `id` FROM `guild_wars` WHERE `status` = 1 AND ((`guild1` = " .. killerGuild .. " AND `guild2` = " .. targetGuild .. ") OR (`guild1` = " .. targetGuild .. " AND `guild2` = " .. killerGuild .. "))")
 				if resultId ~= false then
-					warId = result.getNumber(resultId, "id")
-					result.free(resultId)
+					warId = Result.getNumber(resultId, "id")
+					Result.free(resultId)
 				end
 
 				if warId ~= false then

--- a/data-canary/scripts/globalevents/startup.lua
+++ b/data-canary/scripts/globalevents/startup.lua
@@ -17,30 +17,30 @@ function startup.onStartup()
 	local resultId = db.storeQuery("SELECT * FROM `account_bans` WHERE `expires_at` != 0 AND `expires_at` <= " .. os.time())
 	if resultId ~= false then
 		repeat
-			local accountId = result.getNumber(resultId, "account_id")
-			db.asyncQuery("INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, `expired_at`, `banned_by`) VALUES (" .. accountId .. ", " .. db.escapeString(result.getString(resultId, "reason")) .. ", " .. result.getNumber(resultId, "banned_at") .. ", " .. result.getNumber(resultId, "expires_at") .. ", " .. result.getNumber(resultId, "banned_by") .. ")")
+			local accountId = Result.getNumber(resultId, "account_id")
+			db.asyncQuery("INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, `expired_at`, `banned_by`) VALUES (" .. accountId .. ", " .. db.escapeString(Result.getString(resultId, "reason")) .. ", " .. Result.getNumber(resultId, "banned_at") .. ", " .. Result.getNumber(resultId, "expires_at") .. ", " .. Result.getNumber(resultId, "banned_by") .. ")")
 			db.asyncQuery("DELETE FROM `account_bans` WHERE `account_id` = " .. accountId)
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 
 	-- Check house auctions
 	local resultId = db.storeQuery("SELECT `id`, `highest_bidder`, `last_bid`, (SELECT `balance` FROM `players` WHERE `players`.`id` = `highest_bidder`) AS `balance` FROM `houses` WHERE `owner` = 0 AND `bid_end` != 0 AND `bid_end` < " .. os.time())
 	if resultId ~= false then
 		repeat
-			local house = House(result.getNumber(resultId, "id"))
+			local house = House(Result.getNumber(resultId, "id"))
 			if house then
-				local highestBidder = result.getNumber(resultId, "highest_bidder")
-				local balance = result.getNumber(resultId, "balance")
-				local lastBid = result.getNumber(resultId, "last_bid")
+				local highestBidder = Result.getNumber(resultId, "highest_bidder")
+				local balance = Result.getNumber(resultId, "balance")
+				local lastBid = Result.getNumber(resultId, "last_bid")
 				if balance >= lastBid then
 					db.query("UPDATE `players` SET `balance` = " .. (balance - lastBid) .. " WHERE `id` = " .. highestBidder)
 					house:setOwnerGuid(highestBidder)
 				end
 				db.asyncQuery("UPDATE `houses` SET `last_bid` = 0, `bid_end` = 0, `highest_bidder` = 0, `bid` = 0 WHERE `id` = " .. house:getId())
 			end
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 
 	-- store towns in database

--- a/data-canary/scripts/talkactions/god/ban.lua
+++ b/data-canary/scripts/talkactions/god/ban.lua
@@ -29,7 +29,7 @@ function ban.onSay(player, words, param)
 
 	local resultId = db.storeQuery("SELECT 1 FROM `account_bans` WHERE `account_id` = " .. accountId)
 	if resultId ~= false then
-		result.free(resultId)
+		Result.free(resultId)
 		return false
 	end
 

--- a/data-canary/scripts/talkactions/god/gold_highscore.lua
+++ b/data-canary/scripts/talkactions/god/gold_highscore.lua
@@ -18,9 +18,9 @@ function gold_rank.onSay(player, words, param)
 		local x = 0
 		repeat
 			x = x + 1
-				str = str.."\n"..x.."- "..result.getString(resultId, "name").." ("..result.getNumber(resultId, "balance")..")."
-		until not result.next(resultId)
-		result.free(resultId)
+				str = str.."\n"..x.."- "..Result.getString(resultId, "name").." ("..Result.getNumber(resultId, "balance")..")."
+		until not Result.next(resultId)
+		Result.free(resultId)
 		if str == "" then
 			str = "No highscore to show."
 		end

--- a/data-canary/scripts/talkactions/god/ip_ban.lua
+++ b/data-canary/scripts/talkactions/god/ip_ban.lua
@@ -17,9 +17,9 @@ function ipBan.onSay(player, words, param)
 		return false
 	end
 
-	local targetName = result.getString(resultId, "name")
-	local targetIp = result.getNumber(resultId, "lastip")
-	result.free(resultId)
+	local targetName = Result.getString(resultId, "name")
+	local targetIp = Result.getNumber(resultId, "lastip")
+	Result.free(resultId)
 
 	local targetPlayer = Player(param)
 	if targetPlayer then
@@ -34,7 +34,7 @@ function ipBan.onSay(player, words, param)
 	resultId = db.storeQuery("SELECT 1 FROM `ip_bans` WHERE `ip` = " .. targetIp)
 	if resultId ~= false then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, targetName .. "  is already IP banned.")
-		result.free(resultId)
+		Result.free(resultId)
 		return false
 	end
 

--- a/data-canary/scripts/talkactions/god/unban.lua
+++ b/data-canary/scripts/talkactions/god/unban.lua
@@ -15,9 +15,9 @@ function unban.onSay(player, words, param)
 		return false
 	end
 
-	db.asyncQuery("DELETE FROM `account_bans` WHERE `account_id` = " .. result.getNumber(resultId, "account_id"))
-	db.asyncQuery("DELETE FROM `ip_bans` WHERE `ip` = " .. result.getNumber(resultId, "lastip"))
-	result.free(resultId)
+	db.asyncQuery("DELETE FROM `account_bans` WHERE `account_id` = " .. Result.getNumber(resultId, "account_id"))
+	db.asyncQuery("DELETE FROM `ip_bans` WHERE `ip` = " .. Result.getNumber(resultId, "lastip"))
+	Result.free(resultId)
 	player:sendTextMessage(MESSAGE_LOOK, param .. " has been unbanned.")
 	return false
 end

--- a/data-otservbr-global/lib/compat/compat.lua
+++ b/data-otservbr-global/lib/compat/compat.lua
@@ -16,6 +16,9 @@ MESSAGE_EVENT_DEFAULT = MESSAGE_STATUS
 MESSAGE_EVENT_ORANGE = TALKTYPE_MONSTER_SAY
 MESSAGE_STATUS_CONSOLE_ORANGE = TALKTYPE_MONSTER_YELL
 
+if type(result) then
+	result = Result
+end
 result.getDataInt = result.getNumber
 result.getDataLong = result.getNumber
 result.getDataString = result.getString

--- a/data-otservbr-global/npc/hireling.lua
+++ b/data-otservbr-global/npc/hireling.lua
@@ -454,8 +454,8 @@ function createHirelingType(HirelingName)
 			"SELECT `id` FROM `guilds` WHERE `name` = " .. db.escapeString(name),
 			function(resultId)
 				if resultId then
-					func(result.getNumber(resultId, "id"))
-					result.free(resultId)
+					func(Result.getNumber(resultId, "id"))
+					Result.free(resultId)
 				else
 					func(nil)
 				end
@@ -471,8 +471,8 @@ function createHirelingType(HirelingName)
 			local balance
 			local resultId = db.storeQuery("SELECT `balance` FROM `guilds` WHERE `id` = " .. id)
 			if resultId then
-				balance = result.getNumber(resultId, "balance")
-				result.free(resultId)
+				balance = Result.getNumber(resultId, "balance")
+				Result.free(resultId)
 			end
 
 			return balance

--- a/data-otservbr-global/scripts/actions/other/golden_outfit_memorial.lua
+++ b/data-otservbr-global/scripts/actions/other/golden_outfit_memorial.lua
@@ -10,15 +10,15 @@ local function updateGoldenOutfitCache()
 
 	local resultId = db.storeQuery("SELECT `name`, `value` FROM `player_storage` INNER JOIN `players` as `p` ON `p`.`id` = `player_id` WHERE `key` = " .. Storage.OutfitQuest.GoldenOutfit .. " AND `value` >= 1;")
 	if not resultId then
-		result.free(resultId)
+		Result.free(resultId)
 		lastUpdated = os.time()
 		return
 	end
 
 	repeat
-		table.insert(goldenOutfitCache[result.getNumber(resultId, "value")], result.getString(resultId, "name"))
-	until not result.next(resultId)
-	result.free(resultId)
+		table.insert(goldenOutfitCache[Result.getNumber(resultId, "value")], Result.getString(resultId, "name"))
+	until not Result.next(resultId)
+	Result.free(resultId)
 
 	lastUpdated = os.time()
 end

--- a/data-otservbr-global/scripts/creaturescripts/others/login.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/login.lua
@@ -78,7 +78,7 @@ function playerLogin.onLogin(player)
 
 	-- Recruiter system
 	local resultId = db.storeQuery('SELECT `recruiter` from `accounts` where `id`='..getAccountNumberByPlayerName(getPlayerName(player)))
-	local recruiterStatus = result.getNumber(resultId, 'recruiter')
+	local recruiterStatus = Result.getNumber(resultId, 'recruiter')
 	local sex = player:getSex()
 	if recruiterStatus >= 1 then
 		if sex == 1 then

--- a/data-otservbr-global/scripts/creaturescripts/others/player_death.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/player_death.lua
@@ -63,12 +63,12 @@ function playerDeath.onDeath(player, corpse, killer, mostDamageKiller, unjustifi
 	local deathRecords = 0
 	local tmpResultId = resultId
 	while tmpResultId ~= false do
-		tmpResultId = result.next(resultId)
+		tmpResultId = Result.next(resultId)
 		deathRecords = deathRecords + 1
 	end
 
 	if resultId ~= false then
-		result.free(resultId)
+		Result.free(resultId)
 	end
 
 	if byPlayer == 1 then
@@ -83,8 +83,8 @@ function playerDeath.onDeath(player, corpse, killer, mostDamageKiller, unjustifi
 					((`guild1` = ' .. killerGuild .. ' AND `guild2` = ' .. targetGuild .. ') OR \z
 					(`guild1` = ' .. targetGuild .. ' AND `guild2` = ' .. killerGuild .. '))')
 				if resultId ~= false then
-					warId = result.getNumber(resultId, 'id')
-					result.free(resultId)
+					warId = Result.getNumber(resultId, 'id')
+					Result.free(resultId)
 				end
 
 				if warId ~= false then

--- a/data-otservbr-global/scripts/globalevents/others/check_inbox.lua
+++ b/data-otservbr-global/scripts/globalevents/others/check_inbox.lua
@@ -4,11 +4,11 @@ function checkInbox.onThink(interval, lastExecution)
 	if records ~= false then
 		local count = 0
 		repeat
-			local player_id = result.getNumber(records, 'player_id')
+			local player_id = Result.getNumber(records, 'player_id')
 			db.asyncQuery('DELETE FROM `player_inboxitems` WHERE `player_id` = ' .. player_id)
 			db.asyncQuery('DELETE FROM `player` WHERE `id` = ' .. player_id)
-		until not result.next(records)
-		result.free(records)
+		until not Result.next(records)
+		Result.free(records)
 	end
 	return true
 end

--- a/data-otservbr-global/scripts/globalevents/others/startup.lua
+++ b/data-otservbr-global/scripts/globalevents/others/startup.lua
@@ -85,15 +85,15 @@ function serverstartup.onStartup()
 	local banResultId = db.storeQuery('SELECT * FROM `account_bans` WHERE `expires_at` != 0 AND `expires_at` <= ' .. time)
 	if banResultId ~= false then
 		repeat
-			local accountId = result.getNumber(banResultId, 'account_id')
+			local accountId = Result.getNumber(banResultId, 'account_id')
 			db.asyncQuery('INSERT INTO `account_ban_history` (`account_id`, `reason`, `banned_at`, \z
 			`expired_at`, `banned_by`) VALUES (' .. accountId .. ', \z
-			' .. db.escapeString(result.getString(banResultId, 'reason')) .. ', \z
-			' .. result.getNumber(banResultId, 'banned_at') .. ', ' .. result.getNumber(banResultId, 'expires_at') .. ', \z
-			' .. result.getNumber(banResultId, 'banned_by') .. ')')
+			' .. db.escapeString(Result.getString(banResultId, 'reason')) .. ', \z
+			' .. Result.getNumber(banResultId, 'banned_at') .. ', ' .. Result.getNumber(banResultId, 'expires_at') .. ', \z
+			' .. Result.getNumber(banResultId, 'banned_by') .. ')')
 			db.asyncQuery('DELETE FROM `account_bans` WHERE `account_id` = ' .. accountId)
-		until not result.next(banResultId)
-		result.free(banResultId)
+		until not Result.next(banResultId)
+		Result.free(banResultId)
 	end
 
 	-- Ferumbras Ascendant quest
@@ -108,11 +108,11 @@ function serverstartup.onStartup()
 	`bid_end` != 0 AND `bid_end` < ' .. time)
 	if resultId ~= false then
 		repeat
-			local house = House(result.getNumber(resultId, 'id'))
+			local house = House(Result.getNumber(resultId, 'id'))
 			if house then
-				local highestBidder = result.getNumber(resultId, 'highest_bidder')
-				local balance = result.getNumber(resultId, 'balance')
-				local lastBid = result.getNumber(resultId, 'last_bid')
+				local highestBidder = Result.getNumber(resultId, 'highest_bidder')
+				local balance = Result.getNumber(resultId, 'balance')
+				local lastBid = Result.getNumber(resultId, 'last_bid')
 				if balance >= lastBid then
 					db.query('UPDATE `players` SET `balance` = ' .. (balance - lastBid) .. ' WHERE `id` = ' .. highestBidder)
 					house:setOwnerGuid(highestBidder)
@@ -120,8 +120,8 @@ function serverstartup.onStartup()
 				db.asyncQuery('UPDATE `houses` SET `last_bid` = 0, `bid_end` = 0, `highest_bidder` = 0, \z
 				`bid` = 0 WHERE `id` = ' .. house:getId())
 			end
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 
 	do -- Event Schedule rates

--- a/data-otservbr-global/scripts/talkactions/god/ban.lua
+++ b/data-otservbr-global/scripts/talkactions/god/ban.lua
@@ -29,7 +29,7 @@ function ban.onSay(player, words, param)
 
 	local resultId = db.storeQuery("SELECT 1 FROM `account_bans` WHERE `account_id` = " .. accountId)
 	if resultId ~= false then
-		result.free(resultId)
+		Result.free(resultId)
 		return false
 	end
 

--- a/data-otservbr-global/scripts/talkactions/god/gold_highscore.lua
+++ b/data-otservbr-global/scripts/talkactions/god/gold_highscore.lua
@@ -18,9 +18,9 @@ function gold_rank.onSay(player, words, param)
 		local x = 0
 		repeat
 			x = x + 1
-				str = str.."\n"..x.."- "..result.getDataString(resultId, "name").." ("..result.getDataInt(resultId, "balance")..")."
-		until not result.next(resultId)
-		result.free(resultId)
+				str = str.."\n"..x.."- "..Result.getDataString(resultId, "name").." ("..Result.getDataInt(resultId, "balance")..")."
+		until not Result.next(resultId)
+		Result.free(resultId)
 		if str == "" then
 			str = "No highscore to show."
 		end

--- a/data-otservbr-global/scripts/talkactions/god/ip_ban.lua
+++ b/data-otservbr-global/scripts/talkactions/god/ip_ban.lua
@@ -17,9 +17,9 @@ function ipBan.onSay(player, words, param)
 		return false
 	end
 
-	local targetName = result.getString(resultId, "name")
-	local targetIp = result.getNumber(resultId, "lastip")
-	result.free(resultId)
+	local targetName = Result.getString(resultId, "name")
+	local targetIp = Result.getNumber(resultId, "lastip")
+	Result.free(resultId)
 
 	local targetPlayer = Player(param)
 	if targetPlayer then
@@ -34,7 +34,7 @@ function ipBan.onSay(player, words, param)
 	resultId = db.storeQuery("SELECT 1 FROM `ip_bans` WHERE `ip` = " .. targetIp)
 	if resultId ~= false then
 		player:sendTextMessage(MESSAGE_ADMINISTRADOR, targetName .. "  is already IP banned.")
-		result.free(resultId)
+		Result.free(resultId)
 		return false
 	end
 

--- a/data-otservbr-global/scripts/talkactions/god/unban.lua
+++ b/data-otservbr-global/scripts/talkactions/god/unban.lua
@@ -15,9 +15,9 @@ function unban.onSay(player, words, param)
 		return false
 	end
 
-	db.asyncQuery("DELETE FROM `account_bans` WHERE `account_id` = " .. result.getNumber(resultId, "account_id"))
-	db.asyncQuery("DELETE FROM `ip_bans` WHERE `ip` = " .. result.getNumber(resultId, "lastip"))
-	result.free(resultId)
+	db.asyncQuery("DELETE FROM `account_bans` WHERE `account_id` = " .. Result.getNumber(resultId, "account_id"))
+	db.asyncQuery("DELETE FROM `ip_bans` WHERE `ip` = " .. Result.getNumber(resultId, "lastip"))
+	Result.free(resultId)
 	player:sendTextMessage(MESSAGE_ADMINISTRADOR, param .. " has been unbanned.")
 	return false
 end

--- a/data/libs/daily_reward/daily_reward.lua
+++ b/data/libs/daily_reward/daily_reward.lua
@@ -95,8 +95,8 @@ end
 function RetrieveGlobalStorage(key)
 	local resultId = db.storeQuery("SELECT `value` FROM `global_storage` WHERE `key` = " .. key)
 	if resultId ~= false then
-		local val = result.getNumber(resultId, "value")
-		result.free(resultId)
+		local val = Result.getNumber(resultId, "value")
+		Result.free(resultId)
 		return val
 	end
 	return 1

--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -69,8 +69,8 @@ function getAccountNumberByPlayerName(name)
 
 	local resultId = db.storeQuery("SELECT `account_id` FROM `players` WHERE `name` = " .. db.escapeString(name))
 	if resultId ~= false then
-		local accountId = result.getNumber(resultId, "account_id")
-		result.free(resultId)
+		local accountId = Result.getNumber(resultId, "account_id")
+		Result.free(resultId)
 		return accountId
 	end
 	return 0
@@ -136,8 +136,8 @@ end
 function getPlayerSpouse(id)
 	local resultQuery = db.storeQuery("SELECT `marriage_spouse` FROM `players` WHERE `id` = " .. db.escapeString(id))
 	if resultQuery ~= false then
-		local ret = result.getDataInt(resultQuery, "marriage_spouse")
-		result.free(resultQuery)
+		local ret = Result.getDataInt(resultQuery, "marriage_spouse")
+		Result.free(resultQuery)
 		return ret
 	end
 	return -1
@@ -146,8 +146,8 @@ end
 function getPlayerMarriageStatus(id)
 	local resultQuery = db.storeQuery("SELECT `marriage_status` FROM `players` WHERE `id` = " .. db.escapeString(id))
 	if resultQuery ~= false then
-		local ret = result.getDataInt(resultQuery, "marriage_status")
-		result.free(resultQuery)
+		local ret = Result.getDataInt(resultQuery, "marriage_status")
+		Result.free(resultQuery)
 		return ret
 	end
 	return -1
@@ -155,9 +155,9 @@ end
 
 function getPlayerNameById(id)
 	local resultName = db.storeQuery("SELECT `name` FROM `players` WHERE `id` = " .. db.escapeString(id))
-	local name = result.getDataString(resultName, "name")
+	local name = Result.getDataString(resultName, "name")
 	if resultName ~= false then
-		result.free(resultName)
+		Result.free(resultName)
 		return name
 	end
 	return false
@@ -248,7 +248,7 @@ end
 function playerExists(name)
 	local resultId = db.storeQuery("SELECT `name` FROM `players` WHERE `name` = " .. db.escapeString(name))
 	if resultId then
-		result.free(resultId)
+		Result.free(resultId)
 		return true
 	end
 	return false
@@ -853,7 +853,7 @@ function Player:loadSpecialStorage()
 	PLAYER_STORAGE[self:getGuid()] = {}
 	local resultId = db.storeQuery("SELECT * FROM `player_misc` WHERE `player_id` = " .. self:getGuid())
 	if resultId then
-		local info = result.getStream(resultId , "info") or "{}"
+		local info = Result.getStream(resultId , "info") or "{}"
 		unserializeTable(info, PLAYER_STORAGE[self:getGuid()])
 	end
 end

--- a/data/libs/functions/game.lua
+++ b/data/libs/functions/game.lua
@@ -3,14 +3,14 @@ function getGlobalStorage(key)
 	if not keyNumber then key = "'"..key.."'" end
     local resultId = db.storeQuery("SELECT `value` FROM `global_storage` WHERE `key` = " .. key)
     if resultId ~= false then
-		local isNumber = tonumber(result.getString(resultId, "value"))
+		local isNumber = tonumber(Result.getString(resultId, "value"))
 		if isNumber then
-			local val = result.getNumber(resultId, "value")
-			result.free(resultId)
+			local val = Result.getNumber(resultId, "value")
+			Result.free(resultId)
 			return val
 		else
-			local val = result.getString(resultId, "value")
-			result.free(resultId)
+			local val = Result.getString(resultId, "value")
+			Result.free(resultId)
 			return val
 		end
     end

--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -210,14 +210,14 @@ function Player.transferMoneyTo(self, target, amount)
 
 		local query_town = db.storeQuery('SELECT `town_id` FROM `players` WHERE `name` = ' .. db.escapeString(target) ..' LIMIT 1;')
 		if query_town ~= false then
-			local town = result.getDataInt(query_town, "town_id")
+			local town = Result.getDataInt(query_town, "town_id")
 			if town then
 				local town_id = Town(town) and Town(town):getId()
 				if town_id and town_id  == TOWNS_LIST.DAWNPORT or town_id == TOWNS_LIST.DAWNPORT_TUTORIAL then -- Blocking transfer to Dawnport
 					return false
 				end
 			end
-			result.free(consulta)
+			Result.free(consulta)
 			db.query("UPDATE `players` SET `balance` = `balance` + '" .. amount .. "' WHERE `name` = " .. db.escapeString(target))
 		end
 	end
@@ -322,9 +322,9 @@ function Player.getAccountStorage(self, accountId, key, forceUpdate)
 
 	local query = db.storeQuery("SELECT `key`, MAX(`value`) as value FROM `player_storage` WHERE `player_id` IN (SELECT `id` FROM `players` WHERE `account_id` = ".. accountId ..") AND `key` = ".. key .." GROUP BY `key` LIMIT 1;")
 	if query ~= false then
-		local value = result.getDataInt(query, "value")
+		local value = Result.getDataInt(query, "value")
 		ACCOUNT_STORAGES[accountId] = value
-		result.free(query)
+		Result.free(query)
 		return value
 	end
 	return false

--- a/data/libs/hireling_lib.lua
+++ b/data/libs/hireling_lib.lua
@@ -150,13 +150,13 @@ local function initStorageCache()
 	if resultId ~= false then
 		local player_id, key, value
 		repeat
-			player_id = result.getNumber(resultId,"player_id")
-			key = result.getNumber(resultId,"key")
-			value = result.getNumber(resultId,"value")
+			player_id = Result.getNumber(resultId,"player_id")
+			key = Result.getNumber(resultId,"key")
+			value = Result.getNumber(resultId,"value")
 
 			addStorageCacheValue(player_id, key, value)
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 end
 
@@ -443,31 +443,31 @@ function HirelingsInit()
 
 	if rows then
 		repeat
-			local player_id = result.getNumber(rows, "player_id")
+			local player_id = Result.getNumber(rows, "player_id")
 
 			if not PLAYER_HIRELINGS[player_id] then
 				PLAYER_HIRELINGS[player_id] = {}
 			end
 
 			local hireling = Hireling:new()
-			hireling.id = result.getNumber(rows, "id")
+			hireling.id = Result.getNumber(rows, "id")
 			hireling.player_id = player_id
-			hireling.name = result.getString(rows, "name")
-			hireling.active = result.getNumber(rows, "active")
-			hireling.sex = result.getNumber(rows, "sex")
-			hireling.posx = result.getNumber(rows, "posx")
-			hireling.posy = result.getNumber(rows, "posy")
-			hireling.posz = result.getNumber(rows, "posz")
-			hireling.lookbody = result.getNumber(rows, "lookbody")
-			hireling.lookfeet = result.getNumber(rows, "lookfeet")
-			hireling.lookhead = result.getNumber(rows, "lookhead")
-			hireling.looklegs = result.getNumber(rows, "looklegs")
-			hireling.looktype = result.getNumber(rows, "looktype")
+			hireling.name = Result.getString(rows, "name")
+			hireling.active = Result.getNumber(rows, "active")
+			hireling.sex = Result.getNumber(rows, "sex")
+			hireling.posx = Result.getNumber(rows, "posx")
+			hireling.posy = Result.getNumber(rows, "posy")
+			hireling.posz = Result.getNumber(rows, "posz")
+			hireling.lookbody = Result.getNumber(rows, "lookbody")
+			hireling.lookfeet = Result.getNumber(rows, "lookfeet")
+			hireling.lookhead = Result.getNumber(rows, "lookhead")
+			hireling.looklegs = Result.getNumber(rows, "looklegs")
+			hireling.looktype = Result.getNumber(rows, "looktype")
 
 			table.insert(PLAYER_HIRELINGS[player_id], hireling)
 			table.insert(HIRELINGS, hireling)
-		until not result.next(rows)
-		result.free(rows)
+		until not Result.next(rows)
+		Result.free(rows)
 
 		spawnNPCs()
 		initStorageCache()
@@ -493,7 +493,7 @@ function PersistHireling(hireling)
 	local resultId = db.storeQuery(query)
 
 	if resultId then
-		local id = result.getNumber(resultId, 'id')
+		local id = Result.getNumber(resultId, 'id')
 		hireling.id = id
 		return true
 	else

--- a/data/libs/reward_boss/reward_boss.lua
+++ b/data/libs/reward_boss/reward_boss.lua
@@ -58,9 +58,9 @@ end
 function InsertRewardItems(playerGuid, timestamp, itemList)
 	db.asyncStoreQuery('select `pid`, `sid`, (SELECT max(`sid`) as sid from `player_rewards` where player_id = '..playerGuid..') as max_sid from `player_rewards` where `pid` = (select max(`pid`) from `player_rewards` where player_id = ' .. playerGuid .. ' and `pid` < 100);',
 		function(query)
-			local lastPid = result.getDataInt(query, 'pid') or 0
-			local bagSid = result.getDataInt(query, 'sid') or 100
-			local lastSid = result.getDataInt(query, 'max_sid') or 101
+			local lastPid = Result.getDataInt(query, 'pid') or 0
+			local bagSid = Result.getDataInt(query, 'sid') or 100
+			local lastSid = Result.getDataInt(query, 'max_sid') or 101
 			if lastPid ~= 0 then 
 				db.query('UPDATE `player_rewards` SET `sid` = `sid`+1 WHERE `sid`> '..bagSid..' ORDER BY `sid` DESC')
 				lastSid = lastSid+1

--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -221,13 +221,13 @@ DailyReward.retrieveHistoryEntries = function(playerId)
 	if resultId ~= false then
 		repeat
 			local entry = {
-				description = result.getDataString(resultId, "description"),
-				timestamp = result.getDataInt(resultId, "timestamp"),
-				daystreak = result.getDataInt(resultId, "daystreak"),
+				description = Result.getDataString(resultId, "description"),
+				timestamp = Result.getDataInt(resultId, "timestamp"),
+				daystreak = Result.getDataInt(resultId, "daystreak"),
 			}
 			table.insert(entries, entry)
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 	return entries
 end

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -272,7 +272,7 @@ function parseTransferCoins(playerId, msg)
 		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "We couldn't find that player.")
 	end
 
-	local accountId = result.getNumber(resultId, "account_id")
+	local accountId = Result.getNumber(resultId, "account_id")
 	if accountId == player:getAccountId() then
 		return addPlayerEvent(sendStoreError, 350, playerId, GameStore.StoreErrors.STORE_ERROR_TRANSFER, "You cannot transfer coin to a character in the same account.")
 	end
@@ -1071,8 +1071,8 @@ GameStore.retrieveHistoryTotalPages = function (accountId)
 		return 0
 	end
 
-	local totalPages = result.getNumber(resultId, "total")
-	result.free(resultId)
+	local totalPages = Result.getNumber(resultId, "total")
+	Result.free(resultId)
 	return totalPages
 end
 
@@ -1084,15 +1084,15 @@ GameStore.retrieveHistoryEntries = function(accountId, currentPage, entriesPerPa
 	if resultId ~= false then
 		repeat
 			local entry = {
-				mode = result.getNumber(resultId, "mode"),
-				description = result.getDataString(resultId, "description"),
-				amount = result.getNumber(resultId, "coin_amount"),
-				type = result.getNumber(resultId, "coin_type"),
-				time = result.getNumber(resultId, "time"),
+				mode = Result.getNumber(resultId, "mode"),
+				description = Result.getDataString(resultId, "description"),
+				amount = Result.getNumber(resultId, "coin_amount"),
+				type = Result.getNumber(resultId, "coin_type"),
+				time = Result.getNumber(resultId, "time"),
 			}
 			table.insert(entries, entry)
-		until not result.next(resultId)
-		result.free(resultId)
+		until not Result.next(resultId)
+		Result.free(resultId)
 	end
 	return entries
 end
@@ -1594,7 +1594,7 @@ end
 function Player.getCoinsBalance(self)
 	resultId = db.storeQuery("SELECT `coins` FROM `accounts` WHERE `id` = " .. self:getAccountId())
 	if not resultId then return 0 end
-	return result.getNumber(resultId, "coins")
+	return Result.getNumber(resultId, "coins")
 end
 
 function Player.setCoinsBalance(self, coins)
@@ -1629,7 +1629,7 @@ function Player.getTournamentBalance(self)
 	if not resultId then
 		return 0
 	end
-	return result.getNumber(resultId, "tournament_coins")
+	return Result.getNumber(resultId, "tournament_coins")
 end
 
 function Player.setTournamentBalance(self, tournament)

--- a/data/npclib/npc_system/bank_system.lua
+++ b/data/npclib/npc_system/bank_system.lua
@@ -631,8 +631,8 @@ function GetGuildIdByName(name, func)
 	db.asyncStoreQuery("SELECT `id` FROM `guilds` WHERE `name` = " .. db.escapeString(name),
 		function(resultId)
 			if resultId then
-				func(result.getNumber(resultId, "id"))
-				result.free(resultId)
+				func(Result.getNumber(resultId, "id"))
+				Result.free(resultId)
 			else
 				func(nil)
 			end
@@ -648,8 +648,8 @@ function GetGuildBalance(id)
 		local balance
 		local resultId = db.storeQuery("SELECT `balance` FROM `guilds` WHERE `id` = " .. id)
 		if resultId then
-			balance = result.getNumber(resultId, "balance")
-			result.free(resultId)
+			balance = Result.getNumber(resultId, "balance")
+			Result.free(resultId)
 		end
 
 		return balance


### PR DESCRIPTION
By mistake, I uploaded the change from "result" to "Result" in the database functions in Lua, so as not to revert I decided to make a compat and change the files to the new standard.

PR related: https://github.com/opentibiabr/canary/pull/730
Commit related: https://github.com/opentibiabr/canary/commit/6d7c11d8f72987352f8af002fe3378a6bf86400a#diff-5743a0ac8eecaf6cc618362503a9e1a1cb7cbc82c28de926c4d664de7154f0cf