### PR TITLE
fix: thais exhibition levers conflicting with door quests

### DIFF
--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -134,7 +134,6 @@ Storage = {
 	PremiumAccount = 30058,
 	BattleAxeQuest = 30059,
 	ShrineEntrance = 30060,
-
 	--[[
 	Old storages
 	Over time, this will be dropped and replaced by the table above
@@ -1275,10 +1274,10 @@ Storage = {
 			Statue = 51528,
 			LastMissionState = 51529
 		},
-	TheCursedCrystal = {
-		Oneeyedjoe = 51530,
-		MedusaOil = 51531,
-		Questline = 51532
+		TheCursedCrystal = {
+			Oneeyedjoe = 51530,
+			MedusaOil = 51531,
+			Questline = 51532
 		}
 	},
 	TheShatteredIsles = {
@@ -1421,7 +1420,7 @@ Storage = {
 		TrophyWarlord = 51720,
 		GreenhornDoor = 51721,
 		ScrapperDoor = 51722,
-		WarlordDoor= 51723
+		WarlordDoor = 51723
 	},
 	QuestChests = {
 		-- Reserved storage from 51730 - 51999
@@ -2124,18 +2123,18 @@ Storage = {
 			TheBeginning = {},
 			TheDemonOak = {},
 			FishForASerpent = {
-				QuestLine = 41651},
+				QuestLine = 41651 },
 			TheHuntForTheSeaSerpent = {
 				QuestLine = 41652,
 				SuccessSwitch = 41653,
 				Bait = 41654,
 				Direction = 41655,
-				Access = 41656},
+				Access = 41656 },
 			TheInquisition = {},
 			TheThievesGuild = {},
 			TrollSabotage = {
 				Questline = 41840,
-				JumpTimer = 41841},
+				JumpTimer = 41841 },
 			VampireHunter = {},
 		},
 		U8_4 = { -- update 8.4 - Reserved Storages 41901 - 42145
@@ -2149,10 +2148,10 @@ Storage = {
 					Lisander = 41906,
 					Ortheus = 41907,
 					Maris = 41908,
-					Armenius = 41909},
+					Armenius = 41909 },
 				Mission03 = 41910,
 				Mission04 = 41911,
-				VengothAccess = 41912},
+				VengothAccess = 41912 },
 			InServiceOfYalahar = {},
 			TheHiddenCityOfBeregar = {},
 			TopOfTheCity = {},
