### PR TITLE
fix: item not decaying duration and related bugs

### DIFF
--- a/src/enums/item_attribute.hpp
+++ b/src/enums/item_attribute.hpp
@@ -40,7 +40,7 @@ enum ItemAttribute_t : uint64_t {
 	OPENCONTAINER = 1 << 25,
 	QUICKLOOTCONTAINER = 1 << 26,
 	DURATION_TIMESTAMP = 1 << 27,
-	IMBUEMENT_TYPE = 1 << 28,
+	IMBUEMENT_TYPE = 1 << 28, // Deprecated, can be override
 	TIER = 1 << 29,
 
 	CUSTOM = 1U << 31

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1967,19 +1967,11 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 					return nullptr;
 				} else if (newItemId != newId) {
 					// Replacing the the old item with the new while maintaining the old position
-					Item* newItem = Item::CreateItem(newItemId, 1);
+					auto newItem = item->transform(newItemId);
 					if (newItem == nullptr) {
+						SPDLOG_ERROR("[{}] new item with id {} is nullptr, (ERROR CODE: 01)", __FUNCTION__, newItemId);
 						return nullptr;
 					}
-
-					cylinder->replaceThing(itemIndex, newItem);
-					cylinder->postAddNotification(newItem, cylinder, itemIndex);
-
-					item->setParent(nullptr);
-					cylinder->postRemoveNotification(item, cylinder, itemIndex);
-					item->stopDecaying();
-					ReleaseItem(item);
-					newItem->startDecaying();
 
 					return newItem;
 				} else {
@@ -2026,25 +2018,11 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	}
 
 	// Replacing the the old item with the new while maintaining the old position
-	Item* newItem;
-	if (newCount == -1) {
-		newItem = Item::CreateItem(newId);
-	} else {
-		newItem = Item::CreateItem(newId, newCount);
-	}
-
+	auto newItem = item->transform(newId);
 	if (newItem == nullptr) {
+		SPDLOG_ERROR("[{}] new item with id {} is nullptr (ERROR CODE: 02)", __FUNCTION__, newId);
 		return nullptr;
 	}
-
-	cylinder->replaceThing(itemIndex, newItem);
-	cylinder->postAddNotification(newItem, cylinder, itemIndex);
-
-	item->setParent(nullptr);
-	cylinder->postRemoveNotification(item, cylinder, itemIndex);
-	item->stopDecaying();
-	ReleaseItem(item);
-	newItem->startDecaying();
 
 	return newItem;
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2018,7 +2018,7 @@ Item* Game::transformItem(Item* item, uint16_t newId, int32_t newCount /*= -1*/)
 	}
 
 	// Replacing the the old item with the new while maintaining the old position
