### PR TITLE
fix: cleaning external backpacks on death

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2646,6 +2646,7 @@ void Player::despawn() {
 	listWalkDir.clear();
 	stopEventWalk();
 	onWalkAborted();
+	closeAllExternalContainers();
 	g_game().playerSetAttackedCreature(this->getID(), 0);
 	g_game().playerFollowCreature(this->getID(), 0);
 
@@ -6800,6 +6801,29 @@ void Player::registerForgeHistoryDescription(ForgeHistory history) {
 	history.description = detailsResponse.str();
 
 	setForgeHistory(history);
+}
+
+void Player::closeAllExternalContainers()
+{
+    if (openContainers.empty()) {
+		return;
+	}
+
+	std::vector<Container*> containerToClose;
+	for (const auto& it : openContainers) {
+		Container* container = it.second.container;
+		if (!container) {
+			continue;
+		}
+
+		if (container->getHoldingPlayer() != this) {
+			containerToClose.push_back(container);
+		}
+	}
+
+	for (Container* container : containerToClose) {
+		autoCloseContainers(container);
+	}
 }
 
 /*******************************************************************************

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6803,14 +6803,13 @@ void Player::registerForgeHistoryDescription(ForgeHistory history) {
 	setForgeHistory(history);
 }
 
-void Player::closeAllExternalContainers()
-{
-    if (openContainers.empty()) {
+void Player::closeAllExternalContainers() {
+	if (openContainers.empty()) {
 		return;
 	}
 
 	std::vector<Container*> containerToClose;
-	for (const auto& it : openContainers) {
+	for (const auto &it : openContainers) {
 		Container* container = it.second.container;
 		if (!container) {
 			continue;

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -1036,6 +1036,7 @@ class Player final : public Creature, public Cylinder {
 		void sendModalWindow(const ModalWindow &modalWindow);
 
 		// container
+		void closeAllExternalContainers();
 		void sendAddContainerItem(const Container* container, const Item* item);
 		void sendUpdateContainerItem(const Container* container, uint16_t slot, const Item* newItem);
 		void sendRemoveContainerItem(const Container* container, uint16_t slot);


### PR DESCRIPTION
# Description

Close all player external containers on death. Necessary to prevent undefined behaviour when a specific container that was opened and existed before death does not exist and was destroyed on the respawn.
