### PR TITLE
fix: item loaded by map decays duration when moved by player

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1305,6 +1305,8 @@ void Game::playerMoveItem(Player* player, const Position &fromPos, uint16_t item
 	}
 	player->cancelPush();
 
+	item->checkDecayMapItemOnMove();
+
 	g_events().eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 }
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -969,6 +969,13 @@ bool Item::canBeMoved() const {
 	return isMoveable() && !hasAttribute(UNIQUEID) && (!hasAttribute(ACTIONID) || getAttribute<uint16_t>(ItemAttribute_t::ACTIONID) != IMMOVABLE_ACTION_ID);
 }
 
+void Item::checkDecayMapItemOnMove() {
+	if (getDuration() > 0 && getLoadedFromMap() && canBeMoved()) {
+		setLoadedFromMap(false);
+		startDecaying();
+	}
+}
+
 uint32_t Item::getWeight() const {
 	uint32_t baseWeight = getBaseWeight();
 	if (isStackable()) {

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -640,6 +640,8 @@ class Item : virtual public Thing, public ItemProperties {
 		}
 
 		void updateTileFlags();
+		bool canBeMoved() const;
+		void checkDecayMapItemOnMove();
 
 	protected:
 		Cylinder* parent = nullptr;
@@ -658,8 +660,6 @@ class Item : virtual public Thing, public ItemProperties {
 		std::string getWeightDescription(uint32_t weight) const;
 
 		friend class Decay;
-
-		bool canBeMoved() const;
 };
 
 using ItemList = std::list<Item*>;


### PR DESCRIPTION
# Description

This fix ensures that map items decay properly when moved, preventing infinite items from accumulating in the game. When a player interacts with the item by moving it, it will decay and become a common item on the map.

## Behaviour
### **Actual**

Item not decay duration.

### **Expected**

Item decay duration.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Goto position, for example: {x = 33254, y = 31839, z = 3} (it's just for testing, it's not possible to check here with player)
Equip the item and it's go decay duration

