### PR TITLE
improve: trigger source builds only when source files are modified

### DIFF
--- a/.github/workflows/analysis-reviewdog-cppcheck.yml
+++ b/.github/workflows/analysis-reviewdog-cppcheck.yml
@@ -14,6 +14,12 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
 
       - name: Check out code.
         uses: actions/checkout@main

--- a/.github/workflows/analysis-reviewdog-cppcheck.yml
+++ b/.github/workflows/analysis-reviewdog-cppcheck.yml
@@ -1,0 +1,33 @@
+---
+name: Analysis - Review Dog
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+  push:
+    paths:
+      - 'src/**'
+
+jobs:
+
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code.
+        uses: actions/checkout@main
+
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1.0.3
+
+      - name: Setup cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: cppcheck
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          cppcheck --version
+          reviewdog -reporter=github-pr-check -runners=cppcheck

--- a/.github/workflows/analysis-reviewdog.yml
+++ b/.github/workflows/analysis-reviewdog.yml
@@ -8,6 +8,12 @@ jobs:
   luac:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
 
       - name: Check out code.
         uses: actions/checkout@main

--- a/.github/workflows/analysis-reviewdog.yml
+++ b/.github/workflows/analysis-reviewdog.yml
@@ -5,29 +5,6 @@ on:
   pull_request:
 
 jobs:
-
-  cppcheck:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Check out code.
-        uses: actions/checkout@main
-
-      - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1.0.3
-
-      - name: Setup cppcheck
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
-
-      - name: cppcheck
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd "$GITHUB_WORKSPACE"
-          cppcheck --version
-          reviewdog -reporter=github-pr-check -runners=cppcheck
-
-
   luac:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/analysis-sonarcloud.yml
+++ b/.github/workflows/analysis-sonarcloud.yml
@@ -24,6 +24,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - uses: actions/checkout@v3
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         with:

--- a/.github/workflows/analysis-sonarcloud.yml
+++ b/.github/workflows/analysis-sonarcloud.yml
@@ -4,7 +4,11 @@ name: Analysis - SonarCloud
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -5,7 +5,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,6 +18,13 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Checkout
         uses: actions/checkout@main
         with:
@@ -80,6 +87,13 @@ jobs:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Checkout
         uses: actions/checkout@main
         with:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -35,6 +35,13 @@ jobs:
             triplet: x64-linux
 
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Checkout repository
         uses: actions/checkout@main
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -5,7 +5,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
 

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -29,6 +29,13 @@ jobs:
             packages: >
               sccache
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Checkout repository
         uses: actions/checkout@main
 

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
 env:

--- a/.github/workflows/build-windows-solution.yml
+++ b/.github/workflows/build-windows-solution.yml
@@ -5,7 +5,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
     branches:
       - main
 

--- a/.github/workflows/build-windows-solution.yml
+++ b/.github/workflows/build-windows-solution.yml
@@ -32,6 +32,13 @@ jobs:
             packages: >
               sccache
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v1.1
 

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -11,6 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        if: github.ref != 'refs/heads/main'
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          cancel_others: true
+
       - name: Set up Git
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -2,7 +2,11 @@
 name: Clang-format
 on:
   pull_request:
+    paths:
+      - 'src/**'
   push:
+    paths:
+      - 'src/**'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enhances the efficiency of our build process by triggering builds only when changes are made to the source files. This selective triggering applies to various workflows including:

• Windows Build: Both CMake and Solution configurations are affected.
• Ubuntu Build: The build process on the Ubuntu platform has been updated to follow this new rule.
• SonarCloud: The integration with SonarCloud will now only run when relevant source files are modified.
• Docker: The Docker build workflow has been optimized to only execute when necessary.

By focusing on changes to the source files, this improvement ensures that unnecessary builds are avoided, saving both time and resources. It aligns with our commitment to an efficient and streamlined development process.