### PR TITLE
fix: Guarantees that canary_lib is always static

### DIFF
--- a/cmake/modules/BaseConfig.cmake
+++ b/cmake/modules/BaseConfig.cmake
@@ -134,8 +134,6 @@ endfunction()
 
 ## Setup shared target basic configurations
 function(setup_target TARGET_NAME)
-    set_output_directory(${TARGET_NAME})
-
     if (MSVC AND BUILD_STATIC_LIBRARY)
         set_property(TARGET ${TARGET_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()

--- a/cmake/modules/CanaryLib.cmake
+++ b/cmake/modules/CanaryLib.cmake
@@ -1,10 +1,5 @@
 # Define and setup CanaryLib main library target
-if(BUILD_STATIC_LIBRARY)
-    add_library(${PROJECT_NAME}_lib STATIC)
-else()
-    add_library(${PROJECT_NAME}_lib SHARED)
-endif()
-
+add_library(${PROJECT_NAME}_lib)
 setup_target(${PROJECT_NAME}_lib)
 
 # Add subdirectories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,4 +14,5 @@ if(MSVC)
 endif()
 
 setup_target(${PROJECT_NAME})
+set_output_directory(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PROJECT_NAME}_lib)


### PR DESCRIPTION
# Description

There was a small oversight in the CMake improvements, we've made the CanaryLib configurable between shared and static, and right now we are not ready for this change, it needs to be always static. One can still use `BUILD_STATIC_LIBRARY` to choose if the external dependencies should be linked statically or dynamically, but the generated CanaryLib will always be static.