### PR TITLE
fix: inject g_logger from interface not impl

### DIFF
--- a/src/lib/logging/log_with_spd_log.cpp
+++ b/src/lib/logging/log_with_spd_log.cpp
@@ -19,8 +19,8 @@ LogWithSpdLog::LogWithSpdLog() {
 #endif
 }
 
-LogWithSpdLog &LogWithSpdLog::getInstance() {
-	return inject<LogWithSpdLog>();
+Logger &LogWithSpdLog::getInstance() {
+	return inject<Logger>();
 }
 
 void LogWithSpdLog::setLevel(const std::string &name) {

--- a/src/lib/logging/log_with_spd_log.hpp
+++ b/src/lib/logging/log_with_spd_log.hpp
@@ -13,10 +13,10 @@ public:
 	LogWithSpdLog();
 	~LogWithSpdLog() override = default;
 
-	static LogWithSpdLog &getInstance();
+	static Logger &getInstance();
 
 	void setLevel(const std::string &name) override;
-	[[nodiscard]] virtual std::string getLevel() const override;
+	[[nodiscard]] std::string getLevel() const override;
 
 	void log(std::string lvl, fmt::basic_string_view<char> msg) const override;
 };


### PR DESCRIPTION
Logger interface was created to generate testable abstraction to tests. This is working fine for log ingestion in construction level. However, for those using g_logger it has a hard bind to the impl class LogWithSpdLog instead of the Interface.

This commit changes this to make it more flexible and improve testing.