### PR TITLE
fix: added condition argument to wait calls in threadMain functions

### DIFF
--- a/src/database/databasetasks.cpp
+++ b/src/database/databasetasks.cpp
@@ -48,7 +48,9 @@ void DatabaseTasks::threadMain()
 			if (flushTasks) {
 				flushSignal.notify_one();
 			}
-			taskSignal.wait(taskLockUnique);
+			taskSignal.wait(taskLockUnique, [this] {
+				return !tasks.empty();
+			});
 		}
 
 		if (!tasks.empty()) {
@@ -102,7 +104,9 @@ void DatabaseTasks::flush()
 	std::unique_lock<std::mutex> guard{ taskLock };
 	if (!tasks.empty()) {
 		flushTasks = true;
-		flushSignal.wait(guard);
+		flushSignal.wait(guard, [this] {
+			return !flushTasks;
+		});
 		flushTasks = false;
 	}
 }

--- a/src/game/scheduling/scheduler.cpp
+++ b/src/game/scheduling/scheduler.cpp
@@ -19,7 +19,9 @@ void Scheduler::threadMain()
 
 		eventLockUnique.lock();
 		if (eventList.empty()) {
-			eventSignal.wait(eventLockUnique);
+			eventSignal.wait(eventLockUnique, [this] {
+				return eventList.empty();
+			});
 		} else {
 			ret = eventSignal.wait_until(eventLockUnique, eventList.top()->getCycle());
 		}

--- a/src/game/scheduling/tasks.cpp
+++ b/src/game/scheduling/tasks.cpp
@@ -33,7 +33,9 @@ void Dispatcher::threadMain()
 
 		if (taskList.empty()) {
 			//if the list is empty wait for signal
-			taskSignal.wait(taskLockUnique);
+			taskSignal.wait(taskLockUnique, [this] {
+				return taskList.empty();
+			});
 		}
 
 		if (!taskList.empty()) {

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -42,6 +42,7 @@
 std::mutex g_loaderLock;
 std::condition_variable g_loaderSignal;
 std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
+bool g_loaderDone = false;
 
 /**
  *It is preferable to keep the close button off as it closes the server without saving (this can cause the player to lose items from houses and others informations, since windows automatically closes the process in five seconds, when forcing the close)
@@ -217,7 +218,9 @@ int main(int argc, char* argv[]) {
 	g_dispatcher().addTask(createTask(std::bind(mainLoader, argc, argv,
 												&serviceManager)));
 
-	g_loaderSignal.wait(g_loaderUniqueLock);
+	g_loaderSignal.wait(g_loaderUniqueLock, [] {
+		return g_loaderDone;
+	});
 
 	if (serviceManager.is_running()) {
 		SPDLOG_INFO("{} {}", g_configManager().getString(SERVER_NAME),
@@ -382,6 +385,8 @@ void mainLoader(int, char*[], ServiceManager* services) {
 
 	std::string url = g_configManager().getString(DISCORD_WEBHOOK_URL);
 	webhook_send_message("Server is now online", "Server has successfully started.", WEBHOOK_COLOR_ONLINE, url);
+
+	g_loaderDone = true;
 
 	g_loaderSignal.notify_all();
 }


### PR DESCRIPTION
# Description

This addresses the issues reported by SonarCloud regarding the use of wait() without a condition argument in several threadMain functions. The changes made include the addition of a condition argument to the wait() calls in the threadMain functions in the DatabaseTasks, Scheduler and other classes. These changes ensure that the threads will not wait indefinitely and will only wake up when there is a task to be executed, thus avoiding any potential race conditions and deadlocks.

## Behaviour
### **Actual**

Doesn't check the wait()

### **Expected**

Check wait to avoid loops

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
 