### PR TITLE
fix: children of the revolution teleport

### DIFF
--- a/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
+++ b/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
@@ -6,22 +6,23 @@ local positions = {
 local teleport = MoveEvent()
 
 function teleport.onStepIn(creature, item, position, fromPosition)
-	if not creature:isPlayer() then
+	local player = creature:getPlayer()
+	if not creature or not player then
 		return true
 	end
-	if creature:getStorageValue(Storage.ChildrenoftheRevolution.teleportAccess) == 1 then
-		if creature:getPosition() == Position(positions[1]) then
-			creature:teleportTo(Position(33261, 31077, 8))
-			creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+	if player:getStorageValue(Storage.ChildrenoftheRevolution.teleportAccess) == 1 then
+		if player:getPosition() == Position(positions[1]) then
+			player:teleportTo(Position(33261, 31077, 8))
+			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			return true
 		else
-			creature:teleportTo(Position(33356, 31126, 7))
-			creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			player:teleportTo(Position(33356, 31126, 7))
+			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			return true
 		end
 	end
-	creature:teleportTo(fromPosition)
-	creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+	player:teleportTo(fromPosition)
+	player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	return true
 end
 

--- a/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
+++ b/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
@@ -5,23 +5,23 @@ local positions = {
 
 local teleport = MoveEvent()
 
-function teleport.onStepIn(player, item, position, fromPosition)
-	if not player then
+function teleport.onStepIn(creature, item, position, fromPosition)
+	if not creature:isPlayer() then
 		return true
 	end
-	if player:getStorageValue(Storage.ChildrenoftheRevolution.teleportAccess) == 1 then
-		if player:getPosition() == Position(positions[1]) then
-			player:teleportTo(Position(33261, 31077, 8))
-			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+	if creature:getStorageValue(Storage.ChildrenoftheRevolution.teleportAccess) == 1 then
+		if creature:getPosition() == Position(positions[1]) then
+			creature:teleportTo(Position(33261, 31077, 8))
+			creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			return true
 		else
-			player:teleportTo(Position(33356, 31126, 7))
-			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			creature:teleportTo(Position(33356, 31126, 7))
+			creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 			return true
 		end
 	end
-	player:teleportTo(fromPosition)
-	player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+	creature:teleportTo(fromPosition)
+	creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	return true
 end
 

--- a/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
+++ b/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua
@@ -13,14 +13,15 @@ function teleport.onStepIn(player, item, position, fromPosition)
 		if player:getPosition() == Position(positions[1]) then
 			player:teleportTo(Position(33261, 31077, 8))
 			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			return true
 		else
 			player:teleportTo(Position(33356, 31126, 7))
 			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			return true
 		end
-	else
-		player:teleportTo(position)
-		position:sendMagicEffect(CONST_ME_TELEPORT)
 	end
+	player:teleportTo(fromPosition)
+	player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	return true
 end
 


### PR DESCRIPTION
Upon entering the portal:

![image](https://user-images.githubusercontent.com/91164222/220158197-0d296643-c1ad-452d-a89b-2b79ff0a687d.png)
(Position: 33356, 31124, 7)

returns this error in the console:

    [2023-20-02 13:19:40.321] [warning] [luaCreatureTeleportTo] - Cannot teleport creature: Jackye, fromPosition: ( 33356, 31124, 7 ), as same of toPosition: ( 33356, 31124, 7 )
    [2023-20-02 13:19:40.321] [error] Lua script error:
    scriptInterface: [Scripts Interface]
    scriptId: [/home/main-canary/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/teleport.lua:callback]
    timerEvent: []
     callbackId:[]
    function: [Scripts Interface]
    error [The new position is the same as the old one.
    stack traceback:
            [C]: in function 'teleportTo'
            ...movements/quests/children_of_the_revolution/teleport.lua:21: in function <...movements/quests/children_of_the_revolution/teleport.lua:8>]

With these changes, this no longer happens.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)