### PR TITLE
fix: out of bounds memory access in setValue function

### DIFF
--- a/src/creatures/combat/combat.h
+++ b/src/creatures/combat/combat.h
@@ -116,8 +116,14 @@ class MatrixArea
 		// non-assignable
 		MatrixArea& operator=(const MatrixArea&) = delete;
 
-		void setValue(uint32_t row, uint32_t col, bool value) const {
-			data_[row][col] = value;
+		void setValue(uint32_t row, uint32_t col, bool value) {
+			if (row < rows && col < cols)
+			{
+				data_[row][col] = value;
+			} else {
+				SPDLOG_ERROR("[{}] Access exceeds the upper limit of memory block");
+				throw std::out_of_range("Access exceeds the upper limit of memory block");
+			}
 		}
 		bool getValue(uint32_t row, uint32_t col) const {
 			return data_[row][col];


### PR DESCRIPTION
# Description

This fixes addresses a SonarCloud warning regarding an out of bounds memory access in the setValue function. Specifically, it checks that the row and col values passed to the function are within the bounds of the data_ array before performing the assignment. This ensures that the program will not attempt to access memory that is outside of the allocated memory block, preventing potential crashes or other errors.

## Behaviour
### **Actual**

Does not check limits

### **Expected**

Checks the limits and throws an exception if it has exceeded the maximum allowed

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
