### PR TITLE
fix: clone exit and not removing the player on the death screen

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -38,7 +38,6 @@ Player::Player(ProtocolGame_ptr p) :
 }
 
 Player::~Player() {
-	g_game().removePlayerUniqueLogin(this);
 	for (Item* item : inventory) {
 		if (item) {
 			item->setParent(nullptr);
@@ -1716,6 +1715,7 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout) {
 				guild->removeMember(this);
 			}
 
+			g_game().removePlayerUniqueLogin(this);
 			loginPosition = getPosition();
 			lastLogout = time(nullptr);
 			SPDLOG_INFO("{} has logged out", getName());
@@ -7381,25 +7381,6 @@ void Player::decrementeHazardSystemReference() {
 		}
 		reloadHazardSystemPointsCounter = true;
 	}
-}
-
-void Player::checkPlayerActivity(int interval) {
-	if (this && !this->isDead() || client == nullptr || (client && !client->getIP())) {
-		return;
-	}
-
-	if (!isAccessPlayer()) {
-		playerDeathTime += interval;
-		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
-		if (playerDeathTime > (kickAfterMinutes * 60000) + 60000) {
-			if (client) {
-				client->disconnect();
-			}
-			return;
-		}
-	}
-
-	g_scheduler().addEvent(createSchedulerTask(1000, std::bind(&Player::checkPlayerActivity, this, interval)));
 }
 
 /*******************************************************************************

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2372,6 +2372,8 @@ class Player final : public Creature, public Cylinder {
 		void decrementeHazardSystemReference();
 		/*******************************************************************************/
 
+		void checkPlayerActivity(int interval);
+
 	private:
 		static uint32_t playerFirstID;
 		static uint32_t playerLastID;
