### PR TITLE
fix: don't remove reward containers on open/close reward chest

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -740,9 +740,6 @@ void Player::closeContainer(uint8_t cid) {
 	OpenContainer openContainer = it->second;
 	Container* container = openContainer.container;
 
-	if (container && container->isAnyKindOfRewardChest() && !hasOtherRewardContainerOpen(container)) {
-		removeEmptyRewards();
-	}
 	openContainers.erase(it);
 	if (container && container->getID() == ITEM_BROWSEFIELD) {
 		container->decrementReferenceCounter();
@@ -762,6 +759,10 @@ void Player::removeEmptyRewards() {
 }
 
 bool Player::hasOtherRewardContainerOpen(const Container* container) const {
+	if (!container) {
+		return false;
+	}
+
 	return std::ranges::any_of(openContainers.begin(), openContainers.end(), [container](const auto &containerPair) {
 		return containerPair.second.container != container && containerPair.second.container->isAnyKindOfRewardContainer();
 	});

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -746,28 +746,6 @@ void Player::closeContainer(uint8_t cid) {
 	}
 }
 
-void Player::removeEmptyRewards() {
-	std::erase_if(rewardMap, [this](const auto &rewardBag) {
-		auto [id, reward] = rewardBag;
-		if (reward->empty()) {
-			getRewardChest()->removeItem(reward);
-			reward->decrementReferenceCounter();
-			return true;
-		}
-		return false;
-	});
-}
-
-bool Player::hasOtherRewardContainerOpen(const Container* container) const {
-	if (!container) {
-		return false;
-	}
-
-	return std::ranges::any_of(openContainers.begin(), openContainers.end(), [container](const auto &containerPair) {
-		return containerPair.second.container != container && containerPair.second.container->isAnyKindOfRewardContainer();
-	});
-}
-
 void Player::setContainerIndex(uint8_t cid, uint16_t index) {
 	auto it = openContainers.find(cid);
 	if (it == openContainers.end()) {

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2851,9 +2851,6 @@ class Player final : public Creature, public Cylinder {
 		void updateDamageReductionFromItemImbuement(std::array<double_t, COMBAT_COUNT> &combatReductionMap, Item* item, uint16_t combatTypeIndex) const;
 		void updateDamageReductionFromItemAbility(std::array<double_t, COMBAT_COUNT> &combatReductionMap, const Item* item, uint16_t combatTypeIndex) const;
 		double_t calculateDamageReduction(double_t currentTotal, int16_t resistance) const;
-
-		void removeEmptyRewards();
-		bool hasOtherRewardContainerOpen(const Container* container) const;
 };
 
 #endif // SRC_CREATURES_PLAYERS_PLAYER_H_

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2600,7 +2600,7 @@ ReturnValue Game::collectRewardChestItems(Player* player, uint32_t maxMoveItems 
 		if (limitMove) {
 			lootedItemsMessage = fmt::format("You can only collect {} items at a time. {} of {} objects were picked up.", maxMoveItems, movedRewardItems, rewardCount);
 			player->sendTextMessage(MESSAGE_EVENT_ADVANCE, lootedItemsMessage);
-			return RETURNVALUE_NOTPOSSIBLE;
+			return RETURNVALUE_NOERROR;
 		}
 
 		ObjectCategory_t category = getObjectCategory(item);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2613,7 +2613,7 @@ ReturnValue Game::collectRewardChestItems(Player* player, uint32_t maxMoveItems 
 	player->sendTextMessage(MESSAGE_EVENT_ADVANCE, lootedItemsMessage);
 
 	if (movedRewardItems == 0) {
-		return RETURNVALUE_NOTENOUGHROOM;
+		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
 	return RETURNVALUE_NOERROR;

--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -273,29 +273,6 @@ bool Container::isHoldingItemWithId(const uint16_t id) const {
 	return false;
 }
 
-bool Container::isInsideContainerWithId(const uint16_t id) const {
-	auto nextParent = parent;
-	while (nextParent != nullptr && nextParent->getContainer()) {
-		if (nextParent->getContainer()->getID() == id) {
-			return true;
-		}
-		nextParent = nextParent->getRealParent();
-	}
-	return false;
-}
-
-bool Container::isAnyKindOfRewardChest() const {
-	return getID() == ITEM_REWARD_CHEST || getID() == ITEM_REWARD_CONTAINER && parent && parent->getContainer() && parent->getContainer()->getID() == ITEM_REWARD_CHEST || isBrowseFieldAndHoldsRewardChest();
-}
-
-bool Container::isAnyKindOfRewardContainer() const {
-	return getID() == ITEM_REWARD_CHEST || getID() == ITEM_REWARD_CONTAINER || isHoldingItemWithId(ITEM_REWARD_CONTAINER) || isInsideContainerWithId(ITEM_REWARD_CONTAINER);
-}
-
-bool Container::isBrowseFieldAndHoldsRewardChest() const {
-	return getID() == ITEM_BROWSEFIELD && isHoldingItemWithId(ITEM_REWARD_CHEST);
-}
-
 void Container::onAddContainerItem(Item* item) {
 	SpectatorHashSet spectators;
 	g_game().map.getSpectators(spectators, getPosition(), false, true, 2, 2, 2, 2);

--- a/src/items/containers/container.h
+++ b/src/items/containers/container.h
@@ -164,11 +164,6 @@ class Container : public Item, public Cylinder {
 		void startDecaying() override;
 		void stopDecaying() override;
 
-		bool isAnyKindOfRewardChest() const;
-		bool isAnyKindOfRewardContainer() const;
-		bool isBrowseFieldAndHoldsRewardChest() const;
-		bool isInsideContainerWithId(const uint16_t id) const;
-
 		virtual void removeItem(Thing* thing, bool sendUpdateToClient = false);
 
 	protected:

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -299,10 +299,6 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 		// reward chest
 		if (container->getRewardChest() != nullptr && container->getParent()) {
 			RewardChest* myRewardChest = player->getRewardChest();
-			if (!player->hasOtherRewardContainerOpen(container->getParent()->getContainer())) {
-				player->removeEmptyRewards();
-			}
-
 			if (myRewardChest->size() == 0) {
 				return RETURNVALUE_REWARDCHESTISEMPTY;
 			}

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -297,9 +297,9 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 		}
 
 		// reward chest
-		if (container->getRewardChest() != nullptr) {
+		if (container->getRewardChest() != nullptr && container->getParent()) {
 			RewardChest* myRewardChest = player->getRewardChest();
-			if (!player->hasOtherRewardContainerOpen(dynamic_cast<const Container*>(container->getParent()))) {
+			if (!player->hasOtherRewardContainerOpen(container->getParent()->getContainer())) {
 				player->removeEmptyRewards();
 			}
 


### PR DESCRIPTION
It will only remove on login. This will possibly fix the crash related to reward collect/reward chest.

Apparently in some scenario there is a reward container being removed from memory and being used later, which causes memory usage after clearing resulting in undefined behavior (crash).