### PR TITLE
fix: added missing boss points persistence when saving player

### DIFF
--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -828,6 +828,7 @@ bool IOLoginData::savePlayer(Player* player) {
 
 	query << "`prey_wildcard` = " << player->getPreyCards() << ',';
 	query << "`task_points` = " << player->getTaskHuntingPoints() << ',';
+	query << "`boss_points` = " << player->getBossPoints() << ',';
 	query << "`forge_dusts` = " << player->getForgeDusts() << ',';
 	query << "`forge_dust_level` = " << player->getForgeDustLevel() << ',';
 	query << "`randomize_mount` = " << static_cast<uint16_t>(player->isRandomMounted()) << ',';


### PR DESCRIPTION
# Description

Simply adding the missing `boss_points` column to player info persistence.

## Behaviour
### **Actual**

- Killing some bosses in a row
- Look the points in `boss points` progress bar
- Logout
- Look again the points in `boss points` progress bar and they will be lost, returning `0/10`

### **Expected**

- Killing some bosses in a row
- Look the points in `boss points` progress bar
- Logout
- Look again the points in `boss points` progress bar and they needs to be the same as before logout

## Fixes
\#956

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

  - Server Version: latest [canary hash fb745cf](https://github.com/opentibiabr/canary/commit/fb745cf59cba37d8ea0635ec0d2ea89f5bb65597)
  - Client: 12.91.12329
  - Operating System: Windows/Linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
