### PR TITLE
improve: init lua environment in the otserv.cpp

### DIFF
--- a/src/lua/scripts/luascript.cpp
+++ b/src/lua/scripts/luascript.cpp
@@ -21,9 +21,6 @@ int32_t LuaFunctionsLoader::scriptEnvIndex = -1;
 
 LuaScriptInterface::LuaScriptInterface(std::string initInterfaceName) :
 	interfaceName(std::move(initInterfaceName)) {
-	if (!g_luaEnvironment.getLuaState()) {
-		g_luaEnvironment.initState();
-	}
 }
 
 LuaScriptInterface::~LuaScriptInterface() {

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -161,6 +161,11 @@ void loadModules() {
 		SPDLOG_INFO("No tables were optimized");
 	}
 
+	SPDLOG_INFO("Initializing lua environment...");
+	if (!g_luaEnvironment.getLuaState()) {
+		g_luaEnvironment.initState();
+	}
+
 	// Core start
 	auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
 	modulesLoadHelper((g_game().loadAppearanceProtobuf(coreFolder + "/items/appearances.dat") == ERROR_NONE), "appearances.dat");


### PR DESCRIPTION
# Description

When there is an error inside the lua environment, for example, crash, the distro closes quickly, without giving time to debug or react with the console, in this way, the lua environment will be initialized during the distro load, facilitating debugging and improving how it is initialized.