### PR TITLE
fix: prevent special characters in house list

### DIFF
--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -410,8 +410,8 @@ void AccessList::parseList(const std::string &list) {
 	playerList.clear();
 	guildRankList.clear();
 	allowEveryone = false;
+	this->list = validList;
 	if (list.empty()) {
-		this->list = validList;
 		return;
 	}
 
@@ -444,7 +444,6 @@ void AccessList::parseList(const std::string &list) {
 			addPlayer(line);
 		}
 	}
-	this->list = validList;
 }
 
 void AccessList::addPlayer(const std::string &name) {

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -406,15 +406,16 @@ bool House::executeTransfer(HouseTransferItem* item, Player* newOwner) {
 }
 
 void AccessList::parseList(const std::string &list) {
+	std::string validList = validateNameHouse(list);
 	playerList.clear();
 	guildRankList.clear();
 	allowEveryone = false;
-	this->list = list;
 	if (list.empty()) {
+		this->list = validList;
 		return;
 	}
 
-	auto lines = explodeString(list, "\n", 100);
+	auto lines = explodeString(validList, "\n", 100);
 	for (auto &line : lines) {
 		trimString(line);
 		trim_left(line, '\t');
@@ -443,6 +444,7 @@ void AccessList::parseList(const std::string &list) {
 			addPlayer(line);
 		}
 	}
+	this->list = validList;
 }
 
 void AccessList::addPlayer(const std::string &name) {

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -1428,6 +1428,17 @@ void consoleHandlerExit() {
 	return;
 }
 
+std::string validateNameHouse(const std::string &list) {
+	std::string result;
+	for (char c : list) {
+		if (isalpha(c) || c == ' ' || c == '\'' || c == '!' || c == '\n'
+			|| c == '?' || c == '#' || c == '@' || c == '*') {
+			result += c;
+		}
+	}
+	return result;
+}
+
 NameEval_t validateName(const std::string &name) {
 	StringVector prohibitedWords = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "cm", "gm", "tutor", "counsellor", "god" };
 	StringVector toks;

--- a/src/utils/tools.h
+++ b/src/utils/tools.h
@@ -92,6 +92,7 @@ const char* getReturnMessage(ReturnValue value);
 
 void capitalizeWords(std::string &source);
 void consoleHandlerExit();
+std::string validateNameHouse(const std::string &name);
 NameEval_t validateName(const std::string &name);
 
 bool isCaskItem(uint16_t itemId);


### PR DESCRIPTION
This script validates the list of people allowed to enter the house, if you put any special characters the script will give an error and it will not save the house, being able to rollback the houses, this script prevents it from having special characters.