### PR TITLE
fix: helmets and hats

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -768,6 +768,18 @@ local items = {
 		slot = "armor"
 	},
 	{
+		-- green demon helmet
+		itemid = 37609,
+		type = "equip",
+		slot = "head"
+	},
+	{
+		-- green demon helmet
+		itemid = 37609,
+		type = "deequip",
+		slot = "head"
+	},
+	{
 		-- changing backpack
 		itemid = 37536,
 		type = "equip",
@@ -2195,6 +2207,18 @@ local items = {
 		itemid = 32585,
 		type = "deequip",
 		slot = "armor"
+	},
+	{
+		-- Traditional Gamsbart Hat
+		itemid = 32100,
+		type = "equip",
+		slot = "head"
+	},
+	{
+		-- Traditional Gamsbart Hat
+		itemid = 32100,
+		type = "deequip",
+		slot = "head"
 	},
 	{
 		-- meat hammer
@@ -5940,18 +5964,6 @@ local items = {
 		type = "deequip",
 		slot = "feet",
 		level = 150
-	},
-	{
-		-- Traditional Gamsbart Hat
-		itemid = 32100,
-		type = "equip",
-		slot = "head"
-	},
-	{
-		-- Traditional Gamsbart Hat
-		itemid = 32100,
-		type = "deequip",
-		slot = "head"
 	},
 	{
 		-- tiara of power
@@ -16641,18 +16653,6 @@ local items = {
 		itemid = 3366,
 		type = "deequip",
 		slot = "armor"
-	},
-	{
-		-- green demon helmet
-		itemid = 37609,
-		type = "equip",
-		slot = "head"
-	},
-	{
-		-- green demon helmet
-		itemid = 37609,
-		type = "deequip",
-		slot = "head"
 	},
 	{
 		-- golden helmet

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -7227,7 +7227,7 @@ local items = {
 		slot = "necklace"
 	},
 	{
-		-- enchanted werewolf amulet - sword
+		-- enchanted werewolf helmet - sword
 		itemid = 22132,
 		type = "equip",
 		slot = "necklace"
@@ -7238,7 +7238,7 @@ local items = {
 		}
 	},
 	{
-		-- enchanted werewolf amulet - sword
+		-- enchanted werewolf helmet - sword
 		itemid = 22132,
 		type = "deequip",
 		slot = "necklace",

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -16643,6 +16643,18 @@ local items = {
 		slot = "armor"
 	},
 	{
+		-- green demon helmet
+		itemid = 37609,
+		type = "equip",
+		slot = "head"
+	},
+	{
+		-- green demon helmet
+		itemid = 37609,
+		type = "deequip",
+		slot = "head"
+	},
+	{
 		-- golden helmet
 		itemid = 3365,
 		type = "equip",

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -5942,6 +5942,18 @@ local items = {
 		level = 150
 	},
 	{
+		-- Traditional Gamsbart Hat
+		itemid = 32100,
+		type = "equip",
+		slot = "head"
+	},
+	{
+		-- Traditional Gamsbart Hat
+		itemid = 32100,
+		type = "deequip",
+		slot = "head"
+	},
+	{
 		-- tiara of power
 		itemid = 23475,
 		type = "equip",
@@ -7203,8 +7215,46 @@ local items = {
 		slot = "necklace"
 	},
 	{
-		-- enchanted werewolf helmet
+		-- enchanted werewolf amulet - sword
+		itemid = 22132,
+		type = "equip",
+		slot = "necklace"
+		level = 100,
+		vocation = {
+			{"Knight", true},
+			{"Elite Knight"}
+		}
+	},
+	{
+		-- enchanted werewolf amulet - sword
+		itemid = 22132,
+		type = "deequip",
+		slot = "necklace",
+		level = 100
+	},
+	{
+		-- enchanted werewolf helmet - ml
 		itemid = 22130,
+		type = "equip",
+		slot = "head",
+		level = 100,
+		vocation = {
+			{"Sorcerer", true},
+			{"Druid", true, true},
+			{"Master Sorcerer"},
+			{"Elder Druid"}
+		}
+	},
+	{
+		-- enchanted werewolf helmet - ml
+		itemid = 22130,
+		type = "deequip",
+		slot = "head",
+		level = 100
+	},
+	{
+		-- enchanted werewolf helmet - distance
+		itemid = 22129,
 		type = "equip",
 		slot = "head",
 		level = 100,
@@ -7214,15 +7264,15 @@ local items = {
 		}
 	},
 	{
-		-- enchanted werewolf helmet
-		itemid = 22130,
+		-- enchanted werewolf helmet - distance
+		itemid = 22129,
 		type = "deequip",
 		slot = "head",
 		level = 100
 	},
 	{
-		-- enchanted werewolf helmet
-		itemid = 22129,
+		-- enchanted werewolf helmet - club
+		itemid = 22128,
 		type = "equip",
 		slot = "head",
 		level = 100,
@@ -7232,43 +7282,25 @@ local items = {
 		}
 	},
 	{
-		-- enchanted werewolf helmet
-		itemid = 22129,
-		type = "deequip",
-		slot = "head",
-		level = 100
-	},
-	{
-		-- enchanted werewolf helmet
-		itemid = 22128,
-		type = "equip",
-		slot = "head",
-		level = 100,
-		vocation = {
-			{"Druid", true},
-			{"Elder Druid"}
-		}
-	},
-	{
-		-- enchanted werewolf helmet
+		-- enchanted werewolf helmet - club
 		itemid = 22128,
 		type = "deequip",
 		slot = "head",
 		level = 100
 	},
 	{
-		-- enchanted werewolf helmet
+		-- enchanted werewolf helmet - axe
 		itemid = 22127,
 		type = "equip",
 		slot = "head",
 		level = 100,
 		vocation = {
-			{"Sorcerer", true},
-			{"Master Sorcerer"}
+			{"Knight", true},
+			{"Elite Knight"}
 		}
 	},
 	{
-		-- enchanted werewolf helmet
+		-- enchanted werewolf helmet - axe
 		itemid = 22127,
 		type = "deequip",
 		slot = "head",
@@ -13706,13 +13738,13 @@ local items = {
 	},
 	{
 		-- mining helmet
-		itemid = 139,
+		itemid = 875,
 		type = "equip",
 		slot = "head"
 	},
 	{
 		-- mining helmet
-		itemid = 139,
+		itemid = 875,
 		type = "deequip",
 		slot = "head"
 	},

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4508,7 +4508,6 @@
 		<attribute key="weight" value="179"/>
 	</item>
 	<item id="3011" article="a" name="crown">
-		<attribute key="defense" value="1"/>
 		<attribute key="weight" value="1900"/>
 	</item>
 	<item id="3012" article="a" name="wolf tooth chain">
@@ -4543,7 +4542,7 @@
 		<attribute key="weight" value="680"/>
 	</item>
 	<item id="3022" article="an" name="ancient tiara">
-		<attribute key="weight" value="819"/>
+		<attribute key="weight" value="820"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
 			<attribute key="skillboost axe" value="3"/>
@@ -5461,10 +5460,10 @@
 	</item>
 	<item id="3229" article="a" name="helmet of the ancients">
 		<attribute key="description" value="The gem of the helmet is burned out and should be replaced"/>
-		<attribute key="armor" value="11"/>
+		<attribute key="armor" value="8"/>
 		<attribute key="weight" value="2760"/>
 	</item>
-	<item id="3230" article="a" name="helmet of the ancients">
+	<item id="3230" article="a" name="full helmet of the ancients">
 		<attribute key="description" value="The gem is glowing with power"/>
 		<attribute key="duration" value="1800"/>
 		<attribute key="decayTo" value="3229"/>
@@ -6433,14 +6432,6 @@
 	<item id="3352" article="a" name="chain helmet">
 		<attribute key="armor" value="2"/>
 		<attribute key="weight" value="4200"/>
-		<attribute key="imbuementslot" value="1">
-			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost axe" value="3"/>
-			<attribute key="skillboost sword" value="3"/>
-			<attribute key="skillboost club" value="3"/>
-			<attribute key="skillboost shielding" value="3"/>
-			<attribute key="skillboost distance" value="3"/>
-		</attribute>
 	</item>
 	<item id="3353" article="an" name="iron helmet">
 		<attribute key="armor" value="5"/>
@@ -34543,6 +34534,7 @@
 	</item>
 	<item id="22757" article="a" name="shroud of despair">
 		<attribute key="armor" value="7"/>
+		<attribute key="absorbpercentdeath" value="3"/>
 		<attribute key="weight" value="3400"/>
 	</item>
 	<item id="22758" article="a" name="death gaze">
@@ -35317,7 +35309,7 @@
 		<attribute key="managain" value="8"/>
 		<attribute key="healthticks" value="6000"/>
 		<attribute key="healthgain" value="2"/>
-		<attribute key="speed" value="10"/>
+		<attribute key="speed" value="20"/>
 		<attribute key="duration" value="3600"/>
 		<attribute key="transformdeequipto" value="23474"/>
 		<attribute key="decayTo" value="0"/>
@@ -39947,7 +39939,7 @@
 		<attribute key="absorbpercentice" value="-2"/>
 		<attribute key="absorbpercentenergy" value="8"/>
 		<attribute key="magicpoints" value="2"/>
-		<attribute key="armor" value="7"/>
+		<attribute key="armor" value="8"/>
 		<attribute key="weight" value="2400"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
@@ -46923,16 +46915,7 @@
 	</item>
 	<item id="32630" article="a" name="spooky hood">
 		<attribute key="description" value="Every time you look away you have a strange feeling, as if something watches you from its depths"/>
-		<attribute key="armor" value="1"/>
 		<attribute key="weight" value="1250"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost axe" value="3"/>
-			<attribute key="skillboost sword" value="3"/>
-			<attribute key="skillboost club" value="3"/>
-			<attribute key="skillboost shielding" value="3"/>
-			<attribute key="skillboost distance" value="3"/>
-		</attribute>
 	</item>
 	<item id="32631" article="a" name="ghost claw">
 		<attribute key="description" value="It is glowing in an unhealthy light"/>
@@ -51588,6 +51571,7 @@
 	<item id="36670" article="a" name="eldritch cowl">
 		<attribute key="absorbpercentice" value="7"/>
 		<attribute key="armor" value="7"/>
+		<attribute key="magicpoints" value="2"/>
 		<attribute key="weight" value="2600"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
@@ -51601,6 +51585,7 @@
 	<item id="36671" article="a" name="eldritch hood">
 		<attribute key="absorbpercentpoison" value="7"/>
 		<attribute key="armor" value="7"/>
+		<attribute key="magicpoints" value="2"/>
 		<attribute key="weight" value="2700"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>


### PR DESCRIPTION
# Description

- Fixado o peso do item Ancient Tiara: de 819 para 820;
- Removido imbuement slot do item Chain Helmet;
- Removido o atributo defense do item Crown;
- Adicionado atributo +2 de ml no item Eldritch Cowl;
- Adicionado atributo +2 de ml no item Eldritch Hood;
- Fixado as restrições de vocações do item Enchanted Werewolf Helmet (estavam todas invertidas). Adicionado ao nome de identificação de cada um, o bonus deles de acordo com o que está em items.xml, para facilitar a identificação;
- Fixado o nome do item de id 3230: de Helmet of the Ancients para Full Helmet of the Ancients;
- Fixado atributo arm do Gnome Helmet: de 7 para 8;
- Adicionado Green Demon Helmet no arquivo unscripted_equipments.lua;
- Fixado o atributo armor do item Helmet of the Ancients: de 11 para 8.
- Fixado id do item Mining Helmet, em unscripted_equipments.lua: de 139 paa 875 (139 é o item que fica com o NPC, e o mesmo não pode ser equipado no char, em troca ele te dá o 875. Ambos são a mesma sprite);
- Adicionado atributo de absorção de 3% de dano no elemento death no item: Shroud of Despair, id: 22757;
- Fixado speed bonus do item Tiara of Power: de 10 para 20;
- Adicionado o item: Traditional Gamsbart Hat, id: 32100 no arquivo unscripted_equipments.lua;

## Behaviour
### **Actual**

Alguns helmets com atributos errados / faltando / a mais.

### **Expected**

Editei conforme o global, deixando mais fiel ao mesmo.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Observei as diferenças, conforme fui pesquisando por cada um deles.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
