### PR TITLE
fix: rings attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -275,7 +275,7 @@ local items = {
 		slot = "ring"
 	},
 	{
-		-- charged arcanomancer ring
+		-- charged arcanomancer sigil
 		itemid = 39184,
 		type = "equip",
 		slot = "ring",
@@ -286,7 +286,7 @@ local items = {
 		}
 	},
 	{
-		-- charged arcanomancer ring
+		-- charged arcanomancer sigil
 		itemid = 39184,
 		type = "deequip",
 		slot = "ring"
@@ -320,7 +320,7 @@ local items = {
 		}
 	},
 	{
-		-- charged alicorn ring
+		-- alicorn ring
 		itemid = 39182,
 		type = "deequip",
 		slot = "ring"
@@ -1997,19 +1997,13 @@ local items = {
 		-- lion ring
 		itemid = 34080,
 		type = "deequip",
-		slot = "ring",
-		level = 270
+		slot = "ring"
 	},
 	{
 		-- lion ring
 		itemid = 34080,
 		type = "equip",
-		slot = "ring",
-		level = 270,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+		slot = "ring"
 	},
 	{
 		-- Lit Torch (Sparkling)
@@ -2050,14 +2044,14 @@ local items = {
 		level = 200
 	},
 	{
-		-- ring of souls
+		-- enchanted ring of souls
 		itemid = 32635,
 		type = "equip",
 		slot = "ring",
 		level = 200
 	},
 	{
-		-- ring of souls
+		-- enchanted ring of souls
 		itemid = 32635,
 		type = "deequip",
 		slot = "ring",
@@ -2094,14 +2088,14 @@ local items = {
 		level = 230
 	},
 	{
-		-- ring of souls
+		-- enchanted ring of souls
 		itemid = 32621,
 		type = "equip",
 		slot = "ring",
 		level = 200
 	},
 	{
-		-- ring of souls
+		-- enchanted ring of souls
 		itemid = 32621,
 		type = "deequip",
 		slot = "ring",
@@ -2303,14 +2297,14 @@ local items = {
 		level = 220,
 	},
 	{
-		-- blister ring
+		-- enchanted blister ring
 		itemid = 31616,
 		type = "equip",
 		slot = "ring",
 		level = 220,
 	},
 	{
-		-- blister ring
+		-- enchanted blister ring
 		itemid = 31616,
 		type = "deequip",
 		slot = "ring",
@@ -2458,14 +2452,14 @@ local items = {
 		level = 230,
 	},
 	{
-		-- blister ring
+		-- enchanted blister ring
 		itemid = 31557,
 		type = "equip",
 		slot = "ring",
 		level = 220,
 	},
 	{
-		-- blister ring
+		-- enchanted blister ring
 		itemid = 31557,
 		type = "deequip",
 		slot = "ring",
@@ -13771,25 +13765,25 @@ local items = {
 		slot = "legs"
 	},
 	{
-		-- suspicious signet ring
+		-- family signet ring
 		itemid = 406,
 		type = "equip",
 		slot = "ring"
 	},
 	{
-		-- suspicious signet ring
+		-- family signet ring
 		itemid = 406,
 		type = "deequip",
 		slot = "ring"
 	},
 	{
-		-- family signet ring
+		-- suspicious signet ring
 		itemid = 349,
 		type = "equip",
 		slot = "ring"
 	},
 	{
-		-- family signet ring
+		-- suspicious signet ring
 		itemid = 349,
 		type = "deequip",
 		slot = "ring"

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -5544,7 +5544,7 @@
 	</item>
 	<item id="3245" article="a" name="ring of wishes">
 		<attribute key="description" value="(This item has 3 charges left)"/>
-		<attribute key="weight" value="90"/>
+		<attribute key="weight" value="50"/>
 	</item>
 	<item id="3246" name="boots of waterwalking">
 		<attribute key="description" value="(This item has 5 charges left)"/>
@@ -30948,7 +30948,7 @@
 	</item>
 	<item id="20209" article="an" name="unstable ring of ending">
 		<attribute key="description" value="Something is happening to this ring"/>
-		<attribute key="weight" value="0"/>
+		<attribute key="weight" value="60"/>
 	</item>
 	<item id="20210" article="a" name="filled cup">
 		<attribute key="description" value="The blend inside smells as if a dead green fairy had been dropped in it"/>
@@ -45368,7 +45368,7 @@
 		<attribute key="armor" value="3"/>
 		<attribute key="weight" value="570"/>
 	</item>
-	<item id="31557" article="a" name="blister ring">
+	<item id="31557" article="a" name="enchanted blister ring">
 		<attribute key="stopduration" value="1"/>
 		<attribute key="showduration" value="1"/>
 		<attribute key="transformequipto" value="31616"/>
@@ -45618,7 +45618,7 @@
 		<attribute key="description" value="The spell on it has faded"/>
 		<attribute key="weight" value="4500"/>
 	</item>
-	<item id="31616" article="a" name="blister ring">
+	<item id="31616" article="a" name="enchanted blister ring">
 		<attribute key="showduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentfire" value="6"/>
@@ -46877,7 +46877,7 @@
 			<attribute key="increase capacity" value="3"/>
 		</attribute>
 	</item>
-	<item id="32621" article="a" name="ring of souls">
+	<item id="32621" article="a" name="enchanted ring of souls">
 		<attribute key="stopduration" value="1"/>
 		<attribute key="showduration" value="1"/>
 		<attribute key="transformequipto" value="32635"/>
@@ -46937,8 +46937,7 @@
 		<attribute key="weight" value="250"/>
 	</item>
 	<item id="32634" article="a" name="raw crystal deposit"/>
-	<item id="32635" article="a" name="ring of souls">
-		<attribute key="description" value="Wearing it makes you feel a little weaker than usual."/>
+	<item id="32635" article="a" name="enchanted ring of souls">
 		<attribute key="showduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentphysical" value="2"/>
@@ -54886,7 +54885,7 @@
 		<attribute key="weight" value="95"/>
 	</item>
 	<item id="39179" article="a" name="spiritthorn ring">
-		<attribute key="absorbpercentphysical" value="8"/>
+		<attribute key="absorbpercentphysical" value="2"/>
 		<attribute key="absorbpercentfire" value="4"/>
 		<attribute key="absorbpercentearth" value="4"/>
 		<attribute key="absorbpercentenergy" value="4"/>
@@ -54906,6 +54905,8 @@
 		<attribute key="absorbpercentearth" value="4"/>
 		<attribute key="absorbpercentenergy" value="4"/>
 		<attribute key="absorbpercentice" value="4"/>
+		<attribute key="absorbpercentholy" value="4"/>
+		<attribute key="absorbpercentdeath" value="4"/>
 		<!--attribute key="holymagiclevelpoints" value="1"/-->
 		<attribute key="magicpoints" value="1"/>
 		<attribute key="skilldist" value="3"/>
@@ -54932,7 +54933,7 @@
 		<attribute key="showattributes" value="1" />
 		<attribute key="weight" value="90"/>
 	</item>
-	<item id="39184" article="a" name="charged arcanomancer ring">
+	<item id="39184" article="a" name="charged arcanomancer sigil">
 		<attribute key="absorbpercentfire" value="4"/>
 		<attribute key="absorbpercentearth" value="4"/>
 		<attribute key="absorbpercentenergy" value="4"/>


### PR DESCRIPTION
# Description

- Fixado nome do item com id: 39182 em unscripted_equipments.lua. De charged alicorn ring para alicorn ring.
- Adicionado defesa elemental holy 4% e death 4% no item Charged Alicorn Ring id: 39181.
- Fixado nome do item de id: 39184 em items.xml e em unscripted_equipments.lua. De charged arcanomancer ring para charged arcanomancer sigil.
- Fixado nome do item de id: 31557 e 31616 em items.xml e em unscripted_equipments.lua. De blister ring para enchanted blister ring.
- Fixado nome do item de id: 32621 e 32635 em items.xml e em unscripted_equipments.lua. De ring of souls para enchanted ring of souls. Removido o texto de descrição do item id: 32635.
- Removidas as restriçõoes de level e vocação do item Lion Ring id: 34080.
- Fixado o peso do item Ring of Wishes id: 3245. De 90 para 50.
- Fixado  bônus de protção física do item Spiritthorn Ring, id: 39179. De 8% para 2%.
- Fixados os IDs dos itens Suspicious Signet Ring e Family Signet Ring em unscripted_equipments.lua. Estavam trocados.
- Fixado o peso do item Unstable Ring of Ending id: 20209. De 0 para 60.

## Behaviour
### **Actual**

Alguns atributos e nomes de alguns rings errados.

## Type of change

Alterações feitas para que os itens afetados fiquem mais fieis ao global.

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações, nenhum erro/bug ocorreu na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
