### PR TITLE
fix: remove target without accessing freed memory

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -355,12 +355,12 @@ void Monster::removeTarget(Creature* creature)
 
 	auto it = std::find(targetList.begin(), targetList.end(), creature);
 	if (it != targetList.end()) {
-		creature->decrementReferenceCounter();
-		targetList.erase(it);
-
 		if (!master && getFaction() != FACTION_DEFAULT && creature->getPlayer()) {
 			totalPlayersOnScreen--;
 		}
+
+		creature->decrementReferenceCounter();
+		targetList.erase(it);
 	}
 }
 


### PR DESCRIPTION
# Description

This change addresses an issue where the function removeTarget was accessing a pointer after it had been freed by decrementing its reference counter. This was causing a use of memory after it was freed error. This ensures that the pointer is not accessed after it has been freed. This change also moves the decrement reference counter line to the end of the function, making sure that the pointer is not accessed after it is freed.

## Behaviour
### **Actual**

Using the "creature" pointer after it is deleted

### **Expected**

Use "creature" pointer before deleting

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
