### PR TITLE
fix: use mana potions in pz

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -237,7 +237,7 @@ ReturnValue Combat::canTargetCreature(Player* player, Creature* target) {
 		}
 	}
 
-	return Combat::canDoCombat(player, target);
+	return Combat::canDoCombat(player, target, true);
 }
 
 ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive) {
@@ -296,7 +296,11 @@ bool Combat::isProtected(const Player* attacker, const Player* target) {
 	return false;
 }
 
-ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target) {
+ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target, bool aggressive) {
+	if (!aggressive) {
+		return RETURNVALUE_NOERROR;
+	}
+
 	if (target) {
 		const Tile* tile = target->getTile();
 		if (tile->hasProperty(CONST_PROP_BLOCKPROJECTILE)) {
@@ -909,7 +913,7 @@ void Combat::doChainEffect(const Position &origin, const Position &dest, uint8_t
 	}
 }
 
-bool Combat::doCombatChain(Creature* caster, Creature* target) const {
+bool Combat::doCombatChain(Creature* caster, Creature* target, bool aggressive) const {
 	auto targets = std::vector<Creature*>();
 	auto targetSet = std::set<uint32_t>();
 	auto visitedChain = std::set<uint32_t>();
@@ -924,7 +928,7 @@ bool Combat::doCombatChain(Creature* caster, Creature* target) const {
 		uint8_t maxTargets, chainDistance;
 		bool backtracking = false;
 		params.chainCallback->onChainCombat(caster, maxTargets, chainDistance, backtracking);
-		pickChainTargets(caster, targets, targetSet, visitedChain, params, chainDistance, maxTargets, backtracking);
+		pickChainTargets(caster, targets, targetSet, visitedChain, params, chainDistance, maxTargets, backtracking, aggressive);
 	}
 	if (targets.empty() || targets.size() == 1 && targets[0] == caster) {
 		return false;
@@ -947,7 +951,7 @@ bool Combat::doCombatChain(Creature* caster, Creature* target) const {
 
 bool Combat::doCombat(Creature* caster, Creature* target) const {
 	if (caster != nullptr && params.chainCallback) {
-		return doCombatChain(caster, target);
+		return doCombatChain(caster, target, params.aggressive);
 	}
 
 	return doCombat(caster, target, caster != nullptr ? caster->getPosition() : Position());
@@ -971,7 +975,7 @@ bool Combat::doCombat(Creature* caster, Creature* target, const Position &origin
 
 bool Combat::doCombat(Creature* caster, const Position &position) const {
 	if (caster != nullptr && params.chainCallback) {
-		return doCombatChain(caster, caster);
+		return doCombatChain(caster, caster, params.aggressive);
 	}
 
 	// area combat callback function
@@ -1041,7 +1045,7 @@ void Combat::CombatFunc(Creature* caster, const Position &origin, const Position
 					}
 				}
 
-				if (!params.aggressive || (caster != creature && Combat::canDoCombat(caster, creature) == RETURNVALUE_NOERROR)) {
+				if (!params.aggressive || (caster != creature && Combat::canDoCombat(caster, creature, params.aggressive) == RETURNVALUE_NOERROR)) {
 					affected++;
 				}
 			}
@@ -1095,7 +1099,7 @@ void Combat::CombatFunc(Creature* caster, const Position &origin, const Position
 					}
 				}
 
-				if (!params.aggressive || (caster != creature && Combat::canDoCombat(caster, creature) == RETURNVALUE_NOERROR)) {
+				if (!params.aggressive || (caster != creature && Combat::canDoCombat(caster, creature, params.aggressive) == RETURNVALUE_NOERROR)) {
 					// Wheel of destiny update beam mastery damage
 					if (casterPlayer) {
 						casterPlayer->wheel()->updateBeamMasteryDamage(tmpDamage, beamAffectedTotal, beamAffectedCurrent);
@@ -1127,7 +1131,7 @@ void Combat::doCombatHealth(Creature* caster, Creature* target, CombatDamage &da
 }
 
 void Combat::doCombatHealth(Creature* caster, Creature* target, const Position &origin, CombatDamage &damage, const CombatParams &params) {
-	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR);
+	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target, params.aggressive) == RETURNVALUE_NOERROR);
 	if ((caster && target)
 		&& (caster == target || canCombat)
 		&& (params.impactEffect != CONST_ME_NONE)) {
@@ -1225,7 +1229,7 @@ void Combat::doCombatMana(Creature* caster, Creature* target, CombatDamage &dama
 }
 
 void Combat::doCombatMana(Creature* caster, Creature* target, const Position &origin, CombatDamage &damage, const CombatParams &params) {
-	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR);
+	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target, params.aggressive) == RETURNVALUE_NOERROR);
 	if ((caster && target)
 		&& (caster == target || canCombat)
 		&& (params.impactEffect != CONST_ME_NONE)) {
@@ -1278,7 +1282,7 @@ void Combat::doCombatCondition(Creature* caster, const Position &position, const
 }
 
 void Combat::doCombatCondition(Creature* caster, Creature* target, const CombatParams &params) {
-	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR);
+	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target, params.aggressive) == RETURNVALUE_NOERROR);
 	if ((caster == target || canCombat) && params.impactEffect != CONST_ME_NONE) {
 		g_game().addMagicEffect(target->getPosition(), params.impactEffect);
 	}
@@ -1307,7 +1311,7 @@ void Combat::doCombatDispel(Creature* caster, const Position &position, const Ar
 }
 
 void Combat::doCombatDispel(Creature* caster, Creature* target, const CombatParams &params) {
-	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR);
+	bool canCombat = !params.aggressive || (caster != target && Combat::canDoCombat(caster, target, params.aggressive) == RETURNVALUE_NOERROR);
 	if ((caster && target)
 		&& (caster == target || canCombat)
 		&& (params.impactEffect != CONST_ME_NONE)) {
@@ -1337,7 +1341,7 @@ void Combat::doCombatDefault(Creature* caster, Creature* target, const CombatPar
 }
 
 void Combat::doCombatDefault(Creature* caster, Creature* target, const Position &origin, const CombatParams &params) {
-	if (!params.aggressive || (caster != target && Combat::canDoCombat(caster, target) == RETURNVALUE_NOERROR)) {
+	if (!params.aggressive || (caster != target && Combat::canDoCombat(caster, target, params.aggressive) == RETURNVALUE_NOERROR)) {
 		SpectatorHashSet spectators;
 		g_game().map.getSpectators(spectators, target->getPosition(), true, true);
 
@@ -1374,7 +1378,7 @@ void Combat::setRuneSpellName(const std::string &value) {
 	runeSpellName = value;
 }
 
-void Combat::pickChainTargets(Creature* caster, std::vector<Creature*> &targets, std::set<uint32_t> &targetSet, std::set<uint32_t> &visited, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool backtracking) {
+void Combat::pickChainTargets(Creature* caster, std::vector<Creature*> &targets, std::set<uint32_t> &targetSet, std::set<uint32_t> &visited, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool backtracking, bool aggressive) {
 	if (maxTargets == 0 || targets.size() > maxTargets) {
 		return;
 	}
@@ -1398,7 +1402,7 @@ void Combat::pickChainTargets(Creature* caster, std::vector<Creature*> &targets,
 			if (creature == nullptr || visited.contains(creature->getID())) {
 				continue;
 			}
-			bool canCombat = canDoCombat(caster, creature) == RETURNVALUE_NOERROR;
+			bool canCombat = canDoCombat(caster, creature, aggressive) == RETURNVALUE_NOERROR;
 			bool pick = params.chainPickerCallback ? params.chainPickerCallback->onChainCombat(caster, creature) : true;
 			bool hasSight = g_game().isSightClear(currentTarget->getPosition(), creature->getPosition(), true);
 			if (!canCombat || !pick || !hasSight) {
@@ -1420,7 +1424,7 @@ void Combat::pickChainTargets(Creature* caster, std::vector<Creature*> &targets,
 			targets.push_back(closestSpectator);
 			targetSet.insert(closestSpectator->getID());
 			visited.insert(closestSpectator->getID());
-			pickChainTargets(caster, targets, targetSet, visited, params, chainDistance, maxTargets, backtracking);
+			pickChainTargets(caster, targets, targetSet, visited, params, chainDistance, maxTargets, backtracking, aggressive);
 		}
 
 		if (!backtracking || closestSpectator == nullptr) {

--- a/src/creatures/combat/combat.h
+++ b/src/creatures/combat/combat.h
@@ -277,7 +277,7 @@ class Combat {
 		static ConditionType_t DamageToConditionType(CombatType_t type);
 		static ReturnValue canTargetCreature(Player* attacker, Creature* target);
 		static ReturnValue canDoCombat(Creature* caster, Tile* tile, bool aggressive);
-		static ReturnValue canDoCombat(Creature* attacker, Creature* target);
+		static ReturnValue canDoCombat(Creature* attacker, Creature* target, bool aggressive);
 		static void postCombatEffects(Creature* caster, const Position &origin, const Position &pos, const CombatParams &params);
 
 		static void addDistanceEffect(Creature* caster, const Position &fromPos, const Position &toPos, uint16_t effect);
@@ -324,7 +324,7 @@ class Combat {
 
 	private:
 		static void doChainEffect(const Position &origin, const Position &pos, uint8_t effect);
-		static void pickChainTargets(Creature* caster, std::vector<Creature*> &targets, std::set<uint32_t> &targetSet, std::set<uint32_t> &visited, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool backtracking);
+		static void pickChainTargets(Creature* caster, std::vector<Creature*> &targets, std::set<uint32_t> &targetSet, std::set<uint32_t> &visited, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool backtracking, bool aggressive);
 
 		static void doCombatDefault(Creature* caster, Creature* target, const CombatParams &params);
 
@@ -369,7 +369,7 @@ class Combat {
 		int32_t getLevelFormula(const Player* player, const Spell* wheelSpell, const CombatDamage &damage) const;
 		CombatDamage getCombatDamage(Creature* creature, Creature* target) const;
 
-		bool doCombatChain(Creature* caster, Creature* target) const;
+		bool doCombatChain(Creature* caster, Creature* target, bool aggressive) const;
 
 		// configureable
 		CombatParams params;

--- a/src/creatures/combat/condition.cpp
+++ b/src/creatures/combat/condition.cpp
@@ -1656,7 +1656,7 @@ bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange) {
 		damage.primary.value = static_cast<int32_t>(std::round(damage.primary.value / 2.));
 	}
 
-	if (!creature->isAttackable() || Combat::canDoCombat(attacker, creature) != RETURNVALUE_NOERROR) {
+	if (!creature->isAttackable() || Combat::canDoCombat(attacker, creature, damage.primary.type != COMBAT_HEALING) != RETURNVALUE_NOERROR) {
 		if (!creature->isInGhostMode() && !creature->getNpc()) {
 			g_game().addMagicEffect(creature->getPosition(), CONST_ME_POFF);
 		}

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -417,12 +417,15 @@ int GlobalFunctions::luaDoTargetCombatMana(lua_State* L) {
 	}
 
 	CombatParams params;
+	auto minval = getNumber<int32_t>(L, 3);
+	auto maxval = getNumber<int32_t>(L, 4);
+	params.aggressive = minval + maxval < 0;
 	params.impactEffect = getNumber<uint16_t>(L, 5);
 
 	CombatDamage damage;
 	damage.origin = getNumber<CombatOrigin>(L, 6, ORIGIN_SPELL);
 	damage.primary.type = COMBAT_MANADRAIN;
-	damage.primary.value = normal_random(getNumber<int32_t>(L, 3), getNumber<int32_t>(L, 4));
+	damage.primary.value = normal_random(minval, maxval);
 
 	damage.instantSpellName = getString(L, 7);
 	damage.runeSpellName = getString(L, 8);


### PR DESCRIPTION
When in #1339 we had to implement PZ checks for chaning, it incidentally prevented players from gaining mana from potions in PZ.

This was due to the mechanic of adding mana using `MANA_DRAIN` and not setting itself to non-aggressive.

This PR makes changing mana non-aggressive if it is positive, and also adds a bunch of facilities in Combat to pass agression around for when it needs to be overriden.
