### PR TITLE
fix: stash crashes and duplicates item

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6167,7 +6167,7 @@ bool Player::addItemFromStash(uint16_t itemId, uint32_t itemCount) {
 		itemCount -= addValue;
 		Item* newItem = Item::CreateItem(itemId, addValue);
 
-		if (g_game().canRetrieveStashItems(this, newItem)) {
+		if (!g_game().tryRetrieveStashItems(this, newItem)) {
 			g_game().internalPlayerAddItem(this, newItem, true);
 		}
 	}
@@ -6564,7 +6564,7 @@ void Player::retrieveAllItemsFromDepotSearch(uint16_t itemId, uint8_t tier, bool
 	ReturnValue ret = RETURNVALUE_NOERROR;
 	for (Item* item : itemsVector) {
 		// First lets try to retrieve the item to the stash retrieve container.
-		if (g_game().canRetrieveStashItems(this, item)) {
+		if (g_game().tryRetrieveStashItems(this, item)) {
 			continue;
 		}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9669,7 +9669,7 @@ bool Game::createHazardArea(const Position &positionFrom, const Position &positi
 	return true;
 }
 
-bool Game::canRetrieveStashItems(Player* player, Item* item) {
+bool Game::tryRetrieveStashItems(Player* player, Item* item) {
 	return internalCollectLootItems(player, item, OBJECTCATEGORY_STASHRETRIEVE) == RETURNVALUE_NOERROR;
 }
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -638,7 +638,7 @@ class Game {
 		bool createHazardArea(const Position &positionFrom, const Position &positionTo);
 
 		/**
-		 * @brief Checks if the player can retrieve stash items for a given item.
+		 * @brief Attemtps to retrieve an item from the stash.
 		 *
 		 * @details This function leverages the internalCollectLootItems function with the OBJECTCATEGORY_STASHRETRIEVE category
 		 * to determine if the player is capable of retrieving the stash items.
@@ -647,7 +647,7 @@ class Game {
 		 * @param item Pointer to the item to be checked.
 		 * @return True if stash items can be retrieved, false otherwise.
 		 */
-		bool canRetrieveStashItems(Player* player, Item* item);
+		bool tryRetrieveStashItems(Player* player, Item* item);
 
 		std::unique_ptr<IOWheel> &getIOWheel();
 		const std::unique_ptr<IOWheel> &getIOWheel() const;


### PR DESCRIPTION
The method `tryRetrieveStashItems` was actually already retrieving, and the logic for adding items was duplicating them and causing a crash (not actually sure why, but the stash item would get freed in that case)