### PR TITLE
fix: summons move items off the way and follow correct moving pattern

### DIFF
--- a/data-otservbr-global/monster/demons/fire_devil.lua
+++ b/data-otservbr-global/monster/demons/fire_devil.lua
@@ -113,9 +113,9 @@ monster.elements = {
 }
 
 monster.immunities = {
-	{type = "paralyze", condition = false},
+	{type = "paralyze", condition = true},
 	{type = "outfit", condition = false},
-	{type = "invisible", condition = false},
+	{type = "invisible", condition = true},
 	{type = "bleed", condition = false}
 }
 

--- a/data-otservbr-global/monster/magicals/icecold_book.lua
+++ b/data-otservbr-global/monster/magicals/icecold_book.lua
@@ -58,7 +58,7 @@ monster.flags = {
 	healthHidden = false,
 	isBlockable = false,
 	canWalkOnEnergy = true,
-	canWalkOnFire = true,
+	canWalkOnFire = false,
 	canWalkOnPoison = true
 }
 

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -492,7 +492,11 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 			stopEventWalk();
 		}
 
-		checkSummonMove(newPos, g_configManager().getBoolean(TELEPORT_SUMMONS));
+		bool configTeleportSummons = g_configManager().getBoolean(TELEPORT_SUMMONS);
+		checkSummonMove(newPos, configTeleportSummons);
+		if(isLostSummon()) {
+			handleLostSummon(configTeleportSummons);
+		}
 
 		if (Player* player = creature->getPlayer()) {
 			if (player->isExerciseTraining()){
@@ -755,7 +759,7 @@ bool Creature::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreatur
 					int32_t money = 0;
 					for (Item* item : corpse->getContainer()->getItems()) {
 						if (uint32_t worth = item->getWorth(); worth > 0) {
-							money += worth; 
+							money += worth;
 							g_game().internalRemoveItem(item);
 						}
 					}
@@ -946,9 +950,13 @@ void Creature::getPathSearchParams(const Creature*, FindPathParams& fpp) const
 void Creature::goToFollowCreature()
 {
 	if (followCreature) {
+		if(isSummon() && !getMonster()->isFamiliar() && !canFollowMaster()){
+			hasFollowPath = false;
+			return;
+		}
+
 		FindPathParams fpp;
 		getPathSearchParams(followCreature, fpp);
-
 		Monster* monster = getMonster();
 		if (monster && !monster->getMaster() && (monster->isFleeing() || fpp.maxTargetDist > 1)) {
 			Direction dir = DIRECTION_NONE;
@@ -988,6 +996,10 @@ void Creature::goToFollowCreature()
 	}
 
 	onFollowCreatureComplete(followCreature);
+}
+
+bool Creature::canFollowMaster() {
+	return !master->getTile()->hasFlag(TILESTATE_PROTECTIONZONE) && (canSeeInvisibility() || !master->isInvisible());
 }
 
 bool Creature::setFollowCreature(Creature* creature)
@@ -1695,4 +1707,22 @@ void Creature::turnToCreature(Creature* creature)
 		}
 	}
 	g_game().internalCreatureTurn(this, dir);
+}
+
+bool Creature::isLostSummon() {
+	if (!isSummon()) {
+		return false;
+	}
+	const Position &masterPosition = getMaster()->getPosition();
+	return std::max<int32_t>(Position::getDistanceX(getPosition(), masterPosition),
+							 Position::getDistanceY(getPosition(), masterPosition)) > 30;
+}
+
+void Creature::handleLostSummon(bool teleportSummons) {
+	if (teleportSummons) {
+		g_game().internalTeleport(this, getMaster()->getPosition(), true);
+	} else {
+		g_game().removeCreature(this, true);
+	}
+	g_game().addMagicEffect(getPosition(), CONST_ME_POFF);
 }

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -998,7 +998,7 @@ void Creature::goToFollowCreature()
 	onFollowCreatureComplete(followCreature);
 }
 
-bool Creature::canFollowMaster() {
+bool Creature::canFollowMaster() const {
 	return !master->getTile()->hasFlag(TILESTATE_PROTECTIONZONE) && (canSeeInvisibility() || !master->isInvisible());
 }
 
@@ -1709,7 +1709,7 @@ void Creature::turnToCreature(Creature* creature)
 	g_game().internalCreatureTurn(this, dir);
 }
 
