### PR TITLE
fix: removing "error" message when using asuraMirror to teleport

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/the_secret_library/asura_mirror.lua
+++ b/data-otservbr-global/scripts/actions/quests/the_secret_library/asura_mirror.lua
@@ -14,6 +14,7 @@ function asuraMirror.onUse(creature, item, position, fromPosition, pos, target, 
     else
         player:sendCancelMessage('You do not have enough level.')
     end
+        return true
 end
 
 asuraMirror:aid(64019)

--- a/data-otservbr-global/scripts/actions/quests/the_secret_library/asura_mirror.lua
+++ b/data-otservbr-global/scripts/actions/quests/the_secret_library/asura_mirror.lua
@@ -14,7 +14,7 @@ function asuraMirror.onUse(creature, item, position, fromPosition, pos, target, 
     else
         player:sendCancelMessage('You do not have enough level.')
     end
-        return true
+    return true
 end
 
 asuraMirror:aid(64019)


### PR DESCRIPTION
 > fix: removing "error" message when using asuraMirror to teleport.

> When teleporting by asuraMirror you get this "error" message: "```You cannot use this object```".

```In fact, the teleport works like a charm... but this message shouldn't appear.```

* After this simple change, the message won't appear anymore!

> This is the mirror position: 32953, 32669, 7.

* Update data-otservbr-global/scripts/actions/quests/the_secret_library/asura_mirror.lua