### PR TITLE
fix: use loot modifiers correctly when creating loot

### DIFF
--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -72,14 +72,14 @@ function Monster:onDropLoot(corpse)
 		end
 
 		for i = 1, #monsterLoot do
-			corpse:createLootItem(monsterLoot[i], charmBonus)
+			corpse:createLootItem(monsterLoot[i], charmBonus, modifier)
 			if self:getName():lower() == Game.getBoostedCreature():lower() then
 				 corpse:createLootItem(monsterLoot[i], charmBonus, modifier)
 			end
 			if self:hazard() and player then
 				local chanceTo = math.random(1, 100)
 				if chanceTo <= (2 * player:getHazardSystemPoints() * configManager.getNumber(configKeys.HAZARDSYSTEM_LOOT_BONUS_MULTIPLIER)) then
-					if corpse:createLootItem(monsterLoot[i], charmBonus, preyChanceBoost) then
+					if corpse:createLootItem(monsterLoot[i], charmBonus, modifier) then
 						hazardMsg = true
 					end
 				end
@@ -100,7 +100,7 @@ function Monster:onDropLoot(corpse)
 				local probability = math.random(0, 100)
 				if probability < preyLootPercent then
 					for _, loot in pairs(monsterLoot) do
-						 corpse:createLootItem(loot, charmBonus)
+						 corpse:createLootItem(loot, charmBonus, modifier)
 					end
 				end
 			end

--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -108,11 +108,8 @@ function Monster:onDropLoot(corpse)
 			if preyLootPercent > 0 then
 				local probability = math.random(0, 100)
 				if probability < preyLootPercent then
-					for i, loot in pairs(monsterLoot) do
-						local item = corpse:createLootItem(monsterLoot[i], charmBonus)
-						if not item then
-							Spdlog.warn(string.format("[3][Monster:onDropLoot] - Could not add loot item to monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
-						end
+					for _, loot in pairs(monsterLoot) do
+						 corpse:createLootItem(loot, charmBonus)
 					end
 				end
 			end

--- a/data/events/scripts/monster.lua
+++ b/data/events/scripts/monster.lua
@@ -72,26 +72,17 @@ function Monster:onDropLoot(corpse)
 		end
 
 		for i = 1, #monsterLoot do
-			local item = corpse:createLootItem(monsterLoot[i], charmBonus)
+			corpse:createLootItem(monsterLoot[i], charmBonus)
 			if self:getName():lower() == Game.getBoostedCreature():lower() then
-				local itemBoosted = corpse:createLootItem(monsterLoot[i], charmBonus, modifier)
-				if not itemBoosted then
-					Spdlog.warn(string.format("[1][Monster:onDropLoot] - Could not add loot item to boosted monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
-				end
+				 corpse:createLootItem(monsterLoot[i], charmBonus, modifier)
 			end
 			if self:hazard() and player then
 				local chanceTo = math.random(1, 100)
 				if chanceTo <= (2 * player:getHazardSystemPoints() * configManager.getNumber(configKeys.HAZARDSYSTEM_LOOT_BONUS_MULTIPLIER)) then
-					local podItem = corpse:createLootItem(monsterLoot[i], charmBonus, preyChanceBoost)
-					if not podItem then
-						Spdlog.warn(string.format("[Monster:onDropLoot] - Could not add loot item to hazard monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
-					else
+					if corpse:createLootItem(monsterLoot[i], charmBonus, preyChanceBoost) then
 						hazardMsg = true
 					end
 				end
-			end
-			if not item then
-				Spdlog.warn(string.format("[2][Monster:onDropLoot] - Could not add loot item to monster: %s, from corpse id: %d.", self:getName(), corpse:getId()))
 			end
 		end
 

--- a/data/libs/functions/container.lua
+++ b/data/libs/functions/container.lua
@@ -4,6 +4,7 @@ end
 
 function Container.createLootItem(self, item, charm, modifier)
 	if self:getEmptySlots() == 0 then
+		Spdlog.warn(string.format("[3][Container:createLootItem] - Could not add loot item to ontainer id: %d because no more empty slots were available", self:getId()))
 		return false
 	end
 
@@ -13,6 +14,7 @@ function Container.createLootItem(self, item, charm, modifier)
 	local chanceTo = item.chance
 
 	if not lootBlockType then
+		Spdlog.warn(string.format("[3][Container:createLootItem] - Could not add loot item to ontainer id: %d because item type was not found", self:getId(), item.itemId))
 		return false
 	end
 

--- a/data/libs/functions/container.lua
+++ b/data/libs/functions/container.lua
@@ -4,7 +4,7 @@ end
 
 function Container.createLootItem(self, item, charm, modifier)
 	if self:getEmptySlots() == 0 then
-		Spdlog.warn(string.format("[3][Container:createLootItem] - Could not add loot item to ontainer id: %d because no more empty slots were available", self:getId()))
+		Spdlog.warn(string.format("[Container:createLootItem] - Could not add loot item to ontainer id: %d because no more empty slots were available", self:getId()))
 		return false
 	end
 
@@ -14,7 +14,7 @@ function Container.createLootItem(self, item, charm, modifier)
 	local chanceTo = item.chance
 
 	if not lootBlockType then
-		Spdlog.warn(string.format("[3][Container:createLootItem] - Could not add loot item to ontainer id: %d because item type was not found", self:getId(), item.itemId))
+		Spdlog.warn(string.format("[Container:createLootItem] - Could not add loot item to ontainer id: %d because item type was not found", self:getId(), item.itemId))
 		return false
 	end
 


### PR DESCRIPTION
`Container:createLootItem` now returns false when no loot was created (either by error or because we rolled a random that didn't add it). This was causing a warning to pop up on the monster callback. This was a harmless warning but we were missing logs when something actually went wrong (not enough space on the corpse or invalid itemID).

This adds logs inside `createLootItem` and silences the spurious alerts above.