### PR TITLE
feat: improve to loads all maps in custom folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,6 +377,9 @@ client_assertions.txt
 *.manifest
 *.otbm
 *.rar
+*-house.xml
+*-monster.xml
+*-npc.xml
 
 # SFTP for Sublime
 sftp-config.json

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -235,10 +235,8 @@ mapAuthor = "OpenTibiaBR"
 partyListMaxDistance = 30
 
 -- Custom Map
--- NOTE: mapCustomEnabled = activate the map, false = disable the map
+-- NOTE: toggleMapCustom set to true will load all maps in custom map folder
 toggleMapCustom = true
-mapCustomName = "otservbr-custom"
-mapCustomAuthor = "OpenTibiaBR"
 
 -- Market
 marketOfferDuration = 30 * 24 * 60 * 60

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -38,6 +38,10 @@
 #include "server/network/webhook/webhook.h"
 #include "protobuf/appearances.pb.h"
 
+#include <string>
+#include <iostream>
+#include <filesystem>
+
 Game::Game() {
 	offlineTrainingWindow.choices.emplace_back("Sword Fighting and Shielding", SKILL_SWORD);
 	offlineTrainingWindow.choices.emplace_back("Axe Fighting and Shielding", SKILL_AXE);
@@ -186,8 +190,12 @@ void Game::setGameState(GameState_t newState) {
 			map.spawnsNpc.startup();
 
 			// Load monsters and npcs custom stored by the "loadFromXML" function
-			map.spawnsMonsterCustom.startup();
-			map.spawnsNpcCustom.startup();
+			for (int i = 0; i < 50; i++) {
+					map.spawnsNpcCustomMaps[i].startup();
+			}
+			for (int i = 0; i < 50; i++) {
+					map.spawnsMonsterCustomMaps[i].startup();
+			}
 
 			raids.loadFromXml();
 			raids.startup();
@@ -305,11 +313,55 @@ bool Game::loadMainMap(const std::string &filename) {
 	return map.loadMap(g_configManager().getString(DATA_DIRECTORY) + "/world/" + filename + ".otbm", true, true, true, true);
 }
 
-bool Game::loadCustomMap(const std::string &filename) {
+bool Game::loadCustomMaps(const std::string &customMapPath) {
 	Monster::despawnRange = g_configManager().getNumber(DEFAULT_DESPAWNRANGE);
 	Monster::despawnRadius = g_configManager().getNumber(DEFAULT_DESPAWNRADIUS);
-	return map.loadMapCustom(g_configManager().getString(DATA_DIRECTORY) + "/world/custom/" + filename + ".otbm", true, true, true);
+
+	namespace fs =  std::filesystem;
+
+	int customMapIndex = 0;
+	for (const auto &entry : fs::directory_iterator(customMapPath)) {
+		const auto &realPath = entry.path();
+
+		if (realPath.extension() != ".otbm") {
+			continue;
+		}
+
+		std::string filename = realPath.stem().string();
+
+		//Do not load more maps than possible
+		if (customMapIndex >= 50) {
+			SPDLOG_WARN("Maximum number of custom maps loaded. Custom map {} [ignored]", filename);
+			continue;
+		}
+
+		// Filenames that start with a # are ignored.
+		if (filename.at(0) == '#') {
+			SPDLOG_INFO("Custom map {} [disabled]", filename);
+			continue;
+		}
+
+		//Avoid loading main map again.
+		if (filename == g_configManager().getString(MAP_NAME)) {
+			SPDLOG_WARN("Custom map {} is main map", filename);
+			continue;
+		}
+
+		SPDLOG_INFO("Loading custom map {}", filename);
+		if (!map.loadMapCustom(filename, true, true, true, customMapIndex)) {
+			SPDLOG_ERROR("Failed to load custom map {}", filename);
+			return false;
+		}
+		customMapIndex += 1;
+	}
+
+	// Must be done after all maps have been loaded
+	map.loadHouseInfo();
+
+	return true;
 }
+
+
 
 void Game::loadMap(const std::string &path, const Position &pos, bool unload) {
 	map.loadMap(path, false, false, false, false, pos, unload);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -38,10 +38,6 @@
 #include "server/network/webhook/webhook.h"
 #include "protobuf/appearances.pb.h"
 
-#include <string>
-#include <iostream>
-#include <filesystem>
-
 Game::Game() {
 	offlineTrainingWindow.choices.emplace_back("Sword Fighting and Shielding", SKILL_SWORD);
 	offlineTrainingWindow.choices.emplace_back("Axe Fighting and Shielding", SKILL_AXE);
@@ -192,8 +188,6 @@ void Game::setGameState(GameState_t newState) {
 			// Load monsters and npcs custom stored by the "loadFromXML" function
 			for (int i = 0; i < 50; i++) {
 					map.spawnsNpcCustomMaps[i].startup();
-			}
-			for (int i = 0; i < 50; i++) {
 					map.spawnsMonsterCustomMaps[i].startup();
 			}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -356,7 +356,6 @@ bool Game::loadCustomMaps(const std::string &customMapPath) {
 }
 
 
-
 void Game::loadMap(const std::string &path, const Position &pos, bool unload) {
 	map.loadMap(path, false, false, false, false, pos, unload);
 }

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -76,6 +76,7 @@ class Game {
 		 * \param filename Is the map custom name (Example: "map".otbm, not is necessary add extension .otbm)
 		 * \returns true if the custom map was loaded successfully
 		 */
+		bool loadCustomMaps(const std::string &customMapPath);
 		bool loadCustomMap(const std::string &filename);
 		void loadMap(const std::string &path, const Position &pos = Position(), bool unload = false);
 

--- a/src/io/iomap.h
+++ b/src/io/iomap.h
@@ -101,15 +101,14 @@ class IOMap {
 		 * \param map Is the map class
 		 * \returns true if the monsters spawn map custom was loaded successfully
 		 */
-		static bool loadMonstersCustom(Map* map) {
+		static bool loadMonstersCustom(Map* map, const std::string &mapName, int customMapIndex) {
 			if (map->monsterfile.empty()) {
 				// OTBM file doesn't tell us about the monsterfile,
 				// Lets guess it is mapname-monster.xml.
-				map->monsterfile = g_configManager().getString(MAP_CUSTOM_NAME);
+				map->monsterfile = mapName;
 				map->monsterfile += "-monster.xml";
 			}
-
-			return map->spawnsMonsterCustom.loadFromXML(map->monsterfile);
+			return map->spawnsMonsterCustomMaps[customMapIndex].loadFromXML(map->monsterfile);
 		}
 
 		/**
@@ -117,15 +116,15 @@ class IOMap {
 		 * \param map Is the map class
 		 * \returns true if the npcs spawn map custom was loaded successfully
 		 */
-		static bool loadNpcsCustom(Map* map) {
+		static bool loadNpcsCustom(Map* map, const std::string &mapName, int customMapIndex) {
 			if (map->npcfile.empty()) {
 				// OTBM file doesn't tell us about the npcfile,
 				// Lets guess it is mapname-npc.xml.
-				map->npcfile = g_configManager().getString(MAP_CUSTOM_NAME);
+				map->npcfile = mapName;
 				map->npcfile += "-npc.xml";
 			}
 
-			return map->spawnsNpcCustom.loadFromXml(map->npcfile);
+			return map->spawnsNpcCustomMaps[customMapIndex].loadFromXml(map->npcfile);
 		}
 
 		/**
@@ -133,15 +132,15 @@ class IOMap {
 		 * \param map Is the map class
 		 * \returns true if the map custom houses was loaded successfully
 		 */
-		static bool loadHousesCustom(Map* map) {
+		static bool loadHousesCustom(Map* map, const std::string &mapName, int customMapIndex) {
 			if (map->housefile.empty()) {
 				// OTBM file doesn't tell us about the housefile,
 				// Lets guess it is mapname-house.xml.
-				map->housefile = g_configManager().getString(MAP_CUSTOM_NAME);
+				map->housefile = mapName;
 				map->housefile += "-house.xml";
 			}
-
-			return map->housesCustom.loadHousesXML(map->housefile);
+			
+			return map->housesCustomMaps[customMapIndex].loadHousesXML(map->housefile);
 		}
 
 		const std::string &getLastErrorString() const {

--- a/src/io/iomap.h
+++ b/src/io/iomap.h
@@ -139,7 +139,6 @@ class IOMap {
 				map->housefile = mapName;
 				map->housefile += "-house.xml";
 			}
-			
 			return map->housesCustomMaps[customMapIndex].loadHousesXML(map->housefile);
 		}
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -99,32 +99,41 @@ bool Map::loadMap(const std::string &identifier, bool mainMap /*= false*/, bool 
 	return true;
 }
 
-bool Map::loadMapCustom(const std::string &identifier, bool loadHouses, bool loadMonsters, bool loadNpcs) {
+
+bool Map::loadMapCustom(const std::string &mapName, bool loadHouses, bool loadMonsters, bool loadNpcs, int customMapIndex) {
 	// Load the map
-	this->load(identifier, Position(0, 0, 0), true);
-	this->load(identifier);
+	std::string path = g_configManager().getString(DATA_DIRECTORY) + "/world/custom/" + mapName + ".otbm";
+	this->load(path, Position(0, 0, 0), true);
+	this->load(path);
 
 	if (loadMonsters) {
-		if (!IOMap::loadMonstersCustom(this)) {
+		if (!IOMap::loadMonstersCustom(this, mapName, customMapIndex)) {
 			SPDLOG_WARN("Failed to load monster custom data");
 		}
 	}
 
 	if (loadHouses) {
-		if (!IOMap::loadHousesCustom(this)) {
+		if (!IOMap::loadHousesCustom(this, mapName, customMapIndex)) {
 			SPDLOG_WARN("Failed to load house custom data");
 		}
-
-		IOMapSerialize::loadHouseInfo();
-		IOMapSerialize::loadHouseItems(this);
 	}
 
 	if (loadNpcs) {
-		if (!IOMap::loadNpcsCustom(this)) {
+		if (!IOMap::loadNpcsCustom(this, mapName, customMapIndex)) {
 			SPDLOG_WARN("Failed to load npc custom spawn data");
 		}
 	}
+
+	// Files need to be cleaned up or will try to load previous map files again
+	this->monsterfile.clear();
+	this->housefile.clear();
+	this->npcfile.clear();
 	return true;
+}
+
+void Map::loadHouseInfo() {
+	IOMapSerialize::loadHouseInfo();
+	IOMapSerialize::loadHouseItems(this);
 }
 
 bool Map::save() {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -190,7 +190,9 @@ class Map {
 		 * \param loadNpcs if true, the map custom npcs is loaded
 		 * \returns true if the custom map was loaded successfully
 		 */
-		bool loadMapCustom(const std::string &identifier, bool loadHouses, bool loadMonsters, bool loadNpcs);
+		bool loadMapCustom(const std::string &mapName, bool loadHouses, bool loadMonsters, bool loadNpcs, const int customMapIndex);
+
+		void loadHouseInfo();
 
 		/**
 		 * Save a map.
@@ -270,10 +272,10 @@ class Map {
 		Towns towns;
 		Houses houses;
 
-		// Storage made by "loadFromXML" of houses, monsters and npcs for custom map
-		SpawnsMonster spawnsMonsterCustom;
-		SpawnsNpc spawnsNpcCustom;
-		Houses housesCustom;
+		// Storage made by "loadFromXML" of houses, monsters and npcs for custom maps
+		SpawnsMonster spawnsMonsterCustomMaps[50];
+		SpawnsNpc spawnsNpcCustomMaps[50];
+		Houses housesCustomMaps[50];
 
 	private:
 		SpectatorCache spectatorCache;

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -309,19 +309,20 @@ void mainLoader(int, char*[], ServiceManager* services) {
 
 	SPDLOG_INFO("World type set as {}", asUpperCaseString(worldType));
 
-	SPDLOG_INFO("Loading map...");
+	SPDLOG_INFO("Loading main map...");
 	if (!g_game().loadMainMap(g_configManager().getString(MAP_NAME))) {
-		SPDLOG_ERROR("Failed to load map");
+		SPDLOG_ERROR("Failed to load main map");
 		startupErrorMessage();
 	}
 
 	// If "mapCustomEnabled" is true on config.lua, then load the custom map
 	if (g_configManager().getBoolean(TOGGLE_MAP_CUSTOM)) {
-		SPDLOG_INFO("Loading custom map...");
-		if (!g_game().loadCustomMap(g_configManager().getString(MAP_CUSTOM_NAME))) {
-			SPDLOG_ERROR("Failed to load custom map");
+		SPDLOG_INFO("Loading custom maps...");
+		std::string customMapPath = g_configManager().getString(DATA_DIRECTORY) + "/world/custom/";
+		if (!g_game().loadCustomMaps(customMapPath)) {
+			SPDLOG_ERROR("Failed to load custom maps");
 			startupErrorMessage();
-		}
+		}	
 	}
 
 	SPDLOG_INFO("Initializing gamestate...");

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -322,7 +322,7 @@ void mainLoader(int, char*[], ServiceManager* services) {
 		if (!g_game().loadCustomMaps(customMapPath)) {
 			SPDLOG_ERROR("Failed to load custom maps");
 			startupErrorMessage();
-		}	
+		}
 	}
 
 	SPDLOG_INFO("Initializing gamestate...");

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -52,4 +52,8 @@
 #include <pugixml.hpp>
 #include <zlib.h>
 
+#include <string>
+#include <iostream>
+#include <filesystem>
+
 #endif // SRC_PCH_HPP_

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -54,6 +54,5 @@
 
 #include <string>
 #include <iostream>
-#include <filesystem>
 
 #endif // SRC_PCH_HPP_


### PR DESCRIPTION
Update to load all maps in custom maps folder instead of only the one specified. Loads maximum 50 custom maps.
Removed old configuration and kept the toggle for loading custom maps or not.

Added house, monster and npc xml files to gitignore to avoid pushing these if not intended.