### PR TITLE
fix: client debug and show not targeting player when dying near temple

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2709,7 +2709,7 @@ bool Player::spawn()
 	}
 
 	SpectatorHashSet spectators;
-	g_game().map.getSpectators(spectators, position);
+	g_game().map.getSpectators(spectators, position, true);
 	for (Creature* spectator : spectators) {
 		if (!spectator) {
 			continue;


### PR DESCRIPTION
# Description

fix: client debug and show not targeting player when dying near temple
