### PR TITLE
fix: send only valid monsters to prey data

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6313,7 +6313,7 @@ void Player::initializePrey() {
 void Player::removePreySlotById(PreySlot_t slotid) {
 	auto it = std::remove_if(preys.begin(), preys.end(), [slotid](const PreySlot* preyIt) {
 		return preyIt->id == slotid;
-		});
+	});
 
 	for (auto i = it; i != preys.end(); ++i) {
 		delete *i;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6310,6 +6310,18 @@ void Player::initializePrey() {
 	}
 }
 
+void Player::removePreySlotById(PreySlot_t slotid) {
+	auto it = std::remove_if(preys.begin(), preys.end(), [slotid](const PreySlot* preyIt) {
+		return preyIt->id == slotid;
+		});
+
+	for (auto i = it; i != preys.end(); ++i) {
+		delete *i;
+	}
+
+	preys.erase(it, preys.end());
+}
+
 void Player::initializeTaskHunting() {
 	if (taskHunting.empty()) {
 		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2005,6 +2005,7 @@ class Player final : public Creature, public Cylinder {
 
 		// Prey system
 		void initializePrey();
+		void removePreySlotById(PreySlot_t slotid);
 
 		void sendPreyData() const {
 			if (client) {


### PR DESCRIPTION
# Description

When a creature with an invalid race ID is saved in the player and tries to send it to the client, it debugs and sends the log. This way, now it will only send the log, removes the prey slot referring to the player's monster and send the empty bytes.
