### PR TITLE
fix: stow all stowable items by moving depot above stash

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1367,7 +1367,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 }
 
 bool Game::isTryingToStow(const Position &toPos, Cylinder *toCylinder) const {
-	return toCylinder->getContainer() != NULL &&
+	return toCylinder->getContainer() &&
 			toCylinder->getItem()->getID() == ITEM_LOCKER &&
 			toPos.getZ() == ITEM_SUPPLY_STASH_INDEX;
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -866,7 +866,7 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos,
 	if (!player) {
 		return;
 	}
-	
+
 	// Prevent the player from being able to move the item within the imbuement window
 	if (player->hasImbuingItem()) {
         return;
@@ -1221,6 +1221,11 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 		}
 	}
 
+	if (isTryingToStow(toPos, toCylinder)) {
+		player->stowItem(item, count, false);
+		return;
+	}
+
 	if (!item->isPushable() || item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTMOVEABLE);
 		return;
@@ -1320,13 +1325,6 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 		return;
 	}
 
-	if (toCylinder->getContainer() != NULL &&
-		toCylinder->getItem()->getID() == ITEM_LOCKER &&
-		toPos.getZ() == ITEM_SUPPLY_STASH_INDEX) {
-		player->stowItem(item, count, false);
-			return;
-	}
-
 	if (!canThrowObjectTo(mapFromPos, mapToPos)) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTTHROW);
 		return;
@@ -1366,6 +1364,12 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 	player->cancelPush();
 
 	g_events().eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
+}
+
+bool Game::isTryingToStow(const Position &toPos, Cylinder *toCylinder) const {
+	return toCylinder->getContainer() != NULL &&
+			toCylinder->getItem()->getID() == ITEM_LOCKER &&
+			toPos.getZ() == ITEM_SUPPLY_STASH_INDEX;
 }
 
 ReturnValue Game::internalMoveItem(Cylinder* fromCylinder,
@@ -1556,7 +1560,7 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder,
 	}
 
 	Item* quiver = toCylinder->getItem();
-	if (quiver && quiver->isQuiver() 
+	if (quiver && quiver->isQuiver()
                && quiver->getHoldingPlayer()
                && quiver->getHoldingPlayer()->getThing(CONST_SLOT_RIGHT) == quiver) {
 		quiver->getHoldingPlayer()->sendInventoryItem(CONST_SLOT_RIGHT, quiver);
@@ -5754,7 +5758,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 				{
 					continue;
 				}
-				
+
 				if (tmpPlayer == attackerPlayer && attackerPlayer != targetPlayer) {
 					ss.str({});
 					ss << "You heal " << target->getNameDescription() << " for " << damageString;
@@ -5864,7 +5868,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			if (charmRune_t activeCharm = g_iobestiary().getCharmFromTarget(targetPlayer, g_monsters().getMonsterTypeByRaceId(attackerMonster->getRaceId()));
 				activeCharm != CHARM_NONE && activeCharm != CHARM_CLEANSE) {
 				if (Charm* charm = g_iobestiary().getBestiaryCharm(activeCharm);
-					charm->type == CHARM_DEFENSIVE && charm->chance > normal_random(0, 100) && 
+					charm->type == CHARM_DEFENSIVE && charm->chance > normal_random(0, 100) &&
 					g_iobestiary().parseCharmCombat(charm, targetPlayer, attacker, (damage.primary.value + damage.secondary.value))) {
 					return false; // Dodge charm
 				}
@@ -6031,7 +6035,7 @@ bool Game::combatChangeHealth(Creature* attacker, Creature* target, CombatDamage
 			if (normal_random(0, 100) < lifeChance) {
 				// Vampiric charm rune
 				if (targetMonster) {
-					if (uint16_t playerCharmRaceidVamp = attackerPlayer->parseRacebyCharm(CHARM_VAMP, false, 0); 
+					if (uint16_t playerCharmRaceidVamp = attackerPlayer->parseRacebyCharm(CHARM_VAMP, false, 0);
 						playerCharmRaceidVamp != 0 && playerCharmRaceidVamp == targetMonster->getRaceId()) {
 						if (const Charm* lifec = g_iobestiary().getBestiaryCharm(CHARM_VAMP)) {
 							lifeSkill += lifec->percent;
@@ -8597,7 +8601,7 @@ void Game::updateForgeableMonsters()
 			removeFiendishMonster(monsterId);
 		}
 	}
-	
+
 	uint32_t fiendishLimit = g_configManager().getNumber(FORGE_FIENDISH_CREATURES_LIMIT); // Fiendish Creatures limit
 	if (fiendishMonsters.size() < fiendishLimit)
 		createFiendishMonsters();

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -663,6 +663,8 @@ class Game
 		uint16_t itemsSaleCount;
 
 		std::vector<ItemClassification*> itemsClassifications;
+
+		bool isTryingToStow(const Position &toPos, Cylinder *toCylinder) const;
 };
 
 constexpr auto g_game = &Game::getInstance;


### PR DESCRIPTION
# Description

Should be possible to stow all stowable items moving depot "above" stash

## Behaviour
### **Actual**

You can't stow all items from depot simultaneously

### **Expected**

Capability to store all depot items at one time.

## Fixes

Now it is possible to stow all depot stowable items at once

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)