### PR TITLE
improve: warn user about duplicate storage value

### DIFF
--- a/data-canary/lib/core/storages.lua
+++ b/data-canary/lib/core/storages.lua
@@ -48,34 +48,3 @@ GlobalStorage = {
 		Example = 60000
 	}
 }
-
--- Function to check for duplicate keys in a table
--- Receives the name of the table to be checked as argument
-function checkDuplicatesStorages(varName)
-	-- Retrieve the table to be checked
-	local keys = _G[varName]
-	-- Create a table to keep track of the keys already seen
-	local seen = {}
-	-- Iterate over the keys in the table
-	for k, v in pairs(keys) do
-			-- Check if a key has already been seen
-			if seen[v] then
-					-- If it has, return true and the duplicate key
-					return true, "Duplicate key found: " .. v
-			end
-			-- If not, add the key to the seen table
-			seen[v] = true
-	end
-	-- If no duplicates were found, return false and a message indicating that
-	return false, "No duplicate keys found."
-end
-
--- List of table names to be checked for duplicates
-local variableNames = {"Storage", "GlobalStorage"}
--- Loop through the list of table names
-for _, variableName in ipairs(variableNames) do
-	-- Call the checkDuplicatesStorages function for each table
-	local hasDuplicates, message = checkDuplicatesStorages(variableName)
-	-- Print the result of the check for each table
-	Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
-end

--- a/data-canary/lib/core/storages.lua
+++ b/data-canary/lib/core/storages.lua
@@ -49,29 +49,33 @@ GlobalStorage = {
 	}
 }
 
--- Values extraction function
-local function extractValues(tab, ret)
-	if type(tab) == "number" then
-		table.insert(ret, tab)
-	else
-		for _, v in pairs(tab) do
-			extractValues(v, ret)
-		end
+-- Function to check for duplicate keys in a table
+-- Receives the name of the table to be checked as argument
+function checkDuplicatesStorages(varName)
+	-- Retrieve the table to be checked
+	local keys = _G[varName]
+	-- Create a table to keep track of the keys already seen
+	local seen = {}
+	-- Iterate over the keys in the table
+	for k, v in pairs(keys) do
+			-- Check if a key has already been seen
+			if seen[v] then
+					-- If it has, return true and the duplicate key
+					return true, "Duplicate key found: " .. v
+			end
+			-- If not, add the key to the seen table
+			seen[v] = true
 	end
+	-- If no duplicates were found, return false and a message indicating that
+	return false, "No duplicate keys found."
 end
 
-local extraction = {}
-extractValues(Storage, extraction) -- Call function
-table.sort(extraction) -- Sort the table
--- The choice of sorting is due to the fact that sorting is very cheap O (n log2 (n))
--- And then we can simply compare one by one the elements finding duplicates in O(n)
-
--- Scroll through the extracted table for duplicates
-if #extraction > 1 then
-	for i = 1, #extraction - 1 do
-		if extraction[i] == extraction[i+1] then
-			Spdlog.warn(string.format("Duplicate storage value found: %d",
-				extraction[i]))
-		end
-	end
+-- List of table names to be checked for duplicates
+local variableNames = {"Storage", "GlobalStorage"}
+-- Loop through the list of table names
+for _, variableName in ipairs(variableNames) do
+	-- Call the checkDuplicatesStorages function for each table
+	local hasDuplicates, message = checkDuplicatesStorages(variableName)
+	-- Print the result of the check for each table
+	Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
 end

--- a/data-canary/scripts/globalevents/startup.lua
+++ b/data-canary/scripts/globalevents/startup.lua
@@ -55,31 +55,41 @@ function startup.onStartup()
 		if lootRate ~= 100 then
 			SCHEDULE_LOOT_RATE = lootRate
 		end
-	
+
 		local expRate = EventsScheduler.getEventSExp()
 		if expRate ~= 100 then
 			SCHEDULE_EXP_RATE = expRate
 		end
-	
+
 		local skillRate = EventsScheduler.getEventSSkill()
 		if skillRate ~= 100 then
 			SCHEDULE_SKILL_RATE = skillRate
 		end
