### PR TITLE
fix: wrong message types (error message type does not exist)

### DIFF
--- a/data-canary/scripts/spells/support/find_fiend.lua
+++ b/data-canary/scripts/spells/support/find_fiend.lua
@@ -105,7 +105,7 @@ function spell.onCastSpell(creature, variant)
         message = string.format(message .. " " .. ForgeMonster:getTimeLeftToChangeMonster(target))
     end
 
-    creature:sendTextMessage(MESSAGE_INFO_DESCR, message)
+    creature:sendTextMessage(MESSAGE_LOOK, message)
     creaturePosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)
     return true
 end

--- a/data/libs/concoctions_lib.lua
+++ b/data/libs/concoctions_lib.lua
@@ -165,7 +165,7 @@ function Concoction:activate(player, item)
 	local cooldown = self:cooldown()
 	if self:lastActivatedAt(player) + cooldown > os.time() then
 		local cooldownLeft = self:lastActivatedAt(player) + cooldown - os.time()
-		player:sendTextMessage(MESSAGE_STATUS_SMALL,
+		player:sendTextMessage(MESSAGE_FAILURE,
 			"You must wait " .. getTimeInWords(cooldownLeft) .. " before using " .. item:getName() .. " again.")
 		return true
 	end

--- a/data/scripts/talkactions/god/vip_manager.lua
+++ b/data/scripts/talkactions/god/vip_manager.lua
@@ -20,12 +20,12 @@ function vipGod.onSay(player, words, param)
 	local target = Player(targetName)
 
 	if not action or not targetName then
-		player:sendTextMessage(MESSAGE_INFO_DESCR, 'Command invalid.\nUsage:\n/vip <action>, <name>, [, <value>]\n\nAvailable actions:\ncheck, adddays, removedays, remove')
+		player:sendTextMessage(MESSAGE_LOOK, 'Command invalid.\nUsage:\n/vip <action>, <name>, [, <value>]\n\nAvailable actions:\ncheck, adddays, removedays, remove')
 		return true
 	end
 
 	if not target then
-		player:sendTextMessage(MESSAGE_INFO_DESCR, string.format('Player "%s" is not online or does not exist!', targetName))
+		player:sendTextMessage(MESSAGE_LOOK, string.format('Player "%s" is not online or does not exist!', targetName))
 		return true
 	end
 
@@ -43,7 +43,7 @@ function vipGod.onSay(player, words, param)
 		end
 
 		if amount < config.minDays or amount > config.maxDays then
-			player:sendTextMessage(MESSAGE_INFO_DESCR, string.format('You can only add %d to %d VIP days at a time.', config.minDays, config.maxDays))
+			player:sendTextMessage(MESSAGE_LOOK, string.format('You can only add %d to %d VIP days at a time.', config.minDays, config.maxDays))
 			return true
 		end
 
@@ -55,7 +55,7 @@ function vipGod.onSay(player, words, param)
 	elseif action == 'removedays' then
 		local amount = tonumber(params[3])
 		if not amount then
-			player:sendTextMessage(MESSAGE_INFO_DESCR, '<value> has to be a numeric value.')
+			player:sendTextMessage(MESSAGE_LOOK, '<value> has to be a numeric value.')
 			return true
 		end
 		if amount > targetVipDays then
@@ -75,7 +75,7 @@ function vipGod.onSay(player, words, param)
 		player:sendTextMessage(MESSAGE_STATUS, string.format('You removed all VIP days from %s.', targetName))
 
 	else
-		player:sendTextMessage(MESSAGE_INFO_DESCR, 'Action is required.\nUsage:\n/vip <action>, <name>, [, <value>]\n\nAvailable actions:\ncheck, adddays, removedays, remove')
+		player:sendTextMessage(MESSAGE_LOOK, 'Action is required.\nUsage:\n/vip <action>, <name>, [, <value>]\n\nAvailable actions:\ncheck, adddays, removedays, remove')
 		return true
 	end
 	return true

--- a/data/scripts/talkactions/player/auto_loot.lua
+++ b/data/scripts/talkactions/player/auto_loot.lua
@@ -15,10 +15,10 @@ function autoLoot.onSay(player, words, param)
     end
     if param == "on" then
         player:setStorageValue(STORAGEVALUE_AUTO_LOOT, 1)
-        player:sendTextMessage(MESSAGE_INFO_DESCR, "You have successfully enabled your automatic looting!")
+        player:sendTextMessage(MESSAGE_LOOK, "You have successfully enabled your automatic looting!")
     elseif param == "off" then
         player:setStorageValue(STORAGEVALUE_AUTO_LOOT, 0)
-        player:sendTextMessage(MESSAGE_INFO_DESCR, "You have successfully disabled your automatic looting!")
+        player:sendTextMessage(MESSAGE_LOOK, "You have successfully disabled your automatic looting!")
     end
     return true
 end

--- a/data/scripts/talkactions/player/bank.lua
+++ b/data/scripts/talkactions/player/bank.lua
@@ -1,6 +1,6 @@
 local config = {
 	enabled = true,
-	messageStyle = MESSAGE_INFO_DESCR
+	messageStyle = MESSAGE_LOOK
 }
 
 if not config.enabled then

--- a/data/scripts/talkactions/player/emote_spell.lua
+++ b/data/scripts/talkactions/player/emote_spell.lua
@@ -8,10 +8,10 @@ function emoteSpell.onSay(player, words, param)
 	end
 	if param == "on" then
 		player:setStorageValue(STORAGEVALUE_EMOTE, 1)
-		player:sendTextMessage(MESSAGE_INFO_DESCR, "You activated emoted spells")
+		player:sendTextMessage(MESSAGE_LOOK, "You activated emoted spells")
 	elseif param == "off" then
 		player:setStorageValue(STORAGEVALUE_EMOTE, 0)
-		player:sendTextMessage(MESSAGE_INFO_DESCR, "You desactivated emoted spells")
+		player:sendTextMessage(MESSAGE_LOOK, "You desactivated emoted spells")
 	end
 	return true
 end


### PR DESCRIPTION
# Description

I'm using a data-custom, and it doesn't contain compat.lua (in my opinion this wouldn't even exist in the canary), so with the conversion of talkactions to "data" I got error messages for non-existent message types.

## Behaviour
### **Actual**

Error message:
![image](https://github.com/opentibiabr/canary/assets/6209529/a236e168-8166-4306-ae0a-8ad64fff7919)

**Test Configuration**:

  - Server Version: Canary Main
  - Client: 13.20
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
