### PR TITLE
fix: error in spell of arachnophobica and add neutral damage enum

### DIFF
--- a/data-otservbr-global/scripts/spells/monster/arachnophobica_wavedice.lua
+++ b/data-otservbr-global/scripts/spells/monster/arachnophobica_wavedice.lua
@@ -1,5 +1,5 @@
 local combat = createCombatObject()
-setCombatParam(combat, COMBAT_PARAM_TYPE, CONDITION_DROWN)
+setCombatParam(combat, COMBAT_PARAM_TYPE, COMBAT_DROWNDAMAGE)
 setCombatParam(combat, COMBAT_PARAM_EFFECT, CONST_ME_CRAPS)
 
 	arr = {

--- a/src/lua/functions/core/game/lua_enums.cpp
+++ b/src/lua/functions/core/game/lua_enums.cpp
@@ -262,6 +262,7 @@ void LuaEnums::initCombatEnums(lua_State* L) {
 	registerEnum(L, COMBAT_ICEDAMAGE);
 	registerEnum(L, COMBAT_HOLYDAMAGE);
 	registerEnum(L, COMBAT_DEATHDAMAGE);
+	registerEnum(L, COMBAT_NEUTRALDAMAGE);
 }
 
 void LuaEnums::initCombatParamEnums(lua_State* L) {


### PR DESCRIPTION
The typo error in the spell was causing a very annoying error in the distro, because the enum type (15) does not exist.
Added neutral damage to the lua enum.