### PR TITLE
fix: check if tile exists on forgotten knowledge death

### DIFF
--- a/data-otservbr-global/scripts/creaturescripts/quests/forgotten_knowledge/energy_prism_death.lua
+++ b/data-otservbr-global/scripts/creaturescripts/quests/forgotten_knowledge/energy_prism_death.lua
@@ -1,11 +1,17 @@
 local energyPrismDeath = CreatureEvent("EnergyPrismDeath")
+
 function energyPrismDeath.onKill(creature, target)
 	stopEvent(Storage.ForgottenKnowledge.LloydEvent)
-	local lloyd = Tile(Position(32799, 32826, 14)):getTopCreature()
+	local tile = Tile(Position(32799, 32826, 14))
+	if not tile then
+		return false
+	end
+	local lloyd = tile:getTopCreature()
 	if lloyd then
 		lloyd:teleportTo(Position(32799, 32829, 14))
 		lloyd:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 	end
 	return true
 end
+
 energyPrismDeath:register()


### PR DESCRIPTION
# Description

resolves #890
