### PR TITLE
fix: crazed winter rearguard corpse wrong id

### DIFF
--- a/data-otservbr-global/monster/humanoids/crazed_winter_rearguard.lua
+++ b/data-otservbr-global/monster/humanoids/crazed_winter_rearguard.lua
@@ -29,7 +29,7 @@ monster.Bestiary = {
 monster.health = 5200
 monster.maxHealth = 5200
 monster.race = "blood"
-monster.corpse = 30126
+monster.corpse = 30127
 monster.speed = 200
 monster.manaCost = 0
 


### PR DESCRIPTION
Fix monster.corpse = 30127
Dont open loot with  monster.corpse = 30126

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
