### PR TITLE
fix: add HOUSE_BUY_LEVEL to config_functions.cpp

### DIFF
--- a/src/lua/functions/core/game/config_functions.cpp
+++ b/src/lua/functions/core/game/config_functions.cpp
@@ -60,6 +60,7 @@ void ConfigFunctions::init(lua_State* L) {
 	registerEnumIn(L, "configKeys", TOGGLE_MAP_CUSTOM);
 	registerEnumIn(L, "configKeys", MAP_CUSTOM_NAME);
 	registerEnumIn(L, "configKeys", HOUSE_RENT_PERIOD);
+	registerEnumIn(L, "configKeys", HOUSE_BUY_LEVEL);
 	registerEnumIn(L, "configKeys", SERVER_NAME);
 	registerEnumIn(L, "configKeys", OWNER_NAME);
 	registerEnumIn(L, "configKeys", OWNER_EMAIL);


### PR DESCRIPTION
# Description

HOUSE_BUY_LEVEL was not being loaded from config.lua and got weird value (3306) attributed to it.
Player was receiving message: "You need to be level 3306 to buy a house."

## Behaviour
### **Actual**

HOUSE_BUY_LEVEL loads incorrect value from config.lua

### **Expected**

HOUSE_BUY_LEVEL loads correct value from config.lua

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Compiled and tested in game.
