### PR TITLE
fix: not add "Position" type to the lua types vector

### DIFF
--- a/data-otservbr-global/scripts/globalevents/worldchanges/yasir.lua
+++ b/data-otservbr-global/scripts/globalevents/worldchanges/yasir.lua
@@ -50,13 +50,12 @@ local function yasirwebhook(message) -- New local function that runs on delay to
 end
 
 local yasirEnabled = true
-local yasirChance = 100
-local randTown = config[math.random(#config)]
+local yasirChance = 33
 
-local function spawnYasir()
-	local npc = Game.createNpc('yasir', randTown.yasirPosition)
+local function spawnYasir(position)
+	local npc = Game.createNpc('yasir', position)
 	if npc then
-		npc:setMasterPos(randTown.yasirPosition)
+		npc:setMasterPos(position)
 	end
 end
 
@@ -65,6 +64,7 @@ local yasir = GlobalEvent("yasir")
 function yasir.onStartup()
 	if yasirEnabled then
 		if math.random(100) <= yasirChance then
+			local randTown = config[3]
 			logger.info("[WorldChanges] Yasir: {}", randTown.mapName)
 			local message = string.format("Yasir is in %s today.", randTown.mapName) -- Declaring the message to send to webhook.
 			iterateArea(
@@ -102,7 +102,7 @@ function yasir.onStartup()
 			end
 
 			Game.loadMap(DATA_DIRECTORY.. '/world/world_changes/oriental_trader/' .. randTown.mapName .. '.otbm')
-			addEvent(spawnYasir, 5000)
+			addEvent(spawnYasir, 60000, randTown.yasirPosition)
 			addEvent(yasirwebhook, 60000, message) -- Event with 1 minute delay to send webhook message after server starts.
 			setGlobalStorageValue(GlobalStorage.Yasir, 1)
 		else

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -602,7 +602,7 @@ int GlobalFunctions::luaAddEvent(lua_State* L) {
 			lua_rawgeti(L, -1, 't');
 
 			LuaData_t type = getNumber<LuaData_t>(L, -1);
-			if (type != LuaData_t::Unknown && type != LuaData_t::Tile) {
+			if (type != LuaData_t::Unknown && type != LuaData_t::Tile && type != LuaData_t::Position) {
 				indexes.push_back({ i, type });
 			}
 			lua_pop(globalState, 2);

--- a/src/lua/lua_definitions.hpp
+++ b/src/lua/lua_definitions.hpp
@@ -32,7 +32,6 @@ enum class LuaData_t : uint8_t {
 	Tile,
 	Variant,
 	Position,
-	Spdlog,
 	NetworkMessage,
 	ModalWindow,
 	Guild,


### PR DESCRIPTION
For some reason the "addEvent" doesn't need to pass Tile and Position as safe.