### PR TITLE
fix: house clean-up and item wrap issues

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3382,7 +3382,7 @@ void Game::playerWrapableItem(uint32_t playerId, const Position& pos, uint8_t st
 		return;
 	}
 
-	Thing* thing = internalGetThing(player, pos, stackPos, itemId, STACKPOS_TOPDOWN_ITEM);
+	Thing* thing = internalGetThing(player, pos, stackPos, itemId, STACKPOS_FIND_THING);
 	if (!thing) {
 		return;
 	}
@@ -3444,19 +3444,7 @@ void Game::playerWrapableItem(uint32_t playerId, const Position& pos, uint8_t st
 	}
 
 	if (item->isWrapable() && item->getID() != ITEM_DECORATION_KIT) {
-		uint16_t hiddenCharges = 0;
-		if (isCaskItem(item->getID())) {
-			hiddenCharges = item->getSubType();
-		}
-		uint16_t oldItemID = item->getID();
-		addMagicEffect(item->getPosition(), CONST_ME_POFF);
-		Item* newItem = transformItem(item, ITEM_DECORATION_KIT);
-		newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
-		item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + itemName + ">.");
-		if (hiddenCharges > 0) {
-			item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
-		}
-		newItem->startDecaying();
+		wrapItem(item);
 	}
 	else if (item->getID() == ITEM_DECORATION_KIT && unWrapId != 0) {
 		auto hiddenCharges = item->getAttribute<uint16_t>(ItemAttribute_t::DATE);
@@ -3465,12 +3453,28 @@ void Game::playerWrapableItem(uint32_t playerId, const Position& pos, uint8_t st
 			if (hiddenCharges > 0 && isCaskItem(unWrapId)) {
 				newItem->setSubType(hiddenCharges);
 			}
-			addMagicEffect(pos, CONST_ME_POFF);
 			newItem->removeCustomAttribute("unWrapId");
 			newItem->removeAttribute(ItemAttribute_t::DESCRIPTION);
 			newItem->startDecaying();
 		}
 	}
+	addMagicEffect(pos, CONST_ME_POFF);
+}
+
+Item* Game::wrapItem(Item *item) {
+	uint16_t hiddenCharges = 0;
+	if (isCaskItem(item->getID())) {
+		hiddenCharges = item->getSubType();
+	}
+	uint16_t oldItemID = item->getID();
+	Item* newItem = transformItem(item, ITEM_DECORATION_KIT);
+	newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
+	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + itemName + ">.");
+	if (hiddenCharges > 0) {
+		item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
+	}
+	newItem->startDecaying();
+	return newItem;
 }
 
 void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, const std::string& text)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3462,16 +3462,15 @@ void Game::playerWrapableItem(uint32_t playerId, const Position& pos, uint8_t st
 }
 
 Item* Game::wrapItem(Item *item) {
-	uint16_t hiddenCharges = 0;
-	if (isCaskItem(item->getID())) {
-		hiddenCharges = item->getSubType();
-	}
 	uint16_t oldItemID = item->getID();
 	Item* newItem = transformItem(item, ITEM_DECORATION_KIT);
 	newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
 	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + item->getName() + ">.");
