### PR TITLE
improve: add exhaustion method to player table

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -451,3 +451,20 @@ function Player.getFinalBaseRateExperience(self)
 	end
 	return baseRate
 end
+
+function Player.setExhaustion(self, value, time)
+	self:setStorageValue(value, time + os.time())
+end
+
+function Player.getExhaustion(self, value)
+	local storage = self:getStorageValue(value)
+	if not storage or storage <= os.time() then
+		return 0
+	end
+
+	return storage - os.time()
+end
+
+function Player:hasExhaustion(value)
+	return self:getExhaustion(value) >= os.time() and true or false
+end


### PR DESCRIPTION
https://otland.net/threads/player-setexhaustion-player-getexhaustion-tfs-1-0.224233/


Example

> function onUse(player, item, fromPosition, itemEx, toPosition, isHotkey)
    if player:getExhaustion(1000) <= 0 then
        player:setExhaustion(1000, 10)
    else
        print('You\'re exhausted for: '..player:getExhaustion(1000)..' seconds.')
    end
    return true
end