### PR TITLE
fix: clubs attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -6543,14 +6543,14 @@ local items = {
 		level = 65
 	},
 	{
-		-- Ferumbras' staff
+		-- Ferumbras' staff (club)
 		itemid = 22764,
 		type = "equip",
 		slot = "hand",
 		level = 100
 	},
 	{
-		-- Ferumbras' staff
+		-- Ferumbras' staff (club)
 		itemid = 22764,
 		type = "deequip",
 		slot = "hand"
@@ -13961,7 +13961,11 @@ local items = {
 		itemid = 7452,
 		type = "equip",
 		slot = "hand",
-		level = 30
+		level = 30,
+		vocation = {
+			{"Knight", true},
+			{"Elite Knight"}
+  		}
 	},
 	{
 		-- spiked squelcher
@@ -16949,11 +16953,7 @@ local items = {
 		itemid = 3340,
 		type = "equip",
 		slot = "hand",
-		level = 70,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+		level = 70
 	},
 	{
 		-- heavy mace
@@ -17048,7 +17048,8 @@ local items = {
 		-- crystal mace
 		itemid = 3333,
 		type = "equip",
-		slot = "hand"
+		slot = "hand",
+		level = 35
 	},
 	{
 		-- crystal mace
@@ -17339,7 +17340,8 @@ local items = {
 		-- clerical mace
 		itemid = 3311,
 		type = "equip",
-		slot = "hand"
+		slot = "hand",
+		level = 20
 	},
 	{
 		-- clerical mace
@@ -18044,13 +18046,13 @@ local items = {
 	},
 	{
 		-- giant smithhammer
-		itemid = 12510,
+		itemid = 3208,
 		type = "equip",
 		slot = "hand"
 	},
 	{
 		-- giant smithhammer
-		itemid = 12510,
+		itemid = 3208,
 		type = "deequip",
 		slot = "hand"
 	},

--- a/data-otservbr-global/scripts/weapons/unscripted_weapons.lua
+++ b/data-otservbr-global/scripts/weapons/unscripted_weapons.lua
@@ -4456,11 +4456,7 @@ local weapons = {
 		itemid = 3340,
 		type = WEAPON_CLUB,
 		level = 70,
-		unproperly = true,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+		unproperly = true
 	},
 	{
 		-- djinn blade
@@ -4971,7 +4967,7 @@ local weapons = {
 	},
 	{
 		-- giant smithhammer
-		itemid = 12510,
+		itemid = 3208,
 		type = WEAPON_CLUB
 	},
 	{

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -7249,7 +7249,7 @@
 		<attribute key="weight" value="1500"/>
 	</item>
 	<item id="3453" article="a" name="scythe">
-		<attribute key="weaponType" value="axe"/>
+		<attribute key="weaponType" value="club"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="8"/>
 		<attribute key="defense" value="3"/>
@@ -39352,9 +39352,9 @@
 	<item id="27453" article="a" name="mace of destruction">
 		<attribute key="weaponType" value="club"/>
 		<attribute key="attack" value="50"/>
-		<attribute key="defense" value="30"/>
+		<attribute key="defense" value="32"/>
 		<attribute key="weight" value="5000"/>
-		<attribute key="imbuementslot" value="3">
+		<attribute key="imbuementslot" value="2">
 			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
@@ -39366,7 +39366,7 @@
 		<attribute key="weaponType" value="club"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="53"/>
-		<attribute key="defense" value="30"/>
+		<attribute key="defense" value="29"/>
 		<attribute key="weight" value="7000"/>
 		<attribute key="imbuementslot" value="3">
 			<attribute key="elemental damage" value="3"/>
@@ -42463,6 +42463,7 @@
 	</item>
 	<item id="29419" article="a" name="resizer">
 		<attribute key="weaponType" value="club"/>
+		<attribute key="slotType" value="two-handed"/>
 		<attribute key="elementice" value="46"/>
 		<attribute key="skillclub" value="2"/>
 		<attribute key="attack" value="11"/>


### PR DESCRIPTION
# Description

- Adicionado restrição de level para usar o item Clerical Mace id: 3311, em unscripted_equipments.lua.
- Adicionado restrição de level para usar o item Crystal Mace id: 3333, em unscripted_equipments.lua.
- Fixado o id do item Giant Smithhammer, em unscripted_equipments.lua e unscripted_weapons.lua. Ambos de 12510 para 3208.
- Fixado o atributo defense do item Hammer of Destruction, id: 27454. De 30 para 29.
- Removida a restrição de vocação knight do item Heavy Mace, id: 3340, em unscripted_equipments.lua e em unscripted_weapons.lua.
- Fixados os atributos do item Mace of Destruction, id: 27453:
defense - de 30 para 32;
imbuementslots - de 3 para 2;
- Adicionado o atributo slotType two-handed no item Resizer, id: 29419.
- Fixado o atributo weaponType do item Scythe, id: 3453. De axe para club.
- Adicionado restrição de vocação knight no item Spiked Squelcher, id: 7452, em unscripted_equipments.lua.

## Behaviour
### **Actual**

Atributos e configurações erradas / faltando ou a mais.

### **Expected**

Alterações feitas para que os itens fiquem mais fiéis ao global.

## Type of change

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações, não ocorreu nenhum erro / bug na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
