### PR TITLE
feat: add "script name" to the "LuaTimerEventDesc" struct

### DIFF
--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -677,6 +677,7 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 
 	eventDesc.function = luaL_ref(globalState, LUA_REGISTRYINDEX);
 	eventDesc.scriptId = getScriptEnv()->getScriptId();
+	eventDesc.scriptName = getScriptEnv()->getScriptInterface()->getLoadingScriptName();
 
 	auto &lastTimerEventId = g_luaEnvironment().lastEventTimerId;
 	eventDesc.eventId = g_scheduler().addEvent(

--- a/src/lua/lua_definitions.hpp
+++ b/src/lua/lua_definitions.hpp
@@ -200,6 +200,7 @@ struct LuaVariant {
 
 struct LuaTimerEventDesc {
 		int32_t scriptId = -1;
+		std::string scriptName;
 		int32_t function = -1;
 		std::list<int32_t> parameters;
 		uint32_t eventId = 0;


### PR DESCRIPTION
This will allow that in a possible crash in the addEvent, print to the stack trace the file name also in addition to the id.
![image](https://github.com/opentibiabr/canary/assets/8551443/31c66c55-8264-461c-98c8-f3a9a74f645e)
