### PR TITLE
fix: quest system set container items attributes

### DIFF
--- a/data-otservbr-global/scripts/actions/other/others/quest_system1.lua
+++ b/data-otservbr-global/scripts/actions/other/others/quest_system1.lua
@@ -60,7 +60,7 @@ function questSystem1.onUse(player, item, fromPosition, target, toPosition, isHo
 		player:setStorageValue(Storage.SvargrondArena.PitDoor, -1)
 	end
 
-	if player:getStorageValue(storage) > 0 and player:getAccountType() < ACCOUNT_TYPE_GOD then
+	if player:getStorageValue(storage) > 0 and player:getGroup():getId() < GROUP_TYPE_GAMEMASTER then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The ' .. ItemType(item.itemid):getName() .. ' is empty.')
 		return true
 	end

--- a/data-otservbr-global/scripts/actions/other/others/quest_system1.lua
+++ b/data-otservbr-global/scripts/actions/other/others/quest_system1.lua
@@ -54,17 +54,21 @@ function questSystem1.onUse(player, item, fromPosition, target, toPosition, isHo
 	local items, reward = {}
 	local size = item:isContainer() and item:getSize() or 0
 	if size == 0 then
-		reward = item:clone()
+		local actionId = item:getActionId()
+		reward = Game.createItem(item.itemid, item.type)
+		reward:setActionId(actionId)
 	else
 		local container = Container(item.uid)
 		for i = 0, container:getSize() - 1 do
-			items[#items + 1] = container:getItem(i):clone()
+			local originalItem = container:getItem(i)
+			local newItem = Game.createItem(originalItem.itemid, originalItem.type)
+			newItem:setActionId(originalItem:getActionId())
+			items[#items + 1] = newItem
 		end
-	end
 
-	size = #items
-	if size == 1 then
-		reward = items[1]:clone()
+		if size == 1 then
+			reward = items[1]
+		end
 	end
 
 	local result = ''


### PR DESCRIPTION
# Description
The quest system added exactly the item that was inside the chest, however, if this item had an actionid, like a key, the player receive the key with actionid 0000. if there is a bag or backpack inside the chest, and if there are items inside the bag, the items are not added to the player. 
This pull request fixes the issue and the chest give the key with actionid or a bag/backpack with items.
Fix by @anderkrox 

## Behaviour
### **Actual**

Chest reward key with actionid 0000.
Chest reward item bag or backpack with items are not added to the player.

### **Expected**

Chest reward key with actionid.
Chest reward item inside a bag or backpack.

## Fixes

#941
#918 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

 - [X] Test A
- Open a chest with reward key e receive a key with the actionid.
- Open a chest with reward bag or backpack with items and receive the reward.

**Test Configuration**:

  - Server Version: 12.91
  - Client: 12.91
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
