### PR TITLE
fix: interaction with fields and removal of unused flag

### DIFF
--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -344,7 +344,6 @@ class Monster final : public Creature {
 
 		bool isIdle = true;
 		bool extraMeleeAttack = false;
-		bool isMasterInRange = false;
 		bool randomStepping = false;
 		bool ignoreFieldDamage = false;
 
@@ -415,6 +414,8 @@ class Monster final : public Creature {
 
 		void doFollowCreature(uint32_t &flags, Direction &nextDirection, bool &result);
 		void doRandomStep(Direction &nextDirection, bool &result);
+
+		void onConditionStatusChange(const ConditionType_t &type);
 };
 
 #endif // SRC_CREATURES_MONSTERS_MONSTER_H_


### PR DESCRIPTION
# Description

Interaction with fields
Fixes #67 
Removal of unused flag changed in #823 

## Behaviour
### **Actual**

Monsters ignoring fields even if they walked away from it

### **Expected**

Monsters ignoring fields even if they stepped out it

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)