### PR TITLE
Fix ProtocolGame::sendModalWindow

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5824,8 +5824,8 @@ void ProtocolGame::sendModalWindow(const ModalWindow &modalWindow) {
 		msg.addByte(it.second);
 	}
 
-	msg.addByte(modalWindow.defaultEscapeButton);
 	msg.addByte(modalWindow.defaultEnterButton);
+	msg.addByte(modalWindow.defaultEscapeButton);
 	msg.addByte(modalWindow.priority ? 0x01 : 0x00);
 
 	writeToOutputBuffer(msg);


### PR DESCRIPTION
# Description
Fix sendModalWindow for QT clients because they have swapped default button bytes

**How to reproduce:**

1. go to a bed at any house and use it
2. modal window will open
3. press "enter" at your keyboard

**expected:** execution of the selected menu option

**what happen instead:** action canceled, window closed

and if you do the steps above and press "esc" instead, it will execute the action...

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
