### PR TITLE
fix: canary datapack loading

### DIFF
--- a/data-canary/lib/core/quests.lua
+++ b/data-canary/lib/core/quests.lua
@@ -1,5 +1,3 @@
-dofile(CORE_DIRECTORY .. "/libs/functions/quests.lua")
-
 if not Quests then
 	Quests = {
 		[1] = {

--- a/data/libs/functions/quests.lua
+++ b/data/libs/functions/quests.lua
@@ -1,3 +1,5 @@
+dofile(DATA_DIRECTORY .. "/lib/core/quests.lua")
+
 if not LastQuestlogUpdate then
 	LastQuestlogUpdate = {}
 end


### PR DESCRIPTION
# Description

Fix dofile order, the dofile was in the wrong file order

## Behaviour
### **Actual**
![image](https://user-images.githubusercontent.com/8551443/220033079-6cc528ae-76a5-4fd5-8215-52ea084ce423.png)

### **Expected**
![image](https://user-images.githubusercontent.com/8551443/220032977-9243099f-8f8c-4935-b96b-368272e42b29.png)

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
