### PR TITLE
fix: pirate outfit quest npc transcripts

### DIFF
--- a/data-otservbr-global/npc/ariella.lua
+++ b/data-otservbr-global/npc/ariella.lua
@@ -86,16 +86,14 @@ local function creatureSayCallback(npc, creature, type, message)
 			npcHandler:say("Are you here to bring me the 100 pieces of bread that I requested?", npc, creature)
 			npcHandler:setTopic(playerId, 3)
 		elseif player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 10 then
-			npcHandler:say(
-			{
-				"The sailors always tell tales about the famous beer of Carlin. \
+			npcHandler:say({
+				"The sailors always tell tales about the famous beer of Carlin. \z
 				You must know, alcohol is forbidden in that city. ...",
-				"The beer is served in a secret whisper bar anyway. \
+				"The beer is served in a secret whisper bar anyway. \z
 				Bring me a sample of the whisper beer, NOT the usual beer but whisper beer. I hope you are listening."
-			},
-			npc, creature)
+			}, npc, creature)
 			player:setStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven, 11)
-		elseif player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 12 then
+		elseif player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 12 or player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 11 then
 			npcHandler:say("Did you get a sample of the whisper beer from Carlin?", npc, creature)
 			npcHandler:setTopic(playerId, 4)
 		end

--- a/data-otservbr-global/npc/ariella.lua
+++ b/data-otservbr-global/npc/ariella.lua
@@ -151,7 +151,7 @@ local function creatureSayCallback(npc, creature, type, message)
 				end
 			end
 		elseif npcHandler:getTopic(playerId) == 4 then
-			if player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 12 then
+			if player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 12 or player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 11 then
 				if player:removeItem(6106, 1) then
 					npcHandler:say("Thank you very much. I will test this beauty in privacy.", npc, creature)
 					player:setStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven, 14)

--- a/data-otservbr-global/npc/chondur.lua
+++ b/data-otservbr-global/npc/chondur.lua
@@ -134,18 +134,18 @@ end
 notReadyKeyword(
 	'outfit',
 	{
-		"Hum? Sorry, but I don't sense enough spiritual wisdom in you to even allow \
+		"Hum? Sorry, but I don't sense enough spiritual wisdom in you to even allow \z
 		you to touch the mask and staff I'm wearing... yet. ...",
-		'I know of a really wise ape healer, though, who might be able to bless you with shamanic energy. \
+		'I know of a really wise ape healer, though, who might be able to bless you with shamanic energy. \z
 		You should become his apprentice first if you desire to become mine.'
 	}
 )
 notReadyKeyword(
 	'addon',
 	{
-		"Hum? Sorry, but I don't sense enough spiritual wisdom in you to even allow \
+		"Hum? Sorry, but I don't sense enough spiritual wisdom in you to even allow \z
 		you to touch the mask and staff I'm wearing... yet. ...",
-		'I know of a really wise ape healer, though, who might be able to bless you with shamanic energy. \
+		'I know of a really wise ape healer, though, who might be able to bless you with shamanic energy. \z
 		You should become his apprentice first if you desire to become mine.'
 	}
 )
