### PR TITLE
fix: duplicated active events warning and log

### DIFF
--- a/data/XML/events.xml
+++ b/data/XML/events.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <events>
-	<event name="Otservbr example 1" startdate="11/03/2020" enddate="11/30/2020" script="example.lua" >
-		<ingame exprate="250" lootrate="200" spawnrate="100" skillrate="200" />
+	<event name="Otservbr example 1" startdate="11/03/2020" enddate="12/30/2023" script="example.lua" >
+		<ingame exprate="100" lootrate="100" spawnrate="100" skillrate="100" />
 		<description description="Otserver br example 1 description double exp and a half, double loot !chance!, regular spawn and double skill" />
 		<colors colordark="#235c00" colorlight="#2d7400" />
 		<details displaypriority="6" isseasonal="0" specialevent="0" />
 	</event>
-	<event name="Otservbr example 2" startdate="2/2/2022" enddate="11/7/2022" script="example.lua" >
-		<ingame exprate="500" lootrate="500" spawnrate="500" skillrate="500" />
+	<event name="Otservbr example 2" startdate="2/2/2022" enddate="12/30/2023" script="" >
+		<ingame exprate="100" lootrate="100" spawnrate="100" skillrate="100" />
 		<description description="Otserver br example 2 description 50% less exp, triple loot !chance!, 50% faster spawn and regular skill" />
 		<colors colordark="#735D10" colorlight="#8B6D05" />
 		<details displaypriority="6" isseasonal="0" specialevent="0" />

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -14,92 +14,81 @@
 #include "lua/scripts/scripts.h"
 #include "utils/pugicast.h"
 
