### PR TITLE
improve: enabling checksum sequence method/compression in OTClient 

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -486,14 +486,10 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		return;
 	}
 
+	setChecksumMethod(CHECKSUM_METHOD_SEQUENCE);
+	enableCompression();
+
 	OperatingSystem_t operatingSystem = static_cast<OperatingSystem_t>(msg.get<uint16_t>());
-	if (operatingSystem <= CLIENTOS_NEW_MAC) {
-		setChecksumMethod(CHECKSUM_METHOD_SEQUENCE);
-		enableCompression();
-	} else {
-		setChecksumMethod(CHECKSUM_METHOD_ADLER32);
-	}
-	
 
 	version = msg.get<uint16_t>(); // Protocol version
 


### PR DESCRIPTION
In this feature update, the OTClient Redemption now includes support for both the Checksum Sequence Method and compression. As a result, these features will be enabled by default to improve performance and data integrity for users.