### PR TITLE
Fix:  Npc`s teleporTo

### DIFF
--- a/data/libs/functions/creature.lua
+++ b/data/libs/functions/creature.lua
@@ -19,7 +19,7 @@ function Creature.getClosestFreePosition(self, position, maxRadius, mustBeReacha
 			end
 
 			local tile = Tile(checkPosition)
-			if tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and
+			if tile and tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and
 				(not mustBeReachable or self:getPathTo(checkPosition)) then
 				return checkPosition
 			end


### PR DESCRIPTION
# Description

This PR fixes the problem shown in the code of teleporting the player from one city to another.

returns this error in the console:

```2023-02-25 00:13:56 -  [2023-25-02 00:13:56.656] [error] Lua script error: 
2023-02-25 00:13:56 -  scriptInterface: [Scripts Interface]
2023-02-25 00:13:56 -  scriptId: [/home/ubuntu/canary/data-otservbr-global/npc/captain_bluebear.lua:callback]
2023-02-25 00:13:56 -  timerEvent: []
2023-02-25 00:13:56 -   callbackId:[]
2023-02-25 00:13:56 -  function: [Scripts Interface]
2023-02-25 00:13:56 -  error [The new position is the same as the old one.
2023-02-25 00:13:56 -  stack traceback:
2023-02-25 00:13:56 -  	[C]: in function 'teleportTo'
2023-02-25 00:13:56 -  	data/npclib/npc_system/modules.lua:237: in function 'callback'
2023-02-25 00:13:56 -  	data/npclib/npc_system/keyword_handler.lua:31: in function 'processMessage'
2023-02-25 00:13:56 -  	data/npclib/npc_system/keyword_handler.lua:188: in function 'processNodeMessage'
2023-02-25 00:13:56 -  	data/npclib/npc_system/keyword_handler.lua:153: in function 'processMessage'
2023-02-25 00:13:56 -  	data/npclib/npc_system/npc_handler.lua:428: in function 'onSay'
2023-02-25 00:13:56 -  	...ntu/canary/data-otservbr-global/npc/captain_bluebear.lua:52: in function <...ntu/canary/data-otservbr-global/npc/captain_bluebear.lua:51>] 
2023-02-25 00:13:56 -  [2023-25-02 00:13:56.656] [error] [luaCreatureTeleportTo] Failed to teleport player, error code: An error has occurred, please contact your administrator. 
2023-02-25 00:16:58 -  [2023-25-02 00:16:58.727] [warning] [luaCreatureTeleportTo] - Cannot teleport creature: GOD, fromPosition: ( 33288, 31956, 6 ), as same of toPosition: ( 33288, 31956, 6 )
```

## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)