### PR TITLE
fix: assigning negative value to unsigned integer (getSkillLevel)

### DIFF
--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -761,11 +761,11 @@ class Player final : public Creature, public Cylinder
 		}
 
 		uint16_t getSkillLevel(uint8_t skill) const {
-			uint16_t skillLevel = std::max<uint16_t>(0, skills[skill].level + varSkills[skill]);
+			auto skillLevel = std::max<int32_t>(0, skills[skill].level + varSkills[skill]);
 
-			auto it = maxValuePerSkill.find(skill);
-			if (it != maxValuePerSkill.end()) {
-				skillLevel = std::min<uint16_t>(it->second, skillLevel);
+			if (auto it = maxValuePerSkill.find(skill);
+				it != maxValuePerSkill.end()) {
+				skillLevel = std::min<int32_t>(it->second, skillLevel);
 			}
 
 			return skillLevel;

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -768,7 +768,7 @@ class Player final : public Creature, public Cylinder
 				skillLevel = std::min<int32_t>(it->second, skillLevel);
 			}
 
-			return skillLevel;
+			return static_cast<uint16_t>(skillLevel);
 		}
 		uint16_t getBaseSkill(uint8_t skill) const {
 			return skills[skill].level;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6599,14 +6599,14 @@ void ProtocolGame::AddPlayerSkills(NetworkMessage &msg)
 
 	msg.add<uint16_t>(player->getMagicLevel());
 	msg.add<uint16_t>(player->getBaseMagicLevel());
-	msg.add<uint16_t>(player->getBaseMagicLevel());
+	msg.add<uint16_t>(player->getBaseMagicLevel()); // Loyalty Bonus
 	msg.add<uint16_t>(player->getMagicLevelPercent() * 100);
 
 	for (uint8_t i = SKILL_FIRST; i <= SKILL_FISHING; ++i)
 	{
 		msg.add<uint16_t>(std::min<int32_t>(player->getSkillLevel(i), std::numeric_limits<uint16_t>::max()));
 		msg.add<uint16_t>(player->getBaseSkill(i));
-		msg.add<uint16_t>(player->getBaseSkill(i));
+		msg.add<uint16_t>(player->getBaseSkill(i)); // Loyalty Bonus
 		msg.add<uint16_t>(player->getSkillPercent(i) * 100);
 	}
 


### PR DESCRIPTION
# Description

Negative value was being assigned to a uint16_t, due to a wrong variable type in std::max.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
