### PR TITLE
fix: force clean map when loading custom overlay

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1875,7 +1875,7 @@ ReturnValue Game::internalAddItem(Cylinder* toCylinder, Item* item, int32_t inde
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool test /*= false*/, uint32_t flags /*= 0*/) {
+ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool test /*= false*/, uint32_t flags /*= 0*/, bool force /*= false*/) {
 	if (item == nullptr) {
 		SPDLOG_DEBUG("{} - Item is nullptr", __FUNCTION__);
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -1895,19 +1895,18 @@ ReturnValue Game::internalRemoveItem(Item* item, int32_t count /*= -1*/, bool te
 	if (count == -1) {
 		count = item->getItemCount();
 	}
-	// check if we can remove this item
 	ReturnValue ret = cylinder->queryRemove(*item, count, flags | FLAG_IGNORENOTMOVEABLE);
-	if (ret != RETURNVALUE_NOERROR) {
+	if (!force && ret != RETURNVALUE_NOERROR) {
 		SPDLOG_DEBUG("{} - Failed to execute query remove", __FUNCTION__);
 		return ret;
 	}
-	if (!item->canRemove()) {
+	if (!force && !item->canRemove()) {
 		SPDLOG_DEBUG("{} - Failed to remove item", __FUNCTION__);
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
 	// Not remove item with decay loaded from map
-	if (item->canDecay() && cylinder->getTile() && item->getLoadedFromMap()) {
+	if (!force && item->canDecay() && cylinder->getTile() && item->getLoadedFromMap()) {
 		SPDLOG_DEBUG("Cannot remove item with id {}, name {}, on position {}", item->getID(), item->getName(), cylinder->getPosition().toString());
 		item->stopDecaying();
 		return RETURNVALUE_THISISIMPOSSIBLE;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -186,7 +186,7 @@ class Game {
 
 		ReturnValue internalAddItem(Cylinder* toCylinder, Item* item, int32_t index = INDEX_WHEREEVER, uint32_t flags = 0, bool test = false);
 		ReturnValue internalAddItem(Cylinder* toCylinder, Item* item, int32_t index, uint32_t flags, bool test, uint32_t &remainderCount);
-		ReturnValue internalRemoveItem(Item* item, int32_t count = -1, bool test = false, uint32_t flags = 0);
+		ReturnValue internalRemoveItem(Item* item, int32_t count = -1, bool test = false, uint32_t flags = 0, bool force = false);
 
 		ReturnValue internalPlayerAddItem(Player* player, Item* item, bool dropOnMap = true, Slots_t slot = CONST_SLOT_WHEREEVER);
 

--- a/src/io/iomap.cpp
+++ b/src/io/iomap.cpp
@@ -236,7 +236,7 @@ bool IOMap::parseTileArea(OTB::Loader &loader, const OTB::Node &tileAreaNode, Ma
 					if (!item_list.size() == 0) {
 						for (Item* item : item_list) {
 							if (item) {
-								g_game().internalRemoveItem(item);
+								g_game().internalRemoveItem(item, -1, false, 0, true);
 							}
 						}
 					}
@@ -244,7 +244,7 @@ bool IOMap::parseTileArea(OTB::Loader &loader, const OTB::Node &tileAreaNode, Ma
 
 				if (Item* ground = tile->getGround();
 					ground) {
-					g_game().internalRemoveItem(ground);
+					g_game().internalRemoveItem(ground, -1, false, 0, true);
 				}
 			}
 			continue;


### PR DESCRIPTION
# Description

When dealing with custom maps, things like depot boxes don't get overriden and you may end up with multiple. This forces removal of otherwise non-removable items when unloading a map for a custom overlay.

Note that this does not fix houses in custom maps, those still don't work / can cause crashes.

