### PR TITLE
Update knight_familiar.lua

### DIFF
--- a/data-canary/scripts/spells/familiar/knight_familiar.lua
+++ b/data-canary/scripts/spells/familiar/knight_familiar.lua
@@ -1,7 +1,7 @@
 local spell = Spell("instant")
 
 function spell.onCastSpell(player, variant)
-	player:createFamiliarSpell()
+	player:CreateFamiliarSpell()
 	return true
 end
 


### PR DESCRIPTION
# Description

The function Player:CreateFamiliarSpell() in player.lua at canary/data/libs/functions/ is presented this way but in data-canary familiar files are using the wrong call, anf for that, preventing char to summon its familiar since data is shared across data-otservbr and data-canary, is better to change it inside every familiar spell in data-canary.

## Behaviour
### **Actual**

When trying to summon its familiar you wont be able to and the console will return an error saying that youre attempting to call a method (a nill value)

### **Expected**

player to be able to summon its familiar

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

After the change the test was made by trying to summon the familiar and it worked very well

**Test Configuration**:

Canary - Version 2.6.1
12.91
Windows 10

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
