### PR TITLE
fix: hireling vial item to correct id

### DIFF
--- a/data-otservbr-global/npc/hireling.lua
+++ b/data-otservbr-global/npc/hireling.lua
@@ -271,7 +271,7 @@ function createHirelingType(HirelingName)
 		{itemName = "venorean cabinet", clientId = 17974, buy = 90},
 		{itemName = "venorean drawer", clientId = 17977, buy = 40},
 		{itemName = "venorean wardrobe", clientId = 17975, buy = 50},
-		{itemName = "vial", clientId = 377, sell = 5},
+		{itemName = "vial", clientId = 2874, sell = 5},
 		{itemName = "viking helmet", clientId = 3367, sell = 66},
 		{itemName = "viking shield", clientId = 3431, sell = 85},
 		{itemName = "vortex bolt", clientId = 14252, buy = 6},


### PR DESCRIPTION
# Description

Include correct client id for vial

- [X] Fixes #1201 

![image](https://github.com/opentibiabr/canary/assets/38956084/867ec72a-1a4d-478d-ae80-384ca388c847)