### PR TITLE
fix: crash related to invalid boss race id

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6847,6 +6847,7 @@ void ProtocolGame::parseSendBosstiarySlots() {
 	msg.addByte(isSlotOneUnlocked ? 1 : 0);
 	msg.add<uint32_t>(isSlotOneUnlocked ? bossIdSlotOne : 0);
 	if (isSlotOneUnlocked && bossIdSlotOne != 0) {
+		const MonsterType* mType = g_ioBosstiary().getMonsterTypeByBossRaceId(bossIdSlotOne);
 		if (mType) {
 			// Variables Boss Slot One
 			auto bossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
@@ -6916,8 +6917,8 @@ void ProtocolGame::parseSendBosstiarySlots() {
 		if (mType) {
 			auto boostedBossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
 			auto boostedBossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(boostedBossId));
-			auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(ConfigManager::BOOSTED_BOSS_LOOT_BONUS));
-			auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(ConfigManager::BOOSTED_BOSS_KILL_BONUS));
+			auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(BOOSTED_BOSS_LOOT_BONUS));
+			auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(BOOSTED_BOSS_KILL_BONUS));
 			msg.addByte(boostedBossRace); // Boss Race
 			msg.add<uint32_t>(boostedBossKillCount); // Kill Count
 			msg.add<uint16_t>(boostedLootBonus); // Loot Bonus

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -84,7 +84,7 @@ namespace {
 	}
 
 	// Send bytes function for avoid repetitions
-	void sendBosstiarySlotsBytes(NetworkMessage &msg, uint8_t bossRace = 0, uint32_t bossKillCount = 0, uint16_t bonusBossSlotOne = 0, uint32_t killBonus = 0, bool isSlotOneInactive = 0, uint32_t removePrice = 0) {
+	void sendBosstiarySlotsBytes(NetworkMessage &msg, uint8_t bossRace = 0, uint32_t bossKillCount = 0, uint16_t bonusBossSlotOne = 0, uint32_t killBonus = 0, uint8_t isSlotOneInactive = 0, uint32_t removePrice = 0) {
 		msg.addByte(bossRace); // Boss Race
 		msg.add<uint32_t>(bossKillCount); // Kill Count
 		msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus
@@ -6905,8 +6905,9 @@ void ProtocolGame::parseSendBosstiarySlots() {
 			auto boostedBossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
 			auto boostedBossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(boostedBossId));
 			auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(BOOSTED_BOSS_LOOT_BONUS));
+			auto bosstiaryMultiplier = static_cast<uint8_t>(g_configManager().getNumber(BOSSTIARY_KILL_MULTIPLIER));
 			auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(BOOSTED_BOSS_KILL_BONUS));
