### PR TITLE
improve: change "Mounts*" pointer to use std::shared_ptr

### DIFF
--- a/src/creatures/appearance/mounts/mounts.cpp
+++ b/src/creatures/appearance/mounts/mounts.cpp
@@ -35,42 +35,42 @@ bool Mounts::loadFromXml() {
 			continue;
 		}
 
-		mounts.emplace_back(
+		mounts.emplace_back(std::make_shared<Mount>(
 			static_cast<uint8_t>(pugi::cast<uint16_t>(mountNode.attribute("id").value())),
 			lookType,
 			mountNode.attribute("name").as_string(),
 			pugi::cast<int32_t>(mountNode.attribute("speed").value()),
 			mountNode.attribute("premium").as_bool(),
 			mountNode.attribute("type").as_string()
-		);
+		));
 	}
 	mounts.shrink_to_fit();
 	return true;
 }
 
-Mount* Mounts::getMountByID(uint8_t id) {
-	auto it = std::find_if(mounts.begin(), mounts.end(), [id](const Mount &mount) {
-		return mount.id == id;
+std::shared_ptr<Mount> Mounts::getMountByID(uint8_t id) {
+	auto it = std::find_if(mounts.begin(), mounts.end(), [id](const std::shared_ptr<Mount> &mount) {
+		return mount->id == id; // Note the use of -> operator to access the members of the Mount object
 	});
 
-	return it != mounts.end() ? &*it : nullptr;
+	return it != mounts.end() ? *it : nullptr; // Returning the shared_ptr to the Mount object
 }
 
-Mount* Mounts::getMountByName(const std::string &name) {
+
+std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) {
 	auto mountName = name.c_str();
-	for (auto &it : mounts) {
-		if (strcasecmp(mountName, it.name.c_str()) == 0) {
-			return &it;
-		}
-	}
-
-	return nullptr;
-}
-
-Mount* Mounts::getMountByClientID(uint16_t clientId) {
-	auto it = std::find_if(mounts.begin(), mounts.end(), [clientId](const Mount &mount) {
-		return mount.clientId == clientId;
+	auto it = std::find_if(mounts.begin(), mounts.end(), [mountName](const std::shared_ptr<Mount> &mount) {
+		return strcasecmp(mountName, mount->name.c_str()) == 0;
 	});
 
-	return it != mounts.end() ? &*it : nullptr;
+	return it != mounts.end() ? *it : nullptr;
+}
+
+
+std::shared_ptr<Mount> Mounts::getMountByClientID(uint16_t clientId) {
+	auto it = std::find_if(mounts.begin(), mounts.end(), [clientId](const std::shared_ptr<Mount> &mount) {
+		return mount->clientId == clientId; // Note the use of -> operator to access the members of the Mount object
+	});
+
+	return it != mounts.end() ? *it : nullptr; // Returning the shared_ptr to the Mount object
 }

--- a/src/creatures/appearance/mounts/mounts.cpp
+++ b/src/creatures/appearance/mounts/mounts.cpp
@@ -56,7 +56,6 @@ std::shared_ptr<Mount> Mounts::getMountByID(uint8_t id) {
 	return it != mounts.end() ? *it : nullptr; // Returning the shared_ptr to the Mount object
 }
 
-
 std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) {
 	auto mountName = name.c_str();
 	auto it = std::find_if(mounts.begin(), mounts.end(), [mountName](const std::shared_ptr<Mount> &mount) {
@@ -65,7 +64,6 @@ std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) {
 
 	return it != mounts.end() ? *it : nullptr;
 }
-
 
 std::shared_ptr<Mount> Mounts::getMountByClientID(uint16_t clientId) {
 	auto it = std::find_if(mounts.begin(), mounts.end(), [clientId](const std::shared_ptr<Mount> &mount) {

--- a/src/creatures/appearance/mounts/mounts.h
+++ b/src/creatures/appearance/mounts/mounts.h
@@ -27,16 +27,16 @@ class Mounts {
 	public:
 		bool reload();
 		bool loadFromXml();
-		Mount* getMountByID(uint8_t id);
-		Mount* getMountByName(const std::string &name);
-		Mount* getMountByClientID(uint16_t clientId);
+		std::shared_ptr<Mount> getMountByID(uint8_t id);
+		std::shared_ptr<Mount> getMountByName(const std::string &name);
+		std::shared_ptr<Mount> getMountByClientID(uint16_t clientId);
 
-		const std::vector<Mount> &getMounts() const {
+		[[nodiscard]] const std::vector<std::shared_ptr<Mount>> &getMounts() const {
 			return mounts;
 		}
 
 	private:
-		std::vector<Mount> mounts;
+		std::vector<std::shared_ptr<Mount>> mounts;
 };
 
 #endif // SRC_CREATURES_APPEARANCE_MOUNTS_MOUNTS_H_

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5579,7 +5579,7 @@ bool Player::toggleMount(bool mount) {
 			currentMountId = getRandomMountId();
 		}
 
-		const auto& currentMount = g_game().mounts.getMountByID(currentMountId);
+		const auto &currentMount = g_game().mounts.getMountByID(currentMountId);
 		if (!currentMount) {
 			return false;
 		}
@@ -5666,7 +5666,7 @@ bool Player::untameMount(uint8_t mountId) {
 	return true;
 }
 
-bool Player::hasMount(const std::shared_ptr<Mount>& mount) const {
+bool Player::hasMount(const std::shared_ptr<Mount> &mount) const {
 	if (isAccessPlayer()) {
 		return true;
 	}
@@ -5686,7 +5686,7 @@ bool Player::hasMount(const std::shared_ptr<Mount>& mount) const {
 }
 
 void Player::dismount() {
-	const auto& mount = g_game().mounts.getMountByID(getCurrentMount());
+	const auto &mount = g_game().mounts.getMountByID(getCurrentMount());
 	if (mount && mount->speed > 0) {
 		g_game().changeSpeed(this, -mount->speed);
 	}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5525,8 +5525,8 @@ void Player::setCurrentMount(uint8_t mount) {
 
 bool Player::hasAnyMount() const {
 	for (const auto &mounts = g_game().mounts.getMounts();
-		 const Mount &mount : mounts) {
-		if (hasMount(&mount)) {
+		 const auto &mount : mounts) {
+		if (hasMount(mount)) {
 			return true;
 		}
 	}
@@ -5537,9 +5537,9 @@ uint8_t Player::getRandomMountId() const {
 	std::vector<uint8_t> playerMounts;
 
 	for (const auto &mounts = g_game().mounts.getMounts();
-		 const Mount &mount : mounts) {
-		if (hasMount(&mount)) {
-			playerMounts.push_back(mount.id);
+		 const auto &mount : mounts) {
+		if (hasMount(mount)) {
+			playerMounts.push_back(mount->id);
 		}
 	}
 
@@ -5579,7 +5579,7 @@ bool Player::toggleMount(bool mount) {
 			currentMountId = getRandomMountId();
 		}
 
-		const Mount* currentMount = g_game().mounts.getMountByID(currentMountId);
+		const auto& currentMount = g_game().mounts.getMountByID(currentMountId);
 		if (!currentMount) {
 			return false;
 		}
@@ -5666,7 +5666,7 @@ bool Player::untameMount(uint8_t mountId) {
 	return true;
 }
 
-bool Player::hasMount(const Mount* mount) const {
+bool Player::hasMount(const std::shared_ptr<Mount>& mount) const {
 	if (isAccessPlayer()) {
 		return true;
 	}
@@ -5686,7 +5686,7 @@ bool Player::hasMount(const Mount* mount) const {
 }
 
 void Player::dismount() {
-	const Mount* mount = g_game().mounts.getMountByID(getCurrentMount());
+	const auto& mount = g_game().mounts.getMountByID(getCurrentMount());
 	if (mount && mount->speed > 0) {
 		g_game().changeSpeed(this, -mount->speed);
 	}

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -148,7 +148,7 @@ class Player final : public Creature, public Cylinder, public Bankable {
 		bool toggleMount(bool mount);
 		bool tameMount(uint8_t mountId);
 		bool untameMount(uint8_t mountId);
-		bool hasMount(const Mount* mount) const;
+		bool hasMount(const std::shared_ptr<Mount>& mount) const;
 		bool hasAnyMount() const;
 		uint8_t getRandomMountId() const;
 		void dismount();

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -148,7 +148,7 @@ class Player final : public Creature, public Cylinder, public Bankable {
 		bool toggleMount(bool mount);
 		bool tameMount(uint8_t mountId);
 		bool untameMount(uint8_t mountId);
-		bool hasMount(const std::shared_ptr<Mount>& mount) const;
+		bool hasMount(const std::shared_ptr<Mount> &mount) const;
 		bool hasAnyMount() const;
 		uint8_t getRandomMountId() const;
 		void dismount();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3672,7 +3672,7 @@ void Game::playerSetShowOffSocket(uint32_t playerId, Outfit_t &outfit, const Pos
 		outfit.lookAddons = 0;
 	}
 
-	Mount* mount = mounts.getMountByClientID(outfit.lookMount);
+	const auto& mount = mounts.getMountByClientID(outfit.lookMount);
 	if (!mount || !player->hasMount(mount)) {
 		outfit.lookMount = 0;
 	}
@@ -5307,7 +5307,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 	}
 
 	if (outfit.lookMount != 0) {
-		Mount* mount = mounts.getMountByClientID(outfit.lookMount);
+		const auto& mount = mounts.getMountByClientID(outfit.lookMount);
 		if (!mount) {
 			return;
 		}
@@ -5327,7 +5327,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 
 		auto deltaSpeedChange = mount->speed;
 		if (player->isMounted()) {
-			Mount* prevMount = mounts.getMountByID(player->getCurrentMount());
+			const auto& prevMount = mounts.getMountByID(player->getCurrentMount());
 			if (prevMount) {
 				deltaSpeedChange -= prevMount->speed;
 			}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3672,7 +3672,7 @@ void Game::playerSetShowOffSocket(uint32_t playerId, Outfit_t &outfit, const Pos
 		outfit.lookAddons = 0;
 	}
 
-	const auto& mount = mounts.getMountByClientID(outfit.lookMount);
+	const auto &mount = mounts.getMountByClientID(outfit.lookMount);
 	if (!mount || !player->hasMount(mount)) {
 		outfit.lookMount = 0;
 	}
@@ -5307,7 +5307,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 	}
 
 	if (outfit.lookMount != 0) {
-		const auto& mount = mounts.getMountByClientID(outfit.lookMount);
+		const auto &mount = mounts.getMountByClientID(outfit.lookMount);
 		if (!mount) {
 			return;
 		}
@@ -5327,7 +5327,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, uint8_t isMoun
 
 		auto deltaSpeedChange = mount->speed;
 		if (player->isMounted()) {
-			const auto& prevMount = mounts.getMountByID(player->getCurrentMount());
+			const auto &prevMount = mounts.getMountByID(player->getCurrentMount());
 			if (prevMount) {
 				deltaSpeedChange -= prevMount->speed;
 			}

--- a/src/lua/functions/creatures/player/mount_functions.cpp
+++ b/src/lua/functions/creatures/player/mount_functions.cpp
@@ -37,7 +37,7 @@ int MountFunctions::luaCreateMount(lua_State* L) {
 
 int MountFunctions::luaMountGetName(lua_State* L) {
 	// mount:getName()
-	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
+	const std::shared_ptr<Mount> &mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		pushString(L, mount->name);
 	} else {
@@ -49,7 +49,7 @@ int MountFunctions::luaMountGetName(lua_State* L) {
 
 int MountFunctions::luaMountGetId(lua_State* L) {
 	// mount:getId()
-	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
+	const std::shared_ptr<Mount> &mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->id);
 	} else {
@@ -61,7 +61,7 @@ int MountFunctions::luaMountGetId(lua_State* L) {
 
 int MountFunctions::luaMountGetClientId(lua_State* L) {
 	// mount:getClientId()
-	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
+	const std::shared_ptr<Mount> &mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->clientId);
 	} else {
@@ -73,7 +73,7 @@ int MountFunctions::luaMountGetClientId(lua_State* L) {
 
 int MountFunctions::luaMountGetSpeed(lua_State* L) {
 	// mount:getSpeed()
-	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
+	const std::shared_ptr<Mount> &mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->speed);
 	} else {

--- a/src/lua/functions/creatures/player/mount_functions.cpp
+++ b/src/lua/functions/creatures/player/mount_functions.cpp
@@ -15,7 +15,7 @@
 
 int MountFunctions::luaCreateMount(lua_State* L) {
 	// Mount(id or name)
-	Mount* mount;
+	std::shared_ptr<Mount> mount;
 	if (isNumber(L, 2)) {
 		mount = g_game().mounts.getMountByID(getNumber<uint8_t>(L, 2));
 	} else if (isString(L, 2)) {
@@ -37,7 +37,7 @@ int MountFunctions::luaCreateMount(lua_State* L) {
 
 int MountFunctions::luaMountGetName(lua_State* L) {
 	// mount:getName()
-	Mount* mount = getUserdata<Mount>(L, 1);
+	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		pushString(L, mount->name);
 	} else {
@@ -49,7 +49,7 @@ int MountFunctions::luaMountGetName(lua_State* L) {
 
 int MountFunctions::luaMountGetId(lua_State* L) {
 	// mount:getId()
-	Mount* mount = getUserdata<Mount>(L, 1);
+	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->id);
 	} else {
@@ -61,7 +61,7 @@ int MountFunctions::luaMountGetId(lua_State* L) {
 
 int MountFunctions::luaMountGetClientId(lua_State* L) {
 	// mount:getClientId()
-	Mount* mount = getUserdata<Mount>(L, 1);
+	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->clientId);
 	} else {
@@ -73,7 +73,7 @@ int MountFunctions::luaMountGetClientId(lua_State* L) {
 
 int MountFunctions::luaMountGetSpeed(lua_State* L) {
 	// mount:getSpeed()
-	Mount* mount = getUserdata<Mount>(L, 1);
+	const std::shared_ptr<Mount>& mount = getUserdataShared<Mount>(L, 1);
 	if (mount) {
 		lua_pushnumber(L, mount->speed);
 	} else {

--- a/src/lua/functions/creatures/player/mount_functions.hpp
+++ b/src/lua/functions/creatures/player/mount_functions.hpp
@@ -15,7 +15,7 @@
 class MountFunctions final : LuaScriptInterface {
 	public:
 		static void init(lua_State* L) {
-			registerClass(L, "Mount", "", MountFunctions::luaCreateMount);
+			registerSharedClass(L, "Mount", "", MountFunctions::luaCreateMount);
 			registerMetaMethod(L, "Mount", "__eq", MountFunctions::luaUserdataCompare);
 
 			registerMethod(L, "Mount", "getName", MountFunctions::luaMountGetName);

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2219,7 +2219,7 @@ int PlayerFunctions::luaPlayerAddMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		const std::shared_ptr<Mount>& mount = g_game().mounts.getMountByName(getString(L, 2));
+		const std::shared_ptr<Mount> &mount = g_game().mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;
@@ -2242,7 +2242,7 @@ int PlayerFunctions::luaPlayerRemoveMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		const std::shared_ptr<Mount>& mount = g_game().mounts.getMountByName(getString(L, 2));
+		const std::shared_ptr<Mount> &mount = g_game().mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2219,7 +2219,7 @@ int PlayerFunctions::luaPlayerAddMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		Mount* mount = g_game().mounts.getMountByName(getString(L, 2));
+		const std::shared_ptr<Mount>& mount = g_game().mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;
@@ -2242,7 +2242,7 @@ int PlayerFunctions::luaPlayerRemoveMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		Mount* mount = g_game().mounts.getMountByName(getString(L, 2));
+		const std::shared_ptr<Mount>& mount = g_game().mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;
@@ -2261,7 +2261,7 @@ int PlayerFunctions::luaPlayerHasMount(lua_State* L) {
 		return 1;
 	}
 
-	Mount* mount = nullptr;
+	std::shared_ptr<Mount> mount = nullptr;
 	if (isNumber(L, 2)) {
 		mount = g_game().mounts.getMountByID(getNumber<uint8_t>(L, 2));
 	} else {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3618,7 +3618,7 @@ void ProtocolGame::sendCyclopediaCharacterOutfitsMounts() {
 	uint16_t mountSize = 0;
 	auto startMounts = msg.getBufferPosition();
 	msg.skipBytes(2);
-	for (const auto& mount : g_game().mounts.getMounts()) {
+	for (const auto &mount : g_game().mounts.getMounts()) {
 		const std::string type = mount->type;
 		if (player->hasMount(mount)) {
 			++mountSize;
@@ -6294,7 +6294,7 @@ void ProtocolGame::sendOutfitWindow() {
 
 	if (oldProtocol) {
 		Outfit_t currentOutfit = player->getDefaultOutfit();
-		const auto& currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
+		const auto &currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
 		if (currentMount) {
 			currentOutfit.lookMount = currentMount->clientId;
 		}
@@ -6343,7 +6343,7 @@ void ProtocolGame::sendOutfitWindow() {
 		}
 
 		msg.addByte(mounts.size());
-		for (const auto& mount : mounts) {
+		for (const auto &mount : mounts) {
 			msg.add<uint16_t>(mount->clientId);
 			msg.addString(mount->name);
 		}
@@ -6354,7 +6354,7 @@ void ProtocolGame::sendOutfitWindow() {
 
 	bool mounted = false;
 	Outfit_t currentOutfit = player->getDefaultOutfit();
-	const auto& currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
+	const auto &currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
 	if (currentMount) {
 		mounted = (currentOutfit.lookMount == currentMount->clientId);
 		currentOutfit.lookMount = currentMount->clientId;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3618,13 +3618,13 @@ void ProtocolGame::sendCyclopediaCharacterOutfitsMounts() {
 	uint16_t mountSize = 0;
 	auto startMounts = msg.getBufferPosition();
 	msg.skipBytes(2);
-	for (const Mount &mount : g_game().mounts.getMounts()) {
-		const std::string type = mount.type;
-		if (player->hasMount(&mount)) {
+	for (const auto& mount : g_game().mounts.getMounts()) {
+		const std::string type = mount->type;
+		if (player->hasMount(mount)) {
 			++mountSize;
 
-			msg.add<uint16_t>(mount.clientId);
-			msg.addString(mount.name);
+			msg.add<uint16_t>(mount->clientId);
+			msg.addString(mount->name);
 			if (type == "store")
 				msg.addByte(CYCLOPEDIA_CHARACTERINFO_OUTFITTYPE_STORE);
 			else if (type == "quest")
@@ -6294,7 +6294,7 @@ void ProtocolGame::sendOutfitWindow() {
 
 	if (oldProtocol) {
 		Outfit_t currentOutfit = player->getDefaultOutfit();
-		Mount* currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
+		const auto& currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
 		if (currentMount) {
 			currentOutfit.lookMount = currentMount->clientId;
 		}
@@ -6335,15 +6335,15 @@ void ProtocolGame::sendOutfitWindow() {
 			msg.addByte(outfit.addons);
 		}
 
-		std::vector<const Mount*> mounts;
-		for (const Mount &mount : g_game().mounts.getMounts()) {
-			if (player->hasMount(&mount)) {
-				mounts.push_back(&mount);
+		std::vector<std::shared_ptr<Mount>> mounts;
+		for (const auto &mount : g_game().mounts.getMounts()) {
+			if (player->hasMount(mount)) {
+				mounts.push_back(mount);
 			}
 		}
 
 		msg.addByte(mounts.size());
-		for (const Mount* mount : mounts) {
+		for (const auto& mount : mounts) {
 			msg.add<uint16_t>(mount->clientId);
 			msg.addString(mount->name);
 		}
@@ -6354,7 +6354,7 @@ void ProtocolGame::sendOutfitWindow() {
 
 	bool mounted = false;
 	Outfit_t currentOutfit = player->getDefaultOutfit();
-	const Mount* currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
+	const auto& currentMount = g_game().mounts.getMountByID(player->getCurrentMount());
 	if (currentMount) {
 		mounted = (currentOutfit.lookMount == currentMount->clientId);
 		currentOutfit.lookMount = currentMount->clientId;
@@ -6441,15 +6441,15 @@ void ProtocolGame::sendOutfitWindow() {
 	msg.skipBytes(2);
 
 	const auto &mounts = g_game().mounts.getMounts();
-	for (const Mount &mount : mounts) {
-		if (player->hasMount(&mount)) {
-			msg.add<uint16_t>(mount.clientId);
-			msg.addString(mount.name);
+	for (const auto &mount : mounts) {
+		if (player->hasMount(mount)) {
+			msg.add<uint16_t>(mount->clientId);
+			msg.addString(mount->name);
 			msg.addByte(0x00);
 			++mountSize;
-		} else if (mount.type == "store") {
-			msg.add<uint16_t>(mount.clientId);
-			msg.addString(mount.name);
+		} else if (mount->type == "store") {
+			msg.add<uint16_t>(mount->clientId);
+			msg.addString(mount->name);
 			msg.addByte(0x01);
 			msg.add<uint32_t>(0x00);
 			++mountSize;
@@ -6561,10 +6561,10 @@ void ProtocolGame::sendPodiumWindow(const Item* podium, const Position &position
 	msg.skipBytes(2);
 
 	const auto &mounts = g_game().mounts.getMounts();
-	for (const Mount &mount : mounts) {
-		if (player->hasMount(&mount)) {
-			msg.add<uint16_t>(mount.clientId);
-			msg.addString(mount.name);
+	for (const auto &mount : mounts) {
+		if (player->hasMount(mount)) {
+			msg.add<uint16_t>(mount->clientId);
+			msg.addString(mount->name);
 			msg.addByte(0x00);
 			if (++mountSize == limitMounts) {
 				break;


### PR DESCRIPTION
Introduced a significant refactoring of the code, replacing the use of 'Mount*' raw pointers with std::shared_ptr<Mount>. This modernization enhances memory management, making the code more robust and safe. By utilizing smart pointers, we ensure better control over the memory lifecycle and reduce the risk of memory leaks and undefined behaviour. This change aligns with modern C++ best practices and contributes to the overall quality and maintainability of the codebase.