### PR TITLE
fix for door not opening/closing

### DIFF
--- a/data-canary/scripts/actions/door/custom_door.lua
+++ b/data-canary/scripts/actions/door/custom_door.lua
@@ -12,7 +12,7 @@ end
 local customDoor = Action()
 
 function customDoor.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if Creature.isInsideDoor(player, toPosition) then
+	if Creature.checkCreatureInsideDoor(player, toPosition) then
 		return true
 	end
 

--- a/data-canary/scripts/actions/door/key_door.lua
+++ b/data-canary/scripts/actions/door/key_door.lua
@@ -44,7 +44,7 @@ function keyDoor.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	end
 	for index, value in ipairs(KeyDoorTable) do
 		if value.openDoor == item.itemid then
-			if Creature.isInsideDoor(player, toPosition) then
+			if Creature.checkCreatureInsideDoor(player, toPosition) then
 				return false
 			end
 			item:transform(value.closedDoor)

--- a/data-canary/scripts/actions/door/level_door.lua
+++ b/data-canary/scripts/actions/door/level_door.lua
@@ -26,7 +26,7 @@ function levelDoor.onUse(player, item, fromPosition, target, toPosition, isHotke
 		end
 	end
 
-	if Creature.isInsideDoor(player, toPosition) then
+	if Creature.checkCreatureInsideDoor(player, toPosition) then
 		return true
 	end
 	return true

--- a/data-canary/scripts/actions/door/quest_door.lua
+++ b/data-canary/scripts/actions/door/quest_door.lua
@@ -26,7 +26,7 @@ function questDoor.onUse(player, item, fromPosition, target, toPosition, isHotke
 		end
 	end
 
-	if Creature.isInsideDoor(player, toPosition) then
+	if Creature.checkCreatureInsideDoor(player, toPosition) then
 		return true
 	end
 	return true


### PR DESCRIPTION
# Description

related to https://github.com/opentibiabr/canary/issues/772
Using data-canary and placing a door (rme) the console was returning an error

## Behaviour
You werent able to open/close a door

Do this and that doesn't happens

### **Expected**

being able to open/close a door using key or whatever relates to

## Fixes
changing isInsideDoor to checkCreatureInsideDoor inside these 4 files will fix the problem.

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

teste by placing doors for use with keys and level and even a _normal_ one.

NOTE.: When placing a normal door, RME will use door id 6248 that is the locked one, you need to use locked door instead cuz it has id 6254 that is a normal closed door
Same goes when setting a door for fences, you need to use the locked one instead.

**Test Configuration**:

Canary - Version 2.6.1
12.91
Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
