### PR TITLE
fix: set target when convince creature

### DIFF
--- a/data/libs/functions/creature.lua
+++ b/data/libs/functions/creature.lua
@@ -105,6 +105,7 @@ function Creature:setSummon(monster)
 	end
 
 	summon:setMaster(self, true)
+	summon:setTarget(self.attackedCreature)
 	return true
 end
 


### PR DESCRIPTION
# Description

Convinced creature should attack same target as master
Fixes #539 

## Behaviour
### **Actual**

When the creature is convinced, it does not attack the same target as the master.

### **Expected**

The convinced creature should attack the same target as master

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)