### PR TITLE
fix: remove shared_ptr from reward

### DIFF
--- a/data-canary/scripts/reward_chest/boss_death.lua
+++ b/data-canary/scripts/reward_chest/boss_death.lua
@@ -11,7 +11,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 	-- Make sure it is a boss
 	if monsterType and monsterType:isRewardBoss() then
 		local bossId = creature:getId()
-		local timestamp = systemTime()
+		local rewardId = corpse:getAttribute(ITEM_ATTRIBUTE_DATE)
 
 		ResetAndSetTargetList(creature)
 
@@ -57,7 +57,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 			-- Ignoring stamina for now because I heard you get receive rewards even when it's depleted
 			local reward, stamina
 			if con.player then
-				reward = con.player:getReward(timestamp, true)
+				reward = con.player:getReward(rewardId, true)
 				stamina = con.player:getStamina()
 			else
 				stamina = con.stamina or 0
@@ -87,7 +87,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 				end
 				con.player:sendTextMessage(MESSAGE_LOOT, lootMessage)
 			elseif con.score ~= 0 then
-				InsertRewardItems(con.guid, timestamp, playerLoot)
+				InsertRewardItems(con.guid, rewardId, playerLoot)
 			end
 		end
 

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -76,16 +76,17 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 
 		for _, con in ipairs(scores) do
 			-- Ignoring stamina for now because I heard you get receive rewards even when it's depleted
-			local reward, stamina
-			if con.player and con.score ~= 0 then
-				reward = con.player:getReward(rewardId, true)
-				stamina = con.player:getStamina()
-			elseif con.score ~= 0 then
-				stamina = con.stamina or 0
-			end
-
-			local playerLoot
 			if con.score ~= 0 then
+				local reward, stamina, player
+				if con.player then
+					player = con.player;
+				else
+					player = Game.getOfflinePlayer(con.guid)
+				end
+				reward = player:getReward(rewardId, true)
+				stamina = player:getStamina()
+
+				local playerLoot
 				local lootFactor = 1
 				-- Tone down the loot a notch if there are many participants
 				lootFactor = lootFactor / participants ^ (1 / 3)
@@ -93,54 +94,49 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 				lootFactor = lootFactor * (1 + lootFactor) ^ (con.score / expectedScore)
 				playerLoot = monsterType:getBossReward(lootFactor, _ == 1)
 
-				if con.player then
-					for _, p in ipairs(playerLoot) do
-						reward:addItem(p[1], p[2])
-					end
-				end
-			end
-
-			-- Bosstiary Loot Bonus
-			local bonus, boostedMessage
-			local isBoostedBoss = creature:getName():lower() == (Game.getBoostedBoss()):lower()
-			local bossRaceIds = {con.player:getSlotBossId(1), con.player:getSlotBossId(2)}
-			local isBoss = table.contains(bossRaceIds, monsterType:bossRaceId()) or isBoostedBoss
-			if isBoss and mType:bossRaceId() ~= 0 then
-				if monsterType:bossRaceId() == con.player:getSlotBossId(1) then
-					bonus = con.player:getBossBonus(1)
-				elseif monsterType:bossRaceId() == con.player:getSlotBossId(2) then
-					bonus = con.player:getBossBonus(2)
-				else
-					bonus = configManager.getNumber(configKeys.BOOSTED_BOSS_LOOT_BONUS)
-				end
-
 				for _, p in ipairs(playerLoot) do
-					local isValidItem = checkItemType(p[1])
-					if isValidItem then
-						local realBonus = calculateBonus(bonus)
-						for _ = 1, realBonus do
-							reward:addItem(p[1], p[2])
-							boostedMessage = true
+					reward:addItem(p[1], p[2])
+				end
+
+				-- Bosstiary Loot Bonus
+				local bonus, boostedMessage
+				local isBoostedBoss = creature:getName():lower() == (Game.getBoostedBoss()):lower()
+				local bossRaceIds = {player:getSlotBossId(1), player:getSlotBossId(2)}
+				local isBoss = table.contains(bossRaceIds, monsterType:bossRaceId()) or isBoostedBoss
+				if isBoss then
+					if monsterType:bossRaceId() == con.player:getSlotBossId(1) then
+						bonus = player:getBossBonus(1)
+					elseif monsterType:bossRaceId() == con.player:getSlotBossId(2) then
+						bonus = player:getBossBonus(2)
+					else
+						bonus = configManager.getNumber(configKeys.BOOSTED_BOSS_LOOT_BONUS)
+					end
+
+					for _, p in ipairs(playerLoot) do
+						local isValidItem = checkItemType(p[1])
+						if isValidItem then
+							local realBonus = calculateBonus(bonus)
+							for _ = 1, realBonus do
+								reward:addItem(p[1], p[2])
+								boostedMessage = true
+							end
 						end
 					end
 				end