-bool Creature::isLostSummon() {
+bool Creature::isLostSummon() const {
 	if (!isSummon()) {
 		return false;
 	}

--- a/src/creatures/creature.h
+++ b/src/creatures/creature.h
@@ -611,8 +611,9 @@ class Creature : virtual public Thing
 		friend class Map;
 		friend class CreatureFunctions;
 
-		bool canFollowMaster();
-		bool isLostSummon();
+	private:
+		bool canFollowMaster() const;
+		bool isLostSummon() const;
 		void handleLostSummon(bool teleportSummons);
 };
 

--- a/src/creatures/creature.h
+++ b/src/creatures/creature.h
@@ -396,11 +396,11 @@ class Creature : virtual public Thing
 
 		/**
 		 * @brief Check if the summon can move/spawn and if the familiar can teleport to the master
-		 * 
+		 *
 		 * @param newPos New position to teleport
 		 * @param teleportSummon Can teleport normal summon? Default value is "false"
-		 * @return true 
-		 * @return false 
+		 * @return true
+		 * @return false
 		 */
 		void checkSummonMove(const Position& newPos, bool teleportSummon = false) const;
 		virtual void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
@@ -423,7 +423,7 @@ class Creature : virtual public Thing
 
 		/**
 		 * @brief Check if the "summons" list is empty
-		 * 
+		 *
 		 * @return true = not empty
 		 * @return false = empty
 		 */
@@ -433,7 +433,7 @@ class Creature : virtual public Thing
 			}
 			return false;
 		}
-		
+
 		void setDropLoot(bool newLootDrop) {
 			this->lootDrop = newLootDrop;
 		}
@@ -610,6 +610,10 @@ class Creature : virtual public Thing
 		friend class Game;
 		friend class Map;
 		friend class CreatureFunctions;
+
+		bool canFollowMaster();
+		bool isLostSummon();
+		void handleLostSummon(bool teleportSummons);
 };
 
 #endif  // SRC_CREATURES_CREATURE_H_

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1135,7 +1135,7 @@ void Monster::onThinkYell(uint32_t interval)
 	}
 }
 
