### PR TITLE
fix: training with distance/missile item, advancing club skill

### DIFF
--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -354,10 +354,10 @@ enum PlayerSex_t : uint8_t {
 enum skills_t : int8_t {
 	SKILL_NONE = -1,
 	SKILL_FIST = 0,
-	SKILL_DISTANCE = 1,
+	SKILL_CLUB = 1,
 	SKILL_SWORD = 2,
 	SKILL_AXE = 3,
-	SKILL_CLUB = 4,
+	SKILL_DISTANCE = 4,
 	SKILL_SHIELD = 5,
 	SKILL_FISHING = 6,
 	SKILL_CRITICAL_HIT_CHANCE = 7,


### PR DESCRIPTION
# Description

When training distance, the club skill was advancing. If you logout and login, the skills are adjusted.

## Behaviour
### **Actual**

Training distance, club skill advances.

### **Expected**

Training distance, distance skill advances.

## Type of change

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

**Test Configuration**:

  - Server Version: 12.91
  - Client: Canary
  - Operating System: Ubuntu 22.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
