### PR TITLE
fix: wrap stackable/charges items

### DIFF
--- a/src/enums/item_attribute.hpp
+++ b/src/enums/item_attribute.hpp
@@ -40,7 +40,7 @@ enum ItemAttribute_t : uint64_t {
 	OPENCONTAINER = 1 << 25,
 	QUICKLOOTCONTAINER = 1 << 26,
 	DURATION_TIMESTAMP = 1 << 27,
-	IMBUEMENT_TYPE = 1 << 28, // Deprecated, can be override
+	AMOUNT = 1 << 28,
 	TIER = 1 << 29,
 
 	CUSTOM = 1U << 31

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3360,14 +3360,14 @@ Item* Game::wrapItem(Item* item) {
 	if (hiddenCharges > 0) {
 		newItem->setAttribute(DATE, hiddenCharges);
 	}
-	if(amount > 0){
+	if (amount > 0) {
 		newItem->setAttribute(AMOUNT, amount);
 	}
 	newItem->startDecaying();
 	return newItem;
 }
 
-void Game::unwrapItem(Item *item, uint16_t unWrapId) {
+void Game::unwrapItem(Item* item, uint16_t unWrapId) {
 	auto hiddenCharges = item->getAttribute<uint16_t>(DATE);
 	auto amount = item->getAttribute<uint16_t>(AMOUNT);
 	if (!amount) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3342,33 +3342,46 @@ void Game::playerWrapableItem(uint32_t playerId, const Position &pos, uint8_t st
 	if (item->isWrapable() && item->getID() != ITEM_DECORATION_KIT) {
 		wrapItem(item);
 	} else if (item->getID() == ITEM_DECORATION_KIT && unWrapId != 0) {
-		auto hiddenCharges = item->getAttribute<uint16_t>(ItemAttribute_t::DATE);
-		Item* newItem = transformItem(item, unWrapId);
-		if (newItem) {
-			if (hiddenCharges > 0 && isCaskItem(unWrapId)) {
-				newItem->setSubType(hiddenCharges);
-			}
-			newItem->removeCustomAttribute("unWrapId");
-			newItem->removeAttribute(ItemAttribute_t::DESCRIPTION);
-			newItem->startDecaying();
-		}
+		unwrapItem(item, unWrapId);
 	}
 	addMagicEffect(pos, CONST_ME_POFF);
 }
 
 Item* Game::wrapItem(Item* item) {
+	uint16_t hiddenCharges = 0;
+	uint16_t amount = item->getItemCount();
+	if (isCaskItem(item->getID())) {
+		hiddenCharges = item->getSubType();
+	}
 	uint16_t oldItemID = item->getID();
 	Item* newItem = transformItem(item, ITEM_DECORATION_KIT);
 	newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
 	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + item->getName() + ">.");
-	if (isCaskItem(item->getID())) {
-		auto hiddenCharges = item->getSubType();
-		if (hiddenCharges > 0) {
-			item->setAttribute(ItemAttribute_t::DATE, hiddenCharges);
-		}
+	if (hiddenCharges > 0) {
+		newItem->setAttribute(DATE, hiddenCharges);
+	}
+	if(amount > 0){
+		newItem->setAttribute(AMOUNT, amount);
 	}
 	newItem->startDecaying();
 	return newItem;
+}
+
+void Game::unwrapItem(Item *item, uint16_t unWrapId) {
+	auto hiddenCharges = item->getAttribute<uint16_t>(DATE);
+	auto amount = item->getAttribute<uint16_t>(AMOUNT);
+	if (!amount) {
+		amount = 1;
+	}
+	Item* newItem = transformItem(item, unWrapId, amount);
+	if (newItem) {
+		if (hiddenCharges > 0 && isCaskItem(unWrapId)) {
+			newItem->setSubType(hiddenCharges);
+		}
+		newItem->removeCustomAttribute("unWrapId");
+		newItem->removeAttribute(DESCRIPTION);
+		newItem->startDecaying();
+	}
 }
 
 void Game::playerWriteItem(uint32_t playerId, uint32_t windowTextId, const std::string &text) {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -691,7 +691,7 @@ class Game {
 			const std::string &damageString, std::string &spectatorMessage
 		) const;
 
-		void unwrapItem(Item *item, uint16_t unWrapId);
+		void unwrapItem(Item* item, uint16_t unWrapId);
 };
 
 constexpr auto g_game = &Game::getInstance;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -690,6 +690,8 @@ class Game {
 			const Player* targetPlayer, TextMessage &message, std::stringstream &ss,
 			const std::string &damageString, std::string &spectatorMessage
 		) const;
+
+		void unwrapItem(Item *item, uint16_t unWrapId);
 };
 
 constexpr auto g_game = &Game::getInstance;

--- a/src/items/functions/item/attribute.hpp
+++ b/src/items/functions/item/attribute.hpp
@@ -40,6 +40,7 @@ class ItemAttributeHelper {
 			checkTypes |= ItemAttribute_t::QUICKLOOTCONTAINER;
 			checkTypes |= ItemAttribute_t::DURATION_TIMESTAMP;
 			checkTypes |= ItemAttribute_t::TIER;
+			checkTypes |= ItemAttribute_t::AMOUNT;
 			return (type & static_cast<ItemAttribute_t>(checkTypes)) != 0;
 		}
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -741,6 +741,17 @@ Attr_ReadValue Item::readAttr(AttrTypes_t attr, PropStream &propStream) {
 			break;
 		}
 
+		case ATTR_AMOUNT: {
+			uint16_t amount;
+			if (!propStream.read<uint16_t>(amount)) {
+				SPDLOG_ERROR("[{}] failed to read amount", __FUNCTION__);
+				return ATTR_READ_ERROR;
+			}
+
+			setAttribute(AMOUNT, amount);
+			break;
+		}
+
 		case ATTR_CUSTOM: {
 			uint64_t size;
 			if (!propStream.read<uint64_t>(size)) {
@@ -917,6 +928,11 @@ void Item::serializeAttr(PropWriteStream &propWriteStream) const {
 	if (hasAttribute(ItemAttribute_t::TIER)) {
 		propWriteStream.write<uint8_t>(ATTR_TIER);
 		propWriteStream.write<uint8_t>(getTier());
+	}
+
+	if (hasAttribute(AMOUNT)) {
+		propWriteStream.write<uint8_t>(ATTR_AMOUNT);
+		propWriteStream.write<uint16_t>(getAttribute<uint16_t>(AMOUNT));
 	}
 
 	// Serialize custom attributes, only serialize if the map not is empty

--- a/src/items/items_definitions.hpp
+++ b/src/items/items_definitions.hpp
@@ -228,7 +228,7 @@ enum AttrTypes_t {
 	ATTR_OPENCONTAINER = 36,
 	ATTR_CUSTOM_ATTRIBUTES = 37, // Deprecated (override by ATTR_CUSTOM)
 	ATTR_QUICKLOOTCONTAINER = 38,
-	ATTR_IMBUEMENT_TYPE = 39, // Deprecated, can be override
+	ATTR_AMOUNT = 39,
 	ATTR_TIER = 40,
 	ATTR_CUSTOM = 41,
 

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -1041,6 +1041,8 @@ ItemAttribute_t stringToItemAttribute(const std::string &str) {
 		return ItemAttribute_t::DOORID;
 	} else if (str == "timestamp") {
 		return ItemAttribute_t::DURATION_TIMESTAMP;
+	} else if (str == "amount") {
+		return ItemAttribute_t::AMOUNT;
 	}
 	return ItemAttribute_t::NONE;
 }


### PR DESCRIPTION
# Description

Should be possible to wrap items with different amounts
Fixes bug introduced at #840 where casks were renewing charges after wrap/unwrap

## Behaviour
### **Actual**

Stackables were always being unwraped with a count of 255
Casks were renewing charges

### **Expected**

Stackables should keep the amount after wrap/unwrap
Casks should keep the charges after wrap/unwrap

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)