### PR TITLE
fix: missing path separator in reload

### DIFF
--- a/src/game/functions/game_reload.cpp
+++ b/src/game/functions/game_reload.cpp
@@ -98,7 +98,7 @@ bool GameReload::reloadCore() const {
 		g_luaEnvironment.loadFile(coreFolder + "/core.lua", "core.lua") == 0) {
 		// Reload scripts lib
 		auto datapackFolder = g_configManager().getString(DATA_DIRECTORY);
-		if (!g_scripts().loadScripts(datapackFolder + "scripts/lib", true, false)) {
+		if (!g_scripts().loadScripts(datapackFolder + "/scripts/lib", true, false)) {
 			return false;
 		}
 


### PR DESCRIPTION
![image](https://github.com/opentibiabr/canary/assets/7812282/29c4b494-2175-4ca6-b79c-492216f3aa7f)

(fixed)