### PR TITLE
fix: return true by default on combats

### DIFF
--- a/data-otservbr-global/monster/reptiles/harpy.lua
+++ b/data-otservbr-global/monster/reptiles/harpy.lua
@@ -94,7 +94,7 @@ monster.attacks = {
 	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -345},
 	{name ="combat", interval = 2000, chance = 30, type = COMBAT_PHYSICALDAMAGE, minDamage = -296, maxDamage = -350, range = 3, effect = CONST_ME_BIG_SCRATCH, target = true},
 	{name ="energy ring", interval = 2000, chance = 20, minDamage = -280, maxDamage = -350},
-	{name ="energy chain", interval = 2000, chance = 100, minDamage = -155, maxDamage = -249, range = 3, target = true},
+	{name ="energy chain", interval = 2000, chance = 20, minDamage = -155, maxDamage = -249, range = 3, target = true},
 	{name ="combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -310, maxDamage = -405, length = 5, spread = 3, effect = CONST_ME_SOUND_BLUE, target = false},
 	{name ="combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = -320, maxDamage = -420, range = 7, radius = 4, effect = CONST_ME_ENERGYHIT, target = true},
 	{name ="combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -425, maxDamage = -545, effect = CONST_ME_POISON, target = true},

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1294,7 +1294,8 @@ void Combat::doCombatCondition(Creature* caster, Creature* target, const CombatP
 }
 
 void Combat::doCombatDispel(Creature* caster, const Position &position, const AreaCombat* area, const CombatParams &params) {
-	CombatFunc(caster, caster->getPosition(), position, area, params, CombatDispelFunc, nullptr);
+	auto origin = caster ? caster->getPosition() : Position();
+	CombatFunc(caster, origin, position, area, params, CombatDispelFunc, nullptr);
 }
 
 void Combat::doCombatDispel(Creature* caster, Creature* target, const CombatParams &params) {

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -155,7 +155,7 @@ int CombatFunctions::luaCombatExecute(lua_State* L) {
 	const LuaVariant &variant = getVariant(L, 3);
 	combat->setInstantSpellName(variant.instantName);
 	combat->setRuneSpellName(variant.runeName);
-	bool result = false;
+	bool result = true;
 	switch (variant.type) {
 		case VARIANT_NUMBER: {
 			Creature* target = g_game().getCreatureByID(variant.number);


### PR DESCRIPTION
# Description

If we return false here the spell ends up not casting properly from lua.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
