### PR TITLE
fix: multiple disconnect

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -555,7 +555,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string password = sessionKey.substr(pos + 1);
 	std::string characterName = msg.getString();
 
-	Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
+	Player* foundPlayer = const_cast<Player*>(g_game().getPlayerUniqueLogin(characterName));
 	if (foundPlayer != nullptr) {
 		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -555,8 +555,8 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string password = sessionKey.substr(pos + 1);
 	std::string characterName = msg.getString();
 
-	const Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
-	if (foundPlayer) {
+	Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
+	if (foundPlayer != nullptr) {
 		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -555,9 +555,9 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string password = sessionKey.substr(pos + 1);
 	std::string characterName = msg.getString();
 
-	Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
-	if (foundPlayer != nullptr) {
-		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
+	const Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
+	if (foundPlayer) {
+		disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}
 
 	uint32_t timeStamp = msg.get<uint32_t>();

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -555,7 +555,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string password = sessionKey.substr(pos + 1);
 	std::string characterName = msg.getString();
 
-	auto Player* foundPlayer = const_cast<Player*>(g_game().getPlayerUniqueLogin(characterName));
+	Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
 	if (foundPlayer != nullptr) {
 		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -555,7 +555,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string password = sessionKey.substr(pos + 1);
 	std::string characterName = msg.getString();
 
-	Player* foundPlayer = const_cast<Player*>(g_game().getPlayerUniqueLogin(characterName));
+	auto Player* foundPlayer = const_cast<Player*>(g_game().getPlayerUniqueLogin(characterName));
 	if (foundPlayer != nullptr) {
 		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}


### PR DESCRIPTION
The change removes the unnecessary "foundPlayer->client->" part of the `disconnectClient()` function call. Assuming `disconnectClient()` is a function defined somewhere in the code, the corrected line directly calls that function with the desired error message.

![image](https://github.com/opentibiabr/canary/assets/82473579/6fc66941-6748-4f56-b326-209f9138f486)
