### PR TITLE
fix: "towns" table database fill issue

### DIFF
--- a/data-otservbr-global/scripts/globalevents/others/startup.lua
+++ b/data-otservbr-global/scripts/globalevents/others/startup.lua
@@ -124,6 +124,13 @@ function serverstartup.onStartup()
 		Result.free(resultId)
 	end
 
+	-- store towns in database
+	db.query("TRUNCATE TABLE `towns`")
+	for i, town in ipairs(Game.getTowns()) do
+		local position = town:getTemplePosition()
+		db.query("INSERT INTO `towns` (`id`, `name`, `posx`, `posy`, `posz`) VALUES (" .. town:getId() .. ", " .. db.escapeString(town:getName()) .. ", " .. position.x .. ", " .. position.y .. ", " .. position.z .. ")")
+	end
+
 	do -- Event Schedule rates
 		local lootRate = EventsScheduler.getEventSLoot()
 		if lootRate ~= 100 then


### PR DESCRIPTION
# Description

The towns table was not being populated properly after server startup, causing bugs on the web AAC. This aims to fix this issue and ensure proper data filling in the towns database.

## Behaviour
### **Actual**

`towns` table empty after server startup

### **Expected**

Fill `towns` table during startup

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
