### PR TITLE
fix: otclient login

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -492,7 +492,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 
 	if (oldProtocol) {
 		setChecksumMethod(CHECKSUM_METHOD_ADLER32);
-	} else if (operatingSystem <= CLIENTOS_NEW_MAC) {
+	} else if (operatingSystem <= CLIENTOS_OTCLIENT_MAC) {
 		setChecksumMethod(CHECKSUM_METHOD_SEQUENCE);
 		enableCompression();
 	}


### PR DESCRIPTION
# Description

this fix makes login work again for otclient.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: 13.16
  - Client: OTClient Redemption
  - Operating System: Windows