### PR TITLE
fix: monster runAwayHealth respects multiplier

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -38,6 +38,7 @@ Monster::Monster(MonsterType* mType) :
 	float multiplier = g_configManager().getFloat(RATE_MONSTER_HEALTH);
 	health = mType->info.health * multiplier;
 	healthMax = mType->info.healthMax * multiplier;
+	runAwayHealth = mType->info.runAwayHealth * multiplier;
 	baseSpeed = mType->getBaseSpeed();
 	internalLight = mType->info.light;
 	hiddenHealth = mType->info.hiddenHealth;

--- a/src/creatures/monsters/monster.h
+++ b/src/creatures/monsters/monster.h
@@ -233,7 +233,7 @@ class Monster final : public Creature {
 
 		bool isTarget(const Creature* creature) const;
 		bool isFleeing() const {
-			return !isSummon() && getHealth() <= mType->info.runAwayHealth && challengeFocusDuration <= 0;
+			return !isSummon() && getHealth() <= runAwayHealth && challengeFocusDuration <= 0 && challengeMeleeDuration <= 0;
 		}
 
 		bool getDistanceStep(const Position &targetPos, Direction &direction, bool flee = false);
@@ -366,6 +366,7 @@ class Monster final : public Creature {
 		int32_t targetDistance = 1;
 		int32_t challengeMeleeDuration = 0;
 		uint16_t totalPlayersOnScreen = 0;
+		int32_t runAwayHealth = 0;
 
 		Position masterPos;
 


### PR DESCRIPTION
# Description

Prior to this change, if you change the HP multiplier creatures like rabbit, deer, etc would follow players. This is incorrect behavior since they are meant to run away even in full health.

This happens due to the absolute value based configuration for run away health, which doesn't play well witht he multiplier. So this fix also multiples the run away health by the same factor.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Tested a few non aggressive creatures (rabbit, deer, dog)
  - [x] Tested Spit nettle (a creature that is supposed to stand still)
  - [x] Tested regular creatures that have a run away health < 100% (dragon, hydra)

**Test Configuration**:

  - Server Version: Latest main + this PR
  - Client: 13.16
  - Operating System: Ubuntu 22.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
