### PR TITLE
fix: speed attribute when looking items

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -1681,7 +1681,7 @@ std::string Item::parseShowAttributesDescription(const Item *item, const uint16_
 					itemDescription << ", ";
 				}
 
-				itemDescription << fmt::format("speed {:+}", show);
+				itemDescription << fmt::format("speed {:+}", itemType.abilities->speed);
 			}
 		}
 


### PR DESCRIPTION
# Description

Items should show the amount of their speed attribute when looking at them

## Behaviour
### **Actual**

Items speed attributes are being showed as speed +0

### **Expected**

The looking message should show the item real speed attribute amount

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)