### PR TITLE
fix: quest system unique id

### DIFF
--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -46,7 +46,7 @@ void MapCache::parseItemAttr(const BasicItemPtr &BasicItem, Item* item) {
 		item->setAttribute(ItemAttribute_t::ACTIONID, BasicItem->actionId);
 
 	if (BasicItem->uniqueId > 0)
-		item->setAttribute(ItemAttribute_t::UNIQUEID, BasicItem->uniqueId);
+		item->addUniqueId(BasicItem->uniqueId);
 
 	if (item->getTeleport() && (BasicItem->destX != 0 || BasicItem->destY != 0 || BasicItem->destZ != 0)) {
 		auto dest = Position(BasicItem->destX, BasicItem->destY, BasicItem->destZ);


### PR DESCRIPTION
![image](https://github.com/opentibiabr/canary/assets/8551443/22b60dea-d29a-4214-b0f0-c9e632453c3f)
