### PR TITLE
improve: remove spdlog completely from pch

### DIFF
--- a/src/lib/logging/log_with_spd_log.cpp
+++ b/src/lib/logging/log_with_spd_log.cpp
@@ -6,12 +6,15 @@
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.com/
  */
+#include <spdlog/spdlog.h>
+
 #include "pch.hpp"
 
 LogWithSpdLog::LogWithSpdLog() {
 	spdlog::set_pattern("[%Y-%d-%m %H:%M:%S.%e] [%^%l%$] %v ");
 
 #ifdef DEBUG_LOG
+	spdlog::set_pattern("[%Y-%d-%m %H:%M:%S.%e] [thread %t] [%^%l%$] %v ");
 	setLevel("debug");
 #endif
 }

--- a/src/lua/callbacks/event_callback.cpp
+++ b/src/lua/callbacks/event_callback.cpp
@@ -1061,10 +1061,10 @@ void EventCallback::monsterOnDropLoot(Monster* monster, Container* corpse) const
 
 void EventCallback::monsterPostDropLoot(Monster* monster, Container* corpse) const {
 	if (!getScriptInterface()->reserveScriptEnv()) {
-		SPDLOG_ERROR("[EventCallback::monsterPostDropLoot - "
-					 "Monster corpse {}] "
-					 "Call stack overflow. Too many lua script calls being nested.",
-					 corpse->getName());
+		g_logger().error("[EventCallback::monsterPostDropLoot - "
+						 "Monster corpse {}] "
+						 "Call stack overflow. Too many lua script calls being nested.",
+						 corpse->getName());
 		return;
 	}
 

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -663,9 +663,9 @@ int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 	} else if (immunity == "neutral") {
 		combatType = COMBAT_NEUTRALDAMAGE;
 	} else {
-		SPDLOG_WARN("[MonsterTypeFunctions::luaMonsterTypeCombatImmunities] - "
-					"Unknown immunity name {} for monster: {}",
-					immunity, monsterType->name);
+		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeCombatImmunities] - "
+						"Unknown immunity name {} for monster: {}",
+						immunity, monsterType->name);
 		lua_pushnil(L);
 	}
 
@@ -721,9 +721,9 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 	} else if (immunity == "bleed") {
 		conditionType = CONDITION_BLEEDING;
 	} else {
-		SPDLOG_WARN("[MonsterTypeFunctions::luaMonsterTypeConditionImmunities] - "
-					"Unknown immunity name: {} for monster: {}",
-					immunity, monsterType->name);
+		g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeConditionImmunities] - "
+						"Unknown immunity name: {} for monster: {}",
+						immunity, monsterType->name);
 		lua_pushnil(L);
 	}
 

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -140,7 +140,7 @@ Tile* MapCache::getOrCreateTileFromCache(const std::unique_ptr<Floor> &floor, ui
 
 void MapCache::setBasicTile(uint16_t x, uint16_t y, uint8_t z, const BasicTilePtr &newTile) {
 	if (z >= MAP_MAX_LAYERS) {
-		SPDLOG_ERROR("Attempt to set tile on invalid coordinate: {}", Position(x, y, z).toString());
+		g_logger().error("Attempt to set tile on invalid coordinate: {}", Position(x, y, z).toString());
 		return;
 	}
 

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -111,9 +111,6 @@
 // PugiXML
 #include <pugixml.hpp>
 
-// SPDLog
-#include <spdlog/spdlog.h>
-
 // Zlib
 #include <zlib.h>
 


### PR DESCRIPTION
# Description

We've moved to Logger interfaces intead of spdlog macros directly, so this PR removes SPDLOG from PCH to reduce chances of wrong usage.