### PR TITLE
fix: crash when teleporting summon to master

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -425,12 +425,18 @@ void Creature::checkSummonMove(const Position &newPos, bool teleportSummon) cons
 			// Check if any of our summons is out of range (+/- 2 floors or 30 tiles away)
 			bool checkRemoveDist = Position::getDistanceZ(newPos, pos) > 2 || (std::max<int32_t>(Position::getDistanceX(newPos, pos), Position::getDistanceY(newPos, pos)) > 30);
 
-			if (monster->isFamiliar() && checkSummonDist || teleportSummon && !protectionZoneCheck && checkSummonDist) {
-				g_game().internalTeleport(creature, creature->getMaster()->getPosition(), true);
-				continue;
+			if (monster && monster->isFamiliar() && checkSummonDist || teleportSummon && !protectionZoneCheck && checkSummonDist) {
+				if (Tile* masterTile = creature->getMaster()->getTile()) {
+					if (masterTile->hasFlag(TILESTATE_TELEPORT)) {
+						SPDLOG_WARN("[{}] cannot teleport summon, position has teleport. {}", __FUNCTION__, creature->getMaster()->getPosition().toString());
+					} else {
+						g_game().internalTeleport(creature, creature->getMaster()->getPosition(), true);
+						continue;
+					}
+				}
 			}
 
-			if (monster->isSummon() && !monster->isFamiliar() && !teleportSummon && checkRemoveDist) {
+			if (monster && monster->isSummon() && !monster->isFamiliar() && !teleportSummon && checkRemoveDist) {
 				despawnMonsterList.push_back(creature);
 			}
 		}


### PR DESCRIPTION
# Description

Conditions for the crash to happen:

- When "teleportSummons" is true in config.lua.
- Player must have a summon (can be a familiar).
- Player enters a portal, which leads close to a SQM that has another portal (1 dist), can generate an infinite teleport loop if the summon is teleported over the next portal.

this change checks if there is a portal in the position where the summon will be teleported.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)