-	auto newItem = item->transform(newId);
+	auto newItem = item->transform(newId, newCount);
 	if (newItem == nullptr) {
 		SPDLOG_ERROR("[{}] new item with id {} is nullptr (ERROR CODE: 02)", __FUNCTION__, newId);
 		return nullptr;

--- a/src/items/decay/decay.cpp
+++ b/src/items/decay/decay.cpp
@@ -18,7 +18,7 @@ void Decay::startDecay(Item* item) {
 		return;
 	}
 
-	auto decayState = static_cast<ItemDecayState_t>(item->getAttribute<uint8_t>(ItemAttribute_t::DECAYSTATE));
+	auto decayState = item->getDecaying();
 	if (decayState == DECAYING_STOPPING || (!item->canDecay() && decayState == DECAYING_TRUE)) {
 		stopDecay(item);
 		return;

--- a/src/items/decay/decay.cpp
+++ b/src/items/decay/decay.cpp
@@ -14,11 +14,11 @@
 #include "game/scheduling/scheduler.h"
 
 void Decay::startDecay(Item* item) {
-	if (!item) {
+	if (!item || item->getLoadedFromMap()) {
 		return;
 	}
 
-	auto decayState = item->getAttribute<ItemDecayState_t>(ItemAttribute_t::DECAYSTATE);
+	auto decayState = static_cast<ItemDecayState_t>(item->getAttribute<uint8_t>(ItemAttribute_t::DECAYSTATE));
 	if (decayState == DECAYING_STOPPING || (!item->canDecay() && decayState == DECAYING_TRUE)) {
 		stopDecay(item);
 		return;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -1642,7 +1642,7 @@ std::string Item::parseClassificationDescription(const Item* item) {
 	return string.str();
 }
 
-std::string Item::parseShowDurationSpeed(int32_t speed, bool& begin) {
+std::string Item::parseShowDurationSpeed(int32_t speed, bool &begin) {
 	std::ostringstream description;
 	if (begin) {
 		begin = false;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -2629,7 +2629,7 @@ void Item::stopDecaying() {
 Item* Item::transform(uint16_t itemId, uint16_t itemCount /*= -1*/) {
 	Cylinder* cylinder = getParent();
 	if (cylinder == nullptr) {
-		SPDLOG_INFO("[{}] failed to transform item {}, cylinder is nullptr", __FUNCTION__,getID());
+		SPDLOG_INFO("[{}] failed to transform item {}, cylinder is nullptr", __FUNCTION__, getID());
 		return nullptr;
 	}
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -1642,7 +1642,7 @@ std::string Item::parseClassificationDescription(const Item* item) {
 	return string.str();
 }
 
-std::string Item::parseShowDurationSpeed(int32_t speed, bool begin) {
+std::string Item::parseShowDurationSpeed(int32_t speed, bool& begin) {
 	std::ostringstream description;
 	if (begin) {
 		begin = false;
@@ -2303,7 +2303,8 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const
 
 		if (it.abilities && it.slotPosition & SLOTP_RING) {
 			if (it.abilities->speed > 0) {
-				s << parseShowDurationSpeed(it.abilities->speed, true) << ")" << parseShowDuration(item);
+				bool begin = true;
+				s << parseShowDurationSpeed(it.abilities->speed, begin) << ")" << parseShowDuration(item);
 			} else if (hasBitSet(CONDITION_DRUNK, it.abilities->conditionSuppressions)) {
 				s << " (hard drinking)";
 			} else if (it.abilities->invisible) {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -239,7 +239,7 @@ bool Item::equals(const Item* compareItem) const {
 		return false;
 	}
 
-	for (const auto &attribute : initAttributePtr()->getAttributeVector()) {
+	for (const auto &attribute : getAttributeVector()) {
 		for (const auto &compareAttribute : compareItem->getAttributeVector()) {
 			if (attribute.getAttributeType() != compareAttribute.getAttributeType()) {
 				continue;
@@ -730,16 +730,6 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream &propStream) {
 			break;
 		}
 
-		case ATTR_IMBUEMENT_TYPE: {
-			std::string imbuementType;
-			if (!propStream.readString(imbuementType)) {
-				return ATTR_READ_ERROR;
-			}
-
-			setAttribute(ItemAttribute_t::IMBUEMENT_TYPE, imbuementType);
-			break;
-		}
-
 		case ATTR_TIER: {
 			uint8_t tier;
 			if (!propStream.read<uint8_t>(tier)) {
@@ -848,7 +838,7 @@ void Item::serializeAttr(PropWriteStream &propWriteStream) const {
 		propWriteStream.write<int32_t>(getDuration());
 	}
 
-	if (auto decayState = getAttribute<ItemDecayState_t>(ItemAttribute_t::DECAYSTATE);
+	if (auto decayState = static_cast<ItemDecayState_t>(getAttribute<uint8_t>(ItemAttribute_t::DECAYSTATE));
 		decayState == DECAYING_TRUE || decayState == DECAYING_PENDING) {
 		propWriteStream.write<uint8_t>(ATTR_DECAYING_STATE);
 		propWriteStream.write<uint8_t>(decayState);
@@ -922,11 +912,6 @@ void Item::serializeAttr(PropWriteStream &propWriteStream) const {
 	if (hasAttribute(ItemAttribute_t::QUICKLOOTCONTAINER)) {
 		propWriteStream.write<uint8_t>(ATTR_QUICKLOOTCONTAINER);
 		propWriteStream.write<uint32_t>(getAttribute<uint32_t>(ItemAttribute_t::QUICKLOOTCONTAINER));
-	}
-
-	if (hasAttribute(ItemAttribute_t::IMBUEMENT_TYPE)) {
-		propWriteStream.write<uint8_t>(ATTR_IMBUEMENT_TYPE);
-		propWriteStream.writeString(getString(ItemAttribute_t::IMBUEMENT_TYPE));
 	}
 
 	if (hasAttribute(ItemAttribute_t::TIER)) {
@@ -2655,13 +2640,13 @@ bool Item::hasMarketAttributes() const {
 			return false;
 		}
 
-		if (attribute.getAttributeType() == ItemAttribute_t::IMBUEMENT_TYPE && !hasImbuements()) {
-			return false;
-		}
-
 		if (attribute.getAttributeType() == ItemAttribute_t::TIER && static_cast<uint8_t>(attribute.getInteger()) != getTier()) {
 			return false;
 		}
+	}
+
+	if (hasImbuements()) {
+		return false;
 	}
 
 	return true;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -1692,7 +1692,7 @@ std::string Item::parseShowDuration(const Item* item) {
 			description << duration << " second" << (duration != 1 ? "s" : "");
 		}
 	} else {
-	description << " that is brand-new";
+		description << " that is brand-new";
 	}
 
 	return description.str();

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -30,6 +30,7 @@ class Door;
 class MagicField;
 class BedItem;
 class Imbuement;
+class Item;
 
 // This class ItemProperties that serves as an interface to access and modify attributes of an item. The item's attributes are stored in an instance of ItemAttribute. The class ItemProperties has methods to get and set integer and string attributes, check if an attribute exists, remove an attribute, get the underlying attribute bits, and get a vector of attributes. It also has methods to get and set custom attributes, which are stored in a std::map<std::string, CustomAttribute, std::less<>>. The class has a data member attributePtr of type std::unique_ptr<ItemAttribute> that stores a pointer to the item's attributes methods.
 class ItemProperties {
@@ -136,7 +137,7 @@ class ItemProperties {
 			}
 		}
 		ItemDecayState_t getDecaying() const {
-			auto decayState = getAttribute<uint8_t>(ItemAttribute_t::DECAYSTATE);
+			auto decayState = getAttribute<int64_t>(ItemAttribute_t::DECAYSTATE);
 			return static_cast<ItemDecayState_t>(decayState);
 		}
 
@@ -212,6 +213,8 @@ class ItemProperties {
 
 	private:
 		std::unique_ptr<ItemAttribute> attributePtr;
+
+		friend class Item;
 };
 
 class Item : virtual public Thing, public ItemProperties {
@@ -502,6 +505,8 @@ class Item : virtual public Thing, public ItemProperties {
 
 		virtual void startDecaying();
 		virtual void stopDecaying();
+
+		Item* transform(uint16_t itemId, uint16_t itemCount = -1);
 
 		bool getLoadedFromMap() const {
 			return loadedFromMap;

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -45,6 +45,7 @@ class ItemProperties {
 					std::numeric_limits<T>::max()
 				);
 			}
+			SPDLOG_ERROR("Failed to convert attribute for type {}", type);
 			return {};
 		}
 
@@ -124,6 +125,10 @@ class ItemProperties {
 			}
 		}
 
+		void setDuration(int32_t time) {
+			setAttribute(ItemAttribute_t::DURATION, std::max<int32_t>(0, time));
+		}
+
 		void setDecaying(ItemDecayState_t decayState) {
 			setAttribute(ItemAttribute_t::DECAYSTATE, static_cast<int64_t>(decayState));
 			if (decayState == DECAYING_FALSE) {
@@ -131,7 +136,8 @@ class ItemProperties {
 			}
 		}
 		ItemDecayState_t getDecaying() const {
-			return getAttribute<ItemDecayState_t>(ItemAttribute_t::DECAYSTATE);
+			auto decayState = getAttribute<uint8_t>(ItemAttribute_t::DECAYSTATE);
+			return static_cast<ItemDecayState_t>(decayState);
 		}
 
 		uint32_t getCorpseOwner() const {
@@ -478,9 +484,6 @@ class Item : virtual public Thing, public ItemProperties {
 			if (duration != 0) {
 				setDuration(duration);
 			}
-		}
-		void setDuration(time_t time) {
-			setAttribute(ItemAttribute_t::DURATION, std::max<time_t>(0, time));
 		}
 		uint32_t getDefaultDuration() const {
 			return items[id].decayTime * 1000;

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -289,6 +289,8 @@ class Item : virtual public Thing, public ItemProperties {
 		}
 
 		static std::string parseImbuementDescription(const Item* item);
+		static std::string parseShowDurationSpeed(int32_t speed, bool begin);
+		static std::string parseShowDuration(const Item* item);
 		static std::string parseShowAttributesDescription(const Item* item, const uint16_t itemId);
 		static std::string parseClassificationDescription(const Item* item);
 

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -289,7 +289,7 @@ class Item : virtual public Thing, public ItemProperties {
 		}
 
 		static std::string parseImbuementDescription(const Item* item);
-		static std::string parseShowDurationSpeed(int32_t speed, bool begin);
+		static std::string parseShowDurationSpeed(int32_t speed, bool& begin);
 		static std::string parseShowDuration(const Item* item);
 		static std::string parseShowAttributesDescription(const Item* item, const uint16_t itemId);
 		static std::string parseClassificationDescription(const Item* item);

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -289,7 +289,7 @@ class Item : virtual public Thing, public ItemProperties {
 		}
 
 		static std::string parseImbuementDescription(const Item* item);
-		static std::string parseShowDurationSpeed(int32_t speed, bool& begin);
+		static std::string parseShowDurationSpeed(int32_t speed, bool &begin);
 		static std::string parseShowDuration(const Item* item);
 		static std::string parseShowAttributesDescription(const Item* item, const uint16_t itemId);
 		static std::string parseClassificationDescription(const Item* item);

--- a/src/items/items_definitions.hpp
+++ b/src/items/items_definitions.hpp
@@ -227,7 +227,7 @@ enum AttrTypes_t {
 	ATTR_OPENCONTAINER = 36,
 	ATTR_CUSTOM_ATTRIBUTES = 37, // Deprecated (override by ATTR_CUSTOM)
 	ATTR_QUICKLOOTCONTAINER = 38,
-	ATTR_IMBUEMENT_TYPE = 39,
+	ATTR_IMBUEMENT_TYPE = 39, // Deprecated, can be override
 	ATTR_TIER = 40,
 	ATTR_CUSTOM = 41,
 


### PR DESCRIPTION
# Description

• Fixed item decay with duration (both equip/deEquip and onUse),
• Fixed the look of items with duration, it did not show the duration of some items (eg rings, when equipped),
• Functions created in the Item class to avoid code duplication and facilitate the maintenance readability of some systems
• Removed old code from imbuement, which is no longer used
• Removed the decay of items created by loading the .otbm from decay map, thus decreasing by about three thousand five hundred items in the decay check.

## Behaviour
### **Actual**

Systems mentioned in the description did not work correctly.

### **Expected**

Everything working perfectly.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Basically test the decay of the duration of items and also the decay of items for other ids.