-			end
-
-			if con.player and con.score ~= 0 then
-				local lootMessage = ("The following items dropped by %s are available in your reward chest: %s"):format(creature:getName(), reward:getContentDescription())
-				if boostedMessage then
-					lootMessage = lootMessage .. " (Boss bonus)"
+				if con.player then
+					local lootMessage = ("The following items dropped by %s are available in your reward chest: %s"):format(creature:getName(), reward:getContentDescription())
+					if boostedMessage then
+						lootMessage = lootMessage .. " (Boss bonus)"
+					end
+					if stamina > 840 then
+						reward:getContentDescription(lootMessage)
+					end
+					player:sendTextMessage(MESSAGE_LOOT, lootMessage)
+				else
+					player:save()
 				end
-
-				if stamina > 840 then
-					reward:getContentDescription(lootMessage)
-				end
-				con.player:sendTextMessage(MESSAGE_LOOT, lootMessage)
-			elseif con.score ~= 0 then
-				InsertRewardItems(con.guid, rewardId, playerLoot)
 			end
 		end
-
 		GlobalBosses[bossId] = nil
 	end
 	return true

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -104,9 +104,9 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 				local bossRaceIds = {player:getSlotBossId(1), player:getSlotBossId(2)}
 				local isBoss = table.contains(bossRaceIds, monsterType:bossRaceId()) or isBoostedBoss
 				if isBoss then
-					if monsterType:bossRaceId() == con.player:getSlotBossId(1) then
+					if monsterType:bossRaceId() == player:getSlotBossId(1) then
 						bonus = player:getBossBonus(1)
-					elseif monsterType:bossRaceId() == con.player:getSlotBossId(2) then
+					elseif monsterType:bossRaceId() == player:getSlotBossId(2) then
 						bonus = player:getBossBonus(2)
 					else
 						bonus = configManager.getNumber(configKeys.BOOSTED_BOSS_LOOT_BONUS)

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -103,7 +103,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 				local isBoostedBoss = creature:getName():lower() == (Game.getBoostedBoss()):lower()
 				local bossRaceIds = {player:getSlotBossId(1), player:getSlotBossId(2)}
 				local isBoss = table.contains(bossRaceIds, monsterType:bossRaceId()) or isBoostedBoss
-				if isBoss then
+				if isBoss and monsterType:bossRaceId() ~= 0 then
 					if monsterType:bossRaceId() == player:getSlotBossId(1) then
 						bonus = player:getBossBonus(1)
 					elseif monsterType:bossRaceId() == player:getSlotBossId(2) then

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -77,10 +77,10 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 		for _, con in ipairs(scores) do
 			-- Ignoring stamina for now because I heard you get receive rewards even when it's depleted
 			local reward, stamina
-			if con.player then
+			if con.player and con.score ~= 0 then
 				reward = con.player:getReward(timestamp, true)
 				stamina = con.player:getStamina()
-			else
+			elseif con.score ~= 0 then
 				stamina = con.stamina or 0
 			end
 

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -105,7 +105,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 			local isBoostedBoss = creature:getName():lower() == (Game.getBoostedBoss()):lower()
 			local bossRaceIds = {con.player:getSlotBossId(1), con.player:getSlotBossId(2)}
 			local isBoss = table.contains(bossRaceIds, monsterType:bossRaceId()) or isBoostedBoss
-			if isBoss then
+			if isBoss and mType:bossRaceId() ~= 0 then
 				if monsterType:bossRaceId() == con.player:getSlotBossId(1) then
 					bonus = con.player:getBossBonus(1)
 				elseif monsterType:bossRaceId() == con.player:getSlotBossId(2) then

