### PR TITLE
fix: error ferumbras ascendant habitats

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_corrupted.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_corrupted.lua
@@ -393,7 +393,14 @@ function ferumbrasAscendantHabitatCorrupted.onUse(player, item, fromPosition, ta
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33628, 32721, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_desert.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_desert.lua
@@ -373,7 +373,14 @@ function ferumbrasAscendantHabitatDesert.onUse(player, item, fromPosition, targe
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33631, 32685, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_dimension.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_dimension.lua
@@ -409,7 +409,14 @@ function ferumbrasAscendantHabitatDimension.onUse(player, item, fromPosition, ta
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33631, 32721, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_grass.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_grass.lua
@@ -441,7 +441,14 @@ function ferumbrasAscendantHabitatGlass.onUse(player, item, fromPosition, target
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33631, 32667, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_ice.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_ice.lua
@@ -456,7 +456,14 @@ function ferumbrasAscendantHabitatIce.onUse(player, item, fromPosition, target, 
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33631, 32703, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_mushroom.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_mushroom.lua
@@ -409,7 +409,14 @@ function ferumbrasAscendantHabitatMushroom.onUse(player, item, fromPosition, tar
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33628, 32685, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_roshamuul.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_roshamuul.lua
@@ -482,7 +482,14 @@ function ferumbrasAscendantHabitatRoshamuul.onUse(player, item, fromPosition, ta
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function()
+				resetFerumbrasAscendantHabitats()
+				local basin = Tile(Position(33628, 32667, 12)):getItemById(22196)
+				if basin then
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_venom.lua
+++ b/data-otservbr-global/scripts/actions/quests/ferumbras_ascendant/habitat_venom.lua
@@ -464,7 +464,14 @@ function ferumbrasAscendantHabitatVenom.onUse(player, item, fromPosition, target
 		Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) + 1)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'The room transforms into a completely different landscape.')
 		if Game.getStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats) >= 8 then
-			addEvent(functionRevert, 1 * 60 * 60 * 1000)
+			addEvent(function() 
+				local basin = Tile(Position(33628, 32703, 12)):getItemById(22196)
+				if basin then
+					resetFerumbrasAscendantHabitats()
+					basin:getPosition():sendMagicEffect(CONST_ME_ENERGYAREA)
+					basin:transform(11114)
+				end
+			end, 1 * 60 * 60 * 1000)
 		end
 	elseif item.itemid == 9126 then
 		item:transform(9125)

--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -268,7 +268,7 @@ function resetFerumbrasAscendantHabitats()
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Roshamuul, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Venom, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, 0)
-	
+
 	for _, spec in pairs(Game.getSpectators(Position(33629, 32693, 12), false, false, 25, 25, 85, 85)) do
 		if spec:isPlayer() then
 			spec:teleportTo(Position(33630, 32648, 12))
@@ -278,7 +278,7 @@ function resetFerumbrasAscendantHabitats()
 			spec:remove()
 		end
 	end
-	
+
 	for x = 33611, 33625 do
 		for y = 32658, 32727 do
 			local position = Position(x, y, 12)

--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -258,7 +258,7 @@ function playerExists(name)
 	return false
 end
 
-function functionRevert()
+function resetFerumbrasAscendantHabitats()
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Corrupted, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Desert, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Dimension, 0)
@@ -268,13 +268,8 @@ function functionRevert()
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Roshamuul, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.Venom, 0)
 	Game.setStorageValue(GlobalStorage.FerumbrasAscendant.Habitats.AllHabitats, 0)
-	for a = 1, #basins do
-		local item = Tile(basins[a].pos):getItemById(22196)
-		item:transform(11114)
-	end
-	local specs, spec = Game.getSpectators(Position(33629, 32693, 12), false, false, 25, 25, 85, 85)
-	for i = 1, #specs do
-		spec = specs[i]
+	
+	for _, spec in pairs(Game.getSpectators(Position(33629, 32693, 12), false, false, 25, 25, 85, 85)) do
 		if spec:isPlayer() then
 			spec:teleportTo(Position(33630, 32648, 12))
 			spec:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
@@ -283,6 +278,7 @@ function functionRevert()
 			spec:remove()
 		end
 	end
+	
 	for x = 33611, 33625 do
 		for y = 32658, 32727 do
 			local position = Position(x, y, 12)


### PR DESCRIPTION
# Description

The error happens because the null variable "basins" is being called without being defined anywhere.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)


