### PR TITLE
fix: incorrect variable name in Result.free 

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -216,6 +216,7 @@ function Player.transferMoneyTo(self, target, amount)
 		local query_town = db.storeQuery('SELECT `town_id` FROM `players` WHERE `name` = ' .. db.escapeString(target) .. ' LIMIT 1;')
 		if query_town ~= false then
 			local town = Result.getNumber(query_town, "town_id")
+			Result.free(query_town)
 			if town then
 				local town_id = Town(town) and Town(town):getId()
 				if town_id and town_id == TOWNS_LIST.DAWNPORT or town_id == TOWNS_LIST.DAWNPORT_TUTORIAL then
@@ -223,7 +224,6 @@ function Player.transferMoneyTo(self, target, amount)
 					return false
 				end
 			end
-			Result.free(consulta)
 			db.query("UPDATE `players` SET `balance` = `balance` + '" .. amount .. "' WHERE `name` = " .. db.escapeString(target))
 		end
 	end


### PR DESCRIPTION
Placing the function **result.free** before checking the initial cities and **adjusting** the correct name of the variable used.