### PR TITLE
fix: use player ids to safely check party events

### DIFF
--- a/data/events/scripts/party.lua
+++ b/data/events/scripts/party.lua
@@ -31,7 +31,7 @@ function Party:onLeave(player)
 			player:updateHazard()
 		end
 
-		for _, memberId in ipairs(membersIds) do
+		for _, memberId in ipairs(memberIds) do
 			local member = Player(memberId)
 			local party = member:getParty()
 			if party then
@@ -53,7 +53,7 @@ function Party:onDisband()
 		end
 	end
 	addEvent(function()
-		for _, memberId in ipairs(membersIds) do
+		for _, memberId in ipairs(memberIds) do
 			local member = Player(memberId)
 			if member then
 				member:updateHazard()
@@ -89,7 +89,6 @@ function Party:refreshHazard()
 		end
 	end
 	for _, member in ipairs(members) do
-		Spdlog.info("Party:refreshHazard: " .. member:getName() .. " level: " .. level)
 		member:setHazardSystemPoints(level)
 	end
 end

--- a/data/events/scripts/party.lua
+++ b/data/events/scripts/party.lua
@@ -1,20 +1,65 @@
 function Party:onJoin(player)
-	addEvent(function() self:refreshHazard() end, 100)
+	local playerId = player:getId()
+	addEvent(function()
+		player = Player(playerId)
+		if not player then
+			return
+		end
+		local party = player:getParty()
+		if not party then
+			return
+		end
+		party:refreshHazard()
+	end, 100)
 	return true
 end
 
 function Party:onLeave(player)
-	addEvent(function() self:refreshHazard() end, 100)
-	addEvent(function() player:updateHazard() end, 100)
+	local playerId = player:getId()
+	local members = self:getMembers()
+	table.insert(members, self:getLeader())
+	local memberIds = {}
+	for _, member in ipairs(members) do
+		if member:getId() ~= playerId then
+			table.insert(memberIds, member:getId())
+		end
+	end
+
+	addEvent(function()
+		player = Player(playerId)
+		if player then
+			player:updateHazard()
+		end
+
+		for _, memberId in ipairs(membersIds) do
+			local member = Player(memberId)
+			local party = member:getParty()
+			if party then
+				party:refreshHazard()
+				return -- Only one player needs to refresh the hazard for the party
+			end
+		end
+	end, 100)
 	return true
 end
 
 function Party:onDisband()
 	local members = self:getMembers()
 	table.insert(members, self:getLeader())
+	local memberIds = {}
 	for _, member in ipairs(members) do
-		addEvent(function() member:updateHazard() end, 100)
+		if member:getId() ~= playerId then
+			table.insert(memberIds, member:getId())
+		end
 	end
+	addEvent(function()
+		for _, memberId in ipairs(membersIds) do
+			local member = Player(memberId)
+			if member then
+				member:updateHazard()
+			end
+		end
+	end, 100)
 	return true
 end
 


### PR DESCRIPTION
Using objects from the outer closure in the event was causing a crash because the`party` or the `player` may no longer exist by the time the event runs. We now re-fetch everything based on the party members when the event runs.