### PR TITLE
fix: intialize participants as empty table

### DIFF
--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -43,7 +43,7 @@ function Monster:onDropLoot(corpse)
 			end
 		end
 
-		local participants = nil
+		local participants = {}
 		local modifier = 1
 
 		if player then


### PR DESCRIPTION
Small fix -- when mobs kill each other, which happens with factions participants being nil causes an error. Initialize it to an empty table, it's used as a list so it'll just count as no players killing the monster.