### PR TITLE
improve: add position:toString lua function

### DIFF
--- a/src/lua/functions/map/position_functions.cpp
+++ b/src/lua/functions/map/position_functions.cpp
@@ -226,3 +226,10 @@ int PositionFunctions::luaPositionSendDoubleSoundEffect(lua_State* L) {
 	pushBoolean(L, true);
 	return 1;
 }
+
+int PositionFunctions::luaPositionToString(lua_State* L) {
+	// position:toString()
+	const Position &position = getPosition(L, 1);
+	pushString(L, position.toString());
+	return 1;
+}

--- a/src/lua/functions/map/position_functions.hpp
+++ b/src/lua/functions/map/position_functions.hpp
@@ -30,6 +30,8 @@ class PositionFunctions final : LuaScriptInterface {
 
 			registerMethod(L, "Position", "sendSingleSoundEffect", PositionFunctions::luaPositionSendSingleSoundEffect);
 			registerMethod(L, "Position", "sendDoubleSoundEffect", PositionFunctions::luaPositionSendDoubleSoundEffect);
+
+			registerMethod(L, "Position", "toString", PositionFunctions::luaPositionToString);
 		}
 
 	private:
@@ -48,6 +50,8 @@ class PositionFunctions final : LuaScriptInterface {
 
 		static int luaPositionSendSingleSoundEffect(lua_State* L);
 		static int luaPositionSendDoubleSoundEffect(lua_State* L);
+
+		static int luaPositionToString(lua_State* L);
 };
 
 #endif


### PR DESCRIPTION
Addition of position:toString() function in Lua. This enhancement simplifies the process of printing positions within Lua scripts, allowing for a more intuitive and efficient workflow.