### PR TITLE
fix: axes attributes

### DIFF
--- a/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data-otservbr-global/scripts/movements/equipment/unscripted_equipments.lua
@@ -3907,7 +3907,7 @@ local items = {
 		itemid = 27452,
 		type = "equip",
 		slot = "hand",
-                level = 200,
+		level = 200,
 		vocation = {
 			{"Knight", true},
 			{"Elite Knight"}
@@ -6683,11 +6683,7 @@ local items = {
 		itemid = 22727,
 		type = "equip",
 		slot = "hand",
-        level = 70,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+        level = 70
 	},
 	{
 		-- rift lance
@@ -7734,7 +7730,7 @@ local items = {
 		itemid = 21174,
 		type = "equip",
 		slot = "hand",
-        level = 40
+        level = 45
 	},
 	{
 		-- mino lance
@@ -8243,7 +8239,12 @@ local items = {
 		-- umbral master chopper
 		itemid = 20075,
 		type = "equip",
-		slot = "hand"
+		slot = "hand",
+        level = 250,
+		vocation = {
+			{"Knight", true},
+			{"Elite Knight"}
+        }
 	},
 	{
 		-- umbral master chopper
@@ -8256,7 +8257,7 @@ local items = {
 		itemid = 20074,
 		type = "equip",
 		slot = "hand",
-                level = 120,
+        level = 120,
 		vocation = {
 			{"Knight", true},
 			{"Elite Knight"}
@@ -8325,7 +8326,7 @@ local items = {
 		itemid = 20070,
 		type = "equip",
 		slot = "hand",
-              level = 75,
+        level = 75,
 		vocation = {
 			{"Knight", true},
 			{"Elite Knight"}
@@ -16923,7 +16924,11 @@ local items = {
 		itemid = 3342,
 		type = "equip",
 		slot = "hand",
-        level = 65
+        level = 65,
+		vocation = {
+			{"Knight", true},
+			{"Elite Knight"}
+		}
 	},
 	{
 		-- war axe
@@ -17078,11 +17083,7 @@ local items = {
 		itemid = 3331,
 		type = "equip",
 		slot = "hand",
-        level = 70,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+        level = 70
 	},
 	{
 		-- ravager's axe
@@ -17915,7 +17916,11 @@ local items = {
 		-- battle axe
 		itemid = 3266,
 		type = "equip",
-		slot = "hand"
+		slot = "hand",
+		vocation = {
+			{"Knight", true},
+			{"Elite Knight"}
+		}
 	},
 	{
 		-- battle axe

--- a/data-otservbr-global/scripts/weapons/unscripted_weapons.lua
+++ b/data-otservbr-global/scripts/weapons/unscripted_weapons.lua
@@ -2061,6 +2061,7 @@ local weapons = {
 		type = WEAPON_AXE,
 		level = 75,
 		unproperly = true,
+		action = "removecharge",
 		vocation = {
 			{"Knight", true},
 			{"Elite Knight"}
@@ -2072,6 +2073,7 @@ local weapons = {
 		type = WEAPON_SWORD,
 		level = 75,
 		unproperly = true,
+		action = "removecharge",
 		vocation = {
 			{"Knight", true},
 			{"Elite Knight"}
@@ -2294,7 +2296,7 @@ local weapons = {
 		}
 	},
 	{
-		-- guardian halberd
+		-- crude umbral chopper
 		itemid = 20073,
 		type = WEAPON_AXE,
 		level = 75,
@@ -4525,11 +4527,7 @@ local weapons = {
 		itemid = 3331,
 		type = WEAPON_AXE,
 		level = 70,
-		unproperly = true,
-		vocation = {
-			{"Knight", true},
-			{"Elite Knight"}
-		}
+		unproperly = true
 	},
 	{
 		-- heavy machete

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -18717,7 +18717,7 @@
 	</item>
 	<item id="9384" article="a" name="scythe of the reaper">
 		<attribute key="description" value="This scythe has harvested countless souls and still hungers for more"/>
-		<attribute key="weaponType" value="club"/>
+		<attribute key="weaponType" value="axe"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="16"/>
 		<attribute key="defense" value="6"/>
@@ -18732,7 +18732,7 @@
 	</item>
 	<item id="9386" article="a" name="farmer's avenger">
 		<attribute key="description" value="A weapon forged to fight oppression of the poor underdogs"/>
-		<attribute key="weaponType" value="sword"/>
+		<attribute key="weaponType" value="axe"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="17"/>
 		<attribute key="defense" value="7"/>
@@ -22897,7 +22897,7 @@
 		<attribute key="weight" value="4000"/>
 	</item>
 	<item id="12683" article="a" name="heavy trident">
-		<attribute key="weaponType" value="sword"/>
+		<attribute key="weaponType" value="axe"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="35"/>
 		<attribute key="defense" value="17"/>
@@ -39327,7 +39327,7 @@
 		<attribute key="attack" value="51"/>
 		<attribute key="defense" value="31"/>
 		<attribute key="weight" value="5000"/>
-		<attribute key="imbuementslot" value="3">
+		<attribute key="imbuementslot" value="2">
 			<attribute key="elemental damage" value="3"/>
 			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
@@ -39339,7 +39339,7 @@
 		<attribute key="weaponType" value="axe"/>
 		<attribute key="slotType" value="two-handed"/>
 		<attribute key="attack" value="52"/>
-		<attribute key="defense" value="32"/>
+		<attribute key="defense" value="30"/>
 		<attribute key="weight" value="7000"/>
 		<attribute key="imbuementslot" value="3">
 			<attribute key="elemental damage" value="3"/>
@@ -48820,7 +48820,7 @@
 		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="attack" value="10"/>
-		<attribute key="defense" value="35"/>
+		<attribute key="defense" value="34"/>
 		<attribute key="weight" value="7200"/>
 		<attribute key="imbuementslot" value="3">
 			<attribute key="life leech" value="3"/>


### PR DESCRIPTION
# Description

- Fixado o atributo imbuementslot do item Axe of Destruction, id: 27451. De 3 para 2.
- Adicionado restriçã de vocação knight no item Battle Axe, id: 3266, em unscripted_equipments.lua.
- Fixado o atributo defense do item Chopper of Destruction, id: 27452. De 32 para 30.
- Fixado nome do item com id: 20073 em unscripted_weapons.lua. De guardian halberd para crude umbral chopper.
- Fixado o atributo weaponType do item Farmer's Avender, id: 9386. De sword para axe.
- Adicionada a função removecharges no item Glooth Axe, id: 21180, em unscripted_weapons.lua.
- Adicionada a função removecharges no item Glooth Blade, id: 21179, em unscripted_weapons.lua.
- Fixado o atributo weaponType do item Heavy Trident, id: 1268. De sword para axe.
- Fixado o level mínimo para usar o item Mino Lance, id: 21174 em unscripted_equipments.lua. De 40 para 45.
- Removida a restrição de vocação do item Ravager's Axe, id: 3331 em unscripted_equipments.lua e em unscripted_weapons.lua.
- Removida a restrição de vocação do item Rift Lance, id: 22727 em unscripted_equipments.lua.
- Fixado  atributo weaponType do item Scythe of the Reaper, id: 9384. De club para axe.
- Fixado o atributo defense do item Souleater (axe), id: 34085. De 35 para 34.
- Adicionado restrição de level 250 e vocação knight no item Umbral Master Chopper, id: 20075 em unscripted_equipments.lua.
- Adicionado restrição de vocação knight no item War Axe, id: 3342 em unscripted_equipments.lua.

## Behaviour
### **Actual**

Atributos e configurações erradas.

### **Expected**

Alterações feitas para que os itens fiquem mais fiéis ao global.

## Type of change

  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

Após as alterações, não ocorreu nenhum erro / bug na distro.

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
