### PR TITLE
fix: armors attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -144,6 +144,18 @@ local items = {
 		level = 250
 	},
 	{
+		-- broken iks cuirass
+		itemid = 40533,
+		type = "equip",
+		slot = "armor"
+	},
+	{
+		-- broken iks cuirass
+		itemid = 40533,
+		type = "deequip",
+		slot = "armor"
+	},
+	{
 		-- 25 years backpack
 		itemid = 39693,
 		type = "equip",
@@ -778,6 +790,18 @@ local items = {
 		itemid = 37609,
 		type = "deequip",
 		slot = "head"
+	},
+	{
+		-- green demon armor
+		itemid = 37608,
+		type = "equip",
+		slot = "armor"
+	},
+	{
+		-- green demon armor
+		itemid = 37608,
+		type = "deequip",
+		slot = "armor"
 	},
 	{
 		-- changing backpack
@@ -1753,13 +1777,13 @@ local items = {
 		}
 	},
 	{
-		-- soulmantel armor
+		-- soulmantle
 		itemid = 34095,
 		type = "deequip",
 		slot = "armor"
 	},
 	{
-		-- soulmantel armor
+		-- soulmantle
 		itemid = 34095,
 		type = "equip",
 		slot = "armor",
@@ -2213,6 +2237,18 @@ local items = {
 		itemid = 32100,
 		type = "deequip",
 		slot = "head"
+	},
+	{
+		-- traditional shirt
+		itemid = 32099,
+		type = "equip",
+		slot = "armor"
+	},
+	{
+		-- traditional shirt
+		itemid = 32099,
+		type = "deequip",
+		slot = "armor"
 	},
 	{
 		-- meat hammer

--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -154,8 +154,8 @@ local items = {
 		itemid = 40533,
 		type = "deequip",
 		slot = "armor"
-  },
-  {
+	},
+	{
 		-- broken iks faulds
 		itemid = 40531,
 		type = "equip",
@@ -864,8 +864,8 @@ local items = {
 		itemid = 37608,
 		type = "deequip",
 		slot = "armor"
-  },
-  {
+	},
+	{
 		-- green demon legs
 		itemid = 37607,
 		type = "equip",
@@ -2324,8 +2324,8 @@ local items = {
 		itemid = 32099,
 		type = "deequip",
 		slot = "armor"
-  },
-  {
+	},
+	{
 		-- lederhosen
 		itemid = 32097,
 		type = "equip",

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -30045,7 +30045,7 @@
 		<attribute key="absorbpercentpoison" value="2"/>
 		<attribute key="absorbpercentfire" value="-2"/>
 		<attribute key="armor" value="12"/>
-		<attribute key="weight" value="4800"/>
+		<attribute key="weight" value="5800"/>
 	</item>
 	<item id="19373" article="a" name="haunted mirror piece">
 		<attribute key="weaponType" value="shield"/>
@@ -46994,7 +46994,7 @@
 	</item>
 	<item id="32705" article="a" name="pair of old bracers">
 		<attribute key="armor" value="1"/>
-		<attribute key="weight" value="20"/>
+		<attribute key="weight" value="200"/>
 	</item>
 	<item id="32706" article="a" name="unknow">
 		<attribute key="weight" value="4"/>


### PR DESCRIPTION
# Description

- Adicionado o item Broken iks Cuirass id: 40533, em unscripted_equipments.lua.
- Fixado o peso do item Goo Shell, id: 19372. De 4800 para 5800.
- Adicionado o item Green Demon Armor id: 37608, em unscripted_equipments.lua.
- Fixado o peso do item Pair of Old Bracers, id: 32705. De 20 para 200.
- Fixado nome do item de id: 34095 em unscripted_equipments.lua. De soulmantel armor para soulmantle.
- Adicionado o item Traditional Shirt id: 32099, em unscripted_equipments.lua.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Armors com atributos errados e itens faltando em unscripted_equipments.lua.

## Type of change

Please delete options that are not relevant.

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações, não ocorreu nenhum erro / bug na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
