### PR TITLE
fix: monster spells and duplicated monster bosstiary

### DIFF
--- a/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
+++ b/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
@@ -46,12 +46,6 @@ monster.flags = {
 	rewardBoss = true
 }
 
-monster.bosstiary = {
-	bossRaceId = 2250,
-	bossRace = RARITY_ARCHFOE,
-	storageCooldown = Storage.Marapur.Timira
-}
-
 monster.light = {
 	level = 0,
 	color = 0

--- a/data-otservbr-global/scripts/spells/monster/renegade_knight.lua
+++ b/data-otservbr-global/scripts/spells/monster/renegade_knight.lua
@@ -1,11 +1,13 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
-combat:setParameter(COMBAT_PARAM_EFFECT, 6)
-combat:setArea(createCombatArea(AREA_SQUARE1X1))
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_BLOCKHIT)
 
-local condition = Condition(COMBAT_PHYSICALDAMAGE)
+local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_DELAYED, 1)
 condition:addDamage(3, 10000, -25)
+
+local area = createCombatArea(AREA_SQUARE1X1)
+combat:setArea(area)
 combat:addCondition(condition)
 
 local spell = Spell("instant")

--- a/data-otservbr-global/scripts/spells/monster/vile_grandmaster.lua
+++ b/data-otservbr-global/scripts/spells/monster/vile_grandmaster.lua
@@ -1,17 +1,19 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_GROUNDSHAKER)
-combat:setArea(createCombatArea(AREA_CIRCLE3X3))
 
-local condition = Condition(COMBAT_PHYSICALDAMAGE)
+local condition = Condition(CONDITION_ATTRIBUTES)
 condition:setParameter(CONDITION_PARAM_DELAYED, 1)
 condition:addDamage(3, 100, -35)
+
+local area = createCombatArea(AREA_CIRCLE3X3)
+combat:setArea(area)
 combat:addCondition(condition)
 
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, var)
- return combat:execute(creature, var)
+	return combat:execute(creature, var)
 end
 
 spell:name("vile grandmaster")


### PR DESCRIPTION
# Description

  - [X] Removed duplicated monster bosstiary from timira the many headed.
  - [X] Fixed renegade knight spell.
  - [X] Fixed vile grandmaster spell.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)
 
**Test Configuration**:

  - Server Version: 2.6.1
  - Client: 13.20
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works