### PR TITLE
fix: load map npcs and monsters from main map

### DIFF
--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -362,6 +362,8 @@ void CanaryServer::loadModules() {
 	g_game().loadBoostedCreature();
 	g_ioBosstiary().loadBoostedBoss();
 	g_ioprey().InitializeTaskHuntOptions();
+	// Spawn monsters and npcs
+	g_game().map.spawnCreatures();
 }
 
 void CanaryServer::modulesLoadHelper(bool loaded, std::string moduleName) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -441,7 +441,7 @@ bool Game::loadItemsPrice() {
 void Game::loadMainMap(const std::string &filename) {
 	Monster::despawnRange = g_configManager().getNumber(DEFAULT_DESPAWNRANGE);
 	Monster::despawnRadius = g_configManager().getNumber(DEFAULT_DESPAWNRADIUS);
-	map.loadMap(g_configManager().getString(DATA_DIRECTORY) + "/world/" + filename + ".otbm", true, true, true, true);
+	map.loadMap(g_configManager().getString(DATA_DIRECTORY) + "/world/" + filename + ".otbm", true, true, false, false);
 }
 
 void Game::loadCustomMaps(const std::filesystem::path &customMapPath) {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -119,6 +119,11 @@ void Map::loadHouseInfo() {
 	IOMapSerialize::loadHouseItems(this);
 }
 
+void Map::spawnCreatures() {
+	IOMap::loadNpcs(this);
+	IOMap::loadMonsters(this);
+}
+
 bool Map::save() {
 	bool saved = false;
 	for (uint32_t tries = 0; tries < 6; tries++) {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -64,6 +64,7 @@ public:
 	void loadMapCustom(const std::string &mapName, bool loadHouses, bool loadMonsters, bool loadNpcs, const int customMapIndex);
 
 	void loadHouseInfo();
+	void spawnCreatures();
 
 	/**
 	 * Save a map.


### PR DESCRIPTION
Sometimes, monsters and NPCs were loaded before the map, causing errors in the server console. To prevent these errors, we've disabled loading them during the map loading process. Instead, they will now be loaded only after the map has completely loaded.