### PR TITLE
fix: boots attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -154,8 +154,8 @@ local items = {
 		itemid = 40534,
 		type = "deequip",
 		slot = "feet"
-  },
-  {
+	},
+	{
 		-- broken macuahuitl
 		itemid = 40530,
 		type = "equip",
@@ -802,8 +802,8 @@ local items = {
 		itemid = 37610,
 		type = "deequip",
 		slot = "feet"
-  },
-  {
+	},
+	{
 		-- Morshabaal's mask
 		itemid = 37611,
 		type = "equip",

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -144,6 +144,18 @@ local items = {
 		level = 250
 	},
 	{
+		-- broken iks sandals
+		itemid = 40534,
+		type = "equip",
+		slot = "feet"
+	},
+	{
+		-- broken iks sandals
+		itemid = 40534,
+		type = "deequip",
+		slot = "feet"
+	},
+	{
 		-- 25 years backpack
 		itemid = 39693,
 		type = "equip",
@@ -766,6 +778,18 @@ local items = {
 		itemid = 39147,
 		type = "deequip",
 		slot = "armor"
+	},
+	{
+		-- green demon slippers
+		itemid = 37610,
+		type = "equip",
+		slot = "feet"
+	},
+	{
+		-- green demon slippers
+		itemid = 37610,
+		type = "deequip",
+		slot = "feet"
 	},
 	{
 		-- green demon helmet
@@ -2213,6 +2237,18 @@ local items = {
 		itemid = 32100,
 		type = "deequip",
 		slot = "head"
+	},
+	{
+		-- traditional leather shoes
+		itemid = 32098,
+		type = "equip",
+		slot = "feet"
+	},
+	{
+		-- traditional leather shoes
+		itemid = 32098,
+		type = "deequip",
+		slot = "feet"
 	},
 	{
 		-- meat hammer
@@ -14963,15 +14999,13 @@ local items = {
 		-- pair of soft boots
 		itemid = 6529,
 		type = "equip",
-		slot = "feet",
-		level = 10
+		slot = "feet"
 	},
 	{
 		-- pair of soft boots
 		itemid = 6529,
 		type = "deequip",
-		slot = "feet",
-		level = 10
+		slot = "feet"
 	},
 	{
 		-- tortoise shield
@@ -15750,15 +15784,13 @@ local items = {
 		-- pair of soft boots
 		itemid = 3549,
 		type = "equip",
-		slot = "feet",
-		level = 10
+		slot = "feet"
 	},
 	{
 		-- pair of soft boots
 		itemid = 3549,
 		type = "deequip",
-		slot = "feet",
-		level = 10
+		slot = "feet"
 	},
 	{
 		-- scythe

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -17631,7 +17631,7 @@
 	</item>
 	<item id="9020" name="worn firewalker boots">
 		<attribute key="description" value="They can be recharged with an enchanted ruby"/>
-		<attribute key="weight" value="800"/>
+		<attribute key="weight" value="950"/>
 	</item>
 	<item id="9021" article="a" name="dead gozzler">
 		<attribute key="duration" value="300"/>
@@ -50365,7 +50365,7 @@
 		<attribute key="absorbpercentice" value="6"/>
 		<attribute key="magicpoints" value="1"/>
 		<attribute key="armor" value="2"/>
-		<attribute key="weight" value="1200"/>
+		<attribute key="weight" value="1450"/>
 		<attribute key="imbuementslot" value="1">
 			<attribute key="increase speed" value="3"/>
 		</attribute>


### PR DESCRIPTION
# Description

- Adicionado o item Broken iks Sandals, id: 40534, em unscripted_equipments.lua. Removido o artigo "the" do nome do mesmo.
- Adicionado o item Green Demon Slippers id: 37610, em unscripted_equipments.lua.
- Fixado o peso do item Make-do Boots, id: 35520. De 1200 para 1450.
- Removida a restrição de level 10 para usar o item Pair of Soft Boots, ids: 3549 / 6529.
- Adicionado o item Traditional Leather Shoes id: 32098, em unscripted_equipments.lua.
- Fixado o peso do item Worn Firewalker Boots, id: 9020. De 800 para 950.

## Behaviour
### **Actual**

Atributos errados, e itens faltando em unscripted_equipments.lua.

### **Expected**

Alterações feitas para que os itens fiquem mais fiéis ao global.

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações, não ocorreu nenhum erro / bug na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
