### PR TITLE
fix: emote spells validation and storage conflict

### DIFF
--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -85,7 +85,8 @@ Storage = {
 	GhostShipQuest = 30005,
 	OrcKingGreeting = 30006,
 	MarkwinGreeting = 30007,
-	-- empty = 30008
+	-- EmoteSpells Storage cannot be changed, it is set in source code
+	EmoteSpells = 30008,
 	WagonTicket = 30009,
 	BloodHerbQuest = 30010,
 	firstMageWeapon = 30011,

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5071,7 +5071,7 @@ bool Game::playerSaySpell(Player* player, SpeakClasses type, const std::string &
 			player->cancelPush();
 		}
 
-		if (g_configManager().getBoolean(EMOTE_SPELLS)) {
+		if (g_configManager().getBoolean(EMOTE_SPELLS) && player->getStorageValue(STORAGEVALUE_EMOTE) == 1) {
 			return internalCreatureSay(player, TALKTYPE_MONSTER_SAY, words, false);
 		} else {
 			return player->saySpell(type, words, false);

--- a/src/utils/const.hpp
+++ b/src/utils/const.hpp
@@ -26,8 +26,8 @@ static constexpr int32_t CHANNEL_PRIVATE = 0xFFFF;
 static constexpr int32_t EVENT_IMBUEMENT_INTERVAL = 1000;
 static constexpr uint8_t IMBUEMENT_MAX_TIER = 3;
 
+static constexpr int32_t STORAGEVALUE_EMOTE = 30008;
 static constexpr int32_t STORAGEVALUE_PROMOTION = 30018;
-static constexpr int32_t STORAGEVALUE_EMOTE = 30019;
 static constexpr int32_t STORAGEVALUE_PODIUM = 30020;
 static constexpr int32_t STORAGEVALUE_DAILYREWARD = 14898;
 static constexpr int32_t STORAGEVALUE_BESTIARYKILLCOUNT = 61305000; // Can get up to 2000 storages!


### PR DESCRIPTION
# Description

Adjusted function to show or not the spells emoted, set by the player.

before:
![image](https://user-images.githubusercontent.com/7812282/236506286-27ca364b-9568-4ec3-b1a3-1926b63057c0.png)

after:
![](https://user-images.githubusercontent.com/7812282/236504180-1925145b-feaa-4f7a-b5aa-29ede9e945d0.png)
![](https://user-images.githubusercontent.com/7812282/236504215-f4000f2d-deea-4323-b16a-328951d44a58.png)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

**Test Configuration**:

  - Server Version: Canary
  - Client: 13.16
  - Operating System: Ubuntu 22.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