@@ -196,14 +196,14 @@ end
 -- Staff
 addTaskKeyword(
 	{
-		"If you fulfil a task for me, I'll grant you a staff like the one I'm wearing. \
+		"If you fulfil a task for me, I'll grant you a staff like the one I'm wearing. \z
 		Do you want to hear the requirements?",
 		{
-			'Deep in the Tiquandian jungle a monster lurks which is seldom seen. \
+			'Deep in the Tiquandian jungle a monster lurks which is seldom seen. \z
 			It is the revenge of the jungle against humankind. ...',
-			'This monster, if slain, carries a rare root called Mandrake. If you find it, bring it to me. \
+			'This monster, if slain, carries a rare root called Mandrake. If you find it, bring it to me. \z
 			Also, gather 5 of the voodoo dolls used by the mysterious dworc voodoomasters. ...',
-			'If you manage to fulfil this task, I will grant you your own staff. \
+			'If you manage to fulfil this task, I will grant you your own staff. \z
 			Have you understood everything and are ready for this test?'
 		},
 		"Good! Come back once you've found a mandrake and collected 5 dworcish voodoo dolls."
@@ -215,15 +215,15 @@ addTaskKeyword(
 -- Mask
 addTaskKeyword(
 	{
-		"You have successfully passed the first task. \
-		If you can fulfil my second task, I'll grant you a mask like the one I'm wearing. \
+		"You have successfully passed the first task. \z
+		If you can fulfil my second task, I'll grant you a mask like the one I'm wearing. \z
 		Do you want to hear the requirements?",
 		{
-			"The dworcs of Tiquanda like to wear certain tribal masks which I'd like to take a look at. \
+			"The dworcs of Tiquanda like to wear certain tribal masks which I'd like to take a look at. \z
 			Please bring me 5 of these masks. ...",
-			"Secondly, the high ape magicians of Banuta use banana staffs. \
+			"Secondly, the high ape magicians of Banuta use banana staffs. \z
 			I'd love to learn more about theses staffs, so please bring me 5 of them, too. ...",
-			"If you manage to fulfil this task, I'll grant you your own mask. \
+			"If you manage to fulfil this task, I'll grant you your own mask. \z
 			Have you understood everything and are you ready for this test?"
 		},
 		'Good! Come back once you have collected 5 tribal masks and 5 banana staffs.'

--- a/data-otservbr-global/npc/duncan.lua
+++ b/data-otservbr-global/npc/duncan.lua
@@ -62,16 +62,16 @@ local function creatureSayCallback(npc, creature, type, message)
 
 	if isInArray({'outfit', 'addon'}, message) and player:getStorageValue(Storage.OutfitQuest.PirateBaseOutfit) == 1 then
 		npcHandler:say(
-			"You're talking about my sabre? Well, even though you earned our trust, \
+			"You're talking about my sabre? Well, even though you earned our trust, \z
 			you'd have to fulfill a task first before you are granted to wear such a sabre.",
-		creature)
+		npc, creature)
 	elseif MsgContains(message, 'mission') then
 		if player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 6 then
 			npcHandler:say(
-				'I need a new quality atlas for our captains. Only one of the best will do it. \
-				I heard the explorers society sells the best, but only to members of a certain rank. \
+				'I need a new quality atlas for our captains. Only one of the best will do it. \z
+				I heard the explorers society sells the best, but only to members of a certain rank. \z
 				You will have to get this rank or ask a high ranking member to buy it for you.',
-			creature)
+			npc, creature)
 			player:setStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven, 7)
 			npcHandler:setTopic(playerId, 0)
 		elseif player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 7 then
@@ -82,10 +82,9 @@ local function creatureSayCallback(npc, creature, type, message)
 				player:getStorageValue(Storage.TheShatteredIsles.TortoiseEggNargorDoor) < 0
 		 then
 			npcHandler:say(
-				'You did some impressive things. I think people here start considering you as one of us. \
-				But these are dire times and everyone of us is expected to give his best and even exceed himself. \
-				Do you think you can handle that?',
-				creature)
+				'You did some impressive things. I think people here start considering you as one of us. \z
+				But these are dire times and everyone of us is expected to give his best and even exceed himself. \z
+				Do you think you can handle that?', npc, creature)
 			npcHandler:setTopic(playerId, 7)
 		elseif player:getStorageValue(Storage.TheShatteredIsles.TortoiseEggNargorDoor) == 1 then
 			npcHandler:say('Did you rescue one of those poor soon-to-be baby tortoises from Nargor?', npc, creature)
@@ -95,7 +94,7 @@ local function creatureSayCallback(npc, creature, type, message)
 		if player:getStorageValue(storage) < 1 then
 			npcHandler:say(
 				"Are you up to the task which I'm going to give you and willing to prove you're worthy of wearing such a sabre?",
-				creature)
+				npc, creature)
 			npcHandler:setTopic(playerId, 1)
 		end
 	elseif MsgContains(message, 'eye patches') then
@@ -115,14 +114,12 @@ local function creatureSayCallback(npc, creature, type, message)
 		end
 	elseif MsgContains(message, 'yes') then
 		if npcHandler:getTopic(playerId) == 1 then
-			npcHandler:say(
-				{
-					'Listen, the task is not that hard. Simply prove that you are with us and not with the \
+			npcHandler:say( {
+					'Listen, the task is not that hard. Simply prove that you are with us and not with the \z
 					pirates from Nargor by bringingme some of their belongings. ...',
 					'Bring me 100 of their eye patches, 100 of their peg legs and 100 of their hooks, in that order. ...',
 					'Have you understood everything I told you and are willing to handle this task?'
-				},
-				creature)
+				}, npc, creature)
 			npcHandler:setTopic(playerId, 2)
 		elseif npcHandler:getTopic(playerId) == 2 then
 			player:setStorageValue(storage, 1)
