### PR TITLE
fix: amulets attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -167,7 +167,7 @@ local items = {
 		},
 	},
 	{
-		-- enchanted turtle amulet
+		-- turtle amulet
 		itemid = 39235,
 		type = "deequip",
 		slot = "necklace"
@@ -2570,7 +2570,7 @@ local items = {
 		slot = "ring",
 	},
 	{
-		-- amulet of theurgy
+		-- enchanted theurgic amulet
 		itemid = 30403,
 		type = "equip",
 		slot = "necklace",
@@ -2583,7 +2583,7 @@ local items = {
 		},
 	},
 	{
-		-- amulet of theurgy
+		-- enchanted theurgic amulet
 		itemid = 30403,
 		type = "deequip",
 		slot = "necklace",

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4502,7 +4502,7 @@
 		<attribute key="weight" value="490"/>
 	</item>
 	<item id="3009" article="a" name="bronze necklace">
-		<attribute key="weight" value="409"/>
+		<attribute key="weight" value="410"/>
 	</item>
 	<item id="3010" article="an" name="emerald bangle">
 		<attribute key="weight" value="179"/>
@@ -20454,7 +20454,7 @@
 	<item id="10457" article="a" name="beetle necklace">
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="speed" value="2"/>
-		<attribute key="weight" value="819"/>
+		<attribute key="weight" value="820"/>
 	</item>
 	<item id="10458" article="a" name="dead lancer beetle">
 		<attribute key="fluidsource" value="slime"/>
@@ -23892,7 +23892,7 @@
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentlifedrain" value="50"/>
 		<attribute key="charges" value="50"/>
-		<attribute key="weight" value="500"/>
+		<attribute key="weight" value="509"/>
 	</item>
 	<item id="13991" article="a" name="deepling axe">
 		<attribute key="weaponType" value="axe"/>
@@ -25533,7 +25533,7 @@
 		<attribute key="absorbpercentphysical" value="15"/>
 		<attribute key="absorbpercentpoison" value="10"/>
 		<attribute key="charges" value="750"/>
-		<attribute key="weight" value="409"/>
+		<attribute key="weight" value="410"/>
 	</item>
 	<item id="16109" article="a" name="prismatic helmet">
 		<attribute key="absorbpercentphysical" value="5"/>
@@ -31959,7 +31959,12 @@
 		<attribute key="showCharges" value="1"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentphysical" value="10"/>
-		<attribute key="absorbpercentmagic" value="10"/>
+		<attribute key="absorbpercentfire" value="10"/>
+		<attribute key="absorbpercentpoison" value="10"/>
+		<attribute key="absorbpercentenergy" value="10"/>
+		<attribute key="absorbpercentice" value="10"/>
+		<attribute key="absorbpercentholy" value="10"/>
+		<attribute key="absorbpercentdeath" value="10"/>
 		<attribute key="charges" value="20"/>
 		<attribute key="weight" value="220"/>
 	</item>
@@ -33746,7 +33751,6 @@
 		<attribute key="duration" value="60"/>
 		<attribute key="decayTo" value="0"/>
 	</item>
-	<!-- axe -->
 	<item id="22134" article="an" name="enchanted werewolf amulet">
 		<attribute key="showduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
@@ -33754,7 +33758,6 @@
 		<attribute key="duration" value="3600"/>
 		<attribute key="decayTo" value="22060"/>
 		<attribute key="transformDeEquipTo" value="22061" />
-		<attribute key="duration" value="3600" />
 		<attribute key="armor" value="3"/>
 		<attribute key="weight" value="550"/>
 	</item>
@@ -55142,6 +55145,7 @@
 		<attribute key="skillclub" value="3"/>
 		<attribute key="skillaxe" value="3"/>
 		<attribute key="skillsword" value="3"/>
+		<attribute key="armor" value="3"/>
 		<attribute key="transformDeEquipTo" value="39233"/>>
 		<attribute key="showduration" value="1" />
 		<attribute key="duration" value="7200"/>


### PR DESCRIPTION
# Description

- Fixado o nome do item com id: 30403 apenas para identificação, em unscipted_equipments.lua. De amulet of theurgy para enchanted theurgic amulet.
- Fixado o peso do item Brone Amulet id: 3009. De 409 para 410.
- Fixado o peso do item Beetle Necklace id: 10457. De 819 para 820.
- Fixado o nome do item com id: 30403 em unscripted_equipments.lua. De amulet of theurgy para enchanted theurgic amulet, para melhor identificação.
- Adicionado  atributo armor 2 no item Enchanted Turtle Amulet id: 39234.
- Removido uma linha de atributo duration no item Enchanted Werewolf Amulet id: 22134. Estava duplicada.
- Fixado o peso do item Gill Necklace id: 16108. De 409 para 410.
- Removido o atributo absorbpercentmagic 0 do item Glooth Amulet id: 21183. Adicionado os atributos:
absorbpercentfire 10, 
absorbpercentpoison 10, 
absorbpercentenergy 10, 
absorbpercentice 10, 
absorbpercentholy 10, 
absorbpercentdeath 10.
- Fixado o peso do item Necklace of the Deep id: 13990. De 500 para 509.

## Behaviour
### **Actual**

Alguns nomes invertidos / errados.
Alguns atributos erados / faltando / a mais.

### **Expected**

Alterado para que fique mais fiel ao global.

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações feitas, não ocorreu nenhum erro / bug na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
