### PR TITLE
fix: player transferable coins transaction function

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1841,13 +1841,16 @@ end
 	@param coins (number) - The amount of coins to be removed.
 	@return (boolean) - Returns true if the coins were successfully removed, false otherwise.
 --]]
-function Player.removeAllCoins(self, coins)
+function Player.removeAllCoins(self, coins, offerCoinType)
 	-- Check if it is possible to remove all the coins.
 	if self:canRemoveAllCoins(coins) then
 		local tibiaCoins = self:getTibiaCoins()
 		-- Check if there are enough Tibia coins to remove.
-		if tibiaCoins >= coins then
+		if tibiaCoins >= coins and (offerCoinType == GameStore.CoinType.Coin or offerCoinType == GameStore.CoinType.Transferable) then
 			self:removeTibiaCoins(coins)
+		elseif offerCoinType == GameStore.CoinType.Transferable then
+			-- Remove as moedas transferíveis.
+			self:removeTransferableCoinsBalance(coins)		
 		else
 			-- Remove the available Tibia coins and calculate the remaining amount to remove from transferable coins.
 			self:removeTibiaCoins(tibiaCoins)
@@ -1897,8 +1900,8 @@ function Player.makeCoinTransaction(self, offer, desc)
 	end
 
 	-- First try remove normal coins, later the transferable coins
-	if self:canRemoveAllCoins(offer.price) then
-		op = self:removeAllCoins(offer.price)
+	if self:canRemoveAllCoins(offer.price, offer.coinType) then
+		op = self:removeAllCoins(offer.price, offer.coinType)
 	elseif self:canRemoveCoins(offer.price) then
 		-- Remove normal coins
 		op = self:removeCoinsBalance(offer.price)

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1849,7 +1849,7 @@ function Player.removeAllCoins(self, coins, offerCoinType)
 		if tibiaCoins >= coins and (offerCoinType == GameStore.CoinType.Coin or offerCoinType == GameStore.CoinType.Transferable) then
 			self:removeTibiaCoins(coins)
 		elseif offerCoinType == GameStore.CoinType.Transferable then
-			-- Remove as moedas transferíveis.
+			-- Remove transferable coins.
 			self:removeTransferableCoinsBalance(coins)		
 		else
 			-- Remove the available Tibia coins and calculate the remaining amount to remove from transferable coins.

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1845,12 +1845,13 @@ function Player.removeAllCoins(self, coins, offerCoinType)
 	-- Check if it is possible to remove all the coins.
 	if self:canRemoveAllCoins(coins) then
 		local tibiaCoins = self:getTibiaCoins()
+		local transferableCoins = self:getTransferableCoins()
 		-- Check if there are enough Tibia coins to remove.
-		if tibiaCoins >= coins and (offerCoinType == GameStore.CoinType.Coin or offerCoinType == GameStore.CoinType.Transferable) then
+		if tibiaCoins >= coins and offerCoinType == GameStore.CoinType.Coin then
 			self:removeTibiaCoins(coins)
-		elseif offerCoinType == GameStore.CoinType.Transferable then
+		elseif transferableCoins >= coins and offerCoinType == GameStore.CoinType.Transferable then
 			-- Remove transferable coins.
-			self:removeTransferableCoinsBalance(coins)
+			self:removeTransferableCoins(coins)
 		else
 			-- Remove the available Tibia coins and calculate the remaining amount to remove from transferable coins.
 			self:removeTibiaCoins(tibiaCoins)
@@ -1872,7 +1873,7 @@ function Player.canRemoveTransferableCoins(self, coins)
 	return true
 end
 
-function Player.removeTransferableCoinsBalance(self, coins)
+function Player.removeTransferableCoins(self, coins)
 	if self:canRemoveTransferableCoins(coins) then
 		sendStoreBalanceUpdating(self:getId(), true)
 		return self:removeTransferableCoins(coins)
@@ -1907,7 +1908,7 @@ function Player.makeCoinTransaction(self, offer, desc)
 		op = self:removeCoinsBalance(offer.price)
 	else
 		-- Remove transferable coins
-		op = self:removeTransferableCoinsBalance(offer.price)
+		op = self:RemoveTransferableCoin(offer.price)
 	end
 
 	-- When the transaction is suscessfull add to the history

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1850,7 +1850,7 @@ function Player.removeAllCoins(self, coins, offerCoinType)
 			self:removeTibiaCoins(coins)
 		elseif offerCoinType == GameStore.CoinType.Transferable then
 			-- Remove transferable coins.
-			self:removeTransferableCoinsBalance(coins)		
+			self:removeTransferableCoinsBalance(coins)
 		else
 			-- Remove the available Tibia coins and calculate the remaining amount to remove from transferable coins.
 			self:removeTibiaCoins(tibiaCoins)

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1908,7 +1908,7 @@ function Player.makeCoinTransaction(self, offer, desc)
 		op = self:removeCoinsBalance(offer.price)
 	else
 		-- Remove transferable coins
-		op = self:removeTransferableCoins(offer.price)
+		op = self:RemoveTransferableCoins(offer.price)
 	end
 
 	-- When the transaction is suscessfull add to the history

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1908,7 +1908,7 @@ function Player.makeCoinTransaction(self, offer, desc)
 		op = self:removeCoinsBalance(offer.price)
 	else
 		-- Remove transferable coins
-		op = self:RemoveTransferableCoin(offer.price)
+		op = self:removeTransferableCoins(offer.price)
 	end
 
 	-- When the transaction is suscessfull add to the history

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1908,7 +1908,7 @@ function Player.makeCoinTransaction(self, offer, desc)
 		op = self:removeCoinsBalance(offer.price)
 	else
 		-- Remove transferable coins
-		op = self:RemoveTransferableCoins(offer.price)
+		op = self:removeTransferableCoins(offer.price)
 	end
 
 	-- When the transaction is suscessfull add to the history


### PR DESCRIPTION
Fixed code in `Player.makeCoinTransaction` function to ensure correct removal of coins based on offer type. Now, coins are removed based on the availability of regular coins, transferable coins or a combination of both.