### PR TITLE
fix: shop debug on client 13.16

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4043,7 +4043,6 @@ void ProtocolGame::sendSaleItemList(const std::vector<ShopBlock> &shopVector, co
 
 		it = inventoryMap.find(shopBlock.itemId);
 		if (it != inventoryMap.end()) {
-			itemsToSend++;
 			msg.add<uint16_t>(shopBlock.itemId);
 			if (oldProtocol) {
 				msg.addByte(static_cast<uint8_t>(std::min<uint16_t>(it->second, std::numeric_limits<uint8_t>::max())));


### PR DESCRIPTION
# Description

Removed duplicate iteration of itemsToSend (fix npc shop debug)

## Behaviour
### **Actual**

Debug on request player items to send for npc shop.

### **Expected**

No debug.

### Fixes #1041

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