--- a/data-otservbr-global/scripts/reward_chest/boss_death.lua
+++ b/data-otservbr-global/scripts/reward_chest/boss_death.lua
@@ -32,7 +32,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 	-- Make sure it is a boss
 	if monsterType and monsterType:isRewardBoss() then
 		local bossId = creature:getId()
-		local timestamp = systemTime()
+		local rewardId = corpse:getAttribute(ITEM_ATTRIBUTE_DATE)
 
 		ResetAndSetTargetList(creature)
 
@@ -78,7 +78,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 			-- Ignoring stamina for now because I heard you get receive rewards even when it's depleted
 			local reward, stamina
 			if con.player and con.score ~= 0 then
-				reward = con.player:getReward(timestamp, true)
+				reward = con.player:getReward(rewardId, true)
 				stamina = con.player:getStamina()
 			elseif con.score ~= 0 then
 				stamina = con.stamina or 0
@@ -137,7 +137,7 @@ function bossDeath.onDeath(creature, corpse, killer, mostDamageKiller, lastHitUn
 				end
 				con.player:sendTextMessage(MESSAGE_LOOT, lootMessage)
 			elseif con.score ~= 0 then
-				InsertRewardItems(con.guid, timestamp, playerLoot)
+				InsertRewardItems(con.guid, rewardId, playerLoot)
 			end
 		end
 

--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -73,7 +73,7 @@ function Monster:onDropLoot(corpse)
 			local isBoostedBoss = self:getName():lower() == (Game.getBoostedBoss()):lower()
 			local bossRaceIds = {player:getSlotBossId(1), player:getSlotBossId(2)}
 			local isBoss = table.contains(bossRaceIds, mType:bossRaceId()) or isBoostedBoss
-			if isBoss then
+			if isBoss and mType:bossRaceId() ~= 0 then
 				local bonus
 				if mType:bossRaceId() == player:getSlotBossId(1) then
 					bonus = player:getBossBonus(1)
@@ -137,8 +137,8 @@ function Monster:onSpawn(position)
 
 	-- We won't run anything from here on down if we're opening the global pack
 	if IsRunningGlobalDatapack() then
-		if self:getName():lower() == "cobra scout" or 
-			self:getName():lower() == "cobra vizier" or 
+		if self:getName():lower() == "cobra scout" or
+			self:getName():lower() == "cobra vizier" or
 			self:getName():lower() == "cobra assassin" then
 			if getGlobalStorageValue(GlobalStorage.CobraBastionFlask) >= os.time() then
 				self:setHealth(self:getMaxHealth() * 0.75)

--- a/data/libs/reward_boss/reward_boss.lua
+++ b/data/libs/reward_boss/reward_boss.lua
@@ -72,8 +72,8 @@ function InsertRewardItems(playerGuid, timestamp, itemList)
 			local total = InsertItems(buffer, info, bagSid, {bag})
 
 			if total ~= 0 then
-				local query = table.concat(buffer):sub(1, -2)..";";
-				db.query(query)
+				local insertItemsQuery = table.concat(buffer):sub(1, -2)..";";
+				db.query(insertItemsQuery)
 			end
 		end
 	)

--- a/data/libs/reward_boss/reward_boss.lua
+++ b/data/libs/reward_boss/reward_boss.lua
@@ -53,30 +53,27 @@ function InsertItems(buffer, info, parent, items)
 end
 
 function InsertRewardItems(playerGuid, timestamp, itemList)
