### PR TITLE
fix: ignore items missing id from assets (appearances.dat object)

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -129,8 +129,8 @@ Attr_ReadValue Container::readAttr(AttrTypes_t attr, PropStream &propStream) {
 	return Item::readAttr(attr, propStream);
 }
 
-bool Container::unserializeItemNode(OTB::Loader &loader, const OTB::Node &node, PropStream &propStream) {
-	bool ret = Item::unserializeItemNode(loader, node, propStream);
+bool Container::unserializeItemNode(OTB::Loader &loader, const OTB::Node &node, PropStream &propStream, Position &itemPosition) {
+	bool ret = Item::unserializeItemNode(loader, node, propStream, itemPosition);
 	if (!ret) {
 		return false;
 	}
@@ -147,13 +147,18 @@ bool Container::unserializeItemNode(OTB::Loader &loader, const OTB::Node &node, 
 			return false;
 		}
 
-		Item* item = Item::CreateItem(itemPropStream);
-		if (!item) {
+		uint16_t id;
+		if (!itemPropStream.read<uint16_t>(id)) {
 			return false;
 		}
 
-		if (!item->unserializeItemNode(loader, itemNode, itemPropStream)) {
-			return false;
+		Item* item = Item::CreateItem(id, itemPosition);
+		if (!item) {
+			continue;
+		}
+
+		if (!item->unserializeItemNode(loader, itemNode, itemPropStream, itemPosition)) {
+			continue;
 		}
 
 		addItem(item);

--- a/src/items/containers/container.h
+++ b/src/items/containers/container.h
@@ -84,7 +84,7 @@ class Container : public Item, public Cylinder {
 		}
 
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream &propStream) override;
-		bool unserializeItemNode(OTB::Loader &loader, const OTB::Node &node, PropStream &propStream) override;
+		bool unserializeItemNode(OTB::Loader &loader, const OTB::Node &node, PropStream &propStream, Position &itemPosition) override;
 		std::string getContentDescription() const;
 
 		size_t size() const {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -65,7 +65,7 @@ Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/, Position* it
 		}
 
 		newItem->incrementReferenceCounter();
-	} else if (it.id == 0 && type > 0 && itemPosition) {
+	} else if (type > 0 && itemPosition) {
 		auto position = *itemPosition;
 		SPDLOG_WARN("[Item::CreateItem] Item with id '{}', in position '{}' not exists in the appearances.dat and cannot be created.", type, position.toString());
 	} else {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -28,7 +28,7 @@
 
 Items Item::items;
 
-Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/, Position *itemPosition /*= nullptr*/) {
+Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/, Position* itemPosition /*= nullptr*/) {
 	Item* newItem = nullptr;
 
 	const ItemType &it = Item::items[type];

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -28,7 +28,7 @@
 
 Items Item::items;
 
-Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/) {
+Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/, Position *itemPosition /*= nullptr*/) {
 	Item* newItem = nullptr;
 
 	const ItemType &it = Item::items[type];
@@ -65,7 +65,10 @@ Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/) {
 		}
 
 		newItem->incrementReferenceCounter();
-	} else if (type != 0) {
+	} else if (it.id == 0 && type > 0 && itemPosition) {
+		auto position = *itemPosition;
+		SPDLOG_WARN("[Item::CreateItem] Item with id '{}', in position '{}' not exists in the appearances.dat and cannot be created.", type, position.toString());
+	} else {
 		SPDLOG_WARN("[Item::CreateItem] Item with id '{}' is not registered and cannot be created.", type);
 	}
 
@@ -144,46 +147,41 @@ Container* Item::CreateItemAsContainer(const uint16_t type, uint16_t size) {
 	return newItem;
 }
 
-Item* Item::CreateItem(PropStream &propStream) {
-	uint16_t id;
-	if (!propStream.read<uint16_t>(id)) {
-		return nullptr;
-	}
-
-	switch (id) {
+Item* Item::CreateItem(uint16_t itemId, Position &itemPosition) {
+	switch (itemId) {
 		case ITEM_FIREFIELD_PVP_FULL:
-			id = ITEM_FIREFIELD_PERSISTENT_FULL;
+			itemId = ITEM_FIREFIELD_PERSISTENT_FULL;
 			break;
 
 		case ITEM_FIREFIELD_PVP_MEDIUM:
-			id = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
+			itemId = ITEM_FIREFIELD_PERSISTENT_MEDIUM;
 			break;
 
 		case ITEM_FIREFIELD_PVP_SMALL:
-			id = ITEM_FIREFIELD_PERSISTENT_SMALL;
+			itemId = ITEM_FIREFIELD_PERSISTENT_SMALL;
 			break;
 
 		case ITEM_ENERGYFIELD_PVP:
-			id = ITEM_ENERGYFIELD_PERSISTENT;
+			itemId = ITEM_ENERGYFIELD_PERSISTENT;
 			break;
 
 		case ITEM_POISONFIELD_PVP:
-			id = ITEM_POISONFIELD_PERSISTENT;
+			itemId = ITEM_POISONFIELD_PERSISTENT;
 			break;
 
 		case ITEM_MAGICWALL:
-			id = ITEM_MAGICWALL_PERSISTENT;
+			itemId = ITEM_MAGICWALL_PERSISTENT;
 			break;
 
 		case ITEM_WILDGROWTH:
-			id = ITEM_WILDGROWTH_PERSISTENT;
+			itemId = ITEM_WILDGROWTH_PERSISTENT;
 			break;
 
 		default:
 			break;
 	}
 
-	return Item::CreateItem(id, 0);
+	return Item::CreateItem(itemId, 0, &itemPosition);
 }
 
 Item::Item(const uint16_t itemId, uint16_t itemCount /*= 0*/) :
@@ -798,7 +796,7 @@ bool Item::unserializeAttr(PropStream &propStream) {
 	return true;
 }
 
-bool Item::unserializeItemNode(OTB::Loader &, const OTB::Node &, PropStream &propStream) {
+bool Item::unserializeItemNode(OTB::Loader &, const OTB::Node &, PropStream &propStream, Position &itemPosition) {
 	return unserializeAttr(propStream);
 }
 

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -220,7 +220,7 @@ class ItemProperties {
 class Item : virtual public Thing, public ItemProperties {
 	public:
 		// Factory member to create item of right type based on type
-		static Item* CreateItem(const uint16_t type, uint16_t count = 0, Position *itemPosition = nullptr);
+		static Item* CreateItem(const uint16_t type, uint16_t count = 0, Position* itemPosition = nullptr);
 		static Container* CreateItemAsContainer(const uint16_t type, uint16_t size);
 		static Item* CreateItem(uint16_t itemId, Position &itemPosition);
 		static Items items;

--- a/src/items/item.h
+++ b/src/items/item.h
@@ -220,9 +220,9 @@ class ItemProperties {
 class Item : virtual public Thing, public ItemProperties {
 	public:
 		// Factory member to create item of right type based on type
-		static Item* CreateItem(const uint16_t type, uint16_t count = 0);
+		static Item* CreateItem(const uint16_t type, uint16_t count = 0, Position *itemPosition = nullptr);
 		static Container* CreateItemAsContainer(const uint16_t type, uint16_t size);
-		static Item* CreateItem(PropStream &propStream);
+		static Item* CreateItem(uint16_t itemId, Position &itemPosition);
 		static Items items;
 
 		// Constructor for items
@@ -306,7 +306,7 @@ class Item : virtual public Thing, public ItemProperties {
 		// serialization
 		virtual Attr_ReadValue readAttr(AttrTypes_t attr, PropStream &propStream);
 		bool unserializeAttr(PropStream &propStream);
-		virtual bool unserializeItemNode(OTB::Loader &, const OTB::Node &, PropStream &propStream);
+		virtual bool unserializeItemNode(OTB::Loader &, const OTB::Node &, PropStream &propStream, Position &itemPosition);
 
 		virtual void serializeAttr(PropWriteStream &propWriteStream) const;
 

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -87,6 +87,10 @@ void Items::loadFromProtobuf() {
 			items.resize(object.id() + 1);
 		}
 
+		if (!object.has_id()) {
+			continue;
+		}
+
 		ItemType &iType = items[object.id()];
 		if (object.flags().container()) {
 			iType.type = ITEM_TYPE_CONTAINER;
@@ -169,8 +173,16 @@ bool Items::loadFromXml() {
 	}
 
 	for (auto itemNode : doc.child("items").children()) {
-		if (auto idAttribute = itemNode.attribute("id"); idAttribute) {
-			parseItemNode(itemNode, pugi::cast<uint16_t>(idAttribute.value()));
+		auto idAttribute = itemNode.attribute("id");
+		auto itemId = pugi::cast<uint16_t>(idAttribute.value());
+		// Validating to avoid creating items that don't exist in assets in the item map
+		ItemType &itemType = items[itemId];
+		if (itemType.id == 0) {
+			continue;
+		}
+
+		if (idAttribute) {
+			parseItemNode(itemNode, itemId);
 			continue;
 		}
 

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -174,15 +174,8 @@ bool Items::loadFromXml() {
 
 	for (auto itemNode : doc.child("items").children()) {
 		auto idAttribute = itemNode.attribute("id");
-		auto itemId = pugi::cast<uint16_t>(idAttribute.value());
-		// Validating to avoid creating items that don't exist in assets in the item map
-		ItemType &itemType = items[itemId];
-		if (itemType.id == 0) {
-			continue;
-		}
-
 		if (idAttribute) {
-			parseItemNode(itemNode, itemId);
+			parseItemNode(itemNode, pugi::cast<uint16_t>(idAttribute.value()));
 			continue;
 		}
 
@@ -225,6 +218,10 @@ void Items::parseItemNode(const pugi::xml_node &itemNode, uint16_t id) {
 		items.resize(id + 1);
 	}
 	ItemType &iType = items[id];
+	if (iType.id == 0 && (iType.name.empty() || iType.name == asLowerCaseString("reserved sprite"))) {
+		return;
+	}
+
 	iType.id = id;
 
 	ItemType &itemType = getItemType(id);

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -173,8 +173,7 @@ bool Items::loadFromXml() {
 	}
 
 	for (auto itemNode : doc.child("items").children()) {
-		auto idAttribute = itemNode.attribute("id");
-		if (idAttribute) {
+		if (auto idAttribute = itemNode.attribute("id")) {
 			parseItemNode(itemNode, pugi::cast<uint16_t>(idAttribute.value()));
 			continue;
 		}


### PR DESCRIPTION
# Description

In some specific scenario, the assets editor bugs when saving items without a sprite and starts debug client, this way, we ignore the creation of items that do not have "object id" in the assets, preventing it from being able to debug due to an invalid item.

## Behaviour
### **Actual**

Creating items with no object, example of items:
168, 371, 858 and various others... 

### **Expected**

When creating the item without an ID, a message will appear stating that the item has no ID in the assets and the position of the item on the map, if you try to create it in game it will not work, it will return the message:
![image](https://user-images.githubusercontent.com/8551443/227633042-2c7b5c13-3001-4ec6-94c4-01aac883e14a.png)

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Try to create an item without a sprite, and you will get the error mentioned in the print above, I put some example IDs for testing.

It will also inform the distro if the map has invalid items.