### PR TITLE
fix: re-add windows icon to executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,5 +7,11 @@ include(CanaryLib)
 
 # Define main executable target, set it up and link to main library
 add_executable(${PROJECT_NAME} main.cpp)
+
+if(MSVC)
+    # Add executable icon for Windows
+    target_sources(${PROJECT_NAME} PRIVATE ../cmake/canary.rc)
+endif()
+
 setup_target(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)


### PR DESCRIPTION
# Description

We've accidentaly [removed ](https://github.com/opentibiabr/canary/pull/1438/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L59)windows icon during CMake re-structuring. This PR puts it back.