### PR TITLE
fix: convert cookbook script to client id

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/hot_cuisine/cookbook2.lua
+++ b/data-otservbr-global/scripts/actions/quests/hot_cuisine/cookbook2.lua
@@ -15,5 +15,5 @@ function hotCuisineCook2.onUse(player, item, fromPosition, target, toPosition, i
 	return true
 end
 
-hotCuisineCook2:id(12497)
+hotCuisineCook2:id(11541)
 hotCuisineCook2:register()


### PR DESCRIPTION
open corpse from Remains of an iron servant. Client ID: 12497 
Is showing text from the book Jean Pierre's Cookbook II. 11541
