### PR TITLE
fix: show correct fluid names

### DIFF
--- a/data-otservbr-global/scripts/actions/other/fluids.lua
+++ b/data-otservbr-global/scripts/actions/other/fluids.lua
@@ -10,24 +10,24 @@ poison:setParameter(CONDITION_PARAM_TICKINTERVAL, 4000)
 poison:setParameter(CONDITION_PARAM_FORCEUPDATE, true)
 
 local fluidMessage = {
-	[1] = "Gulp.", -- water
-	[2] = "Aah...", -- wine
-	[3] = "Aah...", -- beer
-	[4] = "Gulp.", -- mud
-	[5] = "Gulp.", -- blood
-	[6] = "Urgh!", -- slime
-	[7] = "Gulp.", -- oil
-	[8] = "Urgh!", -- urine
-	[9] = "Gulp.", -- milk
-	[10] = "Aaaah...", -- manafluid
-	[11] = "Aaaah...", -- lifefluid
-	[12] = "Mmmh.", -- lemonade
-	[13] = "Aah...", -- rum
-	[14] = "Mmmh.", -- fruit juice
-	[15] = "Mmmh.", -- coconut milk
-	[16] = "Aah...", -- mead
-	[17] = "Gulp.", -- tea
-	[18] = "Urgh!" -- ink
+	[FLUID_NONE] = "Gulp.", -- water
+	[FLUID_WATER] = "Aah...", -- wine
+	[FLUID_WINE] = "Aah...", -- beer
+	[FLUID_BEER] = "Gulp.", -- mud
+	[FLUID_MUD] = "Gulp.", -- blood
+	[FLUID_BLOOD] = "Urgh!", -- slime
+	[FLUID_SLIME] = "Gulp.", -- oil
+	[FLUID_OIL] = "Urgh!", -- urine
+	[FLUID_URINE] = "Gulp.", -- milk
+	[FLUID_MILK] = "Aaaah...", -- manafluid
+	[FLUID_MANA] = "Aaaah...", -- lifefluid
+	[FLUID_LIFE] = "Mmmh.", -- lemonade
+	[FLUID_LEMONADE] = "Aah...", -- rum
+	[FLUID_RUM] = "Mmmh.", -- fruit juice
+	[FLUID_FRUITJUICE] = "Mmmh.", -- coconut milk
+	[FLUID_COCONUTMILK] = "Aah...", -- mead
+	[FLUID_MEAD] = "Gulp.", -- tea
+	[FLUID_TEA] = "Urgh!" -- ink
 }
 
 local function graveStoneTeleport(cid, fromPosition, toPosition)
@@ -101,7 +101,7 @@ function fluid.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if target.itemid == 26076 then
 		if item.type == 0 then
 			player:sendTextMessage(MESSAGE_FAILURE, 'It is empty.')
-		
+
 		elseif item.type == 1 then
 			toPosition:sendMagicEffect(CONST_ME_WATER_SPLASH)
 			target:transform(target.itemid + 1)
@@ -111,7 +111,7 @@ function fluid.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		end
 		return true
 	end
