### PR TITLE
fix: add player skill wrong displaying to client

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6637,16 +6637,16 @@ void ProtocolGame::AddPlayerSkills(NetworkMessage &msg) {
 			msg.addByte(std::min<uint8_t>(100, static_cast<uint8_t>(player->getSkillPercent(i))));
 		}
 	} else {
-		msg.add<uint16_t>(static_cast<uint16_t>(std::min<uint32_t>(player->getMagicLevel(), std::numeric_limits<uint16_t>::max())));
-		msg.add<uint16_t>(static_cast<uint16_t>(std::min<uint32_t>(player->getBaseMagicLevel(), std::numeric_limits<uint16_t>::max())));
-		msg.add<uint16_t>(static_cast<uint16_t>(std::min<uint32_t>(player->getBaseMagicLevel(), std::numeric_limits<uint16_t>::max())));
-		msg.add<uint16_t>(std::min<uint16_t>(static_cast<uint16_t>(player->getMagicLevelPercent()), 100));
+		msg.add<uint16_t>(player->getMagicLevel());
+		msg.add<uint16_t>(player->getBaseMagicLevel());
+		msg.add<uint16_t>(player->getBaseMagicLevel()); // Loyalty Bonus
+		msg.add<uint16_t>(player->getMagicLevelPercent() * 100);
 
 		for (uint8_t i = SKILL_FIRST; i <= SKILL_FISHING; ++i) {
-			msg.add<uint16_t>(player->getSkillLevel(i));
+			msg.add<uint16_t>(std::min<int32_t>(player->getSkillLevel(i), std::numeric_limits<uint16_t>::max()));
 			msg.add<uint16_t>(player->getBaseSkill(i));
-			msg.add<uint16_t>(player->getBaseSkill(i));
-			msg.add<uint16_t>(static_cast<uint8_t>(player->getSkillPercent(i)) * 100);
+			msg.add<uint16_t>(player->getBaseSkill(i)); // Loyalty Bonus
+			msg.add<uint16_t>(player->getSkillPercent(i) * 100);
 		}
 	}
 


### PR DESCRIPTION
# Description

Skill goes up but does not update on the client.
Revert wrong change from https://github.com/opentibiabr/canary/commit/46d1080b6d6eeedc4efe1b7413dd78b968e84f59 (https://github.com/opentibiabr/canary/pull/516)

## Behaviour
### **Actual**

Skill do not update in the client.

### **Expected**

Skill up normal in the client.
![image](https://user-images.githubusercontent.com/8551443/236638088-d0498c39-a996-4060-9b04-db1125262cb3.png)
![image](https://user-images.githubusercontent.com/8551443/236638097-523f84f9-ceb7-4808-aa9d-c56a78796675.png)


### Fixes #1042

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
