### PR TITLE
fix: crash on logout player

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -7230,7 +7230,7 @@ local items = {
 		-- enchanted werewolf helmet - sword
 		itemid = 22132,
 		type = "equip",
-		slot = "necklace"
+		slot = "necklace",
 		level = 100,
 		vocation = {
 			{"Knight", true},

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -556,7 +556,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	std::string characterName = msg.getString();
 
 	const Player* foundPlayer = g_game().getPlayerUniqueLogin(characterName);
-	if (foundPlayer) {
+	if (foundPlayer && foundPlayer->client) {
 		foundPlayer->client->disconnectClient("You are already connected through another client. Please use only one client at a time!");
 	}
 


### PR DESCRIPTION
# Description
```
2023-06-07 20:33:03 -  Thread 1 "canary" received signal SIGSEGV, Segmentation fault.
2023-06-07 20:33:03 -  ProtocolGame::disconnectClient (this=this@entry=0x0, message="You are already connected through another client. Please use only one client at a time!") at /home/ubuntu/canary/src/server/network/protocol/protocolgame.cpp:647
2023-06-07 20:33:03 -  647        send(output);
```