### PR TITLE
fix: wands and rods attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -7135,7 +7135,7 @@ local items = {
 		slot = "shield"
 	},
 	{
-		-- ogre sceptra
+		-- ogre scepta
 		itemid = 22183,
 		type = "equip",
 		slot = "hand",
@@ -7146,7 +7146,7 @@ local items = {
 		}
 	},
 	{
-		-- ogre sceptra
+		-- ogre scepta
 		itemid = 22183,
 		type = "deequip",
 		slot = "hand",
@@ -18433,7 +18433,7 @@ local items = {
 		level = 33
 	},
 	{
-		-- snakebit rod
+		-- snakebite rod
 		itemid = 3066,
 		type = "equip",
 		slot = "hand",
@@ -18444,7 +18444,7 @@ local items = {
 		}
 	},
 	{
-		-- snakebit rod
+		-- snakebite rod
 		itemid = 3066,
 		type = "deequip",
 		slot = "hand",

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4807,7 +4807,7 @@
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="shootType" value="fire"/>
 		<attribute key="range" value="3"/>
-		<attribute key="weight" value="2100"/>
+		<attribute key="weight" value="2300"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
@@ -22758,7 +22758,7 @@
 	<item id="12603" article="a" name="wand of dimensions">
 		<attribute key="description" value="This wand controls the rift between time and space"/>
 		<attribute key="weaponType" value="wand"/>
-		<attribute key="shootType" value="death"/>
+		<attribute key="shootType" value="energy"/>
 		<attribute key="range" value="3"/>
 		<attribute key="weight" value="2800"/>
 	</item>
@@ -26207,6 +26207,8 @@
 	<item id="17111" article="a" name="sorcerer and druid staff">
 		<attribute key="description" value="It can only be wielded properly by players without vocation."/>
 		<attribute key="weaponType" value="wand"/>
+		<attribute key="shootType" value="energy"/>
+		<attribute key="range" value="3"/>
 		<attribute key="weight" value="1900"/>
 	</item>
 	<item id="17112" article="a" name="sorc and druid attack rune">
@@ -34614,7 +34616,7 @@
 		<attribute key="duration" value="86400"/>
 		<attribute key="decayTo" value="22764"/>
 		<attribute key="range" value="4"/>
-		<attribute key="weight" value="2900"/>
+		<attribute key="weight" value="2250"/>
 	</item>
 	<item id="22767" article="a" name="Ferumbras' amulet">
 		<attribute key="description" value="The rare jewel is made of sapphire and ruby and has a golden F-pendant"/>
@@ -37265,8 +37267,8 @@
 		<attribute key="description" value="It's a gnarly branch with a gleaming blue blossom"/>
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="shootType" value="energy"/>
-		<attribute key="magicpoints" value="2"/>
-		<attribute key="range" value="4"/>
+		<attribute key="magicpoints" value="1"/>
+		<attribute key="range" value="5"/>
 		<attribute key="weight" value="3200"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="life leech" value="3"/>
@@ -39406,7 +39408,7 @@
 	<item id="27457" article="a" name="wand of destruction">
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="shootType" value="energy"/>
-		<attribute key="magicpoints" value="2"/>
+		<attribute key="magicpoints" value="1"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3500"/>
 		<attribute key="imbuementslot" value="2">
@@ -39419,7 +39421,7 @@
 	<item id="27458" article="a" name="rod of destruction">
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="shootType" value="smallice"/>
-		<attribute key="magicpoints" value="2"/>
+		<attribute key="magicpoints" value="1"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3500"/>
 		<attribute key="imbuementslot" value="2">
@@ -41855,7 +41857,9 @@
 		<attribute key="weaponType" value="wand"/>
 		<attribute key="shootType" value="smallice"/>
 		<attribute key="absorbpercentholy" value="8"/>
-		<attribute key="magicpoints" value="3"/>
+		<attribute key="magicpoints" value="2"/>
+		<attribute key="criticalhitdamage" value="25"/>
+		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="range" value="5"/>
 		<attribute key="weight" value="3300"/>
 		<attribute key="imbuementslot" value="2">
@@ -49241,7 +49245,7 @@
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="lifeleechamount" value="18"/>
 		<attribute key="lifeleechchance" value="100"/>
-		<attribute key="range" value="4"/>
+		<attribute key="range" value="5"/>
 		<attribute key="weight" value="2100"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
@@ -51560,8 +51564,10 @@
 		<attribute key="shootType" value="fire"/>
 		<attribute key="absorbpercentenergy" value="4"/>
 		<attribute key="magicpoints" value="2"/>
-		<attribute key="range" value="4"/>
+		<attribute key="range" value="6"/>
 		<attribute key="weight" value="3700"/>
+		<!--attribute key="perfectshotdamage" value="65"/-->
+		<!--attribute key="perfectshotrange" value="4"/-->
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
 			<attribute key="critical hit" value="3"/>
@@ -51633,6 +51639,7 @@
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3500"/>
+		<!--attribute key="healingmagiclevelpoints" value="2"/-->
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
 			<attribute key="skillboost axe" value="3"/>
@@ -51650,6 +51657,7 @@
 		<attribute key="magicpoints" value="2"/>
 		<attribute key="range" value="4"/>
 		<attribute key="weight" value="3600"/>
+		<!--attribute key="healingmagiclevelpoints" value="2"/-->
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
 			<attribute key="skillboost axe" value="3"/>
@@ -54797,7 +54805,7 @@
 		<attribute key="absorbpercentfire" value="4"/>
 		<attribute key="magicpoints" value="2"/>
 		<!--attribute key="icemagiclevelpoints" value="2"/-->
-		<attribute key="range" value="6"/>
+		<attribute key="range" value="5"/>
 		<attribute key="weight" value="2900"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="life leech" value="3"/>


### PR DESCRIPTION
# Description

- Fixado bônus de ML do item Deepling Fork id: 28826. De 3 para 2. Adicionado os atributos:
criticaldamage 25,
criticalchance 10
- Fixado bônus de ML do item Dream Blossom Staff id: 25700. Fixado o atributo range do mesmo, de 4 para 5.
- Fixado o peso do item Ferumbras' Staff (encantada) id: 22766 para 2250.
- Fixado o atributo range do item Gilded Eldritch Wand id: 36669. De 4 para 6. Adicionados os atributos perfectshot 65 e perfectshotrange 4, ambos como comentário.
- Adicionado o atributo healingmagiclevelpoints 2 no item Eldritch Rod id: 36674 em forma de comentário.
- Adicionado o atributo healingmagiclevelpoints 2 no item Gilded Eldritch Rod id: 36675 em forma de comentário.
- Fixado o atributo range do item Naga Rod id: 39163. De 6 para 5.
- Fixado nome do item com id: 22183 em unscripted_equipments.lua. De ogre sceptra para ogre scepta.
- Fixado bonus de ML do item Rod of Destruction id: 27458. De 2 para 1.
- Fixado nome do item com id: 3066 em unscripted_equipments.lua. De snakebit rod para snakebite rod.

## Behaviour
### **Actual**

Atributos dos itens citados faltando / errados.
Nome de item errado em unscripted_equipments.lua.

### **Expected**

Alterações feitas para tornar os itens mais fiel ao global.

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Com as alterações feitas, não ocorreu nenhum bug / erro na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
