### PR TITLE
fix: Canary NPC example addModule missing parameters

### DIFF
--- a/data-canary/npc/canary.lua
+++ b/data-canary/npc/canary.lua
@@ -155,7 +155,7 @@ npcHandler:setMessage(MESSAGE_FAREWELL, "Yeah, good bye and don't come again!")
 -- Walkaway message
 npcHandler:setMessage(MESSAGE_WALKAWAY, "You not have education?")
 
-npcHandler:addModule(FocusModule:new())
+npcHandler:addModule(FocusModule:new(), npcConfig.name, true, true, true)
 
 -- Register npc
 npcType:register(npcConfig)


### PR DESCRIPTION
Now the NPCs are displayed correctly and everything appears to be functional.
Previously, they were not working in Ghost mode and this is what they looked like.

If you have custom NPCs like I do, and created them some time ago, you may need to update them to function correctly.
Change ```npcHandler:addModule(FocusModule:new())``` to
```npcHandler:addModule(FocusModule:new(), npcConfig.name, true, true, true)```