-bool EventsScheduler::loadScheduleEventFromXml() const {
-	pugi::xml_document doc;
-	auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
-	if (
-		// Init-statement
-		pugi::xml_parse_result result = doc.load_file(folder.c_str());
-		// Condition
-		!result
-	) {
-		printXMLError(__FUNCTION__, folder, result);
-		consoleHandlerExit();
-		return false;
-	}
+bool EventsScheduler::loadScheduleEventFromXml() const
+{
+    pugi::xml_document doc;
+    auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
+    if (!doc.load_file(folder.c_str()))
+    {
+        printXMLError(__FUNCTION__, folder, doc.load_file(folder.c_str()));
+        consoleHandlerExit();
+        return false;
+    }
 
-	int daysNow;
-	time_t t = time(nullptr);
-	const tm* timePtr = localtime(&t);
-	int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
+    time_t t = time(nullptr);
+    const tm* timePtr = localtime(&t);
+    int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
 
-	for (auto schedNode : doc.child("events").children()) {
-		std::string ss_d;
-		std::stringstream ss;
+    // Keep track of loaded scripts to check for duplicates
+    std::set<std::string> loadedScripts;
+    for (const auto& eventNode : doc.child("events").children()) {
+        std::string eventScript = eventNode.attribute("script").as_string();
 
-		pugi::xml_attribute attr;
-		if ((attr = schedNode.attribute("name"))) {
-			ss_d = attr.as_string();
-			ss << ss_d << " event";
-		}
+        int16_t startYear, startMonth, startDay;
+        int16_t endYear, endMonth, endDay;
+        sscanf(eventNode.attribute("startdate").as_string(), "%hd/%hd/%hd", &startMonth, &startDay, &startYear);
+        sscanf(eventNode.attribute("enddate").as_string(), "%hd/%hd/%hd", &endMonth, &endDay, &endYear);
+        int startDays = ((startYear * 365) + (startMonth * 30) + startDay);
+        int endDays = ((endYear * 365) + (endMonth * 30) + endDay);
 
-		int16_t year;
-		int16_t day;
-		int16_t month;
+        if (daysMath < startDays || daysMath > endDays) {
+            continue;
+        }
 
-		if (!(attr = schedNode.attribute("enddate"))) {
-			continue;
-		} else {
-			ss_d = attr.as_string();
-			sscanf(ss_d.c_str(), "%hd/%hd/%hd", &month, &day, &year);
-			daysNow = ((year * 365) + (month * 30) + day);
-			if (daysMath > daysNow) {
-				continue;
-			}
-		}
+        if (loadedScripts.count(eventScript) > 0) {
+            SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
+            continue;
+        }
+        loadedScripts.insert(eventScript);
 
-		if (!(attr = schedNode.attribute("startdate"))) {
-			continue;
-		} else {
-			ss_d = attr.as_string();
-			sscanf(ss_d.c_str(), "%hd/%hd/%hd", &month, &day, &year);
-			daysNow = ((year * 365) + (month * 30) + day);
-			if (daysMath < daysNow) {
-				continue;
-			}
-		}
-
-		if ((attr = schedNode.attribute("script")) && (!(g_scripts().loadEventSchedulerScripts(attr.as_string())))) {
-			SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'", __FUNCTION__, attr.as_string());
+        if (!g_scripts().loadEventSchedulerScripts(eventScript)) {
+            SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'",
+                        __FUNCTION__, eventScript);
 			return false;
 		}
 
-		for (auto schedENode : schedNode.children()) {
-			if ((schedENode.attribute("exprate"))) {
-				uint16_t exprate = pugi::cast<uint16_t>(schedENode.attribute("exprate").value());
-				g_eventsScheduler().setExpSchedule(exprate);
-				ss << " exp: " << exprate << "%";
+		for (const auto& ingameNode : eventNode.children()) {
+			if (ingameNode.attribute("exprate")) {
+				g_eventsScheduler().setExpSchedule(ingameNode.attribute("exprate").as_uint());
 			}
 
-			if ((schedENode.attribute("lootrate"))) {
-				uint16_t lootrate = pugi::cast<uint16_t>(schedENode.attribute("lootrate").value());
-				g_eventsScheduler().setLootSchedule(lootrate);
-				ss << ", loot: " << lootrate << "%";
+			if (ingameNode.attribute("lootrate")) {
+				g_eventsScheduler().setLootSchedule(ingameNode.attribute("lootrate").as_uint());
 			}
 
-			if ((schedENode.attribute("spawnrate"))) {
-				uint32_t spawnrate = pugi::cast<uint32_t>(schedENode.attribute("spawnrate").value());
-				g_eventsScheduler().setSpawnMonsterSchedule(spawnrate);
-				ss << ", spawn: " << spawnrate << "%";
+			if (ingameNode.attribute("spawnrate")) {
+				g_eventsScheduler().setSpawnMonsterSchedule(ingameNode.attribute("spawnrate").as_uint());
 			}
 
-			if ((schedENode.attribute("skillrate"))) {
-				uint16_t skillrate = pugi::cast<uint16_t>(schedENode.attribute("skillrate").value());
-				g_eventsScheduler().setSkillSchedule(skillrate);
-				ss << ", skill: " << skillrate << "%";
-				break;
+			if (ingameNode.attribute("skillrate")) {
+				g_eventsScheduler().setSkillSchedule(ingameNode.attribute("skillrate").as_uint());
 			}
 		}
 	}
+
+    if(expSchedule == 0) {
+       g_eventsScheduler().setExpSchedule(100);
+    }
+    if(lootSchedule == 0) {
+      g_eventsScheduler().setLootSchedule(100);
+    }
+    if(spawnMonsterSchedule == 0) {
+       g_eventsScheduler().setSpawnMonsterSchedule(100);
+    }
+    if(skillSchedule == 0) {
+       g_eventsScheduler().setSkillSchedule(100);
+    }
+
+    SPDLOG_WARN("{}, {}, {}, {}", getExpSchedule(), getLootSchedule(), getSpawnMonsterSchedule(), getSkillSchedule());
 	return true;
 }

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -29,7 +29,7 @@ bool EventsScheduler::loadScheduleEventFromXml() {
 
 	// Keep track of loaded scripts to check for duplicates
 	int count = 0;
-	std::set<std::string> loadedScripts;
+	std::set<std::string_view, std::less<>> loadedScripts;
 	for (const auto &eventNode : doc.child("events").children()) {
 		std::string eventScript = eventNode.attribute("script").as_string();
 		std::string eventName = eventNode.attribute("name").as_string();
@@ -54,7 +54,7 @@ bool EventsScheduler::loadScheduleEventFromXml() {
 			SPDLOG_WARN("{} - More than one event scheduled for the same day.", __FUNCTION__);
 		}
 
-		if (!eventScript.empty() && loadedScripts.count(eventScript) > 0) {
+		if (!eventScript.empty() && loadedScripts.contains(eventScript)) {
 			SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
 			continue;
 		}

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -5,7 +5,7 @@
  * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.org/
-*/
+ */
 
 #include "pch.hpp"
 
@@ -14,61 +14,58 @@
 #include "lua/scripts/scripts.h"
 #include "utils/pugicast.h"
 
-bool EventsScheduler::loadScheduleEventFromXml()
-{
-    pugi::xml_document doc;
-    auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
-    if (!doc.load_file(folder.c_str()))
-    {
-        printXMLError(__FUNCTION__, folder, doc.load_file(folder.c_str()));
-        consoleHandlerExit();
-        return false;
-    }
+bool EventsScheduler::loadScheduleEventFromXml() {
+	pugi::xml_document doc;
+	auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
+	if (!doc.load_file(folder.c_str())) {
+		printXMLError(__FUNCTION__, folder, doc.load_file(folder.c_str()));
+		consoleHandlerExit();
+		return false;
+	}
 
-    time_t t = time(nullptr);
-    const tm* timePtr = localtime(&t);
-    int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
+	time_t t = time(nullptr);
+	const tm* timePtr = localtime(&t);
+	int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
 
-    // Keep track of loaded scripts to check for duplicates
-    int count = 0;
-    std::set<std::string> loadedScripts;
-    for (const auto& eventNode : doc.child("events").children()) {
-        std::string eventScript = eventNode.attribute("script").as_string();
-        std::string eventName = eventNode.attribute("name").as_string();
+	// Keep track of loaded scripts to check for duplicates
+	int count = 0;
+	std::set<std::string> loadedScripts;
+	for (const auto &eventNode : doc.child("events").children()) {
+		std::string eventScript = eventNode.attribute("script").as_string();
+		std::string eventName = eventNode.attribute("name").as_string();
 
-        int16_t startYear;
-        int16_t startMonth;
-        int16_t startDay;
-        int16_t endYear;
-        int16_t endMonth;
-        int16_t endDay;
-        sscanf(eventNode.attribute("startdate").as_string(), "%hd/%hd/%hd", &startMonth, &startDay, &startYear);
-        sscanf(eventNode.attribute("enddate").as_string(), "%hd/%hd/%hd", &endMonth, &endDay, &endYear);
-        int startDays = ((startYear * 365) + (startMonth * 30) + startDay);
-        int endDays = ((endYear * 365) + (endMonth * 30) + endDay);
+		int16_t startYear;
+		int16_t startMonth;
+		int16_t startDay;
+		int16_t endYear;
+		int16_t endMonth;
+		int16_t endDay;
+		sscanf(eventNode.attribute("startdate").as_string(), "%hd/%hd/%hd", &startMonth, &startDay, &startYear);
+		sscanf(eventNode.attribute("enddate").as_string(), "%hd/%hd/%hd", &endMonth, &endDay, &endYear);
+		int startDays = ((startYear * 365) + (startMonth * 30) + startDay);
+		int endDays = ((endYear * 365) + (endMonth * 30) + endDay);
 
-        if (daysMath < startDays || daysMath > endDays) {
-            continue;
-        }
+		if (daysMath < startDays || daysMath > endDays) {
+			continue;
+		}
 
-        ++count;
-        if (count >= 2) {
-            SPDLOG_WARN("{} - More than one event scheduled for the same day.", __FUNCTION__);
-        }
+		++count;
+		if (count >= 2) {
+			SPDLOG_WARN("{} - More than one event scheduled for the same day.", __FUNCTION__);
+		}
 
-        if (!eventScript.empty() && loadedScripts.count(eventScript) > 0) {
-            SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
-            continue;
-        }
+		if (!eventScript.empty() && loadedScripts.count(eventScript) > 0) {
+			SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
+			continue;
+		}
 
-        loadedScripts.insert(eventScript);
-        if (!eventScript.empty() && !g_scripts().loadEventSchedulerScripts(eventScript)) {
-            SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'",
-                        __FUNCTION__, eventScript);
-            return false;
-        }
+		loadedScripts.insert(eventScript);
+		if (!eventScript.empty() && !g_scripts().loadEventSchedulerScripts(eventScript)) {
+			SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'", __FUNCTION__, eventScript);
+			return false;
+		}
 
-		for (const auto& ingameNode : eventNode.children()) {
+		for (const auto &ingameNode : eventNode.children()) {
 			if (ingameNode.attribute("exprate")) {
 				g_eventsScheduler().setExpSchedule(static_cast<uint16_t>(ingameNode.attribute("exprate").as_uint()));
 			}
@@ -85,13 +82,13 @@ bool EventsScheduler::loadScheduleEventFromXml()
 				g_eventsScheduler().setSkillSchedule(static_cast<uint16_t>(ingameNode.attribute("skillrate").as_uint()));
 			}
 		}
-        eventScheduler.push_back(EventScheduler(eventName, startDays, endDays));
+		eventScheduler.push_back(EventScheduler(eventName, startDays, endDays));
 	}
 
-    for (const auto& event : eventScheduler) {
-        if (daysMath >= event.startDays && daysMath <= event.endDays) {
-            SPDLOG_INFO("Active EventScheduler: {}", event.name);
-        }
-    }
+	for (const auto &event : eventScheduler) {
+		if (daysMath >= event.startDays && daysMath <= event.endDays) {
+			SPDLOG_INFO("Active EventScheduler: {}", event.name);
+		}
+	}
 	return true;
 }

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -45,17 +45,18 @@ bool EventsScheduler::loadScheduleEventFromXml() const
             continue;
         }
 
-        if (loadedScripts.count(eventScript) > 0) {
+        if (!eventScript.empty() && loadedScripts.count(eventScript) > 0) {
             SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
             continue;
         }
+
         loadedScripts.insert(eventScript);
 
-        if (!g_scripts().loadEventSchedulerScripts(eventScript)) {
+        if (!eventScript.empty() && !g_scripts().loadEventSchedulerScripts(eventScript)) {
             SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'",
                         __FUNCTION__, eventScript);
-			return false;
-		}
+            return false;
+        }
 
 		for (const auto& ingameNode : eventNode.children()) {
 			if (ingameNode.attribute("exprate")) {

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -34,8 +34,12 @@ bool EventsScheduler::loadScheduleEventFromXml() const
     for (const auto& eventNode : doc.child("events").children()) {
         std::string eventScript = eventNode.attribute("script").as_string();
 
-        int16_t startYear, startMonth, startDay;
-        int16_t endYear, endMonth, endDay;
+        int16_t startYear;
+        int16_t startMonth;
+        int16_t startDay;
+        int16_t endYear;
+        int16_t endMonth;
+        int16_t endDay;
         sscanf(eventNode.attribute("startdate").as_string(), "%hd/%hd/%hd", &startMonth, &startDay, &startYear);
         sscanf(eventNode.attribute("enddate").as_string(), "%hd/%hd/%hd", &endMonth, &endDay, &endYear);
         int startDays = ((startYear * 365) + (startMonth * 30) + startDay);
@@ -60,7 +64,7 @@ bool EventsScheduler::loadScheduleEventFromXml() const
 
 		for (const auto& ingameNode : eventNode.children()) {
 			if (ingameNode.attribute("exprate")) {
-				g_eventsScheduler().setExpSchedule(ingameNode.attribute("exprate").as_uint());
+				g_eventsScheduler().setExpSchedule(static_cast<uint16_t>(ingameNode.attribute("exprate").as_uint()));
 			}
 
 			if (ingameNode.attribute("lootrate")) {
@@ -72,7 +76,7 @@ bool EventsScheduler::loadScheduleEventFromXml() const
 			}
 
 			if (ingameNode.attribute("skillrate")) {
-				g_eventsScheduler().setSkillSchedule(ingameNode.attribute("skillrate").as_uint());
+				g_eventsScheduler().setSkillSchedule(static_cast<uint16_t>(ingameNode.attribute("skillrate").as_uint()));
 			}
 		}
 	}
@@ -90,6 +94,5 @@ bool EventsScheduler::loadScheduleEventFromXml() const
        g_eventsScheduler().setSkillSchedule(100);
     }
 
-    SPDLOG_WARN("{}, {}, {}, {}", getExpSchedule(), getLootSchedule(), getSpawnMonsterSchedule(), getSkillSchedule());
 	return true;
 }

--- a/src/game/scheduling/events_scheduler.cpp
+++ b/src/game/scheduling/events_scheduler.cpp
@@ -5,7 +5,7 @@
  * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.org/
- */
+*/
 
 #include "pch.hpp"
 
@@ -14,7 +14,7 @@
 #include "lua/scripts/scripts.h"
 #include "utils/pugicast.h"
 
-bool EventsScheduler::loadScheduleEventFromXml() const
+bool EventsScheduler::loadScheduleEventFromXml()
 {
     pugi::xml_document doc;
     auto folder = g_configManager().getString(CORE_DIRECTORY) + "/XML/events.xml";
@@ -30,9 +30,11 @@ bool EventsScheduler::loadScheduleEventFromXml() const
     int daysMath = ((timePtr->tm_year + 1900) * 365) + ((timePtr->tm_mon + 1) * 30) + (timePtr->tm_mday);
 
     // Keep track of loaded scripts to check for duplicates
+    int count = 0;
     std::set<std::string> loadedScripts;
     for (const auto& eventNode : doc.child("events").children()) {
         std::string eventScript = eventNode.attribute("script").as_string();
+        std::string eventName = eventNode.attribute("name").as_string();
 
         int16_t startYear;
         int16_t startMonth;
@@ -49,13 +51,17 @@ bool EventsScheduler::loadScheduleEventFromXml() const
             continue;
         }
 
+        ++count;
+        if (count >= 2) {
+            SPDLOG_WARN("{} - More than one event scheduled for the same day.", __FUNCTION__);
+        }
+
         if (!eventScript.empty() && loadedScripts.count(eventScript) > 0) {
             SPDLOG_WARN("{} - Script declaration '{}' in duplicate 'data/XML/events.xml'.", __FUNCTION__, eventScript);
             continue;
         }
 
         loadedScripts.insert(eventScript);
-
         if (!eventScript.empty() && !g_scripts().loadEventSchedulerScripts(eventScript)) {
             SPDLOG_WARN("{} - Can not load the file '{}' on '/events/scripts/scheduler/'",
                         __FUNCTION__, eventScript);
@@ -79,20 +85,13 @@ bool EventsScheduler::loadScheduleEventFromXml() const
 				g_eventsScheduler().setSkillSchedule(static_cast<uint16_t>(ingameNode.attribute("skillrate").as_uint()));
 			}
 		}
+        eventScheduler.push_back(EventScheduler(eventName, startDays, endDays));
 	}
 
-    if(expSchedule == 0) {
-       g_eventsScheduler().setExpSchedule(100);
+    for (const auto& event : eventScheduler) {
+        if (daysMath >= event.startDays && daysMath <= event.endDays) {
+            SPDLOG_INFO("Active EventScheduler: {}", event.name);
+        }
     }
-    if(lootSchedule == 0) {
-      g_eventsScheduler().setLootSchedule(100);
-    }
-    if(spawnMonsterSchedule == 0) {
-       g_eventsScheduler().setSpawnMonsterSchedule(100);
-    }
-    if(skillSchedule == 0) {
-       g_eventsScheduler().setSkillSchedule(100);
-    }
-
 	return true;
 }

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -13,9 +13,9 @@
 #include "utils/tools.h"
 
 struct EventScheduler {
-    std::string name;
-    int startDays;
-    int endDays;
+		std::string name;
+		int startDays;
+		int endDays;
 };
 
 class EventsScheduler {
@@ -41,28 +41,28 @@ class EventsScheduler {
 			return expSchedule;
 		}
 		void setExpSchedule(uint16_t exprate) {
-			expSchedule = (expSchedule * exprate)/100;
+			expSchedule = (expSchedule * exprate) / 100;
 		}
 
 		uint32_t getLootSchedule() const {
 			return lootSchedule;
 		}
 		void setLootSchedule(uint32_t lootrate) {
-			lootSchedule = (lootSchedule * lootrate)/100;
+			lootSchedule = (lootSchedule * lootrate) / 100;
 		}
 
 		uint32_t getSpawnMonsterSchedule() const {
 			return spawnMonsterSchedule;
 		}
 		void setSpawnMonsterSchedule(uint32_t spawnrate) {
-			spawnMonsterSchedule = (spawnMonsterSchedule * spawnrate)/100;
+			spawnMonsterSchedule = (spawnMonsterSchedule * spawnrate) / 100;
 		}
 
 		uint16_t getSkillSchedule() const {
 			return skillSchedule;
 		}
 		void setSkillSchedule(uint16_t skillrate) {
-			skillSchedule = (skillSchedule * skillrate)/100;
+			skillSchedule = (skillSchedule * skillrate) / 100;
 		}
 
 	private:
@@ -73,7 +73,6 @@ class EventsScheduler {
 		uint32_t spawnMonsterSchedule = 100;
 
 		std::vector<EventScheduler> eventScheduler;
-
 };
 
 constexpr auto g_eventsScheduler = &EventsScheduler::getInstance;

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -12,6 +12,12 @@
 
 #include "utils/tools.h"
 
+struct EventScheduler {
+    std::string name;
+    int startDays;
+    int endDays;
+};
+
 class EventsScheduler {
 	public:
 		EventsScheduler() = default;
@@ -28,7 +34,7 @@ class EventsScheduler {
 		}
 
 		// Event schedule xml load
-		bool loadScheduleEventFromXml() const;
+		bool loadScheduleEventFromXml();
 
 		// Event schedule
 		uint16_t getExpSchedule() const {
@@ -65,6 +71,8 @@ class EventsScheduler {
 		uint32_t lootSchedule = 100;
 		uint16_t skillSchedule = 100;
 		uint32_t spawnMonsterSchedule = 100;
+
+		std::vector<EventScheduler> eventScheduler;
 
 };
 

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -35,36 +35,36 @@ class EventsScheduler {
 			return expSchedule;
 		}
 		void setExpSchedule(uint16_t exprate) {
-			expSchedule = exprate;
+			expSchedule = (expSchedule * exprate)/100;
 		}
 
 		uint32_t getLootSchedule() const {
 			return lootSchedule;
 		}
 		void setLootSchedule(uint32_t lootrate) {
-			lootSchedule = lootrate;
+			lootSchedule = (lootSchedule * lootrate)/100;
 		}
 
 		uint32_t getSpawnMonsterSchedule() const {
 			return spawnMonsterSchedule;
 		}
 		void setSpawnMonsterSchedule(uint32_t spawnrate) {
-			spawnMonsterSchedule = spawnrate;
+			spawnMonsterSchedule = (spawnMonsterSchedule * spawnrate)/100;
 		}
 
 		uint16_t getSkillSchedule() const {
 			return skillSchedule;
 		}
 		void setSkillSchedule(uint16_t skillrate) {
-			skillSchedule = skillrate;
+			skillSchedule = (skillSchedule * skillrate)/100;
 		}
 
 	private:
 		// Event schedule
-		uint16_t expSchedule = 0;
-		uint32_t lootSchedule = 0;
-		uint16_t skillSchedule = 0;
-		uint32_t spawnMonsterSchedule = 0;
+		uint16_t expSchedule = 100;
+		uint32_t lootSchedule = 100;
+		uint16_t skillSchedule = 100;
+		uint32_t spawnMonsterSchedule = 100;
 
 };
 

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -35,36 +35,37 @@ class EventsScheduler {
 			return expSchedule;
 		}
 		void setExpSchedule(uint16_t exprate) {
-			expSchedule = (expSchedule * exprate) / 100;
+			expSchedule = exprate;
 		}
 
 		uint32_t getLootSchedule() const {
 			return lootSchedule;
 		}
 		void setLootSchedule(uint32_t lootrate) {
-			lootSchedule = (lootSchedule * lootrate) / 100;
+			lootSchedule = lootrate;
 		}
 
 		uint32_t getSpawnMonsterSchedule() const {
 			return spawnMonsterSchedule;
 		}
 		void setSpawnMonsterSchedule(uint32_t spawnrate) {
-			spawnMonsterSchedule = (spawnMonsterSchedule * spawnrate) / 100;
+			spawnMonsterSchedule = spawnrate;
 		}
 
 		uint16_t getSkillSchedule() const {
 			return skillSchedule;
 		}
 		void setSkillSchedule(uint16_t skillrate) {
-			skillSchedule = (skillSchedule * skillrate) / 100;
+			skillSchedule = skillrate;
 		}
 
 	private:
 		// Event schedule
-		uint16_t expSchedule = 100;
-		uint32_t lootSchedule = 100;
-		uint16_t skillSchedule = 100;
-		uint32_t spawnMonsterSchedule = 100;
+		uint16_t expSchedule = 0;
+		uint32_t lootSchedule = 0;
+		uint16_t skillSchedule = 0;
+		uint32_t spawnMonsterSchedule = 0;
+
 };
 
 constexpr auto g_eventsScheduler = &EventsScheduler::getInstance;


### PR DESCRIPTION
# Description
If you have 2 active events for the same date you will have a warning on the server load, a log was also added for all active events on the server load...

be careful defining 2 events with values ​​other than 100 will double the final value

- [x] Comment about rates in events.xml