### PR TITLE
fix: Morguthis teleport tomb access and poison field damage

### DIFF
--- a/data-otservbr-global/scripts/movements/quests/the_ancient_tombs/step_morguthis_blue_flames.lua
+++ b/data-otservbr-global/scripts/movements/quests/the_ancient_tombs/step_morguthis_blue_flames.lua
@@ -50,5 +50,6 @@ stepMorguthisBlueFlames:type("stepin")
 for index, value in pairs(setting) do
 	stepMorguthisBlueFlames:uid(index)
 end
+stepMorguthisBlueFlames:uid(50146)
 
 stepMorguthisBlueFlames:register()

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -2793,8 +2793,8 @@
 		<attribute key="type" value="magicfield"/>
 		<attribute key="field" value="poison">
 			<attribute key="ticks" value="5000"/>
-			<attribute key="damage" value="100"/>
 			<attribute key="start" value="5"/>
+			<attribute key="damage" value="100"/>
 		</attribute>
 		<attribute key="replaceable" value="0"/>
 	</item>


### PR DESCRIPTION
# Description

Resolves #583
Resolves #282
