### PR TITLE
[crashes server - do not use] feat: collect all from reward chest

### DIFF
--- a/data/modules/modules.xml
+++ b/data/modules/modules.xml
@@ -27,4 +27,7 @@
 	<!-- Hireling Outfit Helper -->
 	<module type="recvbyte" byte="211" script="hirelings/hireling_module.lua" />
 
+	<!-- Collect All -->
+	<module type="recvbyte" byte="255" script="collect_all/init.lua"/>
+
 </modules>

--- a/data/modules/scripts/collect_all/init.lua
+++ b/data/modules/scripts/collect_all/init.lua
@@ -1,0 +1,9 @@
+function onRecvbyte(player, msg, byte)
+	local rewards = player:getRewardList()
+	for i = 1, #rewards do
+		local container = player:getReward(rewards[i])
+		if(container) then
+			player:lootContainer(container)
+		end
+	end
+end

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6891,6 +6891,10 @@ void Player::closeAllExternalContainers() {
 	}
 }
 
+void Player::lootContainer(Container *container) {
+	g_game().internalQuickLootCorpse(this, container);
+}
+
 /*******************************************************************************
  * Interfaces
  ******************************************************************************/

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6891,7 +6891,7 @@ void Player::closeAllExternalContainers() {
 	}
 }
 
-void Player::lootContainer(Container *container) {
+void Player::lootContainer(Container* container) {
 	g_game().internalQuickLootCorpse(this, container);
 }
 

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2290,6 +2290,8 @@ class Player final : public Creature, public Cylinder {
 			}
 		}
 
+		void lootContainer(Container* container);
+
 	private:
 		static uint32_t playerFirstID;
 		static uint32_t playerLastID;

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -3334,3 +3334,23 @@ int PlayerFunctions::luaPlayerGetBossBonus(lua_State* L) {
 	lua_pushnumber(L, static_cast<lua_Number>(bonusBoss));
 	return 1;
 }
+
+int PlayerFunctions::luaPlayerLootContainer(lua_State* L) {
+	// player:lootContainer(container)
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	Container* container = getUserdata<Container>(L, 2);
+	if (!container) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	player->lootContainer(container);
+	pushBoolean(L, true);
+
+	return 1;
+}

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -296,6 +296,8 @@ class PlayerFunctions final : LuaScriptInterface {
 			registerMethod(L, "Player", "getBossBonus", PlayerFunctions::luaPlayerGetBossBonus);
 			registerMethod(L, "Player", "sendBosstiaryCooldownTimer", PlayerFunctions::luaPlayerBosstiaryCooldownTimer);
 
+			registerMethod(L, "Player", "lootContainer", PlayerFunctions::luaPlayerLootContainer);
+
 			GroupFunctions::init(L);
 			GuildFunctions::init(L);
 			MountFunctions::init(L);
@@ -582,6 +584,9 @@ class PlayerFunctions final : LuaScriptInterface {
 		static int luaPlayerGetSlotBossId(lua_State* L);
 		static int luaPlayerGetBossBonus(lua_State* L);
 		static int luaPlayerBosstiaryCooldownTimer(lua_State* L);
+
+		static int luaPlayerLootContainer(lua_State* L);
+
 
 		friend class CreatureFunctions;
 };

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -587,7 +587,6 @@ class PlayerFunctions final : LuaScriptInterface {
 
 		static int luaPlayerLootContainer(lua_State* L);
 
-
 		friend class CreatureFunctions;
 };
 


### PR DESCRIPTION
# Description

Simple script (and engine changes to support it) to enable "Collect all" from the reward chest context menu available in the new protocol.

## Type of change
   - [x] New feature (non-breaking change which adds functionality)
 
## How Has This Been Tested

  - Tried it out with many different bosses locally.
  - Filling in all inventory
  - With and without items on the loot list
  - With the maxiumum amount of reward bags
  - Into regular containers and also loot pouch

**Test Configuration**:

  - Server Version: 
  - Client: 13.16
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