-	if (hiddenCharges > 0) {
-		item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
+	if (isCaskItem(item->getID())) {
+		auto hiddenCharges = item->getSubType();
+		if(hiddenCharges > 0) {
+			item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
+		}
 	}
 	newItem->startDecaying();
 	return newItem;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3468,7 +3468,7 @@ Item* Game::wrapItem(Item *item) {
 	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + item->getName() + ">.");
 	if (isCaskItem(item->getID())) {
 		auto hiddenCharges = item->getSubType();
-		if(hiddenCharges > 0) {
+		if (hiddenCharges > 0) {
 			item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
 		}
 	}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3469,7 +3469,7 @@ Item* Game::wrapItem(Item *item) {
 	uint16_t oldItemID = item->getID();
 	Item* newItem = transformItem(item, ITEM_DECORATION_KIT);
 	newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
-	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + itemName + ">.");
+	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + item->getName() + ">.");
 	if (hiddenCharges > 0) {
 		item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
 	}

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -585,6 +585,7 @@ class Game
 
 		bool addInfluencedMonster(Monster *monster);
 		void sendUpdateCreature(const Creature *creature);
+		Item* wrapItem(Item *item);
 
 	private:
 		std::map<uint32_t, int32_t> forgeMonsterEventIds;

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -270,8 +270,7 @@ void House::handleWrapableItem(ItemList &moveItemList, Item *item) const {
 }
 
 void House::handleContainer(ItemList &moveItemList, Item *item) const {
-	Container* container;
-	if (container = item->getContainer()) {
+	if (const auto container = item->getContainer()) {
 		for (Item* containerItem : container->getItemList()) {
 			moveItemList.push_back(containerItem);
 		}

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -240,47 +240,16 @@ bool House::transferToDepot(Player* player) const
 	if (townId == 0 || owner == 0) {
 		return false;
 	}
-
 	ItemList moveItemList;
 	for (HouseTile* tile : houseTiles) {
 		if (const TileItemVector* items = tile->getItemList()) {
-			for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-				Item* item = (*it);
+			for (Item* item : *items) {
 				if (item->isWrapable()) {
-					Container* container = item->getContainer();
-					if (container) {
-						for (Item* containerItem : container->getItemList()) {
-							moveItemList.push_back(containerItem);
-						}
-					}
-
-					uint16_t hiddenCharges = 0;
-					if (isCaskItem(item->getID())) {
-						hiddenCharges = item->getSubType();
-					}
-					
-					std::string itemName = item->getName();
-					uint16_t itemID = item->getID();
-					Item* newItem = g_game().transformItem(item, ITEM_DECORATION_KIT);
-					newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(itemID));
-					std::ostringstream ss;
-					ss << "Unwrap it in your own house to create a <" << itemName << ">.";
-					newItem->setAttribute(ItemAttribute_t::DESCRIPTION, ss.str());
-					
-					if (hiddenCharges > 0) {
-						item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
-					}
-					
-					moveItemList.push_back(newItem);
+					handleWrapableItem(moveItemList, item);
 				} else if (item->isPickupable()) {
 					moveItemList.push_back(item);
 				} else {
-					Container* container = item->getContainer();
-					if (container) {
-						for (Item* containerItem : container->getItemList()) {
-							moveItemList.push_back(containerItem);
-						}
-					}
+					handleContainer(moveItemList, item);
 				}
 			}
 		}
@@ -290,6 +259,23 @@ bool House::transferToDepot(Player* player) const
 		g_game().internalMoveItem(item->getParent(), player->getInbox(), INDEX_WHEREEVER, item, item->getItemCount(), nullptr, FLAG_NOLIMIT);
 	}
 	return true;
+}
+
+void House::handleWrapableItem(ItemList &moveItemList, Item *item) const {
+	if(item->isWrapContainer()) {
+		handleContainer(moveItemList, item);
+	}
+	Item *newItem = g_game().wrapItem(item);
+	moveItemList.push_back(newItem);
+}
+
+void House::handleContainer(ItemList &moveItemList, Item *item) const {
+	Container* container;
+	if (container = item->getContainer()) {
+		for (Item* containerItem : container->getItemList()) {
+			moveItemList.push_back(containerItem);
+		}
+	}
 }
 
 bool House::getAccessList(uint32_t listId, std::string& list) const

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -262,7 +262,7 @@ bool House::transferToDepot(Player* player) const
 }
 
 void House::handleWrapableItem(ItemList &moveItemList, Item *item) const {
-	if(item->isWrapContainer()) {
+	if (item->isWrapContainer()) {
 		handleContainer(moveItemList, item);
 	}
 	Item *newItem = g_game().wrapItem(item);

--- a/src/map/house/house.h
+++ b/src/map/house/house.h
@@ -229,6 +229,9 @@ class House
 		Position posEntry = {};
 
 		bool isLoaded = false;
+
+		void handleContainer(ItemList &moveItemList, Item *item) const;
+		void handleWrapableItem(ItemList &moveItemList, Item *item) const;
 };
 
 using HouseMap = std::map<uint32_t, House*>;


### PR DESCRIPTION
# Description

When using the command !leavehouse all items should be move to the owner's mailbox.
Should be possible to wrap unrolled carpets.

Fixes #631

## Behaviour
### **Actual**

When removing the ownership of a house the first item above an unrolled carpet wasent being sent to the mailbox
You couldn't wrap unrolled carpets

### **Expected**

When losing the house ownership all items should be move to the owner's mailbox.
Should be possible to wrap unrolled carpets.


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)