### PR TITLE
fix: using a shovel on a stonepile should move to downstairs

### DIFF
--- a/data-canary/scripts/lib/register_actions.lua
+++ b/data-canary/scripts/lib/register_actions.lua
@@ -168,7 +168,13 @@ ActionsLib.useShovel = function(player, item, fromPosition, target, toPosition, 
 	if table.contains(holes, groundId) then
 		ground:transform(groundId + 1)
 		ground:decay()
-
+		toPosition:moveDownstairs()
+		toPosition.y = toPosition.y - 1
+		if Tile(toPosition):hasFlag(TILESTATE_PROTECTIONZONE) and player:isPzLocked() then
+			player:sendCancelMessage(RETURNVALUE_PLAYERISPZLOCKED)
+			return true
+		end
+		player:teleportTo(toPosition, false)
 		toPosition.z = toPosition.z + 1
 		tile:relocateTo(toPosition)
 	elseif table.contains(sandIds, groundId) then

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -387,6 +387,13 @@ function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 	if table.contains(holes, target.itemid) then
 		target:transform(target.itemid + 1)
 		target:decay()
+		toPosition:moveDownstairs()
+		toPosition.y = toPosition.y - 1
+		if Tile(toPosition):hasFlag(TILESTATE_PROTECTIONZONE) and player:isPzLocked() then
+			player:sendCancelMessage(RETURNVALUE_PLAYERISPZLOCKED)
+			return true
+		end
+		player:teleportTo(toPosition, false)
 	elseif target.itemid == 1822 and target:getPosition() == Position(33222, 31100, 7) then
 		player:teleportTo(Position(33223, 31100, 8))
 	elseif table.contains({231, 231}, target.itemid) then


### PR DESCRIPTION
# Description

Using a shovel on a stonepile should move you downstairs

## Behaviour
### **Actual**

When you use a shovel you aren't moved

### **Expected**

Using a shovel on a stonepile should move you downstairs

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)