-	db.asyncStoreQuery('select max(`sid`) as max_sid from `player_rewards` where player_id = '..playerGuid..';',
-		function(query)
-			local bagSid = (Result.getDataInt(query, 'max_sid') or 0) + 1;
-			local nextSid = bagSid + 1;
-			local buffer = {'INSERT INTO `player_rewards` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES'}
-			local info = {
-				playerGuid = playerGuid,
-				running = nextSid
-			}
-			local bag = Game.createItem(ITEM_REWARD_CONTAINER)
-			bag:setAttribute(ITEM_ATTRIBUTE_DATE, timestamp)
-			if itemList then
-				for _, p in ipairs(itemList) do
-					bag:addItem(p[1], p[2])
-				end
-			end
-			local total = InsertItems(buffer, info, bagSid, {bag})
-
-			if total ~= 0 then
-				local insertItemsQuery = table.concat(buffer):sub(1, -2)..";";
-				db.query(insertItemsQuery)
-			end
+	local maxSidQueryResult = db.query('select max(`sid`) as max_sid from `player_rewards` where player_id = '..playerGuid..';')
+	local bagSid = (Result.getDataInt(maxSidQueryResult, 'max_sid') or 0) + 1;
+	local nextSid = bagSid + 1;
+	local buffer = {'INSERT INTO `player_rewards` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES'}
+	local info = {
+		playerGuid = playerGuid,
+		running = nextSid
+	}
+	local bag = Game.createItem(ITEM_REWARD_CONTAINER)
+	bag:setAttribute(ITEM_ATTRIBUTE_DATE, timestamp)
+	if itemList then
+		for _, p in ipairs(itemList) do
+			bag:addItem(p[1], p[2])
 		end
-	)
+	end
+	local total = InsertItems(buffer, info, bagSid, {bag})
+
+	if total ~= 0 then
+		local insertItemsQuery = table.concat(buffer):sub(1, -2)..";";
+		db.query(insertItemsQuery)
+	end
 end
 
 function GetPlayerStats(bossId, playerGuid, autocreate)

--- a/data/libs/reward_boss/reward_boss.lua
+++ b/data/libs/reward_boss/reward_boss.lua
@@ -21,22 +21,19 @@ function PushSeparated(buffer, sep, ...)
 	end
 end
 
-function InsertItems(buffer, info, parent, items, bagSid)
+function InsertItems(buffer, info, parent, items)
 	local start = info.running
 	for _, item in ipairs(items) do
 		if item ~= nil then
-			if _ ~= 1 or parent > 100 then
-				table.insert(buffer, ",")
-			end
-		if item:getId() == ITEM_REWARD_CONTAINER then
+			if item:getId() == ITEM_REWARD_CONTAINER then
 				table.insert(buffer, "(")
-				PushSeparated(buffer, ",", info.playerGuid, 0, bagSid, item:getId(), item:getSubType(), db.escapeString(item:serializeAttributes()))
-				table.insert(buffer, ")")
+				PushSeparated(buffer, ",", info.playerGuid, 0, parent, item:getId(), item:getSubType(), db.escapeString(item:serializeAttributes()))
+				table.insert(buffer, "),")
 			else
 				info.running = info.running + 1
 				table.insert(buffer, "(")
 				PushSeparated(buffer, ",", info.playerGuid, parent, info.running, item:getId(), item:getSubType(), db.escapeString(item:serializeAttributes()))
-				table.insert(buffer, ")")
+				table.insert(buffer, "),")
 			end
 
 			if item:isContainer() then
@@ -47,7 +44,7 @@ function InsertItems(buffer, info, parent, items, bagSid)
 						table.insert(subItems, item:getItem(i - 1))
 					end
 
-					InsertItems(buffer, info, bagSid, subItems, bagSid)
+					InsertItems(buffer, info, info.running, subItems)
 				end
 			end
 		end
