### PR TITLE
fix: loop related to creature destination inside a teleport items

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -284,6 +284,11 @@ bool Map::placeCreature(const Position &centerPos, Creature* creature, bool exte
 				continue;
 			}
 
+			// Will never add the creature inside a teleport, avoiding infinite loop bug
+			if (tile->hasFlag(TILESTATE_TELEPORT)) {
+				continue;
+			}
+
 			if (monster) {
 				monster->ignoreFieldDamage = true;
 			}


### PR DESCRIPTION
# Description

Fixed the issue with the player being moved into the teleport, which causes the game to loop and crash.

The bug only happens in a very specific scenario. Thanks to @travisani for reporting.
