### PR TITLE
feat: move all globals behind di

### DIFF
--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -21,10 +21,7 @@ class ConfigManager {
 		void operator=(const ConfigManager &) = delete;
 
 		static ConfigManager &getInstance() {
-			// Guaranteed to be destroyed
-			static ConfigManager instance;
-			// Instantiated on first use
-			return instance;
+			return inject<ConfigManager>();
 		}
 
 		bool load();
@@ -55,6 +52,6 @@ class ConfigManager {
 		bool loaded = false;
 };
 
-constexpr auto g_configManager = &ConfigManager::getInstance;
+constexpr auto g_configManager = ConfigManager::getInstance;
 
 #endif // SRC_CONFIG_CONFIGMANAGER_H_

--- a/src/creatures/appearance/outfit/outfit.h
+++ b/src/creatures/appearance/outfit/outfit.h
@@ -35,8 +35,7 @@ struct ProtocolOutfit {
 class Outfits {
 	public:
 		static Outfits &getInstance() {
-			static Outfits instance;
-			return instance;
+			return inject<Outfits>();
 		}
 
 		const Outfit* getOpositeSexOutfitByLookType(PlayerSex_t sex, uint16_t lookType);

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -247,7 +247,7 @@ CombatSpell::CombatSpell(Combat* newCombat, bool newNeedTarget, bool newNeedDire
 }
 
 bool CombatSpell::loadScriptCombat() {
-	combat = g_luaEnvironment.getCombatObject(g_luaEnvironment.lastCombatId).get();
+	combat = g_luaEnvironment().getCombatObject(g_luaEnvironment().lastCombatId).get();
 	return combat != nullptr;
 }
 

--- a/src/creatures/combat/spells.h
+++ b/src/creatures/combat/spells.h
@@ -35,10 +35,7 @@ class Spells final : public Scripts {
 		Spells &operator=(const Spells &) = delete;
 
 		static Spells &getInstance() {
-			// Guaranteed to be destroyed
-			static Spells instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Spells>();
 		}
 
 		Spell* getSpellByName(const std::string &name);
@@ -77,7 +74,7 @@ class Spells final : public Scripts {
 		friend class CombatSpell;
 };
 
-constexpr auto g_spells = &Spells::getInstance;
+constexpr auto g_spells = Spells::getInstance;
 
 using RuneSpellFunction = std::function<bool(const RuneSpell* spell, Player* player, const Position &posTo)>;
 

--- a/src/creatures/interactions/chat.h
+++ b/src/creatures/interactions/chat.h
@@ -118,10 +118,7 @@ class Chat {
 		Chat &operator=(const Chat &) = delete;
 
 		static Chat &getInstance() {
-			// Guaranteed to be destroyed
-			static Chat instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Chat>();
 		}
 
 		bool load();
@@ -157,6 +154,6 @@ class Chat {
 		PrivateChatChannel dummyPrivate;
 };
 
-constexpr auto g_chat = &Chat::getInstance;
+constexpr auto g_chat = Chat::getInstance;
 
 #endif // SRC_CREATURES_INTERACTIONS_CHAT_H_

--- a/src/creatures/monsters/monsters.h
+++ b/src/creatures/monsters/monsters.h
@@ -256,10 +256,7 @@ class Monsters {
 		Monsters &operator=(const Monsters &) = delete;
 
 		static Monsters &getInstance() {
-			// Guaranteed to be destroyed
-			static Monsters instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Monsters>();
 		}
 
 		MonsterType* getMonsterType(const std::string &name);
@@ -276,6 +273,6 @@ class Monsters {
 		MonsterType* loadMonster(const std::string &file, const std::string &monsterName, bool reloading = false);
 };
 
-constexpr auto g_monsters = &Monsters::getInstance;
+constexpr auto g_monsters = Monsters::getInstance;
 
 #endif // SRC_CREATURES_MONSTERS_MONSTERS_H_

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -33,10 +33,7 @@ class Npc final : public Creature {
 		void operator=(const Npc &) = delete;
 
 		static Npc &getInstance() {
-			// Guaranteed to be destroyed
-			static Npc instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Npc>();
 		}
 
 		Npc* getNpc() override {
@@ -206,6 +203,6 @@ class Npc final : public Creature {
 		void loadPlayerSpectators();
 };
 
-constexpr auto g_npc = &Npc::getInstance;
+constexpr auto g_npc = Npc::getInstance;
 
 #endif // SRC_CREATURES_NPCS_NPC_H_

--- a/src/creatures/npcs/npcs.cpp
+++ b/src/creatures/npcs/npcs.cpp
@@ -109,7 +109,7 @@ void NpcType::loadShop(NpcType* npcType, ShopBlock shopBlock) {
 bool Npcs::load(bool loadLibs /* = true*/, bool loadNpcs /* = true*/, bool reloading /* = false*/) const {
 	if (loadLibs) {
 		auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
-		return g_luaEnvironment.loadFile(coreFolder + "/npclib/load.lua", "load.lua") == 0;
+		return g_luaEnvironment().loadFile(coreFolder + "/npclib/load.lua", "load.lua") == 0;
 	}
 	if (loadNpcs) {
 		auto datapackFolder = g_configManager().getString(DATA_DIRECTORY);

--- a/src/creatures/npcs/npcs.h
+++ b/src/creatures/npcs/npcs.h
@@ -100,10 +100,7 @@ class Npcs {
 		Npcs &operator=(const Npcs &) = delete;
 
 		static Npcs &getInstance() {
-			// Guaranteed to be destroyed
-			static Npcs instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Npcs>();
 		}
 
 		NpcType* getNpcType(const std::string &name, bool create = false);
@@ -117,6 +114,6 @@ class Npcs {
 		phmap::btree_map<std::string, NpcType*> npcs;
 };
 
-constexpr auto g_npcs = &Npcs::getInstance;
+constexpr auto g_npcs = Npcs::getInstance;
 
 #endif // SRC_CREATURES_NPCS_NPCS_H_

--- a/src/creatures/players/grouping/familiars.h
+++ b/src/creatures/players/grouping/familiars.h
@@ -15,8 +15,7 @@
 class Familiars {
 	public:
 		static Familiars &getInstance() {
-			static Familiars instance;
-			return instance;
+			return inject<Familiars>();
 		}
 		bool loadFromXml();
 		const std::vector<Familiar> &getFamiliars(uint16_t vocation) const {

--- a/src/creatures/players/imbuements/imbuements.h
+++ b/src/creatures/players/imbuements/imbuements.h
@@ -53,10 +53,7 @@ class Imbuements {
 		Imbuements &operator=(const Imbuements &) = delete;
 
 		static Imbuements &getInstance() {
-			// Guaranteed to be destroyed
-			static Imbuements instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Imbuements>();
 		}
 
 		Imbuement* getImbuement(uint16_t id);
@@ -78,7 +75,7 @@ class Imbuements {
 		uint32_t runningid = 0;
 };
 
-constexpr auto g_imbuements = &Imbuements::getInstance;
+constexpr auto g_imbuements = Imbuements::getInstance;
 
 class Imbuement {
 	public:

--- a/src/creatures/players/management/waitlist.cpp
+++ b/src/creatures/players/management/waitlist.cpp
@@ -22,8 +22,7 @@ WaitingList::WaitingList() :
 	info(new WaitListInfo) { }
 
 WaitingList &WaitingList::getInstance() {
-	static WaitingList waitingList;
-	return waitingList;
+	return inject<WaitingList>();
 }
 
 void WaitingList::cleanupList(WaitList &list) {

--- a/src/creatures/players/management/waitlist.h
+++ b/src/creatures/players/management/waitlist.h
@@ -33,6 +33,7 @@ struct WaitListInfo {
 
 class WaitingList {
 	public:
+		WaitingList();
 		static WaitingList &getInstance();
 		bool clientLogin(const Player* player);
 		std::size_t getClientSlot(const Player* player);
@@ -42,7 +43,6 @@ class WaitingList {
 		void cleanupList(WaitList &list);
 		std::size_t getTimeout(std::size_t slot);
 		void addPlayerToList(const Player* player);
-		WaitingList();
 		std::unique_ptr<WaitListInfo> info;
 };
 

--- a/src/creatures/players/storages/storages.hpp
+++ b/src/creatures/players/storages/storages.hpp
@@ -12,15 +12,14 @@
 
 class Storages {
 	public:
+		Storages() = default;
+
 		// Singleton - ensures we don't accidentally copy it
 		Storages(const Storages &) = delete;
 		void operator=(const Storages &) = delete;
 
 		static Storages &getInstance() {
-			// Guaranteed to be destroyed
-			static Storages instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Storages>();
 		}
 
 		bool loadFromXML();
@@ -28,11 +27,9 @@ class Storages {
 		const phmap::btree_map<std::string, uint32_t> &getStorageMap() const;
 
 	private:
-		Storages() = default;
-
 		phmap::btree_map<std::string, uint32_t> m_storageMap;
 };
 
-constexpr auto g_storages = &Storages::getInstance;
+constexpr auto g_storages = Storages::getInstance;
 
 #endif // SRC_CREATURES_PLAYERS_STORAGES_STORAGES_HPP_

--- a/src/creatures/players/vocations/vocation.h
+++ b/src/creatures/players/vocations/vocation.h
@@ -153,10 +153,7 @@ class Vocations {
 		void operator=(const Vocations &) = delete;
 
 		static Vocations &getInstance() {
-			// Guaranteed to be destroyed
-			static Vocations instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Vocations>();
 		}
 
 		bool loadFromXml();
@@ -172,6 +169,6 @@ class Vocations {
 		phmap::btree_map<uint16_t, Vocation> vocationsMap;
 };
 
-constexpr auto g_vocations = &Vocations::getInstance;
+constexpr auto g_vocations = Vocations::getInstance;
 
 #endif // SRC_CREATURES_PLAYERS_VOCATIONS_VOCATION_H_

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -25,10 +25,7 @@ class Database {
 		Database &operator=(const Database &) = delete;
 
 		static Database &getInstance() {
-			// Guaranteed to be destroyed.
-			static Database instance;
-			// Instantiated on first use.
-			return instance;
+			return inject<Database>();
 		}
 
 		bool connect();

--- a/src/database/databasetasks.h
+++ b/src/database/databasetasks.h
@@ -31,10 +31,7 @@ class DatabaseTasks : public ThreadHolder<DatabaseTasks> {
 		void operator=(const DatabaseTasks &) = delete;
 
 		static DatabaseTasks &getInstance() {
-			// Guaranteed to be destroyed
-			static DatabaseTasks instance;
-			// Instantiated on first use
-			return instance;
+			return inject<DatabaseTasks>();
 		}
 
 		bool SetDatabaseInterface(Database* database);
@@ -59,6 +56,6 @@ class DatabaseTasks : public ThreadHolder<DatabaseTasks> {
 		bool flushTasks = false;
 };
 
-constexpr auto g_databaseTasks = &DatabaseTasks::getInstance;
+constexpr auto g_databaseTasks = DatabaseTasks::getInstance;
 
 #endif // SRC_DATABASE_DATABASETASKS_H_

--- a/src/game/functions/game_reload.cpp
+++ b/src/game/functions/game_reload.cpp
@@ -95,7 +95,7 @@ bool GameReload::reloadEvents() const {
 
 bool GameReload::reloadCore() const {
 	if (auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
-		g_luaEnvironment.loadFile(coreFolder + "/core.lua", "core.lua") == 0) {
+		g_luaEnvironment().loadFile(coreFolder + "/core.lua", "core.lua") == 0) {
 		// Reload scripts lib
 		auto datapackFolder = g_configManager().getString(DATA_DIRECTORY);
 		if (!g_scripts().loadScripts(datapackFolder + "/scripts/lib", true, false)) {

--- a/src/game/functions/game_reload.hpp
+++ b/src/game/functions/game_reload.hpp
@@ -44,6 +44,10 @@ class GameReload : public Game {
 		GameReload(const GameReload &) = delete;
 		GameReload &operator=(const GameReload &) = delete;
 
+		static GameReload &getInstance() {
+			return inject<GameReload>();
+		}
+
 		bool init(Reload_t reloadType) const;
 		uint8_t getReloadNumber(Reload_t reloadTypes) const;
 
@@ -65,6 +69,6 @@ class GameReload : public Game {
 		bool reloadGroups() const;
 };
 
-const inline GameReload g_gameReload;
+constexpr auto g_gameReload = GameReload::getInstance;
 
 #endif // SRC_GAME_FUNCTIONS_GAME_RELOAD_HPP_

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5899,12 +5899,11 @@ bool Game::combatBlockHit(CombatDamage &damage, Creature* attacker, Creature* ta
 				// Charm rune (target as player)
 				MonsterType* mType = g_monsters().getMonsterType(attacker->getName());
 				if (mType) {
-					IOBestiary g_bestiary;
-					charmRune_t activeCharm = g_bestiary.getCharmFromTarget(targetPlayer, mType);
+					charmRune_t activeCharm = g_iobestiary().getCharmFromTarget(targetPlayer, mType);
 					if (activeCharm == CHARM_PARRY) {
-						Charm* charm = g_bestiary.getBestiaryCharm(activeCharm);
+						Charm* charm = g_iobestiary().getBestiaryCharm(activeCharm);
 						if (charm && charm->type == CHARM_DEFENSIVE && (charm->chance > normal_random(0, 100))) {
-							g_bestiary.parseCharmCombat(charm, targetPlayer, attacker, (damage.primary.value + damage.secondary.value));
+							g_iobestiary().parseCharmCombat(charm, targetPlayer, attacker, (damage.primary.value + damage.secondary.value));
 						}
 					}
 				}

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -54,10 +54,7 @@ class Game {
 		Game &operator=(const Game &) = delete;
 
 		static Game &getInstance() {
-			// Guaranteed to be destroyed
-			static Game instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Game>();
 		}
 
 		void resetMonsters() const;
@@ -870,6 +867,6 @@ class Game {
 		std::unique_ptr<IOWheel> m_IOWheel;
 };
 
-constexpr auto g_game = &Game::getInstance;
+constexpr auto g_game = Game::getInstance;
 
 #endif // SRC_GAME_GAME_H_

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -34,10 +34,7 @@ class EventsScheduler {
 		EventsScheduler &operator=(const EventsScheduler &) = delete;
 
 		static EventsScheduler &getInstance() {
-			// Guaranteed to be destroyed
-			static EventsScheduler instance;
-			// Instantiated on first use
-			return instance;
+			return inject<EventsScheduler>();
 		}
 
 		// Event schedule xml load
@@ -84,6 +81,6 @@ class EventsScheduler {
 		std::string join(const std::vector<std::string> &vec, const std::string &delim);
 };
 
-constexpr auto g_eventsScheduler = &EventsScheduler::getInstance;
+constexpr auto g_eventsScheduler = EventsScheduler::getInstance;
 
 #endif // SRC_GAME_SCHEDUNLING_EVENTS_SCHEDULER_HPP_

--- a/src/game/scheduling/scheduler.h
+++ b/src/game/scheduling/scheduler.h
@@ -53,10 +53,7 @@ class Scheduler : public ThreadHolder<Scheduler> {
 		void operator=(const Scheduler &) = delete;
 
 		static Scheduler &getInstance() {
-			// Guaranteed to be destroyed
-			static Scheduler instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Scheduler>();
 		}
 
 		uint32_t addEvent(SchedulerTask* task);
@@ -76,6 +73,6 @@ class Scheduler : public ThreadHolder<Scheduler> {
 		phmap::flat_hash_set<uint32_t> eventIds;
 };
 
-constexpr auto g_scheduler = &Scheduler::getInstance;
+constexpr auto g_scheduler = Scheduler::getInstance;
 
 #endif // SRC_GAME_SCHEDULING_SCHEDULER_H_

--- a/src/game/scheduling/tasks.h
+++ b/src/game/scheduling/tasks.h
@@ -60,10 +60,7 @@ class Dispatcher : public ThreadHolder<Dispatcher> {
 		void operator=(const Dispatcher &) = delete;
 
 		static Dispatcher &getInstance() {
-			// Guaranteed to be destroyed
-			static Dispatcher instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Dispatcher>();
 		}
 
 		void addTask(Task* task, bool push_front = false);
@@ -84,6 +81,6 @@ class Dispatcher : public ThreadHolder<Dispatcher> {
 		uint64_t dispatcherCycle = 0;
 };
 
-constexpr auto g_dispatcher = &Dispatcher::getInstance;
+constexpr auto g_dispatcher = Dispatcher::getInstance;
 
 #endif // SRC_GAME_SCHEDULING_TASKS_H_

--- a/src/io/io_bosstiary.hpp
+++ b/src/io/io_bosstiary.hpp
@@ -30,15 +30,14 @@ class Player;
 
 class IOBosstiary {
 	public:
+		IOBosstiary() = default;
+
 		// Non copyable
 		IOBosstiary(const IOBosstiary &) = delete;
 		void operator=(const IOBosstiary &) = delete;
 
 		static IOBosstiary &getInstance() {
-			// Guaranteed to be destroyed
-			static IOBosstiary instance;
-			// Instantiated on first use
-			return instance;
+			return inject<IOBosstiary>();
 		}
 
 		void loadBoostedBoss();
@@ -67,14 +66,11 @@ class IOBosstiary {
 		std::vector<uint16_t> getBosstiaryCooldownRaceId(const Player* player) const;
 
 	private:
-		IOBosstiary() = default;
-		~IOBosstiary() = default;
-
 		phmap::btree_map<uint16_t, std::string> bosstiaryMap;
 		std::string boostedBoss;
 		uint16_t boostedBossId = 0;
 };
 
-constexpr auto g_ioBosstiary = &IOBosstiary::getInstance;
+constexpr auto g_ioBosstiary = IOBosstiary::getInstance;
 
 #endif // SRC_IO_IO_BOSSTIARY_HPP_

--- a/src/io/iobestiary.h
+++ b/src/io/iobestiary.h
@@ -51,10 +51,7 @@ class IOBestiary {
 		void operator=(const IOBestiary &) = delete;
 
 		static IOBestiary &getInstance() {
-			// Guaranteed to be destroyed
-			static IOBestiary instance;
-			// Instantiated on first use
-			return instance;
+			return inject<IOBestiary>();
 		}
 
 		Charm* getBestiaryCharm(charmRune_t activeCharm, bool force = false);
@@ -84,6 +81,6 @@ class IOBestiary {
 		phmap::btree_map<uint16_t, std::string> findRaceByName(const std::string &race, bool Onlystring = true, BestiaryType_t raceNumber = BESTY_RACE_NONE) const;
 };
 
-constexpr auto g_iobestiary = &IOBestiary::getInstance;
+constexpr auto g_iobestiary = IOBestiary::getInstance;
 
 #endif // SRC_IO_IOBESTIARY_H_

--- a/src/io/iomarket.h
+++ b/src/io/iomarket.h
@@ -17,9 +17,10 @@ class IOMarket {
 		using StatisticsMap = phmap::btree_map<uint16_t, phmap::btree_map<uint8_t, MarketStatistics>>;
 
 	public:
+		IOMarket() = default;
+
 		static IOMarket &getInstance() {
-			static IOMarket instance;
-			return instance;
+			return inject<IOMarket>();
 		}
 
 		static MarketOfferList getActiveOffers(MarketAction_t action, uint16_t itemId, uint8_t tier);
@@ -51,8 +52,6 @@ class IOMarket {
 		static uint8_t getTierFromDatabaseTable(const std::string &string);
 
 	private:
-		IOMarket() = default;
-
 		// [uint16_t = item id, [uint8_t = item tier, MarketStatistics = structure of the statistics]]
 		StatisticsMap purchaseStatistics;
 		StatisticsMap saleStatistics;

--- a/src/io/ioprey.h
+++ b/src/io/ioprey.h
@@ -214,10 +214,7 @@ class IOPrey {
 		void operator=(const IOPrey &) = delete;
 
 		static IOPrey &getInstance() {
-			// Guaranteed to be destroyed
-			static IOPrey instance;
-			// Instantiated on first use
-			return instance;
+			return inject<IOPrey>();
 		}
 
 		void CheckPlayerPreys(Player* player, uint8_t amount) const;
@@ -240,6 +237,6 @@ class IOPrey {
 		std::vector<TaskHuntingOption*> taskOption;
 };
 
-constexpr auto g_ioprey = &IOPrey::getInstance;
+constexpr auto g_ioprey = IOPrey::getInstance;
 
 #endif // SRC_IO_IOPREY_H_

--- a/src/items/decay/decay.h
+++ b/src/items/decay/decay.h
@@ -14,22 +14,19 @@
 
 class Decay {
 	public:
+		Decay() = default;
+
 		Decay(const Decay &) = delete;
 		void operator=(const Decay &) = delete;
 
 		static Decay &getInstance() {
-			// Guaranteed to be destroyed
-			static Decay instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Decay>();
 		}
 
 		void startDecay(Item* item);
 		void stopDecay(Item* item);
 
 	private:
-		Decay() = default;
-
 		void checkDecay();
 		void internalDecayItem(Item* item);
 
@@ -37,6 +34,6 @@ class Decay {
 		phmap::btree_map<int64_t, std::vector<Item*>> decayMap;
 };
 
-constexpr auto g_decay = &Decay::getInstance;
+constexpr auto g_decay = Decay::getInstance;
 
 #endif // SRC_ITEMS_DECAY_DECAY_H_

--- a/src/items/weapons/weapons.h
+++ b/src/items/weapons/weapons.h
@@ -34,10 +34,7 @@ class Weapons final : public Scripts {
 		Weapons &operator=(const Weapons &) = delete;
 
 		static Weapons &getInstance() {
-			// Guaranteed to be destroyed
-			static Weapons instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Weapons>();
 		}
 
 		const Weapon* getWeapon(const Item* item) const;
@@ -52,7 +49,7 @@ class Weapons final : public Scripts {
 		phmap::btree_map<uint32_t, Weapon*> weapons;
 };
 
-constexpr auto g_weapons = &Weapons::getInstance;
+constexpr auto g_weapons = Weapons::getInstance;
 
 class Weapon : public Script {
 	public:

--- a/src/lua/callbacks/events_callbacks.cpp
+++ b/src/lua/callbacks/events_callbacks.cpp
@@ -25,10 +25,7 @@ EventsCallbacks::EventsCallbacks() = default;
 EventsCallbacks::~EventsCallbacks() = default;
 
 EventsCallbacks &EventsCallbacks::getInstance() {
-	// Guaranteed to be destroyed
-	static EventsCallbacks instance;
-	// Instantiated on first use
-	return instance;
+	return inject<EventsCallbacks>();
 }
 
 void EventsCallbacks::addCallback(EventCallback* callback) {

--- a/src/lua/callbacks/events_callbacks.hpp
+++ b/src/lua/callbacks/events_callbacks.hpp
@@ -110,6 +110,6 @@ class EventsCallbacks {
 		std::vector<EventCallback*> m_callbacks;
 };
 
-constexpr auto g_callbacks = &EventsCallbacks::getInstance;
+constexpr auto g_callbacks = EventsCallbacks::getInstance;
 
 #endif // SRC_LUA_CALLBACKS_EVENTS_CALLBACKS_HPP_

--- a/src/lua/creature/actions.h
+++ b/src/lua/creature/actions.h
@@ -143,10 +143,7 @@ class Actions final : public Scripts {
 		Actions &operator=(const Actions &) = delete;
 
 		static Actions &getInstance() {
-			// Guaranteed to be destroyed
-			static Actions instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Actions>();
 		}
 
 		bool useItem(Player* player, const Position &pos, uint8_t index, Item* item, bool isHotkey);
@@ -229,6 +226,6 @@ class Actions final : public Scripts {
 		Action* getAction(const Item* item);
 };
 
-constexpr auto g_actions = &Actions::getInstance;
+constexpr auto g_actions = Actions::getInstance;
 
 #endif // SRC_LUA_CREATURE_ACTIONS_H_

--- a/src/lua/creature/creatureevent.h
+++ b/src/lua/creature/creatureevent.h
@@ -75,10 +75,7 @@ class CreatureEvents final : public Scripts {
 		CreatureEvents &operator=(const CreatureEvents &) = delete;
 
 		static CreatureEvents &getInstance() {
-			// Guaranteed to be destroyed
-			static CreatureEvents instance;
-			// Instantiated on first use
-			return instance;
+			return inject<CreatureEvents>();
 		}
 
 		// global events
@@ -98,6 +95,6 @@ class CreatureEvents final : public Scripts {
 		CreatureEventMap creatureEvents;
 };
 
-constexpr auto g_creatureEvents = &CreatureEvents::getInstance;
+constexpr auto g_creatureEvents = CreatureEvents::getInstance;
 
 #endif // SRC_LUA_CREATURE_CREATUREEVENT_H_

--- a/src/lua/creature/events.h
+++ b/src/lua/creature/events.h
@@ -78,10 +78,7 @@ class Events {
 		void operator=(const Events &) = delete;
 
 		static Events &getInstance() {
-			// Guaranteed to be destroyed
-			static Events instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Events>();
 		}
 
 		// Creature
@@ -135,6 +132,6 @@ class Events {
 		EventsInfo info;
 };
 
-constexpr auto g_events = &Events::getInstance;
+constexpr auto g_events = Events::getInstance;
 
 #endif // SRC_LUA_CREATURE_EVENTS_H_

--- a/src/lua/creature/movement.h
+++ b/src/lua/creature/movement.h
@@ -34,10 +34,7 @@ class MoveEvents final : public Scripts {
 		MoveEvents &operator=(const MoveEvents &) = delete;
 
 		static MoveEvents &getInstance() {
-			// Guaranteed to be destroyed
-			static MoveEvents instance;
-			// Instantiated on first use
-			return instance;
+			return inject<MoveEvents>();
 		}
 
 		uint32_t onCreatureMove(Creature &creature, Tile &tile, MoveEvent_t eventType);
@@ -134,7 +131,7 @@ class MoveEvents final : public Scripts {
 		phmap::btree_map<Position, MoveEventList> positionsMap;
 };
 
-constexpr auto g_moveEvents = &MoveEvents::getInstance;
+constexpr auto g_moveEvents = MoveEvents::getInstance;
 
 class MoveEvent final : public Script {
 	public:

--- a/src/lua/creature/talkaction.h
+++ b/src/lua/creature/talkaction.h
@@ -76,10 +76,7 @@ class TalkActions final : public Scripts {
 		TalkActions &operator=(const TalkActions &) = delete;
 
 		static TalkActions &getInstance() {
-			// Guaranteed to be destroyed
-			static TalkActions instance;
-			// Instantiated on first use
-			return instance;
+			return inject<TalkActions>();
 		}
 
 		bool checkWord(Player* player, SpeakClasses type, const std::string &words, const std::string_view &word, const TalkAction_ptr &talkActionPtr) const;
@@ -96,6 +93,6 @@ class TalkActions final : public Scripts {
 		phmap::btree_map<std::string, std::shared_ptr<TalkAction>> talkActions;
 };
 
-constexpr auto g_talkActions = &TalkActions::getInstance;
+constexpr auto g_talkActions = TalkActions::getInstance;
 
 #endif // SRC_LUA_CREATURE_TALKACTION_H_

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -573,20 +573,20 @@ int GameFunctions::luaGameGetClientVersion(lua_State* L) {
 int GameFunctions::luaGameReload(lua_State* L) {
 	// Game.reload(reloadType)
 	Reload_t reloadType = getNumber<Reload_t>(L, 1);
-	if (g_gameReload.getReloadNumber(reloadType) == g_gameReload.getReloadNumber(Reload_t::RELOAD_TYPE_NONE)) {
+	if (g_gameReload().getReloadNumber(reloadType) == g_gameReload().getReloadNumber(Reload_t::RELOAD_TYPE_NONE)) {
 		reportErrorFunc("Reload type is none");
 		pushBoolean(L, false);
 		return 0;
 	}
 
-	if (g_gameReload.getReloadNumber(reloadType) >= g_gameReload.getReloadNumber(Reload_t::RELOAD_TYPE_LAST)) {
+	if (g_gameReload().getReloadNumber(reloadType) >= g_gameReload().getReloadNumber(Reload_t::RELOAD_TYPE_LAST)) {
 		reportErrorFunc("Reload type not exist");
 		pushBoolean(L, false);
 		return 0;
 	}
 
-	pushBoolean(L, g_gameReload.init(reloadType));
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	pushBoolean(L, g_gameReload().init(reloadType));
+	lua_gc(g_luaEnvironment().getLuaState(), LUA_GCCOLLECT, 0);
 	return 1;
 }
 

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -249,8 +249,8 @@ int GlobalFunctions::luaCreateCombatArea(lua_State* L) {
 		return 1;
 	}
 
-	uint32_t areaId = g_luaEnvironment.createAreaObject(env->getScriptInterface());
-	AreaCombat* area = g_luaEnvironment.getAreaObject(areaId);
+	uint32_t areaId = g_luaEnvironment().createAreaObject(env->getScriptInterface());
+	AreaCombat* area = g_luaEnvironment().getAreaObject(areaId);
 
 	int parameters = lua_gettop(L);
 	if (parameters >= 2) {
@@ -287,7 +287,7 @@ int GlobalFunctions::luaDoAreaCombatHealth(lua_State* L) {
 	}
 
 	uint32_t areaId = getNumber<uint32_t>(L, 4);
-	const AreaCombat* area = g_luaEnvironment.getAreaObject(areaId);
+	const AreaCombat* area = g_luaEnvironment().getAreaObject(areaId);
 	if (area || areaId == 0) {
 		CombatType_t combatType = getNumber<CombatType_t>(L, 2);
 
@@ -372,7 +372,7 @@ int GlobalFunctions::luaDoAreaCombatMana(lua_State* L) {
 	}
 
 	uint32_t areaId = getNumber<uint32_t>(L, 3);
-	const AreaCombat* area = g_luaEnvironment.getAreaObject(areaId);
+	const AreaCombat* area = g_luaEnvironment().getAreaObject(areaId);
 	if (area || areaId == 0) {
 		CombatParams params;
 		params.impactEffect = getNumber<uint16_t>(L, 6);
@@ -457,7 +457,7 @@ int GlobalFunctions::luaDoAreaCombatCondition(lua_State* L) {
 	}
 
 	uint32_t areaId = getNumber<uint32_t>(L, 3);
-	const AreaCombat* area = g_luaEnvironment.getAreaObject(areaId);
+	const AreaCombat* area = g_luaEnvironment().getAreaObject(areaId);
 	if (area || areaId == 0) {
 		CombatParams params;
 		params.impactEffect = getNumber<uint16_t>(L, 5);
@@ -512,7 +512,7 @@ int GlobalFunctions::luaDoAreaCombatDispel(lua_State* L) {
 	}
 
 	uint32_t areaId = getNumber<uint32_t>(L, 3);
-	const AreaCombat* area = g_luaEnvironment.getAreaObject(areaId);
+	const AreaCombat* area = g_luaEnvironment().getAreaObject(areaId);
 	if (area || areaId == 0) {
 		CombatParams params;
 		params.impactEffect = getNumber<uint16_t>(L, 5);
@@ -577,7 +577,7 @@ int GlobalFunctions::luaDoChallengeCreature(lua_State* L) {
 
 int GlobalFunctions::luaAddEvent(lua_State* L) {
 	// addEvent(callback, delay, ...)
-	lua_State* globalState = g_luaEnvironment.getLuaState();
+	lua_State* globalState = g_luaEnvironment().getLuaState();
 	if (!globalState) {
 		reportErrorFunc("No valid script interface!");
 		pushBoolean(L, false);
@@ -678,19 +678,19 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 	eventDesc.function = luaL_ref(globalState, LUA_REGISTRYINDEX);
 	eventDesc.scriptId = getScriptEnv()->getScriptId();
 
-	auto &lastTimerEventId = g_luaEnvironment.lastEventTimerId;
+	auto &lastTimerEventId = g_luaEnvironment().lastEventTimerId;
 	eventDesc.eventId = g_scheduler().addEvent(createSchedulerTask(
-		delay, std::bind(&LuaEnvironment::executeTimerEvent, &g_luaEnvironment, lastTimerEventId)
+		delay, std::bind(&LuaEnvironment::executeTimerEvent, &g_luaEnvironment(), lastTimerEventId)
 	));
 
-	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
+	g_luaEnvironment().timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
 	lua_pushnumber(L, lastTimerEventId++);
 	return 1;
 }
 
 int GlobalFunctions::luaStopEvent(lua_State* L) {
 	// stopEvent(eventid)
-	lua_State* globalState = g_luaEnvironment.getLuaState();
+	lua_State* globalState = g_luaEnvironment().getLuaState();
 	if (!globalState) {
 		reportErrorFunc("No valid script interface!");
 		pushBoolean(L, false);
@@ -699,7 +699,7 @@ int GlobalFunctions::luaStopEvent(lua_State* L) {
 
 	uint32_t eventId = getNumber<uint32_t>(L, 1);
 
-	auto &timerEvents = g_luaEnvironment.timerEvents;
+	auto &timerEvents = g_luaEnvironment().timerEvents;
 	auto it = timerEvents.find(eventId);
 	if (it == timerEvents.end()) {
 		pushBoolean(L, false);

--- a/src/lua/functions/core/libs/db_functions.cpp
+++ b/src/lua/functions/core/libs/db_functions.cpp
@@ -25,7 +25,7 @@ int DBFunctions::luaDatabaseAsyncExecute(lua_State* L) {
 		int32_t ref = luaL_ref(L, LUA_REGISTRYINDEX);
 		auto scriptId = getScriptEnv()->getScriptId();
 		callback = [ref, scriptId](DBResult_ptr, bool success) {
-			lua_State* luaState = g_luaEnvironment.getLuaState();
+			lua_State* luaState = g_luaEnvironment().getLuaState();
 			if (!luaState) {
 				return;
 			}
@@ -38,8 +38,8 @@ int DBFunctions::luaDatabaseAsyncExecute(lua_State* L) {
 			lua_rawgeti(luaState, LUA_REGISTRYINDEX, ref);
 			pushBoolean(luaState, success);
 			auto env = getScriptEnv();
-			env->setScriptId(scriptId, &g_luaEnvironment);
-			g_luaEnvironment.callFunction(1);
+			env->setScriptId(scriptId, &g_luaEnvironment());
+			g_luaEnvironment().callFunction(1);
 
 			luaL_unref(luaState, LUA_REGISTRYINDEX, ref);
 		};
@@ -63,7 +63,7 @@ int DBFunctions::luaDatabaseAsyncStoreQuery(lua_State* L) {
 		int32_t ref = luaL_ref(L, LUA_REGISTRYINDEX);
 		auto scriptId = getScriptEnv()->getScriptId();
 		callback = [ref, scriptId](DBResult_ptr result, bool) {
-			lua_State* luaState = g_luaEnvironment.getLuaState();
+			lua_State* luaState = g_luaEnvironment().getLuaState();
 			if (!luaState) {
 				return;
 			}
@@ -80,8 +80,8 @@ int DBFunctions::luaDatabaseAsyncStoreQuery(lua_State* L) {
 				pushBoolean(luaState, false);
 			}
 			auto env = getScriptEnv();
-			env->setScriptId(scriptId, &g_luaEnvironment);
-			g_luaEnvironment.callFunction(1);
+			env->setScriptId(scriptId, &g_luaEnvironment());
+			g_luaEnvironment().callFunction(1);
 
 			luaL_unref(luaState, LUA_REGISTRYINDEX, ref);
 		};

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -16,7 +16,7 @@
 
 int CombatFunctions::luaCombatCreate(lua_State* L) {
 	// Combat()
-	pushUserdata<Combat>(L, g_luaEnvironment.createCombatObject(getScriptEnv()->getScriptInterface()).get());
+	pushUserdata<Combat>(L, g_luaEnvironment().createCombatObject(getScriptEnv()->getScriptInterface()).get());
 	setMetatable(L, -1, "Combat");
 	return 1;
 }
@@ -67,7 +67,7 @@ int CombatFunctions::luaCombatSetArea(lua_State* L) {
 		return 1;
 	}
 
-	const AreaCombat* area = g_luaEnvironment.getAreaObject(getNumber<uint32_t>(L, 2));
+	const AreaCombat* area = g_luaEnvironment().getAreaObject(getNumber<uint32_t>(L, 2));
 	if (!area) {
 		reportErrorFunc(getErrorDesc(LUA_ERROR_AREA_NOT_FOUND));
 		lua_pushnil(L);

--- a/src/lua/functions/items/weapon_functions.cpp
+++ b/src/lua/functions/items/weapon_functions.cpp
@@ -24,7 +24,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_SWORD:
 		case WEAPON_AXE:
 		case WEAPON_CLUB: {
-			if (auto weaponPtr = g_luaEnvironment.createWeaponObject<WeaponMelee>(getScriptEnv()->getScriptInterface())) {
+			if (auto weaponPtr = g_luaEnvironment().createWeaponObject<WeaponMelee>(getScriptEnv()->getScriptInterface())) {
 				pushUserdata<WeaponMelee>(L, weaponPtr.get());
 				setMetatable(L, -1, "Weapon");
 				weaponPtr->weaponType = type;
@@ -36,7 +36,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_MISSILE:
 		case WEAPON_DISTANCE:
 		case WEAPON_AMMO: {
-			if (auto weaponPtr = g_luaEnvironment.createWeaponObject<WeaponDistance>(getScriptEnv()->getScriptInterface())) {
+			if (auto weaponPtr = g_luaEnvironment().createWeaponObject<WeaponDistance>(getScriptEnv()->getScriptInterface())) {
 				pushUserdata<WeaponDistance>(L, weaponPtr.get());
 				setMetatable(L, -1, "Weapon");
 				weaponPtr->weaponType = type;
@@ -46,7 +46,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 			break;
 		}
 		case WEAPON_WAND: {
-			if (auto weaponPtr = g_luaEnvironment.createWeaponObject<WeaponWand>(getScriptEnv()->getScriptInterface())) {
+			if (auto weaponPtr = g_luaEnvironment().createWeaponObject<WeaponWand>(getScriptEnv()->getScriptInterface())) {
 				pushUserdata<WeaponWand>(L, weaponPtr.get());
 				setMetatable(L, -1, "Weapon");
 				weaponPtr->weaponType = type;

--- a/src/lua/global/baseevents.cpp
+++ b/src/lua/global/baseevents.cpp
@@ -86,7 +86,7 @@ Event::Event(LuaScriptInterface* interface) :
 	scriptInterface(interface) { }
 
 bool Event::checkScript(const std::string &basePath, const std::string &scriptsName, const std::string &scriptFile) const {
-	LuaScriptInterface* testInterface = g_luaEnvironment.getTestInterface();
+	LuaScriptInterface* testInterface = g_luaEnvironment().getTestInterface();
 	testInterface->reInitState();
 
 	if (testInterface->loadFile(basePath + "lib/" + scriptsName + ".lua", scriptsName + ".lua") == -1) {

--- a/src/lua/global/globalevent.h
+++ b/src/lua/global/globalevent.h
@@ -27,10 +27,7 @@ class GlobalEvents final : public Scripts {
 		GlobalEvents &operator=(const GlobalEvents &) = delete;
 
 		static GlobalEvents &getInstance() {
-			// Guaranteed to be destroyed
-			static GlobalEvents instance;
-			// Instantiated on first use
-			return instance;
+			return inject<GlobalEvents>();
 		}
 
 		void startup() const;
@@ -49,7 +46,7 @@ class GlobalEvents final : public Scripts {
 		int32_t thinkEventId = 0, timerEventId = 0;
 };
 
-constexpr auto g_globalEvents = &GlobalEvents::getInstance;
+constexpr auto g_globalEvents = GlobalEvents::getInstance;
 
 class GlobalEvent final : public Script {
 	public:

--- a/src/lua/modules/modules.h
+++ b/src/lua/modules/modules.h
@@ -64,10 +64,7 @@ class Modules final : public BaseEvents {
 		Modules &operator=(const Modules &) = delete;
 
 		static Modules &getInstance() {
-			// Guaranteed to be destroyed
-			static Modules instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Modules>();
 		}
 
 		void executeOnRecvbyte(uint32_t playerId, NetworkMessage &msg, uint8_t byte) const;
@@ -86,6 +83,6 @@ class Modules final : public BaseEvents {
 		LuaScriptInterface scriptInterface;
 };
 
-constexpr auto g_modules = &Modules::getInstance;
+constexpr auto g_modules = Modules::getInstance;
 
 #endif // SRC_LUA_MODULES_MODULES_H_

--- a/src/lua/scripts/lua_environment.cpp
+++ b/src/lua/scripts/lua_environment.cpp
@@ -21,7 +21,21 @@ LuaEnvironment::~LuaEnvironment() {
 	if (!testInterface) {
 		delete testInterface;
 	}
+
+	shuttingDown = true;
 	closeState();
+}
+
+lua_State* LuaEnvironment::getLuaState() {
+	if (shuttingDown) {
+		return luaState;
+	}
+
+	if (luaState == nullptr) {
+		initState();
+	}
+
+	return luaState;
 }
 
 bool LuaEnvironment::initState() {

--- a/src/lua/scripts/lua_environment.hpp
+++ b/src/lua/scripts/lua_environment.hpp
@@ -26,9 +26,15 @@ class LuaEnvironment : public LuaScriptInterface {
 		LuaEnvironment();
 		~LuaEnvironment();
 
+		lua_State* getLuaState() override;
+
 		// non-copyable
 		LuaEnvironment(const LuaEnvironment &) = delete;
 		LuaEnvironment &operator=(const LuaEnvironment &) = delete;
+
+		static LuaEnvironment &getInstance() {
+			return inject<LuaEnvironment>();
+		}
 
 		bool initState() override;
 		bool reInitState();
@@ -95,8 +101,10 @@ class LuaEnvironment : public LuaScriptInterface {
 		friend class LuaScriptInterface;
 		friend class GlobalFunctions;
 		friend class CombatSpell;
+
+		bool shuttingDown = false;
 };
 
-inline LuaEnvironment g_luaEnvironment;
+constexpr auto g_luaEnvironment = LuaEnvironment::getInstance;
 
 #endif // SRC_LUA_SCRIPTS_LUA_ENVIRONMENT_HPP_

--- a/src/lua/scripts/luascript.cpp
+++ b/src/lua/scripts/luascript.cpp
@@ -28,8 +28,8 @@ LuaScriptInterface::~LuaScriptInterface() {
 }
 
 bool LuaScriptInterface::reInitState() {
-	g_luaEnvironment.clearCombatObjects(this);
-	g_luaEnvironment.clearAreaObjects(this);
+	g_luaEnvironment().clearCombatObjects(this);
+	g_luaEnvironment().clearAreaObjects(this);
 
 	closeState();
 	return initState();
@@ -196,7 +196,7 @@ bool LuaScriptInterface::pushFunction(int32_t functionId) {
 }
 
 bool LuaScriptInterface::initState() {
-	luaState = g_luaEnvironment.getLuaState();
+	luaState = g_luaEnvironment().getLuaState();
 	if (!luaState) {
 		return false;
 	}
@@ -208,7 +208,7 @@ bool LuaScriptInterface::initState() {
 }
 
 bool LuaScriptInterface::closeState() {
-	if (!g_luaEnvironment.getLuaState() || !luaState) {
+	if (!g_luaEnvironment().getLuaState() || !luaState) {
 		return false;
 	}
 

--- a/src/lua/scripts/luascript.h
+++ b/src/lua/scripts/luascript.h
@@ -54,7 +54,7 @@ class LuaScriptInterface : public LuaFunctionsLoader {
 			loadedScriptName = scriptName;
 		}
 
-		lua_State* getLuaState() const {
+		virtual lua_State* getLuaState() {
 			return luaState;
 		}
 

--- a/src/lua/scripts/scripts.h
+++ b/src/lua/scripts/scripts.h
@@ -22,10 +22,7 @@ class Scripts {
 		Scripts &operator=(const Scripts &) = delete;
 
 		static Scripts &getInstance() {
-			// Guaranteed to be destroyed
-			static Scripts instance;
-			// Instantiated on first use
-			return instance;
+			return inject<Scripts>();
 		}
 
 		void clearAllScripts() const;
@@ -49,7 +46,7 @@ class Scripts {
 		LuaScriptInterface scriptInterface;
 };
 
-constexpr auto g_scripts = &Scripts::getInstance;
+constexpr auto g_scripts = Scripts::getInstance;
 
 class Script {
 	public:

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -162,8 +162,8 @@ void loadModules() {
 	}
 
 	SPDLOG_INFO("Initializing lua environment...");
-	if (!g_luaEnvironment.getLuaState()) {
-		g_luaEnvironment.initState();
+	if (!g_luaEnvironment().getLuaState()) {
+		g_luaEnvironment().initState();
 	}
 
 	auto coreFolder = g_configManager().getString(CORE_DIRECTORY);
@@ -174,7 +174,7 @@ void loadModules() {
 	auto datapackFolder = g_configManager().getString(DATA_DIRECTORY);
 	SPDLOG_INFO("Loading core scripts on folder: {}/", coreFolder);
 	// Load first core Lua libs
-	modulesLoadHelper((g_luaEnvironment.loadFile(coreFolder + "/core.lua", "core.lua") == 0), "core.lua");
+	modulesLoadHelper((g_luaEnvironment().loadFile(coreFolder + "/core.lua", "core.lua") == 0), "core.lua");
 	modulesLoadHelper(g_scripts().loadScripts(coreFolder + "/scripts", false, false), "/data/scripts");
 
 	// Second XML scripts

--- a/src/security/rsa.h
+++ b/src/security/rsa.h
@@ -20,10 +20,7 @@ class RSA {
 		void operator=(RSA const &) = delete;
 
 		static RSA &getInstance() {
-			// Guaranteed to be destroyed
-			static RSA instance;
-			// Instantiated on first use
-			return instance;
+			return inject<RSA>();
 		}
 
 		void setKey(const char* pString, const char* qString, int base = 10);
@@ -39,6 +36,6 @@ class RSA {
 		mpz_t d;
 };
 
-constexpr auto g_RSA = &RSA::getInstance;
+constexpr auto g_RSA = RSA::getInstance;
 
 #endif // SRC_SECURITY_RSA_H_

--- a/src/server/network/connection/connection.h
+++ b/src/server/network/connection/connection.h
@@ -31,9 +31,10 @@ using ConstServicePort_ptr = std::shared_ptr<const ServicePort>;
 
 class ConnectionManager {
 	public:
+		ConnectionManager() = default;
+
 		static ConnectionManager &getInstance() {
-			static ConnectionManager instance;
-			return instance;
+			return inject<ConnectionManager>();
 		}
 
 		Connection_ptr createConnection(asio::io_service &io_service, ConstServicePort_ptr servicePort);
@@ -41,8 +42,6 @@ class ConnectionManager {
 		void closeAll();
 
 	private:
-		ConnectionManager() = default;
-
 		phmap::flat_hash_set<Connection_ptr> connections;
 		std::mutex connectionManagerLock;
 };

--- a/src/server/network/message/outputmessage.h
+++ b/src/server/network/message/outputmessage.h
@@ -69,13 +69,14 @@ class OutputMessage : public NetworkMessage {
 
 class OutputMessagePool {
 	public:
+		OutputMessagePool() = default;
+
 		// non-copyable
 		OutputMessagePool(const OutputMessagePool &) = delete;
 		OutputMessagePool &operator=(const OutputMessagePool &) = delete;
 
 		static OutputMessagePool &getInstance() {
-			static OutputMessagePool instance;
-			return instance;
+			return inject<OutputMessagePool>();
 		}
 
 		void sendAll();
@@ -87,7 +88,6 @@ class OutputMessagePool {
 		void removeProtocolFromAutosend(const Protocol_ptr &protocol);
 
 	private:
-		OutputMessagePool() = default;
 		// NOTE: A vector is used here because this container is mostly read
 		// and relatively rarely modified (only when a client connects/disconnects)
 		std::vector<Protocol_ptr> bufferedProtocols;

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -15,8 +15,6 @@
 #include "game/scheduling/scheduler.h"
 #include "creatures/players/management/ban.h"
 
-Ban g_bans;
-
 ServiceManager::~ServiceManager() {
 	try {
 		stop();
@@ -94,7 +92,7 @@ void ServicePort::onAccept(Connection_ptr connection, const std::error_code &err
 		}
 
 		auto remote_ip = connection->getIP();
-		if (remote_ip != 0 && g_bans.acceptConnection(remote_ip)) {
+		if (remote_ip != 0 && inject<Ban>().acceptConnection(remote_ip)) {
 			Service_ptr service = services.front();
 			if (service->is_single_socket()) {
 				connection->accept(service->make_protocol(connection));

--- a/src/server/signals.cpp
+++ b/src/server/signals.cpp
@@ -122,10 +122,10 @@ void Signals::sighupHandler() {
 	g_chat().load();
 	SPDLOG_INFO("Reloaded chatchannels");
 
-	g_luaEnvironment.loadFile(g_configManager().getString(CORE_DIRECTORY) + "/core.lua", "core.lua");
+	g_luaEnvironment().loadFile(g_configManager().getString(CORE_DIRECTORY) + "/core.lua", "core.lua");
 	SPDLOG_INFO("Reloaded core.lua");
 
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	lua_gc(g_luaEnvironment().getLuaState(), LUA_GCCOLLECT, 0);
 }
 
 void Signals::sigintHandler() {


### PR DESCRIPTION
# Description

Previously, we've introduced a [DI container](https://github.com/opentibiabr/canary/pull/1385) using BoostDI.

This PR now aims to move all the singletons and shared global instances behind the DI container, making sure that everyone uses a single source of truth for instanciation of shared dependencies (the container).

This is done using the inject<>() function, to reduce the effort needed. However, the desired approach is to have injection in the constructor level, to reduce the risks of mutability and inconsistencies. For now, using inject<>() is a nice step in between.

## Type of change

Please delete options that are not relevant.
New feature (non-breaking change which adds functionality)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
