### PR TITLE
fix: remove debug log pattern, disable lua log config in debug mode

### DIFF
--- a/src/config/configmanager.cpp
+++ b/src/config/configmanager.cpp
@@ -89,7 +89,9 @@ bool ConfigManager::load() {
 		return false;
 	}
 
+#ifndef DEBUG_LOG
 	g_logger().setLevel(getGlobalString(L, "logLevel", "info"));
+#endif
 
 	// Parse config
 	// Info that must be loaded one time (unless we reset the modules involved)

--- a/src/lib/logging/LogWithSpdLog.cpp
+++ b/src/lib/logging/LogWithSpdLog.cpp
@@ -24,10 +24,6 @@ void LogWithSpdLog::setLevel(const std::string &name) {
 	info("Setting log level to {}.", name);
 	auto level = spdlog::level::from_str(name);
 	spdlog::set_level(level);
-
-	if (spdlog::level::from_str(name) <= SPDLOG_LEVEL_DEBUG) {
-		spdlog::set_pattern("[%Y-%d-%m %H:%M:%S.%e] [file %@] [func %!] [thread %t] [%^%l%$] %v ");
-	}
 }
 
 std::string LogWithSpdLog::getLevel() const {


### PR DESCRIPTION
File, function, line log pattern only work with macros. Since we've removed macros, we can no longer use those informations in the debug log (the format is still there, but it won't provide the correct information). To make sure we are consistent, we are removing those options from the debug log pattern.

Also, to avoid overriding log level when in debug mode (where we do expect debug log level), the log level definition from lua is now only defined if DEBUG_LOG is disabled.