### PR TITLE
fix: monster target list erasing after player died

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -399,12 +399,18 @@ void Creature::onCreatureAppear(Creature* creature, bool isLogin)
 
 void Creature::onRemoveCreature(Creature* creature, bool)
 {
-  onCreatureDisappear(creature, true);
-  if (creature != this && isMapLoaded) {
-    if (creature->getPosition().z == getPosition().z) {
-      updateTileCache(creature->getTile(), creature->getPosition());
-    }
-  }
+	onCreatureDisappear(creature, true);
+	if (creature != this && isMapLoaded) {
+		if (creature->getPosition().z == getPosition().z) {
+		updateTileCache(creature->getTile(), creature->getPosition());
+		}
+	}
+
+	// Remove player from monster target list (avoid memory usage after clean)
+	if (auto monster = getMonster(); monster && monster->getAttackedCreature() == creature) {
+		monster->setAttackedCreature(creature);
+		monster->setFollowCreature(creature);
+	}
 }
 
 void Creature::onCreatureDisappear(const Creature* creature, bool isLogout)

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -406,7 +406,7 @@ void Creature::onRemoveCreature(Creature* creature, bool)
 		}
 	}
 
-	// Remove player from monster target list (avoid memory usage after clean)
+	// Update player from monster target list (avoid memory usage after clean)
 	if (auto monster = getMonster(); monster && monster->getAttackedCreature() == creature) {
 		monster->setAttackedCreature(creature);
 		monster->setFollowCreature(creature);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2766,14 +2766,6 @@ void Player::despawn()
 			player->sendRemoveTileThing(tile->getPosition(), oldStackPosVector[i++]);
 		}
 
-		// Remove player from monster target list (avoid memory usage after clean)
-		if (auto monster = spectator->getMonster()) {
-			if (auto monsterTarget = monster->getAttackedCreature() == this) {
-				monster->setAttackedCreature(this);
-				monster->setFollowCreature(this);
-			}
-		}
-
 		spectator->onRemoveCreature(this, false)
 	}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2767,9 +2767,13 @@ void Player::despawn()
 		}
 
 		spectator->onRemoveCreature(this, false);
-		// Remove player from spectator target list
-		spectator->setAttackedCreature(nullptr);
-		spectator->setFollowCreature(nullptr);
+		// Remove player from monster target list (avoid memory usage after clean)
+		if (auto monster = spectator->getMonster()) {
+			if (auto monsterTarget = monster->getAttackedCreature()) {
+				monster->setAttackedCreature(this);
+				monster->setFollowCreature(this);
+			}
+		}
 	}
 
 	tile->removeCreature(this);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2709,7 +2709,7 @@ bool Player::spawn()
 	}
 
 	SpectatorHashSet spectators;
-	g_game().map.getSpectators(spectators, position, false, true);
+	g_game().map.getSpectators(spectators, position);
 	for (Creature* spectator : spectators) {
 		if (!spectator) {
 			continue;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2766,14 +2766,15 @@ void Player::despawn()
 			player->sendRemoveTileThing(tile->getPosition(), oldStackPosVector[i++]);
 		}
 
-		spectator->onRemoveCreature(this, false);
 		// Remove player from monster target list (avoid memory usage after clean)
 		if (auto monster = spectator->getMonster()) {
-			if (auto monsterTarget = monster->getAttackedCreature()) {
+			if (auto monsterTarget = monster->getAttackedCreature() == this) {
 				monster->setAttackedCreature(this);
 				monster->setFollowCreature(this);
 			}
 		}
+
+		spectator->onRemoveCreature(this, false)
 	}
 
 	tile->removeCreature(this);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2766,7 +2766,7 @@ void Player::despawn()
 			player->sendRemoveTileThing(tile->getPosition(), oldStackPosVector[i++]);
 		}
 
-		spectator->onRemoveCreature(this, false)
+		spectator->onRemoveCreature(this, false);
 	}
 
 	tile->removeCreature(this);


### PR DESCRIPTION
# Description

When dying, the spectator's list of players was cleared, that is, if a player died, the target of all others was cleared.
Also fixed the bug that when a player dies near the temple and a creature is in his sight, the creature will not target the player.

## Behaviour
### **Actual**

List of players attacking a monster is cleared after a player dies.

### **Expected**

Only the player who died will be removed from the monster's target list.

## Fixes #623, fixes #715, fixes #519

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
See issue #623 