-	
+
 		local spawnRate = EventsScheduler.getSpawnMonsterSchedule()
 		if spawnRate ~= 100 then
 			SCHEDULE_SPAWN_RATE = spawnRate
 		end
 
 		if expRate ~= 100 or lootRate ~= 100 or spawnRate ~= 100 or skillRate ~= 100 then
-		Spdlog.info("Events: " .. "Exp: " .. expRate .. "%, " .. "loot: " .. lootRate .. "%, " .. "Spawn: " .. spawnRate .. "%, " .. "Skill: ".. skillRate .."%")
+			Spdlog.info("Events: " .. "Exp: " .. expRate .. "%, " .. "loot: " .. lootRate .. "%, " .. "Spawn: " .. spawnRate .. "%, " .. "Skill: ".. skillRate .."%")
 		end
 	end
 
-    -- Client XP Display Mode
+	-- Client XP Display Mode
 	-- 0 = ignore exp rate /stage
 	-- 1 = include exp rate / stage
 	Game.setStorageValue(GlobalStorage.XpDisplayMode, 1)
+
+	-- List of table names to be checked for duplicates
+	local variableNames = {"Storage", "GlobalStorage"}
+	-- Loop through the list of table names
+	for _, variableName in ipairs(variableNames) do
+		-- Call the checkDuplicatesStorages function for each table
+		local hasDuplicates, message = checkDuplicatesStorages(variableName)
+		-- Print the result of the check for each table
+		Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
+	end
 end
 
 startup:register()

--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -2913,34 +2913,3 @@ startupGlobalStorages = {
 	GlobalStorage.FerumbrasAscendant.Elements.Third,
 	GlobalStorage.FerumbrasAscendant.Elements.Done
 }
-
--- Function to check for duplicate keys in a table
--- Receives the name of the table to be checked as argument
-function checkDuplicatesStorages(varName)
-	-- Retrieve the table to be checked
-	local keys = _G[varName]
-	-- Create a table to keep track of the keys already seen
-	local seen = {}
-	-- Iterate over the keys in the table
-	for k, v in pairs(keys) do
-			-- Check if a key has already been seen
-			if seen[v] then
-					-- If it has, return true and the duplicate key
-					return true, "Duplicate key found: " .. v
-			end
-			-- If not, add the key to the seen table
-			seen[v] = true
-	end
-	-- If no duplicates were found, return false and a message indicating that
-	return false, "No duplicate keys found."
-end
-
--- List of table names to be checked for duplicates
-local variableNames = {"Storage", "GlobalStorage"}
--- Loop through the list of table names
-for _, variableName in ipairs(variableNames) do
-	-- Call the checkDuplicatesStorages function for each table
-	local hasDuplicates, message = checkDuplicatesStorages(variableName)
-	-- Print the result of the check for each table
-	Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
-end

--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -2914,29 +2914,33 @@ startupGlobalStorages = {
 	GlobalStorage.FerumbrasAscendant.Elements.Done
 }
 
--- Values extraction function
-local function extractValues(tab, ret)
-	if type(tab) == "number" then
-		table.insert(ret, tab)
-	else
-		for _, v in pairs(tab) do
-			extractValues(v, ret)
-		end
+-- Function to check for duplicate keys in a table
+-- Receives the name of the table to be checked as argument
+function checkDuplicatesStorages(varName)
+	-- Retrieve the table to be checked
+	local keys = _G[varName]
+	-- Create a table to keep track of the keys already seen
+	local seen = {}
+	-- Iterate over the keys in the table
+	for k, v in pairs(keys) do
+			-- Check if a key has already been seen
+			if seen[v] then
+					-- If it has, return true and the duplicate key
+					return true, "Duplicate key found: " .. v
+			end
+			-- If not, add the key to the seen table
+			seen[v] = true
 	end
+	-- If no duplicates were found, return false and a message indicating that
+	return false, "No duplicate keys found."
 end
 