@@ -2259,7 +2258,7 @@ Storage = {
 					FahimCount = 42384,
 				},
 				AltKillCount = {
-				-- Grizzly Adams
+					-- Grizzly Adams
 					-- Apes
 					KongraCount = 42450,
 					MerlkinCount = 42451,
@@ -2293,7 +2292,7 @@ Storage = {
 					DrakenEliteCount = 42473,
 					DrakenSpellweaverCount = 42474,
 					DrakenWarmasterCount = 42475,
-				-- Others
+					-- Others
 					-- Minotaurs
 					MinotaurCount = 42476,
 					MinotaurGuardCount = 42477,
@@ -2343,44 +2342,44 @@ Storage = {
 		U8_54 = { -- update 8.54 - Reserved Storages 42551 - 42950
 			AnUneasyAlliance = {
 				Questline = 42551,
-				QuestDoor = 42552}, -- 42551 - 42600
+				QuestDoor = 42552 }, -- 42551 - 42600
 			ChildrenOfTheRevolution = {}, -- 42601 - 42650
 			SeaOfLight = {}, -- 42651 - 42700
 			TheNewFrontier = { -- 42701 - 42750
 				Questline = 42701,
 				FarmineFirstTravel = 42702,
 				Mission01 = 42703,
-				Mission02 = {42704,
-					Beaver1 = 42705,
-					Beaver2 = 42706,
-					Beaver3 = 42707,
+				Mission02 = { 42704,
+											Beaver1 = 42705,
+											Beaver2 = 42706,
+											Beaver3 = 42707,
 				},
 				Mission03 = 42708,
 				Mission04 = 42709,
-				Mission05 = {42710,
-					KingTibianus = 42711,
-					Leeland = 42712,
-					Angus = 42713,
-					Wyrdin = 42714,
-					Telas = 42715,
-					Humgolf = 42716,
-					LeelandKeyword = 42841,
-					AngusKeyword = 42842,
-					WyrdinKeyword = 42843,
-					TelasKeyword = 42844,
-					HumgolfKeyword = 42845,
+				Mission05 = { 42710,
+											KingTibianus = 42711,
+											Leeland = 42712,
+											Angus = 42713,
+											Wyrdin = 42714,
+											Telas = 42715,
+											Humgolf = 42716,
+											LeelandKeyword = 42841,
+											AngusKeyword = 42842,
+											WyrdinKeyword = 42843,
+											TelasKeyword = 42844,
+											HumgolfKeyword = 42845,
 				},
 				Mission06 = 42717,
-				Mission07 = {42718,
-					HiddenNote = 42719,
+				Mission07 = { 42718,
+											HiddenNote = 42719,
 				},
 				Mission08 = 42720,
-				Mission09 = {42721,
-					ArenaDoor = 42722,
-					RewardDoor = 42723,
+				Mission09 = { 42721,
+											ArenaDoor = 42722,
+											RewardDoor = 42723,
 				},
-				Mission10 = {42724,
-					MagicCarpetDoor = 42725,
+				Mission10 = { 42724,
+											MagicCarpetDoor = 42725,
 				},
 				Reward = {
 					Potions = 42726,
@@ -2588,57 +2587,57 @@ Storage = {
 			CultsOfTibia = {}, -- 45651 - 45750
 			ThreatenedDreams = { -- 45751 - 45850
 				QuestLine = 45751,
-				Mission01 = {45752, -- Troubled Animals
-					PoacherChest = 45753,
-					PoacherNotes = 45754,
-					FeathersCount = 45755,
-					Feathers1 = 45756,
-					Feathers2 = 45757,
-					Feathers3 = 45758,
-					Feathers4 = 45759,
-					Feathers5 = 45760
-					},
-				Mission02 = {45761, -- Nightmare Intruders
-					FrazzlemawsCount = 45762,
-					EnfeebledCount = 45763,
-					KroazurAccess = 45764,
-					KroazurTimer = 45765,
-					KroazurKill = 45766,
-					DarkMoonMirror = 45767,
-					FairiesCounter = 45768,
-					Fairy01 = 45769,
-					Fairy02 = 45770,
-					Fairy03 = 45771,
-					Fairy04 = 45772,
-					Fairy05 = 45773,
-					ChargedMoonMirror = 45774,
-					MoonMirrorPos01 = 45775,
-					MoonMirrorPos02 = 45776,
-					MoonMirrorPos03 = 45777,
-					MoonMirrorPos04 = 45778,
-					MoonMirrorPos05 = 45779,
-					ChargedSunCatcher = 45780,
-					SunCatcherPos01 = 45781,
-					SunCatcherPos02 = 45782,
-					SunCatcherPos03 = 45783,
-					SunCatcherPos04 = 45784,
-					SunCatcherPos05 = 45785,
-					ChargedStarlightVial = 45786,
-					StarlightPos01 = 45787,
-					StarlightPos02 = 45788,
-					StarlightPos03 = 45789,
-					StarlightPos04 = 45790,
-					StarlightPos05 = 45791
-					},
-				Mission03 = {45792, -- An Unlikely Couple
-					UnlikelyCouple = 45793,
-					PanpipesTimer = 45794,
-					RavenHerbTimer = 45795,
-					DarkSunCatcher = 45796,
-					EmptyStarlightVial = 45797
-					},
-				Mission04 = {45798,
-					},
+				Mission01 = { 45752, -- Troubled Animals
+											PoacherChest = 45753,
+											PoacherNotes = 45754,
+											FeathersCount = 45755,
+											Feathers1 = 45756,
+											Feathers2 = 45757,
+											Feathers3 = 45758,
+											Feathers4 = 45759,
+											Feathers5 = 45760
+				},
+				Mission02 = { 45761, -- Nightmare Intruders
+											FrazzlemawsCount = 45762,
+											EnfeebledCount = 45763,
+											KroazurAccess = 45764,
+											KroazurTimer = 45765,
+											KroazurKill = 45766,
+											DarkMoonMirror = 45767,
+											FairiesCounter = 45768,
+											Fairy01 = 45769,
+											Fairy02 = 45770,
+											Fairy03 = 45771,
+											Fairy04 = 45772,
+											Fairy05 = 45773,
+											ChargedMoonMirror = 45774,
+											MoonMirrorPos01 = 45775,
+											MoonMirrorPos02 = 45776,
+											MoonMirrorPos03 = 45777,
+											MoonMirrorPos04 = 45778,
+											MoonMirrorPos05 = 45779,
+											ChargedSunCatcher = 45780,
+											SunCatcherPos01 = 45781,
+											SunCatcherPos02 = 45782,
+											SunCatcherPos03 = 45783,
+											SunCatcherPos04 = 45784,
+											SunCatcherPos05 = 45785,
+											ChargedStarlightVial = 45786,
+											StarlightPos01 = 45787,
+											StarlightPos02 = 45788,
+											StarlightPos03 = 45789,
+											StarlightPos04 = 45790,
+											StarlightPos05 = 45791
+				},
+				Mission03 = { 45792, -- An Unlikely Couple
+											UnlikelyCouple = 45793,
+											PanpipesTimer = 45794,
+											RavenHerbTimer = 45795,
+											DarkSunCatcher = 45796,
+											EmptyStarlightVial = 45797
+				},
+				Mission04 = { 45798,
+				},
 				Mission05 = 45799
 			},
 		},
@@ -2817,12 +2816,42 @@ Storage = {
 				MegasylvanYseldaTimer = 47602,
 			},
 			CitizenOfIssaviOutfits = {},
-			RoyalBounaceanAdvisorOutfits= {},
+			RoyalBounaceanAdvisorOutfits = {},
 			TooHotToHandle = {}
 		},
 		U12_80 = { -- update 12.80 - Reserved Storages 47801 - 47850
 			RoyalCostumeOutfits = {}
 		},
+	},
+	-- Reserved storage from 63951 - 63999
+	ThaisExhibition = {
+		FriendshipAmulet = 63951,
+		HandPuppets = 63952,
+		EpaminondasDoll = 63953,
+		NorsemanDoll = 63954,
+		BookwormDoll = 63955,
+		GoldenNewspaper = 63956,
+		TibiacityEncyclopedia = 63957,
+		GoldenFalcon = 63958,
+		DragonGoblet = 63959,
+		FerumbrasDoll = 63960,
+		FrozenHeart = 63961,
+		DrakenDoll = 63962,
+		MusicBox = 63963,
+		DurinTheAlmighty = 63964,
+		DragonEye = 63965,
+		MemoryBox = 63966,
+		NobleSword = 63967,
+		MedusaSkull = 63968,
+		MathmasterShield = 63969,
+		Imortus = 63970,
+		OldRadio = 63971,
+		EpicWisdom = 63972,
+		DreadDoll = 63973,
+		PhoenixStatue = 63974,
+		OrcsJawShredder = 63975,
+		BagOfOrientalSpices = 63976,
+		TibiorasBox = 63977
 	},
 	-- Reserved Storages 64000 - 65000
 	BosstiaryCooldown = {
@@ -2831,7 +2860,8 @@ Storage = {
 		LordAzaram = 64002,
 		SirBaelocNictros = 64003,
 		DukeKrule = 64004
-	}
+	},
+
 }
 
 GlobalStorage = {
@@ -3034,7 +3064,7 @@ table.sort(extraction) -- Sort the table
 -- Scroll through the extracted table for duplicates
 if #extraction > 1 then
 	for i = 1, #extraction - 1 do
-		if extraction[i] == extraction[i+1] then
+		if extraction[i] == extraction[i + 1] then
 			Spdlog.warn(string.format("Duplicate storage value found: %d",
 				extraction[i]))
 		end

--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -134,6 +134,7 @@ Storage = {
 	PremiumAccount = 30058,
 	BattleAxeQuest = 30059,
 	ShrineEntrance = 30060,
+
 	--[[
 	Old storages
 	Over time, this will be dropped and replaced by the table above
@@ -1274,10 +1275,10 @@ Storage = {
 			Statue = 51528,
 			LastMissionState = 51529
 		},
-		TheCursedCrystal = {
-			Oneeyedjoe = 51530,
-			MedusaOil = 51531,
-			Questline = 51532
+	TheCursedCrystal = {
+		Oneeyedjoe = 51530,
+		MedusaOil = 51531,
+		Questline = 51532
 		}
 	},
 	TheShatteredIsles = {
@@ -1420,7 +1421,7 @@ Storage = {
 		TrophyWarlord = 51720,
 		GreenhornDoor = 51721,
 		ScrapperDoor = 51722,
-		WarlordDoor = 51723
+		WarlordDoor= 51723
 	},
 	QuestChests = {
 		-- Reserved storage from 51730 - 51999
@@ -2123,18 +2124,18 @@ Storage = {
 			TheBeginning = {},
 			TheDemonOak = {},
 			FishForASerpent = {
-				QuestLine = 41651 },
+				QuestLine = 41651},
 			TheHuntForTheSeaSerpent = {
 				QuestLine = 41652,
 				SuccessSwitch = 41653,
 				Bait = 41654,
 				Direction = 41655,
-				Access = 41656 },
+				Access = 41656},
 			TheInquisition = {},
 			TheThievesGuild = {},
 			TrollSabotage = {
 				Questline = 41840,
-				JumpTimer = 41841 },
+				JumpTimer = 41841},
 			VampireHunter = {},
 		},
 		U8_4 = { -- update 8.4 - Reserved Storages 41901 - 42145
@@ -2148,10 +2149,10 @@ Storage = {
 					Lisander = 41906,
 					Ortheus = 41907,
 					Maris = 41908,
-					Armenius = 41909 },
+					Armenius = 41909},
 				Mission03 = 41910,
 				Mission04 = 41911,
-				VengothAccess = 41912 },
+				VengothAccess = 41912},
 			InServiceOfYalahar = {},
 			TheHiddenCityOfBeregar = {},
 			TopOfTheCity = {},
@@ -2258,7 +2259,7 @@ Storage = {
 					FahimCount = 42384,
 				},
 				AltKillCount = {
-					-- Grizzly Adams
+				-- Grizzly Adams
 					-- Apes
 					KongraCount = 42450,
 					MerlkinCount = 42451,
@@ -2292,7 +2293,7 @@ Storage = {
 					DrakenEliteCount = 42473,
 					DrakenSpellweaverCount = 42474,
 					DrakenWarmasterCount = 42475,
-					-- Others
+				-- Others
 					-- Minotaurs
 					MinotaurCount = 42476,
 					MinotaurGuardCount = 42477,
@@ -2342,44 +2343,44 @@ Storage = {
 		U8_54 = { -- update 8.54 - Reserved Storages 42551 - 42950
 			AnUneasyAlliance = {
 				Questline = 42551,
-				QuestDoor = 42552 }, -- 42551 - 42600
+				QuestDoor = 42552}, -- 42551 - 42600
 			ChildrenOfTheRevolution = {}, -- 42601 - 42650
 			SeaOfLight = {}, -- 42651 - 42700
 			TheNewFrontier = { -- 42701 - 42750
 				Questline = 42701,
 				FarmineFirstTravel = 42702,
 				Mission01 = 42703,
-				Mission02 = { 42704,
-											Beaver1 = 42705,
-											Beaver2 = 42706,
-											Beaver3 = 42707,
+				Mission02 = {42704,
+					Beaver1 = 42705,
+					Beaver2 = 42706,
+					Beaver3 = 42707,
 				},
 				Mission03 = 42708,
 				Mission04 = 42709,
-				Mission05 = { 42710,
-											KingTibianus = 42711,
-											Leeland = 42712,
-											Angus = 42713,
-											Wyrdin = 42714,
-											Telas = 42715,
-											Humgolf = 42716,
-											LeelandKeyword = 42841,
-											AngusKeyword = 42842,
-											WyrdinKeyword = 42843,
-											TelasKeyword = 42844,
-											HumgolfKeyword = 42845,
+				Mission05 = {42710,
+					KingTibianus = 42711,
+					Leeland = 42712,
+					Angus = 42713,
+					Wyrdin = 42714,
+					Telas = 42715,
+					Humgolf = 42716,
+					LeelandKeyword = 42841,
+					AngusKeyword = 42842,
+					WyrdinKeyword = 42843,
+					TelasKeyword = 42844,
+					HumgolfKeyword = 42845,
 				},
 				Mission06 = 42717,
-				Mission07 = { 42718,
-											HiddenNote = 42719,
+				Mission07 = {42718,
+					HiddenNote = 42719,
 				},
 				Mission08 = 42720,
-				Mission09 = { 42721,
-											ArenaDoor = 42722,
-											RewardDoor = 42723,
+				Mission09 = {42721,
+					ArenaDoor = 42722,
+					RewardDoor = 42723,
 				},
-				Mission10 = { 42724,
-											MagicCarpetDoor = 42725,
+				Mission10 = {42724,
+					MagicCarpetDoor = 42725,
 				},
 				Reward = {
 					Potions = 42726,
@@ -2587,57 +2588,57 @@ Storage = {
 			CultsOfTibia = {}, -- 45651 - 45750
 			ThreatenedDreams = { -- 45751 - 45850
 				QuestLine = 45751,
-				Mission01 = { 45752, -- Troubled Animals
-											PoacherChest = 45753,
-											PoacherNotes = 45754,
-											FeathersCount = 45755,
-											Feathers1 = 45756,
-											Feathers2 = 45757,
-											Feathers3 = 45758,
-											Feathers4 = 45759,
-											Feathers5 = 45760
-				},
-				Mission02 = { 45761, -- Nightmare Intruders
-											FrazzlemawsCount = 45762,
-											EnfeebledCount = 45763,
-											KroazurAccess = 45764,
-											KroazurTimer = 45765,
-											KroazurKill = 45766,
-											DarkMoonMirror = 45767,
-											FairiesCounter = 45768,
-											Fairy01 = 45769,
-											Fairy02 = 45770,
-											Fairy03 = 45771,
-											Fairy04 = 45772,
-											Fairy05 = 45773,
-											ChargedMoonMirror = 45774,
-											MoonMirrorPos01 = 45775,
-											MoonMirrorPos02 = 45776,
-											MoonMirrorPos03 = 45777,
-											MoonMirrorPos04 = 45778,
-											MoonMirrorPos05 = 45779,
-											ChargedSunCatcher = 45780,
-											SunCatcherPos01 = 45781,
-											SunCatcherPos02 = 45782,
-											SunCatcherPos03 = 45783,
-											SunCatcherPos04 = 45784,
-											SunCatcherPos05 = 45785,
-											ChargedStarlightVial = 45786,
-											StarlightPos01 = 45787,
-											StarlightPos02 = 45788,
-											StarlightPos03 = 45789,
-											StarlightPos04 = 45790,
-											StarlightPos05 = 45791
-				},
-				Mission03 = { 45792, -- An Unlikely Couple
-											UnlikelyCouple = 45793,
-											PanpipesTimer = 45794,
-											RavenHerbTimer = 45795,
-											DarkSunCatcher = 45796,
-											EmptyStarlightVial = 45797
-				},
-				Mission04 = { 45798,
-				},
+				Mission01 = {45752, -- Troubled Animals
+					PoacherChest = 45753,
+					PoacherNotes = 45754,
+					FeathersCount = 45755,
+					Feathers1 = 45756,
+					Feathers2 = 45757,
+					Feathers3 = 45758,
+					Feathers4 = 45759,
+					Feathers5 = 45760
+					},
+				Mission02 = {45761, -- Nightmare Intruders
+					FrazzlemawsCount = 45762,
+					EnfeebledCount = 45763,
+					KroazurAccess = 45764,
+					KroazurTimer = 45765,
+					KroazurKill = 45766,
+					DarkMoonMirror = 45767,
+					FairiesCounter = 45768,
+					Fairy01 = 45769,
+					Fairy02 = 45770,
+					Fairy03 = 45771,
+					Fairy04 = 45772,
+					Fairy05 = 45773,
+					ChargedMoonMirror = 45774,
+					MoonMirrorPos01 = 45775,
+					MoonMirrorPos02 = 45776,
+					MoonMirrorPos03 = 45777,
+					MoonMirrorPos04 = 45778,
+					MoonMirrorPos05 = 45779,
+					ChargedSunCatcher = 45780,
+					SunCatcherPos01 = 45781,
+					SunCatcherPos02 = 45782,
+					SunCatcherPos03 = 45783,
+					SunCatcherPos04 = 45784,
+					SunCatcherPos05 = 45785,
+					ChargedStarlightVial = 45786,
+					StarlightPos01 = 45787,
+					StarlightPos02 = 45788,
+					StarlightPos03 = 45789,
+					StarlightPos04 = 45790,
+					StarlightPos05 = 45791
+					},
+				Mission03 = {45792, -- An Unlikely Couple
+					UnlikelyCouple = 45793,
+					PanpipesTimer = 45794,
+					RavenHerbTimer = 45795,
+					DarkSunCatcher = 45796,
+					EmptyStarlightVial = 45797
+					},
+				Mission04 = {45798,
+					},
 				Mission05 = 45799
 			},
 		},
@@ -2816,7 +2817,7 @@ Storage = {
 				MegasylvanYseldaTimer = 47602,
 			},
 			CitizenOfIssaviOutfits = {},
-			RoyalBounaceanAdvisorOutfits = {},
+			RoyalBounaceanAdvisorOutfits= {},
 			TooHotToHandle = {}
 		},
 		U12_80 = { -- update 12.80 - Reserved Storages 47801 - 47850
@@ -2860,8 +2861,7 @@ Storage = {
 		LordAzaram = 64002,
 		SirBaelocNictros = 64003,
 		DukeKrule = 64004
-	},
-
+	}
 }
 
 GlobalStorage = {
@@ -3064,7 +3064,7 @@ table.sort(extraction) -- Sort the table
 -- Scroll through the extracted table for duplicates
 if #extraction > 1 then
 	for i = 1, #extraction - 1 do
-		if extraction[i] == extraction[i + 1] then
+		if extraction[i] == extraction[i+1] then
 			Spdlog.warn(string.format("Duplicate storage value found: %d",
 				extraction[i]))
 		end

--- a/data-otservbr-global/scripts/actions/other/thais_exhibition.lua
+++ b/data-otservbr-global/scripts/actions/other/thais_exhibition.lua
@@ -1,127 +1,127 @@
-local exhibits = {
-	[50030] = {
+local ThaisExhibitionConfig = {
+	[Storage.ThaisExhibition.FriendshipAmulet] = {
 		sounds = {
-			{text = 'Hail |PLAYERNAME|, my friend!'},
-			{text = 'Friends forever!'},
-			{text = 'Look, how our friendship shines!'},
-			{text = 'Hail Tibiafriends!'}
+			{ text = 'Hail |PLAYERNAME|, my friend!' },
+			{ text = 'Friends forever!' },
+			{ text = 'Look, how our friendship shines!' },
+			{ text = 'Hail Tibiafriends!' }
 		},
 		itemid = 9802,
 		dir = DIRECTION_NORTH
 	},
-	[50031] = {
+	[Storage.ThaisExhibition.HandPuppets] = {
 		sounds = {
-			{text = 'Why so serious?'},
-			{text = 'These are not the puppets you are looking for...'},
-			{text = 'May the roleplay be with you.'},
-			{text = 'An age of roleplay, and all will know, that three hundred puppets gave their last breath to defend it!'},
-			{text = 'They stoles it! Sneaky little puppetses!'},
-			{text = 'There was a dream that was roleplay. You could only whisper it. Anything more than a whisper and it would vanish.'}
+			{ text = 'Why so serious?' },
+			{ text = 'These are not the puppets you are looking for...' },
+			{ text = 'May the roleplay be with you.' },
+			{ text = 'An age of roleplay, and all will know, that three hundred puppets gave their last breath to defend it!' },
+			{ text = 'They stoles it! Sneaky little puppetses!' },
+			{ text = 'There was a dream that was roleplay. You could only whisper it. Anything more than a whisper and it would vanish.' }
 		},
 		itemid = 9189,
 		dir = DIRECTION_WEST
 	},
-	[50032] = {
+	[Storage.ThaisExhibition.EpaminondasDoll] = {
 		sounds = {
-			{text = 'Hauopa!'},
-			{text = 'Yala Boom', exhibitEffect = CONST_ME_SOUND_RED},
-			{text = 'Hail Portal Tibia!'}
+			{ text = 'Hauopa!' },
+			{ text = 'Yala Boom', exhibitEffect = CONST_ME_SOUND_RED },
+			{ text = 'Hail Portal Tibia!' }
 		},
 		itemid = 9144,
 		transformid = 9145,
 		dir = DIRECTION_NORTH
 	},
-	[50033] = {
+	[Storage.ThaisExhibition.NorsemanDoll] = {
 		sounds = {
-			{text = 'Hail TibiaNordic!'},
-			{text = 'So cold...'},
-			{text = 'Run, mammoth!'}
+			{ text = 'Hail TibiaNordic!' },
+			{ text = 'So cold...' },
+			{ text = 'Run, mammoth!' }
 		},
 		itemid = 8154,
 		dir = DIRECTION_WEST
 	},
-	[50034] = {
+	[Storage.ThaisExhibition.BookwormDoll] = {
 		sounds = {
-			{text = 'Hail Tibia Library!'},
-			{text = 'Shhhhhh, please be quiet!'},
-			{text = 'Books are great!! Aren\'t they?'}
+			{ text = 'Hail Tibia Library!' },
+			{ text = 'Shhhhhh, please be quiet!' },
+			{ text = 'Books are great!! Aren\'t they?' }
 		},
 		itemid = 18343,
 		dir = DIRECTION_NORTH
 	},
-	[50035] = {
+	[Storage.ThaisExhibition.GoldenNewspaper] = {
 		sounds = {
-			{text = 'It\'s news to me.'},
-			{text = 'News, updated as infrequently as possible!'},
-			{text = 'Extra! Extra! Read all about it!'},
-			{text = 'Fresh off the press!'}
+			{ text = 'It\'s news to me.' },
+			{ text = 'News, updated as infrequently as possible!' },
+			{ text = 'Extra! Extra! Read all about it!' },
+			{ text = 'Fresh off the press!' }
 		},
 		itemid = 8153,
 		dir = DIRECTION_NORTH
 	},
-	[50036] = {
+	[Storage.ThaisExhibition.TibiacityEncyclopedia] = {
 		sounds = {
-			{text = 'I own, Tibiacity owns, perfect match!'},
-			{text = 'Weirdo, you\'re a weirdo! Actually all of you are!'},
-			{text = 'All hail the control panel!'},
-			{text = 'Pie for breakfast, pie for lunch and pie for dinner!'},
-			{text = 'Hug me! Feed me! Hail me!'}
+			{ text = 'I own, Tibiacity owns, perfect match!' },
+			{ text = 'Weirdo, you\'re a weirdo! Actually all of you are!' },
+			{ text = 'All hail the control panel!' },
+			{ text = 'Pie for breakfast, pie for lunch and pie for dinner!' },
+			{ text = 'Hug me! Feed me! Hail me!' }
 		},
 		itemid = 8149,
 		dir = DIRECTION_WEST
 	},
-	[50037] = {
+	[Storage.ThaisExhibition.GoldenFalcon] = {
 		sounds = {
-			{text = 'Oh, when I get my claws on you...'},
-			{text = 'Let\'s hunt, |PLAYERNAME|!'},
-			{text = 'Hail TibiaBR.com! Flap! Flap!'}
+			{ text = 'Oh, when I get my claws on you...' },
+			{ text = 'Let\'s hunt, |PLAYERNAME|!' },
+			{ text = 'Hail TibiaBR.com! Flap! Flap!' }
 		},
 		itemid = 8148,
 		transformid = 8175,
 		dir = DIRECTION_NORTH
 	},
-	[50038] = {
+	[Storage.ThaisExhibition.DragonGoblet] = {
 		sounds = {
-			{text = 'I WILL PROTECT YOUR KNOWLEDGEZZZ.'},
-			{text = 'FCHHH - FEEEEED ME AT TIBIAVENEZUELA.COM'},
-			{text = 'I SENSE WISDOM...HUMILITY...AND...PERSEVERANCE!!!'},
-			{text = 'MAY MY ETERNAL FLAME BE YOUR SHIELD AND PATH OF SUCCESS, |PLAYERNAME|!'}
+			{ text = 'I WILL PROTECT YOUR KNOWLEDGEZZZ.' },
+			{ text = 'FCHHH - FEEEEED ME AT TIBIAVENEZUELA.COM' },
+			{ text = 'I SENSE WISDOM...HUMILITY...AND...PERSEVERANCE!!!' },
+			{ text = 'MAY MY ETERNAL FLAME BE YOUR SHIELD AND PATH OF SUCCESS, |PLAYERNAME|!' }
 		},
 		itemid = 10477,
 		dir = DIRECTION_NORTH
 	},
-	[50039] = {
+	[Storage.ThaisExhibition.FerumbrasDoll] = {
 		sounds = {
-			{text = 'Mwahaha!'},
-			{text = 'NO ONE WILL STOP ME THIS TIME!'},
-			{text = 'THE POWER IS IN TIBIOPEDIA!'},
-			{text = 'THE POWER IS MINE!'}
+			{ text = 'Mwahaha!' },
+			{ text = 'NO ONE WILL STOP ME THIS TIME!' },
+			{ text = 'THE POWER IS IN TIBIOPEDIA!' },
+			{ text = 'THE POWER IS MINE!' }
 		},
 		itemid = 10798,
 		dir = DIRECTION_NORTH
 	},
-	[50040] = {
+	[Storage.ThaisExhibition.FrozenHeart] = {
 		sounds = {
-			{text = 'Could a dead, frozen heart beat again? It felt like mine was about to.'},
-			{text = 'The world was born from Tibiasula\'s love.'},
-			{text = 'Look after TibiaTR\'s frozen heart. I\'ve left it with you.'},
-			{text = 'Hail TibiaTR.net!'}
+			{ text = 'Could a dead, frozen heart beat again? It felt like mine was about to.' },
+			{ text = 'The world was born from Tibiasula\'s love.' },
+			{ text = 'Look after TibiaTR\'s frozen heart. I\'ve left it with you.' },
+			{ text = 'Hail TibiaTR.net!' }
 		},
 		itemid = 12041,
 		transformid = 12042,
 		transformDuration = 12013,
 		dir = DIRECTION_NORTH
 	},
-	[50041] = {
+	[Storage.ThaisExhibition.DrakenDoll] = {
 		sounds = {
-			{text = 'For zze emperor!'},
-			{text = 'Hail TibiaJourney.com!'},
-			{text = 'Hail |PLAYERNAME|!'}
+			{ text = 'For zze emperor!' },
+			{ text = 'Hail TibiaJourney.com!' },
+			{ text = 'Hail |PLAYERNAME|!' }
 		},
 		itemid = 12043,
 		dir = DIRECTION_NORTH
 	},
-	[50042] = {
+	[Storage.ThaisExhibition.MusicBox] = {
 		itemids = {
 			{
 				itemid = 12045,
@@ -134,76 +134,76 @@ local exhibits = {
 		},
 		dir = DIRECTION_NORTH
 	},
-	[50043] = {
+	[Storage.ThaisExhibition.DurinTheAlmighty] = {
 		sounds = {
-			{text = 'My powers are limitless!'},
-			{text = 'Hail Tibia Bariloche!'}
+			{ text = 'My powers are limitless!' },
+			{ text = 'Hail Tibia Bariloche!' }
 		},
 		itemid = 14764,
 		dir = DIRECTION_NORTH
 	},
-	[50044] = {
+	[Storage.ThaisExhibition.DragonEye] = {
 		sounds = {
-			{text = 'Do not trade me!'},
-			{text = 'Hail |PLAYERNAME|!'},
-			{text = 'Hail Tibia-Market!'}
+			{ text = 'Do not trade me!' },
+			{ text = 'Hail |PLAYERNAME|!' },
+			{ text = 'Hail Tibia-Market!' }
 		},
 		itemid = 16262,
 		dir = DIRECTION_NORTH
 	},
-	[50045] = {
+	[Storage.ThaisExhibition.MemoryBox] = {
 		sounds = {
-			{text = 'Uploading to TibiaEvents.... processing...'},
-			{text = 'Say "Rat CHeese!"'},
-			{text = 'I got the perfect shot!'},
-			{text = 'Hold still...got it!'},
-			{text = 'Look at this one! Wasn\'t this your first battle with a dragon?'},
-			{text = 'This picture reminds me of the latest event.'}
+			{ text = 'Uploading to TibiaEvents.... processing...' },
+			{ text = 'Say "Rat CHeese!"' },
+			{ text = 'I got the perfect shot!' },
+			{ text = 'Hold still...got it!' },
+			{ text = 'Look at this one! Wasn\'t this your first battle with a dragon?' },
+			{ text = 'This picture reminds me of the latest event.' }
 		},
 		itemid = 19397,
 		transformid = 19398,
 		transformDuration = 7000,
 		dir = DIRECTION_WEST
 	},
-	[50046] = {
+	[Storage.ThaisExhibition.NobleSword] = {
 		itemid = 16275,
 		transformid = 16276,
 		dir = DIRECTION_NORTH
 	},
-	[50047] = {
+	[Storage.ThaisExhibition.MedusaSkull] = {
 		sounds = {
-			{text = 'I will petrify thisss moment! Sstonesss are forever!!!'},
-			{text = 'Where isss my body?!? I\'ll kill you!!!'}
+			{ text = 'I will petrify thisss moment! Sstonesss are forever!!!' },
+			{ text = 'Where isss my body?!? I\'ll kill you!!!' }
 		},
 		itemid = 14762,
 		dir = DIRECTION_NORTH
 	},
-	[50048] = {
+	[Storage.ThaisExhibition.MathmasterShield] = {
 		sounds = {
-			{exhibitEffect = CONST_ME_LOSEENERGY}
+			{ exhibitEffect = CONST_ME_LOSEENERGY }
 		},
 		itemid = 14760,
 		transformid = 14761,
 		dir = DIRECTION_NORTH
 	},
-	[50049] = {
+	[Storage.ThaisExhibition.Imortus] = {
 		sounds = {
-			{text = 'Now you will see, |PLAYERNAME|!'},
-			{text = 'More eyes for many numbers!'},
-			{text = '594!? So easy...'},
-			{text = 'Numbers for Exhiti...'}
+			{ text = 'Now you will see, |PLAYERNAME|!' },
+			{ text = 'More eyes for many numbers!' },
+			{ text = '594!? So easy...' },
+			{ text = 'Numbers for Exhiti...' }
 		},
 		itemid = 12811,
 		transformid = 12812,
 		dir = DIRECTION_WEST
 	},
-	[50050] = {
+	[Storage.ThaisExhibition.OldRadio] = {
 		itemids = {
 			{
 				sounds = {
-					{text = 'Now Tibia bffff... has sound.'},
-					{text = 'Hail bffff... RadioTibia!'},
-					{text = 'Hello bffff... |PLAYERNAME|.'}
+					{ text = 'Now Tibia bffff... has sound.' },
+					{ text = 'Hail bffff... RadioTibia!' },
+					{ text = 'Hello bffff... |PLAYERNAME|.' }
 				},
 				itemid = 12813,
 				transformid = 12814
@@ -215,58 +215,58 @@ local exhibits = {
 		},
 		dir = DIRECTION_NORTH
 	},
-	[50051] = {
+	[Storage.ThaisExhibition.EpicWisdom] = {
 		sounds = {
-			{text = 'MY BRAIN... TOO MUCH... KNOWLEDGE! AAAAH!', playerEffect = CONST_ME_STUN},
-			{text = 'Excalibug is lying at the heart of every true fighter.'},
-			{text = 'Fire is fascinating. But whether it is going to light your path or burning you till death, you can never tell.'}
+			{ text = 'MY BRAIN... TOO MUCH... KNOWLEDGE! AAAAH!', playerEffect = CONST_ME_STUN },
+			{ text = 'Excalibug is lying at the heart of every true fighter.' },
+			{ text = 'Fire is fascinating. But whether it is going to light your path or burning you till death, you can never tell.' }
 		},
 		itemid = 12809,
 		dir = DIRECTION_NORTH
 	},
-	[50052] = {
+	[Storage.ThaisExhibition.DreadDoll] = {
 		sounds = {
-			{text = 'Mhausheausheu! What a FAIL! Mwahaha!'},
-			{text = 'Hail |PLAYERNAME|! You are wearing old socks!'},
-			{text = 'ou are so unpopular even your own shadow refuses to follow you.'},
-			{text = 'Have fun with FunTibia.com!'}
+			{ text = 'Mhausheausheu! What a FAIL! Mwahaha!' },
+			{ text = 'Hail |PLAYERNAME|! You are wearing old socks!' },
+			{ text = 'ou are so unpopular even your own shadow refuses to follow you.' },
+			{ text = 'Have fun with FunTibia.com!' }
 		},
 		itemid = 12904,
 		dir = DIRECTION_NORTH
 	},
-	[50053] = {
+	[Storage.ThaisExhibition.PhoenixStatue] = {
 		sounds = {
-			{text = 'Come closer, I will show some Tibian mysteries to you!'},
-			{text = 'Feel the eternity of Tibiafans.se!'},
-			{text = '|PLAYERNAME|, you are worthy to feel the power of Tibiafans.se! HAIL TIBIAFANS!'}
+			{ text = 'Come closer, I will show some Tibian mysteries to you!' },
+			{ text = 'Feel the eternity of Tibiafans.se!' },
+			{ text = '|PLAYERNAME|, you are worthy to feel the power of Tibiafans.se! HAIL TIBIAFANS!' }
 		},
 		itemid = 4115,
 		dir = DIRECTION_WEST
 	},
-	[50054] = {
+	[Storage.ThaisExhibition.OrcsJawShredder] = {
 		sounds = {
-			{text = 'Hail |PLAYERNAME|!'},
-			{text = 'Hail TibiaSpy.com!'},
-			{text = 'Wrrrzzzgggrrzzzz...'},
-			{text = 'Yummy...'}
+			{ text = 'Hail |PLAYERNAME|!' },
+			{ text = 'Hail TibiaSpy.com!' },
+			{ text = 'Wrrrzzzgggrrzzzz...' },
+			{ text = 'Yummy...' }
 		},
 		itemid = 10800,
 		dir = DIRECTION_NORTH
 	},
-	[50055] = {
+	[Storage.ThaisExhibition.BagOfOrientalSpices] = {
 		sounds = {
-			{text = 'According to tibia-wiki.net, Jalapeño Peppers are as hot and famous as the place they come from - Ankrahmun.'},
-			{text = 'According to tibia-wiki.net, a Bulb of Garlic is a great spice AND protection against vampires.'},
-			{text = 'According to tibia-wiki.net, star and sling herbs taste like cinnamon and vanilla.'}
+			{ text = 'According to tibia-wiki.net, Jalapeño Peppers are as hot and famous as the place they come from - Ankrahmun.' },
+			{ text = 'According to tibia-wiki.net, a Bulb of Garlic is a great spice AND protection against vampires.' },
+			{ text = 'According to tibia-wiki.net, star and sling herbs taste like cinnamon and vanilla.' }
 		},
 		itemid = 10817,
 		dir = DIRECTION_NORTH
 	},
-	[50056] = {
+	[Storage.ThaisExhibition.TibiorasBox] = {
 		sounds = {
-			{text = 'Click! You don\'t seem experienced enough to open this properly.'},
-			{text = 'Click! The box won\'t open for you.'},
-			{text = 'Click! This item is too precious for a newbie. You are unable to open it.'}
+			{ text = 'Click! You don\'t seem experienced enough to open this properly.' },
+			{ text = 'Click! The box won\'t open for you.' },
+			{ text = 'Click! This item is too precious for a newbie. You are unable to open it.' }
 		},
 		itemid = 3997,
 		transformid = 4010,
@@ -275,8 +275,8 @@ local exhibits = {
 	},
 }
 
-local function resetExhibit(exhibitPosition, actionid)
-	local settings = exhibits[actionid]
+local function resetExhibit(exhibitPosition, uid)
+	local settings = ThaisExhibitionConfig[uid]
 	if not settings.transformid then
 		return
 	end
@@ -295,13 +295,12 @@ local function resetLever(leverPos)
 end
 
 local thaisExhibition = Action()
-
 function thaisExhibition.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 2773 then
 		return false
 	end
 
-	local settings = exhibits[item.actionid]
+	local settings = ThaisExhibitionConfig[item.uid]
 	if not settings then
 		return false
 	end
@@ -352,13 +351,13 @@ function thaisExhibition.onUse(player, item, fromPosition, target, toPosition, i
 	addEvent(resetLever, 6000 or 6000, toPosition)
 
 	if not isToggle then
-		addEvent(resetExhibit, 6000 or 6000, exhibitPosition, item.actionid)
+		addEvent(resetExhibit, 6000 or 6000, exhibitPosition, item.uid)
 	end
 	return true
 end
 
-for index, value in pairs(exhibits) do
-	thaisExhibition:aid(index)
+for uniqueId, value in pairs(ThaisExhibitionConfig) do
+	thaisExhibition:uid(uniqueId)
 end
 
 thaisExhibition:register()

--- a/data-otservbr-global/startup/tables/lever.lua
+++ b/data-otservbr-global/startup/tables/lever.lua
@@ -189,5 +189,113 @@ LeverUnique = {
 	[30028] = {
 		itemId = 2772,
 		itemPos = {x = 32478, y = 31904, z = 3}
+	},
+	[Storage.ThaisExhibition.FriendshipAmulet] = {
+		itemId = 2772,
+		itemPos = { x = 32399, y = 32209, z = 9 }
+	},
+	[Storage.ThaisExhibition.HandPuppets] = {
+		itemId = 2772,
+		itemPos ={ x = 32412, y = 32204, z = 9 },
+	},
+	[Storage.ThaisExhibition.EpaminondasDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32414, y = 32201, z = 9 },
+	},
+	[Storage.ThaisExhibition.NorsemanDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32435, y = 32197, z = 9 },
+	},
+	[Storage.ThaisExhibition.BookwormDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32438, y = 32191, z = 9 },
+	},
+	[Storage.ThaisExhibition.GoldenNewspaper] = {
+		itemId = 2772,
+		itemPos = { x = 32430, y = 32191, z = 9 },
+	},
+	[Storage.ThaisExhibition.TibiacityEncyclopedia] = {
+		itemId = 2772,
+		itemPos = { x = 32404, y = 32195, z = 9 },
+	},
+	[Storage.ThaisExhibition.GoldenFalcon] = {
+		itemId = 2772,
+		itemPos = { x = 32399, y = 32200, z = 9 },
+	},
+	[Storage.ThaisExhibition.DragonGoblet] = {
+		itemId = 2772,
+		itemPos = { x = 32440, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.FerumbrasDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32456, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.FrozenHeart] = {
+		itemId = 2772,
+		itemPos = { x = 32468, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.DrakenDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32476, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.MusicBox] = {
+		itemId = 2772,
+		itemPos = { x = 32484, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.DurinTheAlmighty] = {
+		itemId = 2772,
+		itemPos = { x = 32496, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.DragonEye] = {
+		itemId = 2772,
+		itemPos = { x = 32512, y = 32201, z = 10 },
+	},
+	[Storage.ThaisExhibition.MemoryBox] = {
+		itemId = 2772,
+		itemPos = { x = 32517, y = 32197, z = 10 },
+	},
+	[Storage.ThaisExhibition.NobleSword] = {
+		itemId = 2772,
+		itemPos = { x = 32512, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.MedusaSkull] = {
+		itemId = 2772,
+		itemPos = { x = 32504, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.MathmasterShield] = {
+		itemId = 2772,
+		itemPos = { x = 32496, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.Imortus] = {
+		itemId = 2772,
+		itemPos = { x = 32489, y = 32197, z = 10 },
+	},
+	[Storage.ThaisExhibition.OldRadio] = {
+		itemId = 2772,
+		itemPos = { x = 32484, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.EpicWisdom] = {
+		itemId = 2772,
+		itemPos = { x = 32476, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.DreadDoll] = {
+		itemId = 2772,
+		itemPos = { x = 32468, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.PhoenixStatue] = {
+		itemId = 2772,
+		itemPos = { x = 32461, y = 32197, z = 10 },
+	},
+	[Storage.ThaisExhibition.OrcsJawShredder] = {
+		itemId = 2772,
+		itemPos = { x = 32456, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.BagOfOrientalSpices] = {
+		itemId = 2772,
+		itemPos = { x = 32448, y = 32191, z = 10 },
+	},
+	[Storage.ThaisExhibition.TibiorasBox] = {
+		itemId = 2772,
+		itemPos = { x = 32440, y = 32191, z = 10 },
 	}
 }


### PR DESCRIPTION
Fixed thais exhibition. 
Added the values to the storage to show that they are used and also helps cleaner code. 

Test: 
- Go down to thais exhibition and use levers. 

Will also fix quests doors that had identical action ids