### PR TITLE
fix: little optimization checkImbuements

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3821,7 +3821,7 @@ double_t Player::calculateDamageReduction(double_t currentTotal, int16_t resista
 
 phmap::flat_hash_map<uint8_t, Item*> Player::getAllSlotItems() const {
 	phmap::flat_hash_map<uint8_t, Item*> itemVector;
-	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
+	for (uint8_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		Item* item = inventory[i];
 		if (!item) {
 			continue;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -489,7 +489,7 @@ void Player::updateInventoryImbuement() {
 	bool isInFightMode = hasCondition(CONDITION_INFIGHT);
 
 	// Iterate through all items in the player's inventory
-	for (auto item : getAllSlotItems()) {
+	for (auto [key, item] : getAllSlotItems()) {
 		// Iterate through all imbuement slots on the item
 
 		for (uint8_t slotid = 0; slotid < item->getImbuementSlot(); slotid++) {
@@ -3819,15 +3819,15 @@ double_t Player::calculateDamageReduction(double_t currentTotal, int16_t resista
 	return (100 - currentTotal) / 100.0 * resistance + currentTotal;
 }
 
-std::vector<Item*> Player::getAllSlotItems() const {
-	std::vector<Item*> itemVector;
+phmap::flat_hash_map<uint8_t, Item*> Player::getAllSlotItems() const {
+	phmap::flat_hash_map<uint8_t, Item*> itemVector;
 	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		Item* item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
-		itemVector.push_back(item);
+		itemVector[i] = item;
 	}
 
 	return itemVector;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -489,7 +489,7 @@ void Player::updateInventoryImbuement() {
 	bool isInFightMode = hasCondition(CONDITION_INFIGHT);
 
 	// Iterate through all items in the player's inventory
-	for (auto item : getAllInventoryItems()) {
+	for (auto item : getAllSlotItems()) {
 		// Iterate through all imbuement slots on the item
 
 		for (uint8_t slotid = 0; slotid < item->getImbuementSlot(); slotid++) {
@@ -3817,6 +3817,20 @@ void Player::updateDamageReductionFromItemAbility(
 
 double_t Player::calculateDamageReduction(double_t currentTotal, int16_t resistance) const {
 	return (100 - currentTotal) / 100.0 * resistance + currentTotal;
+}
+
+std::vector<Item*> Player::getAllSlotItems() const {
+	std::vector<Item*> itemVector;
+	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
+		Item* item = inventory[i];
+		if (!item) {
+			continue;
+		}
+
+		itemVector.push_back(item);
+	}
+
+	return itemVector;
 }
 
 std::vector<Item*> Player::getAllInventoryItems(bool ignoreEquiped /*= false*/, bool ignoreItemWithTier /* false*/) const {

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2433,7 +2433,7 @@ class Player final : public Creature, public Cylinder {
 		// This get all player inventory items
 		std::vector<Item*> getAllInventoryItems(bool ignoreEquiped = false, bool ignoreItemWithTier = false) const;
 		// this get all players slot items
-		std::vector<Item*> getAllSlotItems() const;
+		phmap::flat_hash_map<uint8_t, Item*> getAllSlotItems() const;
 
 		// This function is a override function of base class
 		std::map<uint32_t, uint32_t> &getAllItemTypeCount(std::map<uint32_t, uint32_t> &countMap) const override;

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2432,6 +2432,9 @@ class Player final : public Creature, public Cylinder {
 
 		// This get all player inventory items
 		std::vector<Item*> getAllInventoryItems(bool ignoreEquiped = false, bool ignoreItemWithTier = false) const;
+		// this get all players slot items
+		std::vector<Item*> getAllSlotItems() const;
+
 		// This function is a override function of base class
 		std::map<uint32_t, uint32_t> &getAllItemTypeCount(std::map<uint32_t, uint32_t> &countMap) const override;
 		// Function from player class with correct type sizes (uint16_t)


### PR DESCRIPTION
# Description

In search of improvements where each MS matters so that the g_dispatcher queue doesn't wait too long to execute a new task.
I found a small improvement that there was a result thinking on a large scale!
When the user has several items in the main SLOT bag, the verification is very slow and for imbuements it is not necessary!

Below are the test prints.

[GOD] > Too many items inside the main bag SLOT
[Luks] > Few items

![checkImbuementsOld](https://github.com/opentibiabr/canary/assets/38956084/d6ff1c80-51af-42d9-85b2-7ffef7e240b0)

**after correction**
[GOD] Too many items inside the main bag
![CheckImbuementsNew](https://github.com/opentibiabr/canary/assets/38956084/441e768c-415b-4eb8-9cee-3f23893fc02b)