@@ -178,8 +175,7 @@ local function creatureSayCallback(npc, creature, type, message)
 						This is the opportunity to save a tortoise from a gruesome fate! ...',
 						'I will ask Sebastian to bring you there. \
 						Travel to Nargor, find their tortoise eggs and bring me at least one of them.'
-					},
-				creature)
+					}, npc, creature)
 				player:setStorageValue(Storage.TheShatteredIsles.TortoiseEggNargorDoor, 1)
 				npcHandler:setTopic(playerId, 0)
 			end

--- a/data-otservbr-global/npc/eremo.lua
+++ b/data-otservbr-global/npc/eremo.lua
@@ -63,9 +63,9 @@ local function creatureSayCallback(npc, creature, type, message)
 			if player:getItemCount(3506) > 0 then
 				if player:removeItem(3506, 1) then
 					npcHandler:say(
-						'A letter from that youngster Morgan? I believed him dead since years. \
+						'A letter from that youngster Morgan? I believed him dead since years. \z
 						These news are good news indeed. Thank you very much, my friend.',
-					creature)
+						npc, creature)
 					player:setStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven, 5)
 				end
 			end

--- a/data-otservbr-global/npc/morgan.lua
+++ b/data-otservbr-global/npc/morgan.lua
@@ -67,21 +67,19 @@ local function creatureSayCallback(npc, creature, type, message)
 			npcHandler:say(
 				'Ahh. So Duncan sent you, eh? You must have done something really impressive. \
 				Okay, take this fine sabre from me, mate.',
-			creature)
+			npc, creature)
 		end
 	elseif MsgContains(message, 'mission') then
 		if player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 3 then
-			npcHandler:say(
-				{
-					'Hm, if you are that eager to work I have an idea how you could help me out. \
+			npcHandler:say({
+					'Hm, if you are that eager to work I have an idea how you could help me out. \z
 					A distant relative of mine, the old sage Eremo lives on the isle Cormaya, near Edron. ...',
-					"He has not heard from me since ages. He might assume that I am dead. \
-					Since I don't want him to get into trouble for receiving a letter from a \
+					"He has not heard from me since ages. He might assume that I am dead. \z
+					Since I don't want him to get into trouble for receiving a letter from a \z
 					pirate I ask you to deliver it personally. ...",
-					"Of course it's a long journey but you asked for it. \
-					You will have to prove us your worth. Are you up to that?"
-				},
-			creature)
+					"Of course it's a long journey but you asked for it. \z
+					You will have to prove us your worth. Are you up to that?",
+				}, npc, creature)
 			npcHandler:setTopic(playerId, 2)
 		elseif player:getStorageValue(Storage.TheShatteredIsles.ReputationInSabrehaven) == 5 then
 			npcHandler:say('Thank you for delivering my letter to Eremo. I have no more missions for you.', npc, creature)


### PR DESCRIPTION
Just fixes a bunch of bad calls to `npcHandler:say` that were missing the NPC reference itself, thus preventing them from saying their phrases to the player.