### PR TITLE
fix: hireling conflicted with an existing npc

### DIFF
--- a/data-otservbr-global/npc/hireling.lua
+++ b/data-otservbr-global/npc/hireling.lua
@@ -1,5 +1,11 @@
 function createHirelingType(HirelingName)
 	local npcType = Game.createNpcType(HirelingName)
+
+	-- If it's a Hireling with a name like an npc, example "Hireling Canary", we'll remove the name "Hireling" and keep only the npc name for the look description
+	if string.match(HirelingName, "^Hireling%s%w+") then
+		HirelingName = string.sub(HirelingName, 10)
+	end
+
 	local npcConfig = {}
 
 	npcConfig.name = HirelingName

--- a/data/libs/hireling_lib.lua
+++ b/data/libs/hireling_lib.lua
@@ -342,10 +342,9 @@ end
 function Hireling:spawn()
 	self.active = 1
 	-- Creating new hireling with player choose name
-	createHirelingType(self:getName())
+	createHirelingType("Hireling " .. self:getName())
 
-	local npc = Npc(Game.generateNpc(self:getName()))
-	npc:setName(self:getName())
+	local npc = Npc(Game.generateNpc("Hireling " .. self:getName()))
 	local creature = Creature(npc)
 	creature:setOutfit(self:getOutfit())
 	npc:setSpeechBubble(7)


### PR DESCRIPTION
# Description

Creating a hireling with an existing NPC's name was a bug, conflicting lines and sometimes even their look type.

## Behaviour
### **Actual**

Creating a hireling with the name of an existing NPC will conflict.

### **Expected**

Now it's OK.

## Fixes #522

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