-			
+
 	if target.itemid == 1 then
 		if item.type == 0 then
 			player:sendTextMessage(MESSAGE_FAILURE, 'It is empty.')

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -2206,7 +2206,7 @@ std::string Item::parseShowAttributesDescription(const Item* item, const uint16_
 }
 
 std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const Item* item /*= nullptr*/, int32_t subType /*= -1*/, bool addArticle /*= true*/) {
-	const std::string* text = nullptr;
+	std::string text = "";
 
 	std::ostringstream s;
 	s << getNameDescription(it, item, subType, addArticle);
@@ -2810,9 +2810,8 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const
 
 				if (lookDistance <= 4) {
 					if (item) {
-						auto string = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
-						text = &string;
-						if (!text->empty()) {
+						text = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
+						if (!text.empty()) {
 							const std::string &writer = item->getAttribute<std::string>(ItemAttribute_t::WRITER);
 							if (!writer.empty()) {
 								s << writer << " wrote";
@@ -2824,7 +2823,7 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const
 							} else {
 								s << "You read: ";
 							}
-							s << *text;
+							s << text;
 						} else {
 							s << "Nothing is written on it";
 						}
@@ -2864,12 +2863,11 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const
 	if (!it.allowDistRead || (it.id >= 7369 && it.id <= 7371)) {
 		s << '.';
 	} else {
-		if (!text && item) {
-			auto string = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
-			text = &string;
+		if (text.empty() && item) {
+			text = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
 		}
 
-		if (!text || text->empty()) {
+		if (text.empty()) {
 			s << '.';
 		}
 	}
@@ -2937,14 +2935,13 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, const
 	}
 
 	if (it.allowDistRead && it.id >= 7369 && it.id <= 7371) {
-		if (!text && item) {
-			auto string = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
-			text = &string;
+		if (text.empty() && item) {
+			text = item->getAttribute<std::string>(ItemAttribute_t::TEXT);
 		}
 
-		if (text && !text->empty()) {
+		if (!text.empty()) {
 			s << std::endl
-			  << *text;
+			  << text;
 		}
 	}
 	return s.str();

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -237,17 +237,12 @@ void Items::parseItemNode(const pugi::xml_node &itemNode, uint16_t id) {
 	if (id >= items.size()) {
 		items.resize(id + 1);
 	}
-	ItemType &iType = items[id];
-	if (iType.id == 0 && (iType.name.empty() || iType.name == asLowerCaseString("reserved sprite"))) {
-		return;
-	}
-
-	iType.id = id;
-
 	ItemType &itemType = getItemType(id);
-	if (itemType.id == 0) {
+	// Ids 0-100 are used for fluids in the XML
+	if (id >= 100 && (itemType.id == 0 && (itemType.name.empty() || itemType.name == asLowerCaseString("reserved sprite")))) {
 		return;
 	}
+	itemType.id = id;
 
 	if (itemType.loaded) {
 		SPDLOG_WARN("[Items::parseItemNode] - Duplicate item with id: {}", id);

--- a/src/lua/functions/core/game/lua_enums.cpp
+++ b/src/lua/functions/core/game/lua_enums.cpp
@@ -806,25 +806,9 @@ void LuaEnums::initItemTypeEnums(lua_State* L) {
 }
 
 void LuaEnums::initFluidEnums(lua_State* L) {
-	registerEnum(L, FLUID_NONE);
-	registerEnum(L, FLUID_WATER);
-	registerEnum(L, FLUID_WINE);
-	registerEnum(L, FLUID_BEER);
-	registerEnum(L, FLUID_MUD);
-	registerEnum(L, FLUID_BLOOD);
-	registerEnum(L, FLUID_SLIME);
-	registerEnum(L, FLUID_OIL);
-	registerEnum(L, FLUID_URINE);
-	registerEnum(L, FLUID_MILK);
-	registerEnum(L, FLUID_MANA);
-	registerEnum(L, FLUID_LIFE);
-	registerEnum(L, FLUID_LEMONADE);
-	registerEnum(L, FLUID_RUM);
-	registerEnum(L, FLUID_FRUITJUICE);
-	registerEnum(L, FLUID_COCONUTMILK);
-	registerEnum(L, FLUID_MEAD);
-	registerEnum(L, FLUID_TEA);
-	registerEnum(L, FLUID_INK);
+	for (auto value : magic_enum::enum_values<Fluids_t>()) {
+		registerEnumClass(L, value);
+	}
 }
 
 void LuaEnums::initItemIdEnums(lua_State* L) {

--- a/src/lua/functions/core/game/lua_enums.cpp
+++ b/src/lua/functions/core/game/lua_enums.cpp
@@ -89,6 +89,7 @@ void LuaEnums::init(lua_State* L) {
 	initFightModeEnums(L);
 	initItemAttributeEnums(L);
 	initItemTypeEnums(L);
+	initFluidEnums(L);
 	initItemIdEnums(L);
 	initPlayerFlagEnums(L);
 	initReportReasonEnums(L);
@@ -802,6 +803,28 @@ void LuaEnums::initItemTypeEnums(lua_State* L) {
 	registerEnum(L, ITEM_TYPE_RETRIEVE);
 	registerEnum(L, ITEM_TYPE_GOLD);
 	registerEnum(L, ITEM_TYPE_UNASSIGNED);
+}
+
+void LuaEnums::initFluidEnums(lua_State* L) {
+	registerEnum(L, FLUID_NONE);
+	registerEnum(L, FLUID_WATER);
+	registerEnum(L, FLUID_WINE);
+	registerEnum(L, FLUID_BEER);
+	registerEnum(L, FLUID_MUD);
+	registerEnum(L, FLUID_BLOOD);
+	registerEnum(L, FLUID_SLIME);
+	registerEnum(L, FLUID_OIL);
+	registerEnum(L, FLUID_URINE);
+	registerEnum(L, FLUID_MILK);
+	registerEnum(L, FLUID_MANA);
+	registerEnum(L, FLUID_LIFE);
+	registerEnum(L, FLUID_LEMONADE);
+	registerEnum(L, FLUID_RUM);
+	registerEnum(L, FLUID_FRUITJUICE);
+	registerEnum(L, FLUID_COCONUTMILK);
+	registerEnum(L, FLUID_MEAD);
+	registerEnum(L, FLUID_TEA);
+	registerEnum(L, FLUID_INK);
 }
 
 void LuaEnums::initItemIdEnums(lua_State* L) {

--- a/src/lua/functions/core/game/lua_enums.hpp
+++ b/src/lua/functions/core/game/lua_enums.hpp
@@ -47,6 +47,7 @@ class LuaEnums final : LuaScriptInterface {
 		static void initFightModeEnums(lua_State* L);
 		static void initItemAttributeEnums(lua_State* L);
 		static void initItemTypeEnums(lua_State* L);
+		static void initFluidEnums(lua_State* L);
 		static void initItemIdEnums(lua_State* L);
 		static void initPlayerFlagEnums(lua_State* L);
 		static void initReportReasonEnums(lua_State* L);


### PR DESCRIPTION
When we moved to loading appearances.dat we started ignoring the fluids from items.xml. This was done as a protection when people add new items to items.xml that aren't in appearances.dat, but it incorrectly filtered out fluids.

Also: it was previously possible to sell the vial/bucket/whatever on the market because fluid id was some dirty memory space, that is now no longer possible since you can no longer obtain the broken fluid.
