### PR TITLE
fix: add quotes to config.lua.dist default logLevel

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -10,7 +10,7 @@ coreDirectory = "data"
 -- Set log level
 -- It can be trace, debug, info, warning, error, critical, off (default: info).
 -- NOTE: Will only display logs with level higher or equal the one set.
-logLevel = debug
+logLevel = "debug"
 
 -- Combat settings
 -- NOTE: valid values for worldType are: "pvp", "no-pvp" and "pvp-enforced"


### PR DESCRIPTION
Fix missing quotes on config lua logLevel