### PR TITLE
fix: use/move/trade/add/remove item from house logic

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2968,6 +2968,16 @@ void Game::playerUseItemEx(uint32_t playerId, const Position &fromPos, uint8_t f
 		return;
 	}
 
+	if (g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(item->getTile())) {
+			House* house = houseTile->getHouse();
+			if (house && item->getRealParent() && item->getRealParent() != player && (!house->isInvited(player) || house->getHouseAccessLevel(player) == HOUSE_GUEST)) {
+				player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
+				return;
+			}
+		}
+	}
+
 	Position walkToPos = fromPos;
 	ReturnValue ret = g_actions().canUse(player, fromPos);
 	if (ret == RETURNVALUE_NOERROR) {
@@ -3092,6 +3102,16 @@ void Game::playerUseItem(uint32_t playerId, const Position &pos, uint8_t stackPo
 		return;
 	}
 
+	if (g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(item->getTile())) {
+			House* house = houseTile->getHouse();
+			if (house && item->getRealParent() && item->getRealParent() != player && (!house->isInvited(player) || house->getHouseAccessLevel(player) == HOUSE_GUEST)) {
+				player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
+				return;
+			}
+		}
+	}
+
 	const ItemType &it = Item::items[item->getID()];
 	if (it.isRune() || it.type == ITEM_TYPE_POTION) {
 		if (player->walkExhausted()) {
@@ -3191,6 +3211,16 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 	if (!item || !item->isMultiUse() || item->getID() != itemId) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
 		return;
+	}
+
+	if (g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
+		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(item->getTile())) {
+			House* house = houseTile->getHouse();
+			if (house && item->getRealParent() && item->getRealParent() != player && (!house->isInvited(player) || house->getHouseAccessLevel(player) == HOUSE_GUEST)) {
+				player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
+				return;
+			}
+		}
 	}
 
 	const ItemType &it = Item::items[item->getID()];
@@ -3956,8 +3986,8 @@ void Game::playerRequestTrade(uint32_t playerId, const Position &pos, uint8_t st
 	if (g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (HouseTile* houseTile = dynamic_cast<HouseTile*>(tradeItem->getTile())) {
 			House* house = houseTile->getHouse();
-			if (house && !house->isInvited(player)) {
-				player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
+			if (house && tradeItem->getRealParent() != player && (!house->isInvited(player) || house->getHouseAccessLevel(player) == HOUSE_GUEST)) {
+				player->sendCancelMessage(RETURNVALUE_NOTMOVEABLE);
 				return;
 			}
 		}

--- a/src/map/house/housetile.cpp
+++ b/src/map/house/housetile.cpp
@@ -80,7 +80,7 @@ ReturnValue HouseTile::queryAdd(int32_t index, const Thing &thing, uint32_t coun
 		}
 	} else if (thing.getItem() && actor) {
 		Player* actorPlayer = actor->getPlayer();
-		if (!house->isInvited(actorPlayer)) {
+		if (house && (!house->isInvited(actorPlayer) || house->getHouseAccessLevel(actorPlayer) == HOUSE_GUEST) && g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 			return RETURNVALUE_CANNOTTHROW;
 		}
 	}
@@ -122,8 +122,10 @@ ReturnValue HouseTile::queryRemove(const Thing &thing, uint32_t count, uint32_t 
 
 	if (actor && g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		Player* actorPlayer = actor->getPlayer();
-		if (!house->isInvited(actorPlayer)) {
-			return RETURNVALUE_PLAYERISNOTINVITED;
+		if (house && !house->isInvited(actorPlayer)) {
+			return RETURNVALUE_NOTPOSSIBLE;
+		} else if (house && house->getHouseAccessLevel(actorPlayer) == HOUSE_GUEST) {
+			return RETURNVALUE_NOTMOVEABLE;
 		}
 	}
 	return Tile::queryRemove(thing, count, flags);


### PR DESCRIPTION
# Description

The guest player (aleta sio) will no longer be able to:
• Using an item inside the house
• Trade an item inside the house
• Give "use with" item inside house
• Move item inside house
And no other type of interaction with the item (except the "look")

It is also no longer allowed to throw items in the house, unless you are a subowner (aleta som).

## Behaviour
### **Actual**

Guest can execute actions.

### **Expected**

Guest cannot more execute actions.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
