### PR TITLE
fix: Wrath of the Emperor teleport

### DIFF
--- a/data-otservbr-global/scripts/movements/quests/wrath_of_the_emperor/teleports_access.lua
+++ b/data-otservbr-global/scripts/movements/quests/wrath_of_the_emperor/teleports_access.lua
@@ -44,77 +44,83 @@ local config =
 local function tpX(i, player, position)
 	if player:getStorageValue(config[i].Access) == 1 then
 		if player:getPosition() == config[i].teleportPos then
-			player:teleportTo(config[i].destinationA)
-			config[i].destinationA:sendMagicEffect(CONST_ME_TELEPORT)
+			return config[i].destinationA
 		else
-			player:teleportTo(config[i].destinationB)
-			config[i].destinationB:sendMagicEffect(CONST_ME_TELEPORT)
+			return config[i].destinationB
 		end
 	elseif player:getStorageValue(config[i].Access) == 2 then
 		if player:getPosition() == config[i].teleportPos then
-			player:teleportTo(config[i].destinationC)
-			config[i].destinationC:sendMagicEffect(CONST_ME_TELEPORT)
+			return config[i].destinationC
 		else
-			player:teleportTo(config[i].destinationB)
-			config[i].destinationB:sendMagicEffect(CONST_ME_TELEPORT)
+			return config[i].destinationB
 		end
 	elseif player:getStorageValue(config[i].Access) == 3 then
 		if player:getPosition() == config[i].teleportPos then
 			if Tile(config[i].itemPos):getItemById(11673) then
 				config[i].itemPos:removeItem(11673, 1)
-				player:teleportTo(config[i].destinationA)
-				config[i].destinationA:sendMagicEffect(CONST_ME_TELEPORT)
+				return config[i].destinationA
 			else
-				player:teleportTo(position)
-				position:sendMagicEffect(CONST_ME_TELEPORT)
 				player:say("This teleporter constantly flickers. It seems to be instable and completely unworking.", TALKTYPE_MONSTER_SAY)
+				return false
 			end
 		else
-			player:teleportTo(config[i].destinationB)
-			config[i].destinationB:sendMagicEffect(CONST_ME_TELEPORT)
+			return config[i].destinationB
 		end
 	else
-		player:teleportTo(position)
-		position:sendMagicEffect(CONST_ME_TELEPORT)
+		return false
 	end
+	return false
 end
-local teleport = MoveEvent()
 
-function teleport.onStepIn(player, item, position, fromPosition)
-	if not player then
-		return true
-	end
+local function getDestinationByPos(player, position)
+	local pos
 	for j = 1, #positions do
 		if j <= 2 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(1, player, position)
+				pos = tpX(1, player, position)
 			end
 		elseif j > 2 and j <= 5 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(2, player, position)
+				pos = tpX(2, player, position)
 			end
 		elseif j > 5 and j <= 7 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(3, player, position)
+				pos = tpX(3, player, position)
 			end
 		elseif j > 7 and j <= 9 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(4, player, position)
+				pos = tpX(4, player, position)
 			end
 		elseif j > 9 and j <= 12 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(5, player, position)
+				pos = tpX(5, player, position)
 			end
 		elseif j > 12 and j <= 14 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(6, player, position)
+				pos = tpX(6, player, position)
 			end
 		elseif j > 14 and j <= 22 then
 			if player:getPosition() == Position(positions[j]) then
-				tpX(7, player, position)
+				pos = tpX(7, player, position)
 			end
 		end
 	end
+	return pos
+end
+
+local teleport = MoveEvent()
+function teleport.onStepIn(creature, item, position, fromPosition)
+	if not creature:isPlayer() then
+		return true
+	end
+	local pos = getDestinationByPos(creature, position)
+	if pos then
+		creature:teleportTo(pos)
+		pos:sendMagicEffect(CONST_ME_TELEPORT)
+		return true
+	end
+	creature:teleportTo(fromPosition, true)
+	fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
 	return true
 end
 


### PR DESCRIPTION
# Description

Upon entering the portal:

![image](https://user-images.githubusercontent.com/91164222/213108377-e192fae1-1641-4404-a030-e3879404c9dc.png)
(Position: 33136, 31248, 6)

returns this error in the console:

[2023-18-01 04:08:20.313] [error] [MoveEvent::executeStep - Creature Jackye, position ( 33136, 31248, 6 )] Call stack overflow. Too many lua script calls being nested.
[2023-18-01 04:08:31.038] [error] [MoveEvent::executeStep - Creature Jackye, position ( 33136, 31248, 6 )] Call stack overflow. Too many lua script calls being nested.
[2023-18-01 04:08:31.038] [error] [Events::eventPlayerOnChangeZone - Player Jackye] Call stack overflow. Too many lua script calls being nested.
[2023-18-01 04:08:32.556] [error] [MoveEvent::executeStep - Creature Jackye, position ( 33136, 31248, 6 )] Call stack overflow. Too many lua script calls being nested.

With these changes, this no longer happens.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