-			sendBosstiarySlotsBytes(msg, boostedBossRace, boostedBossKillCount, boostedLootBonus, boostedKillBonus, 0, 0);
+			sendBosstiarySlotsBytes(msg, boostedBossRace, boostedBossKillCount, boostedLootBonus, bosstiaryMultiplier + boostedKillBonus, 0, 0);
 		} else {
 			sendBosstiarySlotsBytes(msg);
 		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -84,7 +84,7 @@ namespace {
 	}
 
 	// Send bytes function for avoid repetitions
-	void sendBosstiarySlotsBytes(NetworkMessage &msg, uint8_t bossRace = 0, uint32_t bossKillCount = 0, uint16_t bonusBossSlotOne = 0, uint32_t killBonus = 0, uint8_t isSlotOneInactive = 0, uint32_t removePrice = 0) {
+	void sendBosstiarySlotsBytes(NetworkMessage &msg, uint8_t bossRace = 0, uint32_t bossKillCount = 0, uint16_t bonusBossSlotOne = 0, uint8_t killBonus = 0, uint8_t isSlotOneInactive = 0, uint32_t removePrice = 0) {
 		msg.addByte(bossRace); // Boss Race
 		msg.add<uint32_t>(bossKillCount); // Kill Count
 		msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6847,22 +6847,31 @@ void ProtocolGame::parseSendBosstiarySlots() {
 	msg.addByte(isSlotOneUnlocked ? 1 : 0);
 	msg.add<uint32_t>(isSlotOneUnlocked ? bossIdSlotOne : 0);
 	if (isSlotOneUnlocked && bossIdSlotOne != 0) {
-		// Variables Boss Slot One
-		const MonsterType* mType = g_ioBosstiary().getMonsterTypeByBossRaceId(bossIdSlotOne);
-		auto bossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
-		auto bossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(bossIdSlotOne));
-		auto slotOneBossLevel = g_ioBosstiary().getBossCurrentLevel(player, bossIdSlotOne);
-		uint16_t bonusBossSlotOne = currentBonus + (slotOneBossLevel == 3 ? 25 : 0);
-		uint8_t isSlotOneInactive = bossIdSlotOne == boostedBossId ? 1 : 0;
-		// Bytes Slot One
-		msg.addByte(bossRace); // Boss Race
-		msg.add<uint32_t>(bossKillCount); // Kill Count
-		msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus
-		msg.addByte(0); // Kill Bonus
-		msg.addByte(bossRace); // Boss Race
-		msg.add<uint32_t>(isSlotOneInactive == 1 ? 0 : removePrice); // Remove Price
-		msg.addByte(isSlotOneInactive); // Inactive? (Only true if equal to Boosted Boss)
-		bossesUnlockedSize--;
+		if (mType) {
+			// Variables Boss Slot One
+			auto bossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
+			auto bossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(bossIdSlotOne));
+			auto slotOneBossLevel = g_ioBosstiary().getBossCurrentLevel(player, bossIdSlotOne);
+			uint16_t bonusBossSlotOne = currentBonus + (slotOneBossLevel == 3 ? 25 : 0);
+			uint8_t isSlotOneInactive = bossIdSlotOne == boostedBossId ? 1 : 0;
+			// Bytes Slot One
+			msg.addByte(bossRace); // Boss Race
+			msg.add<uint32_t>(bossKillCount); // Kill Count
+			msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus
+			msg.addByte(0); // Kill Bonus
+			msg.addByte(bossRace); // Boss Race
+			msg.add<uint32_t>(isSlotOneInactive == 1 ? 0 : removePrice); // Remove Price
+			msg.addByte(isSlotOneInactive); // Inactive? (Only true if equal to Boosted Boss)
+			bossesUnlockedSize--;
+		} else {
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Kill Count
+			msg.add<uint16_t>(0); // Loot Bonus
+			msg.addByte(0); // Kill Bonus
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Remove Price
+			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+		}
 	}
 
 	uint32_t slotTwoPoints = 1500;
@@ -6872,20 +6881,30 @@ void ProtocolGame::parseSendBosstiarySlots() {
 	if (isSlotTwoUnlocked && bossIdSlotTwo != 0) {
 		// Variables Boss Slot Two
 		const MonsterType* mType = g_ioBosstiary().getMonsterTypeByBossRaceId(bossIdSlotTwo);
-		auto bossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
-		auto bossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(bossIdSlotTwo));
-		auto slotTwoBossLevel = g_ioBosstiary().getBossCurrentLevel(player, bossIdSlotTwo);
-		uint16_t bonusBossSlotTwo = currentBonus + (slotTwoBossLevel == 3 ? 25 : 0);
-		uint8_t isSlotTwoInactive = bossIdSlotTwo == boostedBossId ? 1 : 0;
-		// Bytes Slot Two
-		msg.addByte(bossRace); // Boss Race
-		msg.add<uint32_t>(bossKillCount); // Kill Count
-		msg.add<uint16_t>(bonusBossSlotTwo); // Loot Bonus
-		msg.addByte(0); // Kill Bonus
-		msg.addByte(bossRace); // Boss Race
-		msg.add<uint32_t>(isSlotTwoInactive == 1 ? 0 : removePrice); // Remove Price
-		msg.addByte(isSlotTwoInactive); // Inactive? (Only true if equal to Boosted Boss)
-		bossesUnlockedSize--;
+		if (mType) {
+			auto bossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
+			auto bossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(bossIdSlotTwo));
+			auto slotTwoBossLevel = g_ioBosstiary().getBossCurrentLevel(player, bossIdSlotTwo);
+			uint16_t bonusBossSlotTwo = currentBonus + (slotTwoBossLevel == 3 ? 25 : 0);
+			uint8_t isSlotTwoInactive = bossIdSlotTwo == boostedBossId ? 1 : 0;
+			// Bytes Slot Two
+			msg.addByte(bossRace); // Boss Race
+			msg.add<uint32_t>(bossKillCount); // Kill Count
+			msg.add<uint16_t>(bonusBossSlotTwo); // Loot Bonus
+			msg.addByte(0); // Kill Bonus
+			msg.addByte(bossRace); // Boss Race
+			msg.add<uint32_t>(isSlotTwoInactive == 1 ? 0 : removePrice); // Remove Price
+			msg.addByte(isSlotTwoInactive); // Inactive? (Only true if equal to Boosted Boss)
+			bossesUnlockedSize--;
+		} else {
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Kill Count
+			msg.add<uint16_t>(0); // Loot Bonus
+			msg.addByte(0); // Kill Bonus
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Remove Price
+			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+		}
 	}
 
 	bool isTodaySlotUnlocked = g_configManager().getBoolean(BOOSTED_BOSS_SLOT);
@@ -6894,18 +6913,27 @@ void ProtocolGame::parseSendBosstiarySlots() {
 	if (isTodaySlotUnlocked && boostedBossId != 0) {
 		std::string boostedBossName = g_ioBosstiary().getBoostedBossName();
 		const MonsterType* mType = g_monsters().getMonsterType(boostedBossName);
-		auto boostedBossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
-		auto boostedBossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(boostedBossId));
-		auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(BOOSTED_BOSS_LOOT_BONUS));
-		auto bosstiaryMultiplier = static_cast<uint8_t>(g_configManager().getNumber(BOSSTIARY_KILL_MULTIPLIER));
-		auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(BOOSTED_BOSS_KILL_BONUS));
-		msg.addByte(boostedBossRace); // Boss Race
-		msg.add<uint32_t>(boostedBossKillCount); // Kill Count
-		msg.add<uint16_t>(boostedLootBonus); // Loot Bonus
-		msg.addByte(bosstiaryMultiplier + boostedKillBonus); // Kill Bonus
-		msg.addByte(boostedBossRace); // Boss Race
-		msg.add<uint32_t>(0); // Remove Price
-		msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+		if (mType) {
+			auto boostedBossRace = magic_enum::enum_integer<BosstiaryRarity_t>(mType->info.bosstiaryRace);
+			auto boostedBossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(boostedBossId));
+			auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(ConfigManager::BOOSTED_BOSS_LOOT_BONUS));
+			auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(ConfigManager::BOOSTED_BOSS_KILL_BONUS));
+			msg.addByte(boostedBossRace); // Boss Race
+			msg.add<uint32_t>(boostedBossKillCount); // Kill Count
+			msg.add<uint16_t>(boostedLootBonus); // Loot Bonus
+			msg.addByte(boostedKillBonus); // Kill Bonus
+			msg.addByte(boostedBossRace); // Boss Race
+			msg.add<uint32_t>(0); // Remove Price
+			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+		} else {
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Kill Count
+			msg.add<uint16_t>(0); // Loot Bonus
+			msg.addByte(0); // Kill Bonus
+			msg.addByte(0); // Boss Race
+			msg.add<uint32_t>(0); // Remove Price
+			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+		}
 	}
 
 	msg.addByte(bossesUnlockedSize != 0 ? 1 : 0);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -83,6 +83,17 @@ namespace {
 		}
 	}
 
