### PR TITLE
fix: party hunt analyzer prices from leader

### DIFF
--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -151,6 +151,7 @@ bool Party::passPartyLeadership(Player* player)
 	memberList.insert(memberList.begin(), oldLeader);
 
 	updateSharedExperience();
+	updateTrackerAnalyzer();
 
 	for (Player* member : memberList) {
 		member->sendPartyCreatureShield(oldLeader);

--- a/src/utils/const.hpp
+++ b/src/utils/const.hpp
@@ -16,9 +16,7 @@ const uint32_t MAX_STATICWALK = 100;
 static constexpr size_t NETWORKMESSAGE_PLAYERNAME_MAXLENGTH = 30;
 static constexpr int32_t NETWORKMESSAGE_MAXSIZE = 65500;
 
-// QT clients probably have bigger input buffer because of exiva options
-// But for now we don't support exiva options
-static constexpr int32_t INPUTMESSAGE_MAXSIZE = 2048;
+static constexpr int32_t INPUTMESSAGE_MAXSIZE = 4096;
 
 static constexpr int32_t CHANNEL_GUILD = 0x00;
 static constexpr int32_t CHANNEL_PARTY = 0x01;


### PR DESCRIPTION
# Description

The connection was being terminated upon altering the party hunt analyzer from market to leader, as the tibia client transmitted packages containing information on all cyclopedia items, and these package sizes exceeded what the server was able to accept.
The party hunt analyzer was not being refreshed following the alteration of the party leader.

## Behaviour
### **Actual**

The party leader was being disconnected subsequent to the alteration of the party hunt analyzer from market to leader.
The party hunt analyzer was not being refreshed following the alteration of the party leader.

### **Expected**

Party leader should not be disconnected
The party hunt analyzer should be updated for all party members

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)