### PR TITLE
fix: use correct manaSpent value when calculating loyalty

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5110,10 +5110,10 @@ uint32_t Player::getLoyaltyMagicLevel() const {
 	}
 
 	absl::uint128 spent = manaSpent;
-	absl::uint128 totalMana = vocation->getTotalMana(level) + mana;
+	absl::uint128 totalMana = vocation->getTotalMana(level) + spent;
 	absl::uint128 loyaltyMana = (totalMana * getLoyaltyBonus()) / 100;
 	while ((spent + loyaltyMana) >= nextReqMana) {
-		loyaltyMana -= nextReqMana - mana;
+		loyaltyMana -= nextReqMana - spent;
 		level++;
 		spent = 0;
 


### PR DESCRIPTION
Use proper `manaSpent` variable when calculating loyalty magic level boosts. We were using `mana` incorrectly which was causing things to get wildly out of control :P

Fixes #1227 

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)