### PR TITLE
improve: update bosstiary cooldown time at monster creation

### DIFF
--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -301,7 +301,7 @@ class Monster final : public Creature {
 		time_t getTimeToChangeFiendish() const {
 			return timeToChangeFiendish;
 		}
-	
+
 		MonsterType* getMonsterType() const {
 			return mType;
 		}

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -301,6 +301,10 @@ class Monster final : public Creature {
 		time_t getTimeToChangeFiendish() const {
 			return timeToChangeFiendish;
 		}
+	
+		MonsterType* getMonsterType() const {
+			return mType;
+		}
 
 		void clearFiendishStatus();
 		bool canDropLoot() const;


### PR DESCRIPTION
Sends the information to the bosstiary cooldown window so that the time is updated.