### PR TITLE
fix: loop when opening server without db

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -75,6 +75,7 @@ std::string getCompiler() {
 void startupErrorMessage() {
 	SPDLOG_ERROR("The program will close after pressing the enter key...");
 	getchar();
+	exit(0);
 	g_loaderSignal.notify_all();
 }
 


### PR DESCRIPTION
# Description

After pr: https://github.com/opentibiabr/canary/pull/790 (https://github.com/opentibiabr/canary/commit/a870e0166aa7647bc16742b945c42e7521786362)

Because it is no longer synchronous (does not fall into a loop), the server does not close after pressing "Enter" when opening without a database. This way, we need to send an exit for the console to close.

## Behaviour
### **Actual**
After this message, the server does not close.
![image](https://cdn.discordapp.com/attachments/1011480399970570281/1066047075378282637/Untitled.png)


### **Expected**
After pressing "enter" the server closes.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)