### PR TITLE
fix: remove light effects for god/gm

### DIFF
--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -752,7 +752,7 @@ struct ProtocolFamiliars {
 
 struct LightInfo {
 		uint8_t level = 0;
-		uint8_t color = 0;
+		uint8_t color = 215;
 		constexpr LightInfo() = default;
 		constexpr LightInfo(uint8_t newLevel, uint8_t newColor) :
 			level(newLevel), color(newColor) { }


### PR DESCRIPTION
When is undercave or with light effect (config).
Always with full light.
@Zbizu

**GOD:**
![image](https://user-images.githubusercontent.com/13306169/224569588-322aa5ce-7d81-408b-9a5f-22eb56eebd81.png)

**NORMAL PLAYER:**
![image](https://user-images.githubusercontent.com/13306169/224569487-602f8107-c4eb-4143-ad92-ea1029bc616f.png)


