### PR TITLE
improve: move container and event out of pch

### DIFF
--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -11,6 +11,7 @@
 #define SRC_CONFIG_CONFIGMANAGER_H_
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class ConfigManager {
 	public:

--- a/src/creatures/appearance/outfit/outfit.h
+++ b/src/creatures/appearance/outfit/outfit.h
@@ -11,6 +11,7 @@
 #define SRC_CREATURES_APPEARANCE_OUTFIT_OUTFIT_H_
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 struct Outfit {
 		Outfit(std::string initName, uint16_t initLookType, bool initPremium, bool initUnlocked, std::string initFrom) :

--- a/src/creatures/combat/spells.h
+++ b/src/creatures/combat/spells.h
@@ -16,6 +16,7 @@
 #include "lua/creature/actions.h"
 #include "lua/creature/talkaction.h"
 #include "lua/scripts/scripts.h"
+#include "lib/di/container.hpp"
 
 class InstantSpell;
 class RuneSpell;

--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -10,6 +10,8 @@
 #ifndef SRC_CREATURES_CREATURES_DEFINITIONS_HPP_
 #define SRC_CREATURES_CREATURES_DEFINITIONS_HPP_
 
+#include <parallel_hashmap/btree.h>
+
 // Enum
 
 enum SkillsId_t {

--- a/src/creatures/interactions/chat.h
+++ b/src/creatures/interactions/chat.h
@@ -11,6 +11,7 @@
 #define SRC_CREATURES_INTERACTIONS_CHAT_H_
 
 #include "utils/utils_definitions.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 
 class Party;

--- a/src/creatures/monsters/monsters.h
+++ b/src/creatures/monsters/monsters.h
@@ -13,6 +13,7 @@
 #include "io/io_bosstiary.hpp"
 #include "creatures/creature.h"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class Loot {
 	public:

--- a/src/creatures/npcs/npc.h
+++ b/src/creatures/npcs/npc.h
@@ -13,6 +13,7 @@
 #include "creatures/npcs/npcs.h"
 #include "declarations.hpp"
 #include "items/tile.h"
+#include "lib/di/container.hpp"
 
 class Creature;
 class Game;

--- a/src/creatures/npcs/npcs.h
+++ b/src/creatures/npcs/npcs.h
@@ -11,6 +11,7 @@
 #define SRC_CREATURES_NPCS_NPCS_H_
 
 #include "creatures/creature.h"
+#include "lib/di/container.hpp"
 
 class Shop {
 	public:

--- a/src/creatures/players/grouping/familiars.h
+++ b/src/creatures/players/grouping/familiars.h
@@ -11,6 +11,7 @@
 #define SRC_CREATURES_PLAYERS_GROUPING_FAMILIARS_H_
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class Familiars {
 	public:

--- a/src/creatures/players/imbuements/imbuements.h
+++ b/src/creatures/players/imbuements/imbuements.h
@@ -12,6 +12,7 @@
 
 #include "creatures/players/player.h"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "utils/tools.h"
 
 class Player;

--- a/src/creatures/players/storages/storages.hpp
+++ b/src/creatures/players/storages/storages.hpp
@@ -10,6 +10,8 @@
 #ifndef SRC_CREATURES_PLAYERS_STORAGES_STORAGES_HPP_
 #define SRC_CREATURES_PLAYERS_STORAGES_STORAGES_HPP_
 
+#include "lib/di/container.hpp"
+
 class Storages {
 	public:
 		Storages() = default;

--- a/src/creatures/players/vocations/vocation.h
+++ b/src/creatures/players/vocations/vocation.h
@@ -12,6 +12,7 @@
 
 #include "declarations.hpp"
 #include "items/item.h"
+#include "lib/di/container.hpp"
 
 class Vocation {
 	public:

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -10,7 +10,10 @@
 #ifndef SRC_DATABASE_DATABASE_H_
 #define SRC_DATABASE_DATABASE_H_
 
+#include <parallel_hashmap/btree.h>
+
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class DBResult;
 using DBResult_ptr = std::shared_ptr<DBResult>;

--- a/src/game/functions/game_reload.hpp
+++ b/src/game/functions/game_reload.hpp
@@ -11,6 +11,7 @@
 #define SRC_GAME_FUNCTIONS_GAME_RELOAD_HPP_
 
 #include "game/game.h"
+#include "lib/di/container.hpp"
 
 class Game;
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -20,6 +20,7 @@
 #include "creatures/npcs/npc.h"
 #include "movement/position.h"
 #include "creatures/players/player.h"
+#include "lib/di/container.hpp"
 #include "lua/creature/raids.h"
 #include "creatures/players/grouping/team_finder.hpp"
 #include "utils/wildcardtree.h"

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -9,6 +9,7 @@
 
 #include "pch.hpp"
 
+#include "lib/di/container.hpp"
 #include "lib/thread/thread_pool.hpp"
 #include "game/scheduling/dispatcher.hpp"
 #include "game/scheduling/task.hpp"

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -10,6 +10,7 @@
 #ifndef SRC_GAME_SCHEDUNLING_EVENTS_SCHEDULER_HPP_
 #define SRC_GAME_SCHEDUNLING_EVENTS_SCHEDULER_HPP_
 
+#include "lib/di/container.hpp"
 #include "utils/tools.h"
 
 struct EventScheduler {

--- a/src/game/scheduling/scheduler.cpp
+++ b/src/game/scheduling/scheduler.cpp
@@ -13,6 +13,7 @@
 #include "game/scheduling/dispatcher.hpp"
 #include "game/scheduling/scheduler.h"
 #include "game/scheduling/task.hpp"
+#include "lib/di/container.hpp"
 
 Scheduler::Scheduler(ThreadPool &threadPool) :
 	threadPool(threadPool) { }

--- a/src/io/io_bosstiary.hpp
+++ b/src/io/io_bosstiary.hpp
@@ -10,9 +10,8 @@
 #ifndef SRC_IO_IO_BOSSTIARY_HPP_
 #define SRC_IO_IO_BOSSTIARY_HPP_
 
-#include <map>
-#include <string>
-#include <vector>
+#include "lib/di/container.hpp"
+#include <parallel_hashmap/btree.h>
 
 enum class BosstiaryRarity_t : uint8_t {
 	RARITY_BANE = 0,

--- a/src/io/iobestiary.h
+++ b/src/io/iobestiary.h
@@ -11,6 +11,7 @@
 #define SRC_IO_IOBESTIARY_H_
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "creatures/players/player.h"
 

--- a/src/io/iomarket.h
+++ b/src/io/iomarket.h
@@ -12,6 +12,7 @@
 
 #include "database/database.h"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class IOMarket {
 		using StatisticsMap = phmap::btree_map<uint16_t, phmap::btree_map<uint8_t, MarketStatistics>>;

--- a/src/io/ioprey.h
+++ b/src/io/ioprey.h
@@ -10,6 +10,7 @@
 #ifndef SRC_IO_IOPREY_H_
 #define SRC_IO_IOPREY_H_
 
+#include "lib/di/container.hpp"
 #include "server/network/protocol/protocolgame.h"
 
 enum PreySlot_t : uint8_t {

--- a/src/items/decay/decay.h
+++ b/src/items/decay/decay.h
@@ -11,6 +11,7 @@
 #define SRC_ITEMS_DECAY_DECAY_H_
 
 #include "items/item.h"
+#include "lib/di/container.hpp"
 
 class Decay {
 	public:

--- a/src/items/weapons/weapons.h
+++ b/src/items/weapons/weapons.h
@@ -16,6 +16,7 @@
 #include "creatures/combat/combat.h"
 #include "utils/utils_definitions.hpp"
 #include "creatures/players/vocations/vocation.h"
+#include "lib/di/container.hpp"
 
 class Weapon;
 class WeaponMelee;

--- a/src/lib/di/container.hpp
+++ b/src/lib/di/container.hpp
@@ -9,6 +9,7 @@
 #ifndef CANARY_CONTAINER_HPP
 #define CANARY_CONTAINER_HPP
 
+#include <boost/di.hpp>
 #include "lib/logging/logger.hpp"
 #include "lib/logging/log_with_spd_log.hpp"
 

--- a/src/lib/logging/log_with_spd_log.cpp
+++ b/src/lib/logging/log_with_spd_log.cpp
@@ -6,7 +6,9 @@
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.com/
  */
-#include "pch.hpp"
+#include <spdlog/spdlog.h>
+
+#include "lib/di/container.hpp"
 
 LogWithSpdLog::LogWithSpdLog() {
 	spdlog::set_pattern("[%Y-%d-%m %H:%M:%S.%e] [%^%l%$] %v ");

--- a/src/lib/logging/log_with_spd_log.hpp
+++ b/src/lib/logging/log_with_spd_log.hpp
@@ -9,6 +9,8 @@
 #ifndef CANARY_LOG_WITH_SPD_LOG_HPP
 #define CANARY_LOG_WITH_SPD_LOG_HPP
 
+#include "lib/logging/logger.hpp"
+
 class LogWithSpdLog final : public Logger {
 	public:
 		LogWithSpdLog();

--- a/src/lib/messaging/command.hpp
+++ b/src/lib/messaging/command.hpp
@@ -9,6 +9,8 @@
 #ifndef CANARY_COMMAND_HPP
 #define CANARY_COMMAND_HPP
 
+#include "lib/messaging/message.hpp"
+
 enum class CommandType {
 	start,
 	load,

--- a/src/lib/messaging/event.hpp
+++ b/src/lib/messaging/event.hpp
@@ -9,6 +9,8 @@
 #ifndef CANARY_EVENT_HPP
 #define CANARY_EVENT_HPP
 
+#include "lib/messaging/message.hpp"
+
 enum class EventType {
 };
 

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -9,6 +9,8 @@
 #ifndef SRC_UTILS_THREAD_POOL_H_
 #define SRC_UTILS_THREAD_POOL_H_
 
+#include "lib/logging/logger.hpp"
+
 class ThreadPool {
 	public:
 		explicit ThreadPool(Logger &logger);

--- a/src/lua/callbacks/event_callback.cpp
+++ b/src/lua/callbacks/event_callback.cpp
@@ -9,10 +9,8 @@
 
 #include "pch.hpp"
 
+#include "lib/logging/log_with_spd_log.hpp"
 #include "lua/callbacks/event_callback.hpp"
-
-#include "lua/callbacks/event_callback.hpp"
-#include "lua/callbacks/events_callbacks.hpp"
 #include "utils/tools.h"
 #include "items/item.h"
 #include "creatures/players/player.h"
@@ -1061,7 +1059,7 @@ void EventCallback::monsterOnDropLoot(Monster* monster, Container* corpse) const
 
 void EventCallback::monsterPostDropLoot(Monster* monster, Container* corpse) const {
 	if (!getScriptInterface()->reserveScriptEnv()) {
-		SPDLOG_ERROR("[EventCallback::monsterPostDropLoot - "
+		g_logger().error("[EventCallback::monsterPostDropLoot - "
 					 "Monster corpse {}] "
 					 "Call stack overflow. Too many lua script calls being nested.",
 					 corpse->getName());

--- a/src/lua/callbacks/event_callback.cpp
+++ b/src/lua/callbacks/event_callback.cpp
@@ -1060,9 +1060,9 @@ void EventCallback::monsterOnDropLoot(Monster* monster, Container* corpse) const
 void EventCallback::monsterPostDropLoot(Monster* monster, Container* corpse) const {
 	if (!getScriptInterface()->reserveScriptEnv()) {
 		g_logger().error("[EventCallback::monsterPostDropLoot - "
-					 "Monster corpse {}] "
-					 "Call stack overflow. Too many lua script calls being nested.",
-					 corpse->getName());
+						 "Monster corpse {}] "
+						 "Call stack overflow. Too many lua script calls being nested.",
+						 corpse->getName());
 		return;
 	}
 

--- a/src/lua/creature/actions.h
+++ b/src/lua/creature/actions.h
@@ -13,6 +13,7 @@
 #include "lua/scripts/scripts.h"
 #include "declarations.hpp"
 #include "lua/scripts/luascript.h"
+#include "lib/di/container.hpp"
 
 class Action;
 class Position;

--- a/src/lua/creature/creatureevent.h
+++ b/src/lua/creature/creatureevent.h
@@ -10,7 +10,10 @@
 #ifndef SRC_LUA_CREATURE_CREATUREEVENT_H_
 #define SRC_LUA_CREATURE_CREATUREEVENT_H_
 
+#include <parallel_hashmap/btree.h>
+
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "lua/scripts/scripts.h"
 

--- a/src/lua/creature/events.h
+++ b/src/lua/creature/events.h
@@ -11,6 +11,7 @@
 #define SRC_LUA_CREATURE_EVENTS_H_
 
 #include "creatures/players/imbuements/imbuements.h"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "creatures/combat/spells.h"
 

--- a/src/lua/creature/movement.h
+++ b/src/lua/creature/movement.h
@@ -12,6 +12,7 @@
 
 #include "declarations.hpp"
 #include "items/item.h"
+#include "lib/di/container.hpp"
 #include "lua/functions/events/move_event_functions.hpp"
 #include "lua/scripts/scripts.h"
 #include "creatures/players/vocations/vocation.h"

--- a/src/lua/creature/talkaction.h
+++ b/src/lua/creature/talkaction.h
@@ -14,6 +14,7 @@
 #include "lua/global/baseevents.h"
 #include "utils/utils_definitions.hpp"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "lua/scripts/scripts.h"
 

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -13,6 +13,7 @@
 #include "io/io_bosstiary.hpp"
 #include "creatures/combat/spells.h"
 #include "creatures/monsters/monsters.h"
+#include "lib/logging/log_with_spd_log.hpp"
 #include "lua/functions/creatures/monster/monster_type_functions.hpp"
 #include "lua/scripts/scripts.h"
 
@@ -663,7 +664,7 @@ int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 	} else if (immunity == "neutral") {
 		combatType = COMBAT_NEUTRALDAMAGE;
 	} else {
-		SPDLOG_WARN("[MonsterTypeFunctions::luaMonsterTypeCombatImmunities] - "
+		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeCombatImmunities] - "
 					"Unknown immunity name {} for monster: {}",
 					immunity, monsterType->name);
 		lua_pushnil(L);
@@ -721,7 +722,7 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 	} else if (immunity == "bleed") {
 		conditionType = CONDITION_BLEEDING;
 	} else {
-		SPDLOG_WARN("[MonsterTypeFunctions::luaMonsterTypeConditionImmunities] - "
+		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeConditionImmunities] - "
 					"Unknown immunity name: {} for monster: {}",
 					immunity, monsterType->name);
 		lua_pushnil(L);

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -665,8 +665,8 @@ int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 		combatType = COMBAT_NEUTRALDAMAGE;
 	} else {
 		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeCombatImmunities] - "
-					"Unknown immunity name {} for monster: {}",
-					immunity, monsterType->name);
+						"Unknown immunity name {} for monster: {}",
+						immunity, monsterType->name);
 		lua_pushnil(L);
 	}
 
@@ -723,8 +723,8 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 		conditionType = CONDITION_BLEEDING;
 	} else {
 		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeConditionImmunities] - "
-					"Unknown immunity name: {} for monster: {}",
-					immunity, monsterType->name);
+						"Unknown immunity name: {} for monster: {}",
+						immunity, monsterType->name);
 		lua_pushnil(L);
 	}
 

--- a/src/lua/global/globalevent.h
+++ b/src/lua/global/globalevent.h
@@ -11,6 +11,7 @@
 #define SRC_LUA_GLOBAL_GLOBALEVENT_H_
 
 #include "utils/utils_definitions.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/scripts.h"
 
 class GlobalEvent;

--- a/src/lua/modules/modules.h
+++ b/src/lua/modules/modules.h
@@ -12,6 +12,7 @@
 
 #include "lua/global/baseevents.h"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "server/network/message/networkmessage.h"
 

--- a/src/lua/scripts/lua_environment.hpp
+++ b/src/lua/scripts/lua_environment.hpp
@@ -12,6 +12,7 @@
 
 #include "creatures/combat/combat.h"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 #include "items/weapons/weapons.h"
 

--- a/src/lua/scripts/scripts.h
+++ b/src/lua/scripts/scripts.h
@@ -10,6 +10,7 @@
 #ifndef SRC_LUA_SCRIPTS_SCRIPTS_H_
 #define SRC_LUA_SCRIPTS_SCRIPTS_H_
 
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.h"
 
 class Scripts {

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -12,6 +12,7 @@
 #include <game/movement/teleport.h>
 #include <items/bed.h>
 #include <io/iologindata.h>
+#include "lib/logging/log_with_spd_log.hpp"
 #include <game/game.h>
 #include <map/map.h>
 #include <utils/hash.h>
@@ -140,7 +141,7 @@ Tile* MapCache::getOrCreateTileFromCache(const std::unique_ptr<Floor> &floor, ui
 
 void MapCache::setBasicTile(uint16_t x, uint16_t y, uint8_t z, const BasicTilePtr &newTile) {
 	if (z >= MAP_MAX_LAYERS) {
-		SPDLOG_ERROR("Attempt to set tile on invalid coordinate: {}", Position(x, y, z).toString());
+		g_logger().error("Attempt to set tile on invalid coordinate: {}", Position(x, y, z).toString());
 		return;
 	}
 

--- a/src/map/town.h
+++ b/src/map/town.h
@@ -10,6 +10,8 @@
 #ifndef SRC_MAP_TOWN_H_
 #define SRC_MAP_TOWN_H_
 
+#include <parallel_hashmap/btree.h>
+
 #include "game/movement/position.h"
 
 class Town {

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -28,8 +28,8 @@
 #include <fstream>
 #include <forward_list>
 #include <list>
-#include <map>
 #include <queue>
+#include <map>
 #include <random>
 #include <ranges>
 #include <regex>
@@ -106,18 +106,12 @@
 
 // Parallel Hash Map
 #include <parallel_hashmap/phmap.h>
-#include <parallel_hashmap/btree.h>
 
 // PugiXML
 #include <pugixml.hpp>
 
-// SPDLog
-#include <spdlog/spdlog.h>
-
 // Zlib
 #include <zlib.h>
-
-#include <boost/di.hpp>
 
 // -------------------------
 // GIT Metadata Includes
@@ -133,17 +127,5 @@
 
 #include <string>
 #include <iostream>
-
-/**
- * Static custom libraries that can be pre-compiled like DI and messaging
- */
-#include "lib/messaging/message.hpp"
-#include "lib/messaging/command.hpp"
-#include "lib/messaging/event.hpp"
-
-#include <eventpp/utilities/scopedremover.h>
-#include <eventpp/eventdispatcher.h>
-
-#include "lib/di/container.hpp"
 
 #endif // SRC_PCH_HPP_

--- a/src/security/rsa.h
+++ b/src/security/rsa.h
@@ -10,6 +10,8 @@
 #ifndef SRC_SECURITY_RSA_H_
 #define SRC_SECURITY_RSA_H_
 
+#include "lib/di/container.hpp"
+
 class Logger;
 
 class RSA {

--- a/src/server/network/connection/connection.h
+++ b/src/server/network/connection/connection.h
@@ -11,6 +11,7 @@
 #define SRC_SERVER_NETWORK_CONNECTION_CONNECTION_H_
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "server/network/message/networkmessage.h"
 
 static constexpr int32_t CONNECTION_WRITE_TIMEOUT = 30;

--- a/src/server/network/message/outputmessage.h
+++ b/src/server/network/message/outputmessage.h
@@ -10,6 +10,7 @@
 #ifndef SRC_SERVER_NETWORK_MESSAGE_OUTPUTMESSAGE_H_
 #define SRC_SERVER_NETWORK_MESSAGE_OUTPUTMESSAGE_H_
 
+#include "lib/di/container.hpp"
 #include "server/network/message/networkmessage.h"
 #include "server/network/connection/connection.h"
 #include "utils/tools.h"

--- a/src/utils/pugicast.h
+++ b/src/utils/pugicast.h
@@ -10,6 +10,8 @@
 #ifndef SRC_UTILS_PUGICAST_H_
 #define SRC_UTILS_PUGICAST_H_
 
+#include "lib/logging/log_with_spd_log.hpp"
+
 namespace pugi {
 	template <typename T>
 	// NOTE: std::clamp returns the minimum value if the value is less than the specified minimum value, the maximum value if the value is greater than the specified maximum value, or the value itself if it falls within the range


### PR DESCRIPTION
# Description

Build is consuming way more memory than usual, we think that it's because we've been abusing pch a bit. This removes some building blocks from pch, like container and messaging.