### PR TITLE
fix: add missing includes for linux full build

### DIFF
--- a/src/map/utils/qtreenode.cpp
+++ b/src/map/utils/qtreenode.cpp
@@ -9,6 +9,8 @@
 
 #include "pch.hpp"
 
+#include "creatures/creature.h"
+#include "map/mapcache.h"
 #include "qtreenode.h"
 
 bool QTreeLeafNode::newLeaf = false;

--- a/src/server/network/webhook/webhook.cpp
+++ b/src/server/network/webhook/webhook.cpp
@@ -12,6 +12,7 @@
 #include "server/network/webhook/webhook.h"
 #include "config/configmanager.h"
 #include "game/scheduling/scheduler.h"
+#include "utils/tools.h"
 
 Webhook::Webhook(ThreadPool &threadPool) :
 	threadPool(threadPool) {


### PR DESCRIPTION
Linux was complaining about those includes when running full build without speed optimizations.