### PR TITLE
fix: compilation with new version mio library from vcpkg

### DIFF
--- a/.github/workflows/analysis-sonarcloud.yml
+++ b/.github/workflows/analysis-sonarcloud.yml
@@ -67,11 +67,17 @@ jobs:
           restore-keys: |
             sonar-${{ runner.os}}-
 
-      - name: Restore artifacts, or setup vcpkg (do not install any package)
+      - name: Restore artifacts and install vcpkg
+        id: vcpkg-step
+        run: |
+          vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')
+          echo "vcpkg commit ID: $vcpkgCommitId"
+          echo "::set-output name=vcpkgGitCommitId::$vcpkgCommitId"
+      - name: Get vcpkg commit id from vcpkg.json
         uses: lukka/run-vcpkg@main
         with:
-          vcpkgGitURL: "https://github.com/opentibiabr/vcpkg.git"
-          vcpkgGitCommitId: 8974d642d47efd578e0da3223b4101c5d59aebcf
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ steps.vcpkg-step.outputs.vcpkgGitCommitId }}
 
       - name: Install sonar-scanner
         uses: SonarSource/sonarcloud-github-c-cpp@v1

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -51,10 +51,16 @@ jobs:
             ccache-${{ matrix.os }}
 
       - name: Restore artifacts and install vcpkg
+        id: vcpkg-step
+        run: |
+          vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')
+          echo "vcpkg commit ID: $vcpkgCommitId"
+          echo "::set-output name=vcpkgGitCommitId::$vcpkgCommitId"
+      - name: Get vcpkg commit id from vcpkg.json
         uses: lukka/run-vcpkg@main
         with:
-          vcpkgGitURL: "https://github.com/opentibiabr/vcpkg.git"
-          vcpkgGitCommitId: 8974d642d47efd578e0da3223b4101c5d59aebcf
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ steps.vcpkg-step.outputs.vcpkgGitCommitId }}
 
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@main

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,10 +44,17 @@ jobs:
         run: rm -r -fo C:/mysql*
 
       - name: Restore artifacts and install vcpkg
+        id: vcpkg-step
+        run: |
+          $json=Get-Content vcpkg.json -Raw | ConvertFrom-Json
+          $vcpkgCommitId=$json.'builtin-baseline'
+          Write-Host "vcpkg commit ID: $vcpkgCommitId"
+          echo "::set-output name=vcpkgGitCommitId::$vcpkgCommitId"
+      - name: Get vcpkg commit id from vcpkg.json
         uses: lukka/run-vcpkg@main
         with:
-          vcpkgGitURL: "https://github.com/opentibiabr/vcpkg.git"
-          vcpkgGitCommitId: 8974d642d47efd578e0da3223b4101c5d59aebcf
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ steps.vcpkg-step.outputs.vcpkgGitCommitId }}
 
       - name: Get latest CMake and ninja
         uses: lukka/get-cmake@main

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -8,8 +8,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends cmake git \
 	&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
-RUN git clone https://github.com/microsoft/vcpkg --depth=1 \
-	&& ./vcpkg/bootstrap-vcpkg.sh
+COPY vcpkg.json /opt
+RUN vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ') \
+	&& echo "vcpkg commit ID: $vcpkgCommitId" \
+	&& git clone https://github.com/Microsoft/vcpkg.git \
+	&& cd vcpkg \
+	&& git checkout $vcpkgCommitId \
+	&& ./bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg
 COPY vcpkg.json /opt/vcpkg/

--- a/docker/Dockerfile.x86
+++ b/docker/Dockerfile.x86
@@ -8,8 +8,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends cmake git \
 	&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
-RUN git clone https://github.com/microsoft/vcpkg --depth=1 \
-	&& ./vcpkg/bootstrap-vcpkg.sh
+COPY vcpkg.json /opt
+RUN vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ') \
+	&& echo "vcpkg commit ID: $vcpkgCommitId" \
+	&& git clone https://github.com/Microsoft/vcpkg.git \
+	&& cd vcpkg \
+	&& git checkout $vcpkgCommitId \
+	&& ./bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg
 COPY vcpkg.json /opt/vcpkg/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,6 +146,7 @@ find_package(spdlog REQUIRED)
 find_package(unofficial-libmariadb CONFIG REQUIRED)
 find_package(mio REQUIRED)
 find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -347,6 +348,7 @@ if (MSVC)
 			spdlog::spdlog
 			unofficial::libmariadb
 			unofficial::mariadbclient
+			ZLIB::ZLIB
 	)
 
 else()
@@ -374,6 +376,7 @@ else()
 			spdlog::spdlog
 			unofficial::libmariadb
 			unofficial::mariadbclient
+			ZLIB::ZLIB
 
 			Threads::Threads
 	)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
     "protobuf",
     "parallel-hashmap",
     "magic-enum",
+    "zlib",
     {"name": "mio", "version>=": "2019-02-10"},
     {
       "name": "luajit",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
     "protobuf",
     "parallel-hashmap",
     "magic-enum",
-    "mio",
+    {"name": "mio", "version>=": "2019-02-10"},
     {
       "name": "luajit",
       "platform": "!arm"
@@ -27,5 +27,6 @@
       "name": "mpir",
       "platform": "windows"
     }
-  ]
+  ],
+  "builtin-baseline":"0e67f312e831b4b897c7f492cf1e2858522c6e18"
 }


### PR DESCRIPTION
# Description

In a recent commit of vcpkg, the library mio was problem to link, which causes problems when trying to link the executable. Until we have a correction in the vcpkg repository, I decided to revert to installing the older lib version.

With that in mind, it was added to the GHA to install vcpkg based on the builtin-baseline in vcpkg.json, so we can set vcpkg to be installed from specific commits, both in GitHub Actions and in ubuntu/windows, centralizing everything in a single local, preventing the builds from breaking due to modifications in the vcpkg repository, we can only update when there is an official release.

## Behaviour
### **Actual**

Do not link executable

### **Expected**

Link executable

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Update your vcpkg to the most current version and try to compile, it won't link the executable.
When applying this correction, it will link, because the vcpkg manifest will install the older version of the lib in vcpkg.

**Test Configuration**:

  - Server Version: 2.6.1
  - Client: 12.91
  - Operating System: Windows 11

