### PR TITLE
fix: schema.sql db_version, add missing table and fix typos

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -609,7 +609,7 @@ CREATE TABLE IF NOT EXISTS `player_items` (
     INDEX `sid` (`sid`),
     CONSTRAINT `player_items_players_fk`
         FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
     CONSTRAINT `player_items_pk`
         PRIMARY KEY (`player_id`, `pid`, `sid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -621,7 +621,7 @@ CREATE TABLE IF NOT EXISTS `player_wheeldata` (
 	INDEX `player_id` (`player_id`),
 	CONSTRAINT `player_wheeldata_players_fk`
 		FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
-		ON DELETE CASCADE
+		ON DELETE CASCADE,
   CONSTRAINT `player_wheeldata_pk`
       PRIMARY KEY (`player_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -671,8 +671,8 @@ CREATE TABLE IF NOT EXISTS `player_prey` (
     `bonus_percentage` varchar(250) NOT NULL,
     `bonus_time` varchar(250) NOT NULL,
     `free_reroll` bigint(20) NOT NULL,
-    `monster_list` BLOB NULL
-    CONSTRAINT `player_prey_pk` PRIMARY KEY (`player_id`, `slot`),
+    `monster_list` BLOB NULL,
+    CONSTRAINT `player_prey_pk` PRIMARY KEY (`player_id`, `slot`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Table structure `player_taskhunt`
@@ -686,8 +686,8 @@ CREATE TABLE IF NOT EXISTS `player_taskhunt` (
     `kills` varchar(250) NOT NULL,
     `disabled_time` bigint(20) NOT NULL,
     `free_reroll` bigint(20) NOT NULL,
-    `monster_list` BLOB NULL
-    CONSTRAINT `player_prey_pk` PRIMARY KEY (`player_id`, `slot`),
+    `monster_list` BLOB NULL,
+    CONSTRAINT `player_prey_pk` PRIMARY KEY (`player_id`, `slot`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Table structure `player_bosstiary`
@@ -719,7 +719,7 @@ CREATE TABLE IF NOT EXISTS `player_spells` (
     INDEX `player_id` (`player_id`),
     CONSTRAINT `player_spells_players_fk`
         FOREIGN KEY (`player_id`) REFERENCES `players` (`id`)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
     CONSTRAINT `player_spells_pk` PRIMARY KEY (`player_id`, `name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -727,8 +727,8 @@ CREATE TABLE IF NOT EXISTS `player_spells` (
 CREATE TABLE IF NOT EXISTS `player_stash` (
     `player_id` INT(16) NOT NULL,
     `item_id` INT(16) NOT NULL,
-    `item_count` INT(32) NOT NULL
-    CONSTRAINT `player_stash_pk` PRIMARY KEY (`player_id`, `item_id`),
+    `item_count` INT(32) NOT NULL,
+    CONSTRAINT `player_stash_pk` PRIMARY KEY (`player_id`, `item_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Table structure `player_storage`

--- a/schema.sql
+++ b/schema.sql
@@ -695,7 +695,8 @@ CREATE TABLE IF NOT EXISTS `player_bosstiary` (
     `player_id` int NOT NULL,
     `bossIdSlotOne` int NOT NULL DEFAULT 0,
     `bossIdSlotTwo` int NOT NULL DEFAULT 0,
-    `removeTimes` int NOT NULL DEFAULT 1
+    `removeTimes` int NOT NULL DEFAULT 1,
+    `tracker` blob NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Table structure `player_rewards`

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
     CONSTRAINT `server_config_pk` PRIMARY KEY (`config`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '25'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '35'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 -- Table structure `accounts`
 CREATE TABLE IF NOT EXISTS `accounts` (


### PR DESCRIPTION
# Description

Fixed schema.sql.

Tested:
![image](https://github.com/opentibiabr/canary/assets/7812282/ae496a61-6325-41ac-a7b9-0d45572f6271)