-bool Monster::pushItem(Item *item, Direction& nextDirection)
+bool Monster::pushItem(Item *item, const Direction& nextDirection)
 {
 	const Position& centerPos = item->getPosition();
 	for (const auto& [x, y] : getPushItemLocationOptions(nextDirection)) {
@@ -1148,7 +1148,7 @@ bool Monster::pushItem(Item *item, Direction& nextDirection)
 	return false;
 }
 
-void Monster::pushItems(Tile *tile, Direction& nextDirection)
+void Monster::pushItems(Tile *tile, const Direction& nextDirection)
 {
 	TileItemVector* items;
 	if (!(items = tile->getItemList())) {
@@ -2212,7 +2212,7 @@ bool Monster::canDropLoot() const {
 	return !mType->info.lootItems.empty();
 }
 
-std::vector<std::pair<int32_t, int32_t>> Monster::getPushItemLocationOptions(const Direction &direction) {
+std::vector<std::pair<int8_t, int8_t>> Monster::getPushItemLocationOptions(const Direction &direction) {
 	if(direction == DIRECTION_WEST || direction == DIRECTION_EAST){
 		return {{0, -1}, {0, 1}};
 	}

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2221,22 +2221,24 @@ bool Monster::canDropLoot() const {
 }
 
 std::vector<std::pair<int8_t, int8_t>> Monster::getPushItemLocationOptions(const Direction &direction) {
-	if(direction == DIRECTION_WEST || direction == DIRECTION_EAST){
+	if (direction == DIRECTION_WEST || direction == DIRECTION_EAST) {
 		return {{0, -1}, {0, 1}};
 	}
-	if(direction == DIRECTION_NORTH || direction == DIRECTION_SOUTH){
+	if (direction == DIRECTION_NORTH || direction == DIRECTION_SOUTH) {
 		return {{-1, 0}, {1, 0}};
 	}
-	if(direction == DIRECTION_NORTHWEST){
+	if (direction == DIRECTION_NORTHWEST) {
 		return {{0, -1}, {-1, 0}};
 	}
-	if(direction == DIRECTION_NORTHEAST){
+	if (direction == DIRECTION_NORTHEAST) {
 		return {{0, -1}, {1, 0}};
 	}
-	if(direction == DIRECTION_SOUTHWEST){
+	if (direction == DIRECTION_SOUTHWEST) {
 		return {{0, 1}, {-1, 0}};
 	}
-	if(direction == DIRECTION_SOUTHEAST){
+	if (direction == DIRECTION_SOUTHEAST) {
 		return {{0, 1}, {1, 0}};
 	}
+
+	return {};
 }

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -416,7 +416,7 @@ class Monster final : public Creature
 		friend class MonsterFunctions;
 		friend class Map;
 
-		static std::vector<std::pair<int32_t, int32_t>> getPushItemLocationOptions(Direction &direction);
+		static std::vector<std::pair<int32_t, int32_t>> getPushItemLocationOptions(const Direction &direction);
 };
 
 #endif  // SRC_CREATURES_MONSTERS_MONSTER_H_

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -418,6 +418,8 @@ class Monster final : public Creature
 
 		static std::vector<std::pair<int8_t, int8_t>> getPushItemLocationOptions(const Direction &direction);
 
+		void doFollowCreature(uint32_t &flags, Direction &nextDirection, bool &result);
+		void doRandomStep(Direction &nextDirection, bool &result);
 };
 
 #endif  // SRC_CREATURES_MONSTERS_MONSTER_H_

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -383,8 +383,8 @@ class Monster final : public Creature
 		bool isInSpawnRange(const Position& pos) const;
 		bool canWalkTo(Position pos, Direction direction) const;
 
-		static bool pushItem(Item *item, Direction& nextDirection);
-		static void pushItems(Tile *tile, Direction& nextDirection);
+		static bool pushItem(Item *item, const Direction& nextDirection);
+		static void pushItems(Tile *tile, const Direction& nextDirection);
 		static bool pushCreature(Creature* creature);
 		static void pushCreatures(Tile* tile);
 
@@ -416,7 +416,8 @@ class Monster final : public Creature
 		friend class MonsterFunctions;
 		friend class Map;
 
-		static std::vector<std::pair<int32_t, int32_t>> getPushItemLocationOptions(const Direction &direction);
+		static std::vector<std::pair<int8_t, int8_t>> getPushItemLocationOptions(const Direction &direction);
+
 };
 
 #endif  // SRC_CREATURES_MONSTERS_MONSTER_H_

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -273,7 +273,7 @@ class Monster final : public Creature
 			return getForgeStack() == 0 && !isSummon() && !isRewardBoss() && canDropLoot() && isForgeCreature() && getRaceId() > 0;
 		}
 
-		
+
 		bool isForgeCreature() const {
 			return mType->info.isForgeCreature;
 		}
@@ -383,8 +383,8 @@ class Monster final : public Creature
 		bool isInSpawnRange(const Position& pos) const;
 		bool canWalkTo(Position pos, Direction direction) const;
 
-		static bool pushItem(Item* item);
-		static void pushItems(Tile* tile);
+		static bool pushItem(Item *item, Direction& nextDirection);
+		static void pushItems(Tile *tile, Direction& nextDirection);
 		static bool pushCreature(Creature* creature);
 		static void pushCreatures(Tile* tile);
 
@@ -415,6 +415,8 @@ class Monster final : public Creature
 
 		friend class MonsterFunctions;
 		friend class Map;
+
+		static std::vector<std::pair<int32_t, int32_t>> getPushItemLocationOptions(Direction &direction);
 };
 
 #endif  // SRC_CREATURES_MONSTERS_MONSTER_H_


### PR DESCRIPTION
# Description

Occasionally summons fail to move items off the way and wasn't following global moving pattern
Summons are not randomly moving when they can not reach their master or can not see him

## Behaviour
### **Actual**

Occasionally summons fail to move items off the way and wasn't following global moving pattern
Summons are not randomly moving when they can not reach their master or can not see him

### **Expected**

Summons moving items off the way in the correct manner
Moving randomly when they can not see or reach their master

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)