+	// Send bytes function for avoid repetitions
+	void sendBosstiarySlotsBytes(NetworkMessage &msg, uint8_t bossRace = 0, uint32_t bossKillCount = 0, uint16_t bonusBossSlotOne = 0, uint32_t killBonus = 0, bool isSlotOneInactive = 0, uint32_t removePrice = 0) {
+		msg.addByte(bossRace); // Boss Race
+		msg.add<uint32_t>(bossKillCount); // Kill Count
+		msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus
+		msg.addByte(killBonus); // Kill Bonus
+		msg.addByte(bossRace); // Boss Race
+		msg.add<uint32_t>(isSlotOneInactive == 1 ? 0 : removePrice); // Remove Price
+		msg.addByte(isSlotOneInactive); // Inactive? (Only true if equal to Boosted Boss)
+	}
+
 } // namespace
 
 ProtocolGame::ProtocolGame(Connection_ptr initConnection) :
@@ -6856,22 +6867,10 @@ void ProtocolGame::parseSendBosstiarySlots() {
 			uint16_t bonusBossSlotOne = currentBonus + (slotOneBossLevel == 3 ? 25 : 0);
 			uint8_t isSlotOneInactive = bossIdSlotOne == boostedBossId ? 1 : 0;
 			// Bytes Slot One
-			msg.addByte(bossRace); // Boss Race
-			msg.add<uint32_t>(bossKillCount); // Kill Count
-			msg.add<uint16_t>(bonusBossSlotOne); // Loot Bonus
-			msg.addByte(0); // Kill Bonus
-			msg.addByte(bossRace); // Boss Race
-			msg.add<uint32_t>(isSlotOneInactive == 1 ? 0 : removePrice); // Remove Price
-			msg.addByte(isSlotOneInactive); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg, bossRace, bossKillCount, bonusBossSlotOne, 0, isSlotOneInactive, removePrice);
 			bossesUnlockedSize--;
 		} else {
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Kill Count
-			msg.add<uint16_t>(0); // Loot Bonus
-			msg.addByte(0); // Kill Bonus
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Remove Price
-			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg);
 		}
 	}
 