@@ -2572,6 +2574,7 @@ class Player final : public Creature, public Cylinder {
 		int8_t offlineTrainingSkill = SKILL_NONE;
 		int32_t offlineTrainingTime = 0;
 		int32_t idleTime = 0;
+		int32_t playerDeathTime = 0;
 		uint32_t coinBalance = 0;
 		uint32_t coinTransferableBalance = 0;
 		uint16_t expBoostStamina = 0;

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2372,8 +2372,6 @@ class Player final : public Creature, public Cylinder {
 		void decrementeHazardSystemReference();
 		/*******************************************************************************/
 
-		void checkPlayerActivity(int interval);
-
 	private:
 		static uint32_t playerFirstID;
 		static uint32_t playerLastID;

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2572,7 +2572,7 @@ class Player final : public Creature, public Cylinder {
 		int8_t offlineTrainingSkill = SKILL_NONE;
 		int32_t offlineTrainingTime = 0;
 		int32_t idleTime = 0;
-		int32_t playerDeathTime = 0;
+		int32_t m_deathTime = 0;
 		uint32_t coinBalance = 0;
 		uint32_t coinTransferableBalance = 0;
 		uint16_t expBoostStamina = 0;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9140,6 +9140,10 @@ void Game::playerCheckActivity(const std::string &playerName, int interval) {
 		return;
 	}
 
+	if (!player->isDead() || player->client == nullptr) {
+		return;
+	}
+
 	if (!player->isAccessPlayer()) {
 		player->playerDeathTime += interval;
 		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9145,9 +9145,9 @@ void Game::playerCheckActivity(const std::string &playerName, int interval) {
 	}
 
 	if (!player->isAccessPlayer()) {
-		player->playerDeathTime += interval;
+		player->m_deathTime += interval;
 		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
-		if (player->playerDeathTime > (kickAfterMinutes * 60000) + 60000) {
+		if (player->m_deathTime > (kickAfterMinutes * 60000) + 60000) {
 			SPDLOG_INFO("Player with name '{}' has logged out due to inactivity after death", player->getName());
 			g_game().removePlayerUniqueLogin(playerName);
 			IOLoginData::updateOnlineStatus(player->guid, false);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9126,6 +9126,35 @@ void Game::removePlayerUniqueLogin(Player* player) {
 	m_uniqueLoginPlayerNames.erase(lowercase_name);
 }
 
+void Game::playerCheckActivity(const std::string &playerName, int interval) {
+	Player* player = getPlayerUniqueLogin(playerName);
+	if (!player) {
+		return;
+	}
+
+	if (player->getIP() == 0) {
+		g_game().removePlayerUniqueLogin(playerName);
+		IOLoginData::updateOnlineStatus(player->guid, false);
+		SPDLOG_INFO("Player with name '{}' has logged out due to exited in death screen", player->getName());
+		player->disconnect();
+		return;
+	}
+
+	if (!player->isAccessPlayer()) {
+		player->playerDeathTime += interval;
+		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
+		if (player->playerDeathTime > (kickAfterMinutes * 60000) + 60000) {
+			SPDLOG_INFO("Player with name '{}' has logged out due to inactivity after death", player->getName());
+			g_game().removePlayerUniqueLogin(playerName);
+			IOLoginData::updateOnlineStatus(player->guid, false);
+			player->disconnect();
+			return;
+		}
+	}
+
+	g_scheduler().addEvent(createSchedulerTask(1000, std::bind(&Game::playerCheckActivity, this, playerName, interval)));
+}
+
 void Game::playerRewardChestCollect(uint32_t playerId, const Position &pos, uint16_t itemId, uint8_t stackPos, uint32_t maxMoveItems /* = 0*/) {
 	Player* player = getPlayerByID(playerId);
 	if (!player) {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -613,6 +613,7 @@ class Game {
 		 * @param player A pointer to the Player object to remove.
 		 */
 		void removePlayerUniqueLogin(Player* player);
+		void playerCheckActivity(const std::string &playerName, int interval);
 
 	private:
 		std::map<uint32_t, int32_t> forgeMonsterEventIds;

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -198,9 +198,7 @@ bool Protocol::RSA_decrypt(NetworkMessage &msg) {
 
 uint32_t Protocol::getIP() const {
 	if (auto protocolConnection = getConnection()) {
-		if (protocolConnection != nullptr) {
-			return protocolConnection->getIP();
-		}
+		return protocolConnection->getIP();
 	}
 
 	return 0;

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -198,7 +198,9 @@ bool Protocol::RSA_decrypt(NetworkMessage &msg) {
 
 uint32_t Protocol::getIP() const {
 	if (auto protocolConnection = getConnection()) {
-		return protocolConnection->getIP();
+		if (protocolConnection != nullptr) {
+			return protocolConnection->getIP();
+		}
 	}
 
 	return 0;

--- a/src/server/network/protocol/protocol.h
+++ b/src/server/network/protocol/protocol.h
@@ -57,11 +57,11 @@ class Protocol : public std::enable_shared_from_this<Protocol> {
 
 	protected:
 		void disconnect() const {
-			auto connection = getConnection();
-			if (connection != nullptr) {
+			if (auto connection = getConnection()) {
 				connection->close();
 			}
 		}
+
 		void enableXTEAEncryption() {
 			encryptionEnabled = true;
 		}

--- a/src/server/network/protocol/protocol.h
+++ b/src/server/network/protocol/protocol.h
@@ -57,8 +57,8 @@ class Protocol : public std::enable_shared_from_this<Protocol> {
 
 	protected:
 		void disconnect() const {
-			if (auto connection = getConnection();
-				connection != nullptr) {
+			auto connection = getConnection();
+			if (connection != nullptr) {
 				connection->close();
 			}
 		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -655,7 +655,7 @@ void ProtocolGame::parsePacket(NetworkMessage &msg) {
 
 	if (player->isDead() || player->getHealth() <= 0) {
 		if (playerDeathTime == 0) {
-			player->checkPlayerActivity(1000);
+			addGameTask(&Game::playerCheckActivity, player->getName(), 1000);
 			playerDeathTime++;
 		}
 		g_dispatcher().addTask(createTask(std::bind(&ProtocolGame::parsePacketDead, getThis(), recvbyte)));
@@ -704,6 +704,10 @@ void ProtocolGame::parsePacketDead(uint8_t recvbyte) {
 }
 
 void ProtocolGame::addBless() {
+	if (!player) {
+		return;
+	}
+
 	std::string bless = player->getBlessingsName();
 	std::ostringstream lostBlesses;
 	(bless.length() == 0) ? lostBlesses << "You lost all your blessings." : lostBlesses << "You are still blessed with " << bless;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -406,19 +406,19 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 			foundPlayer->disconnect();
 			foundPlayer->isConnecting = true;
 
-			eventConnect = g_scheduler().addEvent(createSchedulerTask(1000, std::bind(&ProtocolGame::connect, getThis(), foundPlayer->getID(), operatingSystem)));
+			eventConnect = g_scheduler().addEvent(createSchedulerTask(1000, std::bind(&ProtocolGame::connect, getThis(), foundPlayer->getName(), operatingSystem)));
 		} else {
-			connect(foundPlayer->getID(), operatingSystem);
+			connect(foundPlayer->getName(), operatingSystem);
 		}
 	}
 	OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
 	sendBosstiaryCooldownTimer();
 }
 
-void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem) {
+void ProtocolGame::connect(const std::string &playerName, OperatingSystem_t operatingSystem) {
 	eventConnect = 0;
 
-	Player* foundPlayer = g_game().getPlayerByID(playerId);
+	Player* foundPlayer = g_game().getPlayerUniqueLogin(playerName);
 	if (!foundPlayer) {
 		disconnectClient("You are already logged in.");
 		return;
@@ -654,10 +654,12 @@ void ProtocolGame::parsePacket(NetworkMessage &msg) {
 	}
 
 	if (player->isDead() || player->getHealth() <= 0) {
+		// Check player activity on death screen
 		if (playerDeathTime == 0) {
 			addGameTask(&Game::playerCheckActivity, player->getName(), 1000);
 			playerDeathTime++;
 		}
+
 		g_dispatcher().addTask(createTask(std::bind(&ProtocolGame::parsePacketDead, getThis(), recvbyte)));
 		return;
 	}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -655,9 +655,9 @@ void ProtocolGame::parsePacket(NetworkMessage &msg) {
 
 	if (player->isDead() || player->getHealth() <= 0) {
 		// Check player activity on death screen
-		if (playerDeathTime == 0) {
+		if (m_playerDeathTime == 0) {
 			addGameTask(&Game::playerCheckActivity, player->getName(), 1000);
-			playerDeathTime++;
+			m_playerDeathTime++;
 		}
 
 		g_dispatcher().addTask(createTask(std::bind(&ProtocolGame::parsePacketDead, getThis(), recvbyte)));

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -78,7 +78,7 @@ class ProtocolGame final : public Protocol {
 		ProtocolGame_ptr getThis() {
 			return std::static_pointer_cast<ProtocolGame>(shared_from_this());
 		}
-		void connect(uint32_t playerId, OperatingSystem_t operatingSystem);
+		void connect(const std::string &playerName, OperatingSystem_t operatingSystem);
 		void disconnectClient(const std::string &message) const;
 		void writeToOutputBuffer(const NetworkMessage &msg);
 

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -490,6 +490,12 @@ class ProtocolGame final : public Protocol {
 
 		// Hazard system
 		void reloadHazardSystemIcon(uint16_t reference);
+
+		uint8_t playerDeathTime = 0;
+
+		void resetPlayerDeathTime() {
+			playerDeathTime = 0;
+		}
 };
 
 #endif // SRC_SERVER_NETWORK_PROTOCOL_PROTOCOLGAME_H_

--- a/src/server/network/protocol/protocolgame.h
+++ b/src/server/network/protocol/protocolgame.h
@@ -491,10 +491,10 @@ class ProtocolGame final : public Protocol {
 		// Hazard system
 		void reloadHazardSystemIcon(uint16_t reference);
 
-		uint8_t playerDeathTime = 0;
+		uint8_t m_playerDeathTime = 0;
 
 		void resetPlayerDeathTime() {
-			playerDeathTime = 0;
+			m_playerDeathTime = 0;
 		}
 };
 


### PR DESCRIPTION
# Description

Fixes:
- [x] Force Exit then log in with another client.
- [x] Force exit death screen and log in with another client.
- [x] Getting afk on the death screen
- [x] Die, stay on the death screen, then very quickly log in with a 2nd client on top of the char

Test Ctrl + Q "cannot be a clone of the player".

Test Ctrl + C, "there can be no player clone".

Exit the client with the player online, and log in again "there cannot be a clone of the player".

Die with the player and see if it will log out after spending time configuring it in config.lua, change the variable "kickIdlePlayerAfterMinutes" to a shorter time in config.lua.