### PR TITLE
fix: close server console after done message

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6638,6 +6638,7 @@ void Game::shutdown()
 	ConnectionManager::getInstance().closeAll();
 
 	SPDLOG_INFO("Done!");
+	exit(0);
 }
 
 void Game::cleanup()


### PR DESCRIPTION
# Description

After pr: https://github.com/opentibiabr/canary/pull/790 (https://github.com/opentibiabr/canary/commit/a870e0166aa7647bc16742b945c42e7521786362)

Because it is no longer synchronous (does not fall into a loop), the server does not close after giving "CTRL + c" or receiving a safe sigbreak. This way, we need to send an exit for the console to close.

## Behaviour
### **Actual**
After this message, the server does not close
![image](https://user-images.githubusercontent.com/8551443/213349641-3a46941c-8b5b-4c5f-8c12-34c570d78d38.png)


### **Expected**
After the message "done" the server closes.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