@@ -6889,22 +6888,10 @@ void ProtocolGame::parseSendBosstiarySlots() {
 			uint16_t bonusBossSlotTwo = currentBonus + (slotTwoBossLevel == 3 ? 25 : 0);
 			uint8_t isSlotTwoInactive = bossIdSlotTwo == boostedBossId ? 1 : 0;
 			// Bytes Slot Two
-			msg.addByte(bossRace); // Boss Race
-			msg.add<uint32_t>(bossKillCount); // Kill Count
-			msg.add<uint16_t>(bonusBossSlotTwo); // Loot Bonus
-			msg.addByte(0); // Kill Bonus
-			msg.addByte(bossRace); // Boss Race
-			msg.add<uint32_t>(isSlotTwoInactive == 1 ? 0 : removePrice); // Remove Price
-			msg.addByte(isSlotTwoInactive); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg, bossRace, bossKillCount, bonusBossSlotTwo, 0, isSlotTwoInactive, removePrice);
 			bossesUnlockedSize--;
 		} else {
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Kill Count
-			msg.add<uint16_t>(0); // Loot Bonus
-			msg.addByte(0); // Kill Bonus
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Remove Price
-			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg);
 		}
 	}
 
@@ -6919,21 +6906,9 @@ void ProtocolGame::parseSendBosstiarySlots() {
 			auto boostedBossKillCount = player->getBestiaryKillCount(static_cast<uint16_t>(boostedBossId));
 			auto boostedLootBonus = static_cast<uint16_t>(g_configManager().getNumber(BOOSTED_BOSS_LOOT_BONUS));
 			auto boostedKillBonus = static_cast<uint8_t>(g_configManager().getNumber(BOOSTED_BOSS_KILL_BONUS));
-			msg.addByte(boostedBossRace); // Boss Race
-			msg.add<uint32_t>(boostedBossKillCount); // Kill Count
-			msg.add<uint16_t>(boostedLootBonus); // Loot Bonus
-			msg.addByte(boostedKillBonus); // Kill Bonus
-			msg.addByte(boostedBossRace); // Boss Race
-			msg.add<uint32_t>(0); // Remove Price
-			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg, boostedBossRace, boostedBossKillCount, boostedLootBonus, boostedKillBonus, 0, 0);
 		} else {
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Kill Count
-			msg.add<uint16_t>(0); // Loot Bonus
-			msg.addByte(0); // Kill Bonus
-			msg.addByte(0); // Boss Race
-			msg.add<uint32_t>(0); // Remove Price
-			msg.addByte(0); // Inactive? (Only true if equal to Boosted Boss)
+			sendBosstiarySlotsBytes(msg);
 		}
 	}
 


### PR DESCRIPTION
# Description
It happened in a very specific scenario, for example the wrong edited assets or a monster with an invalid race id in the script.
Additional improve: extracted code in a function to avoid code repetition.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
 