### PR TITLE
fix: crash related to load custom maps with canary datapack

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -313,6 +313,13 @@ bool Game::loadCustomMaps(const std::string &customMapPath) {
 
 	namespace fs = std::filesystem;
 
+	if (!fs::exists(customMapPath)) {
+		if (!fs::create_directory(customMapPath)) {
+			SPDLOG_ERROR("Failed to create custom map directory {}", customMapPath);
+			return false;
+		}
+	}
+
 	int customMapIndex = 0;
 	for (const auto &entry : fs::directory_iterator(customMapPath)) {
 		const auto &realPath = entry.path();
@@ -346,7 +353,7 @@ bool Game::loadCustomMaps(const std::string &customMapPath) {
 			SPDLOG_ERROR("Failed to load custom map {}", filename);
 			return false;
 		}
-		customMapIndex += 1;
+		customMapIndex++;
 	}
 
 	// Must be done after all maps have been loaded


### PR DESCRIPTION
# Description
The canary doesn't have the custom folder, so it crash when trying to read the directory
