### PR TITLE
fix: speed when mounting from outfit window

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4787,14 +4787,16 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 			outfit.lookMount = 0;
 		}
 
+		auto deltaSpeedChange = mount->speed;
 		if (player->isMounted()) {
 			Mount* prevMount = mounts.getMountByID(player->getCurrentMount());
 			if (prevMount) {
-				changeSpeed(player, mount->speed - prevMount->speed);
+				deltaSpeedChange -= prevMount->speed;
 			}
 		}
 
 		player->setCurrentMount(mount->id);
+		changeSpeed(player, deltaSpeedChange);
 	} else if (player->isMounted()) {
 		player->dismount();
 	}


### PR DESCRIPTION
# Description

When a player mounts from the outfit window, they should immediately gain the additional speed bonus provided by the mount.

## Behaviour
### **Actual**

When a player mounts from the outfit window, the additional speed bonus provided by the mount is not being applied.

### **Expected**

Player receives the full speed bonus provided by the mount. 