### PR TITLE
fix: remove prey slot crash

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6728,13 +6728,17 @@ void ProtocolGame::sendPreyTimeLeft(const PreySlot* slot) {
 }
 
 void ProtocolGame::sendPreyData(const PreySlot* slot) {
+	if (!player) {
+		return;
+	}
+
 	std::vector<uint16_t> validRaceIds;
 	for (auto raceId : slot->raceIdList) {
 		if (g_monsters().getMonsterTypeByRaceId(raceId)) {
 			validRaceIds.push_back(raceId);
 		} else {
-			g_logger().debug("[ProtocolGame::sendPreyData] - Unknown monster type raceid: {}, removing prey slot from player {}", raceId, player->getName());
-			player->removePreySlotById(slot->id);
+			g_logger().error("[ProtocolGame::sendPreyData] - Unknown monster type raceid: {}, removing prey slot from player {}", raceId, player->getName());
+			g_logger().warn("[ProtocolGame::sendPreyData] - Remove the prey monster from player");
 			return;
 		}
 	}


### PR DESCRIPTION
This issue occurs under a very specific scenario: if the server removes a monster, and it is saved, except in the player's database. In this case, the monster type will cease to exist, and there may be an attempt to access memory that has already been freed, leading to a crash.

Even though this situation should not occur in a production environment (unless it's due to an error on the part of the server owner), I have decided to take preventive measures to avoid further complications.

Now, instead of causing a crash, the system will simply log a message informing that the monster must be removed from the player's prey list. This change enhances stability and provides clear information for troubleshooting if the issue ever arises.