### PR TITLE
fix: warning in the distro at creature dead with corpse id 0

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -764,8 +764,12 @@ bool Creature::hasBeenAttacked(uint32_t attackerId) {
 	return (OTSYS_TIME() - it->second.ticks) <= g_configManager().getNumber(PZ_LOCKED);
 }
 
-Item* Creature::getCorpse(Creature*, Creature*) {
-	return Item::CreateItem(getLookCorpse());
+Item* Creature::getCorpse(Creature*, Creature*)
+{
+	if (getLookCorpse() != 0) {
+		return Item::CreateItem(getLookCorpse());
+	}
+	return nullptr;
 }
 
 void Creature::changeHealth(int32_t healthChange, bool sendHealthChange /* = true*/) {

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -764,8 +764,7 @@ bool Creature::hasBeenAttacked(uint32_t attackerId) {
 	return (OTSYS_TIME() - it->second.ticks) <= g_configManager().getNumber(PZ_LOCKED);
 }
 
-Item* Creature::getCorpse(Creature*, Creature*)
-{
+Item* Creature::getCorpse(Creature*, Creature*) {
 	if (getLookCorpse() != 0) {
 		return Item::CreateItem(getLookCorpse());
 	}


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/8551443/234751517-7e95b46b-b498-47ae-8453-f5f7f561dbb8.png)

## Behaviour
### **Actual**

Sends a warning if the creature has no corpse.

### **Expected**

No send warning.