@@ -58,9 +55,8 @@ end
 function InsertRewardItems(playerGuid, timestamp, itemList)
 	db.asyncStoreQuery('select max(`sid`) as max_sid from `player_rewards` where player_id = '..playerGuid..';',
 		function(query)
-			local lastSid = Result.getDataInt(query, 'max_sid') or 0;
-			local bagSid = lastSid + 1;
-			local nextSid = bagId + 1;
+			local bagSid = (Result.getDataInt(query, 'max_sid') or 0) + 1;
+			local nextSid = bagSid + 1;
 			local buffer = {'INSERT INTO `player_rewards` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES'}
 			local info = {
 				playerGuid = playerGuid,
@@ -73,11 +69,11 @@ function InsertRewardItems(playerGuid, timestamp, itemList)
 					bag:addItem(p[1], p[2])
 				end
 			end
-			local total = InsertItems(buffer, info, lastPid + 1, {bag}, bagSid)
-			table.insert(buffer, ";")
+			local total = InsertItems(buffer, info, bagSid, {bag})
 
 			if total ~= 0 then
-				db.query(table.concat(buffer))
+				local query = table.concat(buffer):sub(1, -2)..";";
+				db.query(query)
 			end
 		end
 	)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -676,7 +676,7 @@ void Player::closeContainer(uint8_t cid) {
 	OpenContainer openContainer = it->second;
 	Container* container = openContainer.container;
 
-	if(container && container->isAnykindOfRewardContainer() && !hasOtherRewardContainerOpen(container)) {
+	if (container && container->isAnykindOfRewardContainer() && !hasOtherRewardContainerOpen(container)) {
 		removeEmptyRewards();
 	}
 	openContainers.erase(it);

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2617,7 +2617,7 @@ class Player final : public Creature, public Cylinder {
 		double_t calculateDamageReduction(double_t currentTotal, int16_t resistance) const;
 
 		void removeEmptyRewards();
-		bool hasAnykindOfRewardContainerOpen() const;
+		bool hasOtherRewardContainerOpen(const Container* container) const;
 };
 
 #endif // SRC_CREATURES_PLAYERS_PLAYER_H_

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -651,7 +651,7 @@ class Player final : public Creature, public Cylinder {
 		void addConditionSuppressions(uint32_t conditions);
 		void removeConditionSuppressions(uint32_t conditions);
 
-		std::shared_ptr<Reward> getReward(const uint64_t rewardId, const bool autoCreate);
+		Reward* getReward(const uint64_t rewardId, const bool autoCreate);
 		void removeReward(uint64_t rewardId);
 		void getRewardList(std::vector<uint64_t> &rewards) const;
 		RewardChest* getRewardChest();
@@ -2350,7 +2350,7 @@ class Player final : public Creature, public Cylinder {
 			{ SKILL_CRITICAL_HIT_CHANCE, g_configManager().getNumber(CRITICALCHANCE) }
 		};
 
-		std::map<uint64_t, std::shared_ptr<Reward>> rewardMap;
+		std::map<uint64_t, Reward*> rewardMap;
 
 		std::map<ObjectCategory_t, Container*> quickLootContainers;
 		std::vector<ForgeHistory> forgeHistoryVector;

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -59,7 +59,7 @@ bool IOLoginDataSave::saveRewardItems(Player* player) {
 		for (const auto &rewardId : rewardList) {
 			auto reward = player->getReward(rewardId, false);
 			if (!reward->empty() && (getTimeNow() - rewardId / 1000 <= 60 * 60 * 24 * 7)) {
-				itemList.emplace_back(0, reward.get());
+				itemList.emplace_back(0, reward);
 			}
 		}
 

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -58,7 +58,7 @@ bool IOLoginDataSave::saveRewardItems(Player* player) {
 	if (!rewardList.empty()) {
 		for (const auto &rewardId : rewardList) {
 			auto reward = player->getReward(rewardId, false);
-			if (!reward->empty() && (getTimeNow() - rewardId / 1000 <= 60 * 60 * 24 * 7)) {
+			if (!reward->empty() && (getTimeMsNow() - rewardId <= 1000 * 60 * 60 * 24 * 7)) {
 				itemList.emplace_back(0, reward);
 			}
 		}

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -316,7 +316,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 		if (container->getID() == ITEM_REWARD_CONTAINER && !container->getReward()) {
 			if (auto reward = player->getReward(container->getAttribute<uint64_t>(ItemAttribute_t::DATE), false)) {
 				reward->setParent(container->getRealParent());
-				openContainer = reward.get();
+				openContainer = reward;
 			} else {
 				return RETURNVALUE_THISISIMPOSSIBLE;
 			}

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -304,8 +304,8 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 			}
 
 			myRewardChest->setParent(container->getParent()->getTile());
-			for (const auto &[mapRewardId, rewardPtr] : player->rewardMap) {
-				rewardPtr->setParent(myRewardChest);
+			for (const auto &[mapRewardId, reward] : player->rewardMap) {
+				reward->setParent(myRewardChest);
 			}
 
 			openContainer = myRewardChest;
@@ -314,7 +314,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 		auto rewardId = container->getAttribute<uint32_t>(ItemAttribute_t::DATE);
 		// Reward container proxy created when the boss dies
 		if (container->getID() == ITEM_REWARD_CONTAINER && !container->getReward()) {
-			if (auto reward = player->getReward(container->getAttribute<uint64_t>(ItemAttribute_t::DATE), false)) {
+			if (auto reward = player->getReward(rewardId, false)) {
 				reward->setParent(container->getRealParent());
 				openContainer = reward;
 			} else {

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -311,7 +311,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 			openContainer = myRewardChest;
 		}
 
-		auto rewardId = container->getAttribute<uint32_t>(ItemAttribute_t::DATE);
+		auto rewardId = container->getAttribute<time_t>(ItemAttribute_t::DATE);
 		// Reward container proxy created when the boss dies
 		if (container->getID() == ITEM_REWARD_CONTAINER && !container->getReward()) {
 			if (auto reward = player->getReward(rewardId, false)) {

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2562,7 +2562,9 @@ int PlayerFunctions::luaPlayerSave(lua_State* L) {
 	// player:save()
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		player->loginPosition = player->getPosition();
+		if(!player->isOffline()){
+			player->loginPosition = player->getPosition();
+		}
 		pushBoolean(L, IOLoginData::savePlayer(player));
 		if (player->isOffline()) {
 			delete player; // avoiding memory leak

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -636,8 +636,8 @@ int PlayerFunctions::luaPlayerGetReward(lua_State* L) {
 	uint64_t rewardId = getNumber<uint64_t>(L, 2);
 	bool autoCreate = getBoolean(L, 3, false);
 	if (auto reward = player->getReward(rewardId, autoCreate)) {
-		pushUserdata<Item>(L, reward.get());
-		setItemMetatable(L, -1, reward.get());
+		pushUserdata<Item>(L, reward);
+		setItemMetatable(L, -1, reward);
 	} else {
 		pushBoolean(L, false);
 	}

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2562,7 +2562,7 @@ int PlayerFunctions::luaPlayerSave(lua_State* L) {
 	// player:save()
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		if(!player->isOffline()){
+		if (!player->isOffline()) {
 			player->loginPosition = player->getPosition();
 		}
 		pushBoolean(L, IOLoginData::savePlayer(player));

--- a/src/lua/functions/items/container_functions.cpp
+++ b/src/lua/functions/items/container_functions.cpp
@@ -264,10 +264,10 @@ int ContainerFunctions::luaContainerRegisterReward(lua_State* L) {
 		return 1;
 	}
 
-	auto timestamp = time(nullptr);
+	int64_t rewardId = getTimeMsNow();
 	Item* rewardContainer = Item::CreateItem(ITEM_REWARD_CONTAINER);
-	rewardContainer->setAttribute(ItemAttribute_t::DATE, timestamp);
-	container->setAttribute(ItemAttribute_t::DATE, timestamp);
+	rewardContainer->setAttribute(ItemAttribute_t::DATE, rewardId);
+	container->setAttribute(ItemAttribute_t::DATE, rewardId);
 	container->internalAddThing(rewardContainer);
 	container->setRewardCorpse();
 

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -358,6 +358,11 @@ std::time_t getTimeNow() {
 	return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 }
 
+std::time_t getTimeMsNow() {
+	auto duration = std::chrono::system_clock::now().time_since_epoch();
+	return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+}
+
 Direction getDirection(const std::string &string) {
 	Direction direction = DIRECTION_NORTH;
 

--- a/src/utils/tools.h
+++ b/src/utils/tools.h
@@ -53,6 +53,7 @@ std::string getFirstLine(const std::string &str);
 std::string formatDate(time_t time);
 std::string formatDateShort(time_t time);
 std::time_t getTimeNow();
+std::time_t getTimeMsNow();
 std::string convertIPToString(uint32_t ip);
 
 void trimString(std::string &str);


### PR DESCRIPTION
# Description

It is a bit more complex to switch to automatic memory management, it is necessary to modify the Game::cleanup function and other functions, as all items are checked there for cleanliness. In the future, maybe we'll modify this, for now it's better to keep it as manual pointer management.

Complement of: https://github.com/opentibiabr/canary/commit/8a1046a8309848c7f70d505c1401b94f7d180207

Co-author: @ElimarCosta 