-local extraction = {}
-extractValues(Storage, extraction) -- Call function
-table.sort(extraction) -- Sort the table
--- The choice of sorting is due to the fact that sorting is very cheap O (n log2 (n))
--- And then we can simply compare one by one the elements finding duplicates in O(n)
-
--- Scroll through the extracted table for duplicates
-if #extraction > 1 then
-	for i = 1, #extraction - 1 do
-		if extraction[i] == extraction[i+1] then
-			Spdlog.warn(string.format("Duplicate storage value found: %d",
-				extraction[i]))
-		end
-	end
+-- List of table names to be checked for duplicates
+local variableNames = {"Storage", "GlobalStorage"}
+-- Loop through the list of table names
+for _, variableName in ipairs(variableNames) do
+	-- Call the checkDuplicatesStorages function for each table
+	local hasDuplicates, message = checkDuplicatesStorages(variableName)
+	-- Print the result of the check for each table
+	Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
 end

--- a/data-otservbr-global/scripts/globalevents/others/startup.lua
+++ b/data-otservbr-global/scripts/globalevents/others/startup.lua
@@ -1,4 +1,5 @@
 local serverstartup = GlobalEvent("serverstartup")
+
 function serverstartup.onStartup()
 	Spdlog.info("Loading map attributes")
 	Spdlog.info("Loaded ".. Game.getNpcCount() .." npcs and spawned ".. Game.getMonsterCount() .." monsters")
@@ -150,12 +151,23 @@ function serverstartup.onStartup()
 		end
 	end
 
-    -- Client XP Display Mode
+	-- Client XP Display Mode
 	-- 0 = ignore exp rate /stage
 	-- 1 = include exp rate / stage
 	Game.setStorageValue(GlobalStorage.XpDisplayMode, 1)
 
 	-- Hireling System
 	HirelingsInit()
+
+	-- List of table names to be checked for duplicates
+	local variableNames = {"Storage", "GlobalStorage"}
+	-- Loop through the list of table names
+	for _, variableName in ipairs(variableNames) do
+		-- Call the checkDuplicatesStorages function for each table
+		local hasDuplicates, message = checkDuplicatesStorages(variableName)
+		-- Print the result of the check for each table
+		Spdlog.warn(">> Checking storages " .. variableName .. ": " .. message)
+	end
 end
+
 serverstartup:register()

--- a/data/global.lua
+++ b/data/global.lua
@@ -205,19 +205,40 @@ function addStamina(playerId, ...)
 			delay = configManager.getNumber(configKeys.STAMINA_GREEN_DELAY) * 60 * 1000 -- Stamina Green 12 min.
 		elseif actualStamina == 2520 then
 			player:sendTextMessage(MESSAGE_STATUS, "You are no longer refilling stamina, \z
-                                                         because your stamina is already full.")
+														 because your stamina is already full.")
 			staminaBonus.eventsPz[localPlayerId] = nil
 			return false
 		end
 
 		player:setStamina(player:getStamina() + configManager.getNumber(configKeys.STAMINA_PZ_GAIN))
 		player:sendTextMessage(MESSAGE_STATUS,
-                               string.format("%i of stamina has been refilled.",
-                                             configManager.getNumber(configKeys.STAMINA_PZ_GAIN)
-                               )
-        )
+							   string.format("%i of stamina has been refilled.",
+											 configManager.getNumber(configKeys.STAMINA_PZ_GAIN)
+							   )
+		)
 		staminaBonus.eventsPz[localPlayerId] = addEvent(addStamina, delay, nil, localPlayerId, delay)
 		return true
 	end
 	return false
+end
+
+-- Function to check for duplicate keys in a table
+-- Receives the name of the table to be checked as argument
+function checkDuplicatesValues(varName)
+	-- Retrieve the table to be checked
+	local keys = _G[varName]
+	-- Create a table to keep track of the keys already seen
+	local seen = {}
+	-- Iterate over the keys in the table
+	for k, v in pairs(keys) do
+		-- Check if a key has already been seen
+		if seen[v] then
+			-- If it has, return true and the duplicate key
+			return true, "Duplicate key found: " .. v
+		end
+		-- If not, add the key to the seen table
+		seen[v] = true
+	end
+	-- If no duplicates were found, return false and a message indicating that
+	return false, "No duplicate keys found."
 end


### PR DESCRIPTION
# Description
- The script checks for duplicate stores when starting the server.
**Note:** It may not be useful for small storages, but for larger servers like realmap it is very useful.

Example:
![image](https://user-images.githubusercontent.com/26801045/215925290-ba73c753-637c-4270-a10b-6055be26ee53.png)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
