### PR TITLE
fix: gamestore exhaustion

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -223,11 +223,6 @@ function onRecvbyte(player, msg, byte)
 		return player:sendCancelMessage("Store don't have offers for rookgaard citizen.")
 	end
 
-	if player:isUIExhausted(250) then
-		player:sendCancelMessage("You are exhausted.")
-		return false
-	end
-
 	if byte == GameStore.RecivedPackets.C_StoreEvent then
 	elseif byte == GameStore.RecivedPackets.C_TransferCoins then
 		parseTransferCoins(player:getId(), msg)
@@ -241,6 +236,11 @@ function onRecvbyte(player, msg, byte)
 		parseOpenTransactionHistory(player:getId(), msg)
 	elseif byte == GameStore.RecivedPackets.C_RequestTransactionHistory then
 		parseRequestTransactionHistory(player:getId(), msg)
+	end
+	
+	if player:isUIExhausted(250) then
+		player:sendCancelMessage("You are exhausted.")
+		return false
 	end
 
 	player:updateUIExhausted()

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -237,7 +237,7 @@ function onRecvbyte(player, msg, byte)
 	elseif byte == GameStore.RecivedPackets.C_RequestTransactionHistory then
 		parseRequestTransactionHistory(player:getId(), msg)
 	end
-	
+
 	if player:isUIExhausted(250) then
 		player:sendCancelMessage("You are exhausted.")
 		return false


### PR DESCRIPTION
# Description

Added exhaustion when interacting with store buttons.

## Behaviour
### **Actual**

There is exhaution only when opening the store and transferring coins.

### **Expected**

Exhaustion in all actions, as some other buttons generate a large load of information, such as "parseRequestStoreOffers", thus preventing someone from abusing this to generate a freeze on the server.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
