### PR TITLE
fix: npc idle check interactions

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -66,10 +66,6 @@ void Monster::removeList() {
 	g_game().removeMonster(this);
 }
 
-bool Monster::canSee(const Position &pos) const {
-	return Creature::canSee(getPosition(), pos, 10, 10); // jlcvp FIX - range 10 Avoids killing monster without reaction
-}
-
 bool Monster::canWalkOnFieldType(CombatType_t combatType) const {
 	switch (combatType) {
 		case COMBAT_ENERGYDAMAGE:
@@ -698,7 +694,7 @@ void Monster::updateIdleStatus() {
 	if (conditions.empty()) {
 		if (!isSummon() && targetList.empty()) {
 			idle = true;
-		} else if ((!master || master->getMonster()) && getFaction() != FACTION_DEFAULT && (totalPlayersOnScreen == 0 && (!master || master->getMonster()->totalPlayersOnScreen == 0))) {
+		} else if ((!isSummon() && totalPlayersOnScreen == 0 || isSummon() && master->getMonster() && master->getMonster()->totalPlayersOnScreen == 0) && getFaction() != FACTION_DEFAULT) {
 			idle = true;
 		}
 	}

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -118,7 +118,6 @@ class Monster final : public Creature {
 		bool isFamiliar() const {
 			return mType->info.isFamiliar;
 		}
-		bool canSee(const Position &pos) const override;
 		bool canSeeInvisibility() const override {
 			return isImmune(CONDITION_INVISIBLE);
 		}

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -70,7 +70,7 @@ bool Npc::canInteract(const Position &pos) const {
 void Npc::onCreatureAppear(Creature* creature, bool isLogin) {
 	Creature::onCreatureAppear(creature, isLogin);
 
-	if(auto player = creature->getPlayer()){
+	if (auto player = creature->getPlayer()) {
 		onPlayerAppear(player);
 	}
 
@@ -100,7 +100,7 @@ void Npc::onRemoveCreature(Creature* creature, bool isLogout) {
 		return;
 	}
 
-	if(auto player = creature->getPlayer()){
+	if (auto player = creature->getPlayer()) {
 		onPlayerDisappear(player);
 	}
 
@@ -140,22 +140,22 @@ void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position
 void Npc::manageIdle() {
 	if (creatureCheck && playerSpectators.empty()) {
 		g_game().removeCreatureCheck(this);
-	} else if(!creatureCheck){
+	} else if (!creatureCheck) {
 		g_game().addCreatureCheck(this);
 	}
 }
 
-void Npc::onPlayerAppear(Player *player) {
-	if(player->hasFlag(PlayerFlags_t::IgnoredByNpcs) || playerSpectators.contains(player)) {
+void Npc::onPlayerAppear(Player* player) {
+	if (player->hasFlag(PlayerFlags_t::IgnoredByNpcs) || playerSpectators.contains(player)) {
 		return;
 	}
 	playerSpectators.insert(player);
 	manageIdle();
 }
 
-void Npc::onPlayerDisappear(Player *player) {
+void Npc::onPlayerDisappear(Player* player) {
 	removePlayerInteraction(player);
-	if(!player->hasFlag(PlayerFlags_t::IgnoredByNpcs) && playerSpectators.contains(player)) {
+	if (!player->hasFlag(PlayerFlags_t::IgnoredByNpcs) && playerSpectators.contains(player)) {
 		playerSpectators.erase(player);
 		manageIdle();
 	}
@@ -445,7 +445,7 @@ void Npc::onThinkWalk(uint32_t interval) {
 
 void Npc::onCreatureWalk() {
 	Creature::onCreatureWalk();
-	phmap::erase_if(playerSpectators, [this](const auto &creature){return !this->canSee(creature->getPosition());});
+	phmap::erase_if(playerSpectators, [this](const auto &creature) { return !this->canSee(creature->getPosition()); });
 }
 
 void Npc::onPlacedCreature() {
@@ -455,8 +455,8 @@ void Npc::onPlacedCreature() {
 void Npc::loadPlayerSpectators() {
 	SpectatorHashSet spec;
 	g_game().map.getSpectators(spec, position, true, true);
-	for (auto creature : spec){
-		if(creature->getPlayer() || creature->getPlayer()->hasFlag(PlayerFlags_t::IgnoredByNpcs)){
+	for (auto creature : spec) {
+		if (creature->getPlayer() || creature->getPlayer()->hasFlag(PlayerFlags_t::IgnoredByNpcs)) {
 			playerSpectators.insert(creature);
 		}
 	}
@@ -497,7 +497,7 @@ void Npc::setPlayerInteraction(uint32_t playerId, uint16_t topicId /*= 0*/) {
 	playerInteractions[playerId] = topicId;
 }
 
-void Npc::removePlayerInteraction(Player *player) {
+void Npc::removePlayerInteraction(Player* player) {
 	if (playerInteractions.find(player->getID()) != playerInteractions.end()) {
 		playerInteractions.erase(player->getID());
 		player->closeShopWindow(true);
@@ -576,11 +576,11 @@ void Npc::closeAllShopWindows() {
 	shopPlayerSet.clear();
 }
 
-void Npc::handlePlayerMove(Player *player, const Position &newPos) {
+void Npc::handlePlayerMove(Player* player, const Position &newPos) {
 	if (!canInteract(newPos)) {
 		removePlayerInteraction(player);
 	}
-	if(canSee(newPos)) {
+	if (canSee(newPos)) {
 		onPlayerAppear(player);
 	} else {
 		onPlayerDisappear(player);

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -60,22 +60,19 @@ void Npc::removeList() {
 	g_game().removeNpc(this);
 }
 
-bool Npc::canSee(const Position &pos) const {
+bool Npc::canInteract(const Position &pos) const {
 	if (pos.z != getPosition().z) {
 		return false;
 	}
 	return Creature::canSee(getPosition(), pos, 4, 4);
 }
 
-bool Npc::canSeeRange(const Position &pos, int32_t viewRangeX /* = 4*/, int32_t viewRangeY /* = 4*/) const {
-	if (pos.z != getPosition().z) {
-		return false;
-	}
-	return Creature::canSee(getPosition(), pos, viewRangeX, viewRangeY);
-}
-
 void Npc::onCreatureAppear(Creature* creature, bool isLogin) {
 	Creature::onCreatureAppear(creature, isLogin);
+
+	if(auto player = creature->getPlayer()){
+		onPlayerAppear(player);
+	}
 
 	// onCreatureAppear(self, creature)
 	CreatureCallback callback = CreatureCallback(npcType->info.scriptInterface, this);
@@ -103,9 +100,8 @@ void Npc::onRemoveCreature(Creature* creature, bool isLogout) {
 		return;
 	}
 
-	if (creature != this) {
-		updatePlayerInteractions(creature->getPlayer());
-		return;
+	if(auto player = creature->getPlayer()){
+		onPlayerDisappear(player);
 	}
 
 	if (spawnNpc) {
@@ -131,16 +127,37 @@ void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position
 		return;
 	}
 
-	if (creature == this && !canSee(oldPos)) {
+	if (creature == this && !canInteract(oldPos)) {
 		resetPlayerInteractions();
 		closeAllShopWindows();
-		return;
 	}
 
-	Player* player = creature->getPlayer();
-	if (player && !canSee(newPos) && canSee(oldPos)) {
-		updatePlayerInteractions(player);
-		player->closeShopWindow(true);
+	if (auto player = creature->getPlayer()) {
+		handlePlayerMove(player, newPos);
+	}
+}
+
+void Npc::manageIdle() {
+	if (creatureCheck && playerSpectators.empty()) {
+		g_game().removeCreatureCheck(this);
+	} else if(!creatureCheck){
+		g_game().addCreatureCheck(this);
+	}
+}
+
+void Npc::onPlayerAppear(Player *player) {
+	if(player->hasFlag(PlayerFlags_t::IgnoredByNpcs) || playerSpectators.contains(player)) {
+		return;
+	}
+	playerSpectators.insert(player);
+	manageIdle();
+}
+
+void Npc::onPlayerDisappear(Player *player) {
+	removePlayerInteraction(player);
+	if(!player->hasFlag(PlayerFlags_t::IgnoredByNpcs) && playerSpectators.contains(player)) {
+		playerSpectators.erase(player);
+		manageIdle();
 	}
 }
 
@@ -189,16 +206,7 @@ void Npc::onThink(uint32_t interval) {
 		closeAllShopWindows();
 	}
 
-	SpectatorHashSet spectators;
-	// Get a set of spectators that are within the visible range of the NPC
-	g_game().map.getSpectators(spectators, position, false, false);
-	// Check if there is at least one player in the set of spectators that does not have the "IgnoredByNpcs" flag
-	if (std::ranges::any_of(spectators, [](Creature* spectator) {
-			auto player = spectator->getPlayer();
-			// If there are no players or all players have the "IgnoredByNpcs" flag, then the NPC will not walk or yell.
-			return player && !player->hasFlag(PlayerFlags_t::IgnoredByNpcs);
-		})) {
-		// There is at least one normal player on the screen, so the NPC should continue walking and yelling
+	if (!playerSpectators.empty()) {
 		onThinkYell(interval);
 		onThinkWalk(interval);
 	}
@@ -384,8 +392,7 @@ void Npc::onPlayerCloseChannel(Creature* creature) {
 		return;
 	}
 
-	player->closeShopWindow(true);
-	this->removePlayerInteraction(player->getID());
+	removePlayerInteraction(player);
 }
 
 void Npc::onThinkYell(uint32_t interval) {
@@ -436,8 +443,23 @@ void Npc::onThinkWalk(uint32_t interval) {
 	walkTicks = 0;
 }
 
+void Npc::onCreatureWalk() {
+	Creature::onCreatureWalk();
+	phmap::erase_if(playerSpectators, [this](const auto &creature){return !this->canSee(creature->getPosition());});
+}
+
 void Npc::onPlacedCreature() {
-	addEventWalk();
+	loadPlayerSpectators();
+}
+
+void Npc::loadPlayerSpectators() {
+	SpectatorHashSet spec;
+	g_game().map.getSpectators(spec, position, true, true);
+	for (auto creature : spec){
+		if(creature->getPlayer() || creature->getPlayer()->hasFlag(PlayerFlags_t::IgnoredByNpcs)){
+			playerSpectators.insert(creature);
+		}
+	}
 }
 
 bool Npc::isInSpawnRange(const Position &pos) const {
@@ -475,15 +497,10 @@ void Npc::setPlayerInteraction(uint32_t playerId, uint16_t topicId /*= 0*/) {
 	playerInteractions[playerId] = topicId;
 }
 
-void Npc::updatePlayerInteractions(Player* player) {
-	if (player && !canSee(player->getPosition())) {
-		removePlayerInteraction(player->getID());
-	}
-}
-
-void Npc::removePlayerInteraction(uint32_t playerId) {
-	if (playerInteractions.find(playerId) != playerInteractions.end()) {
-		playerInteractions.erase(playerId);
+void Npc::removePlayerInteraction(Player *player) {
+	if (playerInteractions.find(player->getID()) != playerInteractions.end()) {
+		playerInteractions.erase(player->getID());
+		player->closeShopWindow(true);
 	}
 }
 
@@ -557,4 +574,15 @@ void Npc::closeAllShopWindows() {
 		}
 	}
 	shopPlayerSet.clear();
+}
+
+void Npc::handlePlayerMove(Player *player, const Position &newPos) {
+	if (!canInteract(newPos)) {
+		removePlayerInteraction(player);
+	}
+	if(canSee(newPos)) {
+		onPlayerAppear(player);
+	} else {
+		onPlayerDisappear(player);
+	}
 }

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -139,7 +139,7 @@ void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position
 
 void Npc::manageIdle() {
 	if (creatureCheck && playerSpectators.empty()) {
-		g_game().removeCreatureCheck(this);
+		Game::removeCreatureCheck(this);
 	} else if (!creatureCheck) {
 		g_game().addCreatureCheck(this);
 	}
@@ -498,7 +498,7 @@ void Npc::setPlayerInteraction(uint32_t playerId, uint16_t topicId /*= 0*/) {
 }
 
 void Npc::removePlayerInteraction(Player* player) {
-	if (playerInteractions.find(player->getID()) != playerInteractions.end()) {
+	if (playerInteractions.contains(player->getID())) {
 		playerInteractions.erase(player->getID());
 		player->closeShopWindow(true);
 	}

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -122,7 +122,7 @@ class Npc final : public Creature {
 		}
 
 		void setPlayerInteraction(uint32_t playerId, uint16_t topicId = 0);
-		void removePlayerInteraction(Player *player);
+		void removePlayerInteraction(Player* player);
 		void resetPlayerInteractions();
 
 		bool isInteractingWithPlayer(uint32_t playerId) {
@@ -195,12 +195,11 @@ class Npc final : public Creature {
 		friend class LuaScriptInterface;
 		friend class Map;
 
-		void onPlayerAppear(Player *player);
-		void onPlayerDisappear(Player *player);
+		void onPlayerAppear(Player* player);
+		void onPlayerDisappear(Player* player);
 		void manageIdle();
-		void handlePlayerMove(Player *player, const Position &newPos);
+		void handlePlayerMove(Player* player, const Position &newPos);
 		void loadPlayerSpectators();
-
 };
 
 constexpr auto g_npc = &Npc::getInstance;

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -110,8 +110,7 @@ class Npc final : public Creature {
 			return false;
 		}
 
-		bool canSee(const Position &pos) const override;
-		bool canSeeRange(const Position &pos, int32_t viewRangeX = 4, int32_t viewRangeY = 4) const;
+		bool canInteract(const Position &pos) const;
 		bool canSeeInvisibility() const override {
 			return true;
 		}
@@ -123,8 +122,7 @@ class Npc final : public Creature {
 		}
 
 		void setPlayerInteraction(uint32_t playerId, uint16_t topicId = 0);
-		void updatePlayerInteractions(Player* player);
-		void removePlayerInteraction(uint32_t playerId);
+		void removePlayerInteraction(Player *player);
 		void resetPlayerInteractions();
 
 		bool isInteractingWithPlayer(uint32_t playerId) {
@@ -167,6 +165,8 @@ class Npc final : public Creature {
 
 		static uint32_t npcAutoID;
 
+		void onCreatureWalk() override;
+
 	private:
 		void onThinkYell(uint32_t interval);
 		void onThinkWalk(uint32_t interval);
@@ -189,10 +189,18 @@ class Npc final : public Creature {
 
 		bool ignoreHeight;
 
+		SpectatorHashSet playerSpectators;
 		Position masterPos;
 
 		friend class LuaScriptInterface;
 		friend class Map;
+
+		void onPlayerAppear(Player *player);
+		void onPlayerDisappear(Player *player);
+		void manageIdle();
+		void handlePlayerMove(Player *player, const Position &newPos);
+		void loadPlayerSpectators();
+
 };
 
 constexpr auto g_npc = &Npc::getInstance;

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -160,7 +160,7 @@ bool SpawnNpc::spawnNpc(uint32_t spawnId, NpcType* npcType, const Position &pos,
 	std::unique_ptr<Npc> npc_ptr(new Npc(npcType));
 	if (startup) {
 		// No need to send out events to the surrounding since there is no one out there to listen!
-		if (!g_game().internalPlaceCreature(npc_ptr.get(), pos, true, false, true)) {
+		if (!g_game().internalPlaceCreature(npc_ptr.get(), pos, true, false)) {
 			return false;
 		}
 	} else {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -674,7 +674,7 @@ bool Game::placeCreature(Creature* creature, const Position &pos, bool extendedP
 		spectator->onCreatureAppear(creature, true);
 	}
 
-	if(hasPlayerSpectators){
+	if (hasPlayerSpectators) {
 		addCreatureCheck(creature);
 	}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -663,21 +663,22 @@ bool Game::placeCreature(Creature* creature, const Position &pos, bool extendedP
 		return false;
 	}
 
+	bool hasPlayerSpectators = false;
 	SpectatorHashSet spectators;
 	map.getSpectators(spectators, creature->getPosition(), true);
 	for (Creature* spectator : spectators) {
 		if (Player* tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendCreatureAppear(creature, creature->getPosition(), true);
+			hasPlayerSpectators = true;
 		}
-	}
-
-	for (Creature* spectator : spectators) {
 		spectator->onCreatureAppear(creature, true);
 	}
 
-	creature->getParent()->postAddNotification(creature, nullptr, 0);
+	if(hasPlayerSpectators){
+		addCreatureCheck(creature);
+	}
 
-	addCreatureCheck(creature);
+	creature->getParent()->postAddNotification(creature, nullptr, 0);
 	creature->onPlacedCreature();
 	return true;
 }
@@ -977,7 +978,7 @@ void Game::playerMoveCreature(Player* player, Creature* movingCreature, const Po
 			}
 
 			Npc* movingNpc = movingCreature->getNpc();
-			if (movingNpc && movingNpc->canSee(toPos)) {
+			if (movingNpc && movingNpc->canInteract(toPos)) {
 				player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 				return;
 			}

--- a/src/lua/functions/creatures/npc/npc_functions.cpp
+++ b/src/lua/functions/creatures/npc/npc_functions.cpp
@@ -273,7 +273,7 @@ int NpcFunctions::luaNpcRemovePlayerInteraction(lua_State* L) {
 		return 1;
 	}
 
-	npc->removePlayerInteraction(creature->getID());
+	npc->removePlayerInteraction(creature->getPlayer());
 	pushBoolean(L, true);
 	return 1;
 }
@@ -332,7 +332,7 @@ int NpcFunctions::luaNpcIsInTalkRange(lua_State* L) {
 		return 1;
 	}
 
-	pushBoolean(L, npc && npc->canSee(position));
+	pushBoolean(L, npc && npc->canInteract(position));
 	return 1;
 }
 


### PR DESCRIPTION
# Description

Upon loading the map, the engine was appending every NPC to the check creature list.

## Behaviour
### **Actual**

All NPCs  are being perpetually checked

### **Expected**

Only NPCs with player spectators ought to be checked

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Using the performance profiler of Visual Studio to profile the Canary process
Debugging of the method Game::checkCreatures.

These tests were executed with only a single logged-in player walking from the Thais temple to the depot, then to the north bridge, and ultimately to the king's area.

Before the changes
![image](https://user-images.githubusercontent.com/18358335/221734996-3970281d-dcc4-4708-a62c-c5d4f3e402d1.png)

After the changes
![image](https://user-images.githubusercontent.com/18358335/221733793-5363ccbb-93ab-42c3-8a7b-7e548817d1ce.png)

