### PR TITLE
fix: remove checking empty map tile

### DIFF
--- a/src/io/iomap.cpp
+++ b/src/io/iomap.cpp
@@ -270,9 +270,6 @@ void IOMap::parseTileArea(OTB::Loader &loader, const OTB::Node &tileAreaNode, Ma
 			}
 		}
 
-		if (tile->isEmpty())
-			continue;
-
 		map.setBasicTile(x, y, z, tile);
 	}
 }


### PR DESCRIPTION
Prevents some npcs or systems from loading correctly, as the tile will be marked as empty.
For example, Yasir, Rashid, and other worldchanges.