### PR TITLE
fix: give party leader dust and share regardless of damage

### DIFF
--- a/data/libs/forge_lib.lua
+++ b/data/libs/forge_lib.lua
@@ -59,14 +59,14 @@ function ForgeMonster:onDeath(creature, corpse, killer, mostDamageKiller, unjust
 		end
 
 		if party and party:isSharedExperienceEnabled() then
-			local killers = {}
+			local killers = {party:getLeader()}
 			local partyMembers = party:getMembers()
 
-			for pid, _ in pairs(creature:getDamageMap()) do
-				local creatureKiller = Creature(pid)
-				if creatureKiller and creatureKiller:isPlayer() then
-					if not isInArray(killers, creatureKiller) and isInArray(partyMembers, creatureKiller) then
-						table.insert(killers, creatureKiller)
+			for i = 1, #partyMembers do
+				local member = partyMembers[i]
+				if member and member:isPlayer() then
+					if not isInArray(killers, member) then
+						table.insert(killers, member)
 					end
 				end
 			end


### PR DESCRIPTION
# Description

Add party leader to list of dust-receiving characters, and loop over members instead of killers.

## Behaviour
### **Actual**

Killing a forge creature while party sharing is active wasn't giving dust to the party leader.

### **Expected**

From wiki: 
>  Each such party member gets the same amount of Dust a single player would get if they killed the creature by themselves, without being in a party. In other words, there is no downside to "sharing" Dust in this manner.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - Tried killing forge creatures while not in a party
  - Killed forge creatrues in a party (active share and inactive) with 2 and 3 players

**Test Configuration**:

  - Server Version: latest main
  - Client: 13.16
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
