### PR TITLE
fix: legs attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -154,8 +154,8 @@ local items = {
 		itemid = 40531,
 		type = "deequip",
 		slot = "legs"
-  },
-  {
+	},
+	{
 		-- broken iks sandals
 		itemid = 40534,
 		type = "equip",
@@ -2300,8 +2300,8 @@ local items = {
 		itemid = 32097,
 		type = "deequip",
 		slot = "legs"
-  },
-  {
+	},
+	{
 		-- traditional leather shoes
 		itemid = 32098,
 		type = "equip",

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -144,6 +144,18 @@ local items = {
 		level = 250
 	},
 	{
+		-- broken iks faulds
+		itemid = 40531,
+		type = "equip",
+		slot = "legs"
+	},
+	{
+		-- broken iks faulds
+		itemid = 40531,
+		type = "deequip",
+		slot = "legs"
+	},
+	{
 		-- 25 years backpack
 		itemid = 39693,
 		type = "equip",
@@ -778,6 +790,18 @@ local items = {
 		itemid = 37609,
 		type = "deequip",
 		slot = "head"
+	},
+	{
+		-- green demon legs
+		itemid = 37607,
+		type = "equip",
+		slot = "legs"
+	},
+	{
+		-- green demon legs
+		itemid = 37607,
+		type = "deequip",
+		slot = "legs"
 	},
 	{
 		-- changing backpack
@@ -2213,6 +2237,18 @@ local items = {
 		itemid = 32100,
 		type = "deequip",
 		slot = "head"
+	},
+	{
+		-- lederhosen
+		itemid = 32097,
+		type = "equip",
+		slot = "legs"
+	},
+	{
+		-- lederhosen
+		itemid = 32097,
+		type = "deequip",
+		slot = "legs"
 	},
 	{
 		-- meat hammer


### PR DESCRIPTION
# Description

- Adicionado o item Broken Iks Faulds, id: 40531 em unscripted_equipments.lua.
- Adicionado o item Green Demon Legs id: 37607, em unscripted_equipments.lua.
- Adicionado o item Lederhosen id: 32097, em unscripted_equipments.lua.

## Behaviour
### **Actual**

3 legs faltando em unscripted_equipments.lua.

### **Expected**

Adicionado e configurado como legs 3 itens.

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações nenhum erro/ bug foi gerado na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
