### PR TITLE
improve: move DI out of the pch

### DIFF
--- a/src/config/configmanager.hpp
+++ b/src/config/configmanager.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class ConfigManager {
 public:

--- a/src/creatures/appearance/outfit/outfit.hpp
+++ b/src/creatures/appearance/outfit/outfit.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 struct Outfit {
 	Outfit(std::string initName, uint16_t initLookType, bool initPremium, bool initUnlocked, std::string initFrom) :

--- a/src/creatures/interactions/chat.hpp
+++ b/src/creatures/interactions/chat.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "utils/utils_definitions.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.hpp"
 
 class Party;

--- a/src/creatures/npcs/npc.hpp
+++ b/src/creatures/npcs/npc.hpp
@@ -12,6 +12,7 @@
 #include "creatures/npcs/npcs.hpp"
 #include "declarations.hpp"
 #include "items/tile.hpp"
+#include "lib/di/container.hpp"
 
 class Creature;
 class Game;

--- a/src/creatures/npcs/npcs.hpp
+++ b/src/creatures/npcs/npcs.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "creatures/creature.hpp"
+#include "lib/di/container.hpp"
 
 class Shop {
 public:

--- a/src/creatures/players/grouping/familiars.hpp
+++ b/src/creatures/players/grouping/familiars.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class Familiars {
 public:

--- a/src/creatures/players/grouping/party.hpp
+++ b/src/creatures/players/grouping/party.hpp
@@ -11,6 +11,7 @@
 
 #include "creatures/players/player.hpp"
 #include "creatures/monsters/monsters.hpp"
+#include "lib/di/container.hpp"
 
 enum SharedExpStatus_t : uint8_t {
 	SHAREDEXP_OK,

--- a/src/creatures/players/imbuements/imbuements.hpp
+++ b/src/creatures/players/imbuements/imbuements.hpp
@@ -11,6 +11,7 @@
 
 #include "creatures/players/player.hpp"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "utils/tools.hpp"
 
 class Player;

--- a/src/creatures/players/storages/storages.hpp
+++ b/src/creatures/players/storages/storages.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "lib/di/container.hpp"
+
 class Storages {
 public:
 	Storages() = default;

--- a/src/creatures/players/vocations/vocation.hpp
+++ b/src/creatures/players/vocations/vocation.hpp
@@ -11,6 +11,7 @@
 
 #include "declarations.hpp"
 #include "items/item.hpp"
+#include "lib/di/container.hpp"
 
 class Vocation {
 public:

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 
 class DBResult;
 using DBResult_ptr = std::shared_ptr<DBResult>;

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -9,6 +9,7 @@
 
 #include "pch.hpp"
 
+#include "lib/di/container.hpp"
 #include "lib/thread/thread_pool.hpp"
 #include "game/scheduling/dispatcher.hpp"
 #include "game/scheduling/task.hpp"

--- a/src/game/scheduling/events_scheduler.hpp
+++ b/src/game/scheduling/events_scheduler.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "lib/di/container.hpp"
 #include "utils/tools.hpp"
 
 struct EventScheduler {

--- a/src/game/scheduling/scheduler.cpp
+++ b/src/game/scheduling/scheduler.cpp
@@ -9,6 +9,7 @@
 
 #include "pch.hpp"
 
+#include "lib/di/container.hpp"
 #include "lib/thread/thread_pool.hpp"
 #include "game/scheduling/dispatcher.hpp"
 #include "game/scheduling/scheduler.hpp"

--- a/src/io/io_bosstiary.hpp
+++ b/src/io/io_bosstiary.hpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "lib/di/container.hpp"
 
 enum class BosstiaryRarity_t : uint8_t {
 	RARITY_BANE = 0,

--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -15,7 +15,7 @@
 #include "creatures/monsters/monsters.hpp"
 #include "creatures/players/player.hpp"
 
-SoftSingleton IOBestiary::instanceTracker(g_logger(), "IOBestiary");
+SoftSingleton IOBestiary::instanceTracker("IOBestiary");
 
 bool IOBestiary::parseCharmCombat(const std::shared_ptr<Charm> charm, Player* player, Creature* target, int32_t realDamage, bool dueToPotion, bool checkArmor) {
 	if (!charm || !player || !target) {

--- a/src/io/ioprey.hpp
+++ b/src/io/ioprey.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "lib/di/container.hpp"
 #include "server/network/protocol/protocolgame.hpp"
 
 enum PreySlot_t : uint8_t {

--- a/src/lib/di/README.md
+++ b/src/lib/di/README.md
@@ -1,0 +1,202 @@
+## Dependency Injection
+
+Dependency injection is a technique for achieving loose coupling between objects and their collaborators, or dependencies. It is a form of inversion of control, where the control being inverted is the setting of object's dependencies.
+
+### Container
+
+A container is a place where dependencies are stored. It is responsible for creating objects and injecting their dependencies.
+It is also responsible for managing the lifetime of objects it creates.
+
+In [boost::di](https://boost-ext.github.io/di/), the container is represented by the `di::injector` class.
+It is a variadic template class that takes a list of modules as template parameters.
+A module is a class that defines how to create objects and how to inject their dependencies.
+A module can be a class or a lambda function. 
+
+#### Getting an Instance of a Type
+
+To get an instance of a type, we call the `create` method of the container.
+
+The default injector created from the `di::make_injector` function can create instances of types that weren't registered, if they are concrete types.
+
+For interfaces, we have to register a provider for the interface.
+For instance:
+```cpp
+class A {
+public:
+    virtual ~A() = default;
+};
+
+class B : public A {};
+
+auto container = di::make_injector(
+    di::bind<A>().to<B>()
+);
+auto a = container.create<A>();
+auto a = container.create<B>();
+```
+
+Both injections above create an instance of `B`, one through the interface `A` and one directly.
+
+#### Scopes
+
+A scope is a way to manage the lifetime of an object.
+There are two main types of scopes in our use cases:  
+
+**Unique**
+
+Unique scope creates a new instance of an object every time it is requested.
+It is the default scope when calling the `create` method of the container.
+
+For instance:
+```cpp
+auto container = di::make_injector(
+    di::bind<Logger>().to<LogWithSpdLog>()
+);
+auto logger1 = container.create<Logger &>();
+auto logger2 = container.create<Logger &>();
+```
+
+In the example above, `logger1` and `logger2` are different instances of `LogWithSpdLog`.
+
+**Shared (Singleton)**  
+
+Singleton scope creates a single instance of an object and returns it every time it is requested.
+It is the default scope when registering a provider via reference or shared pointer.
+
+For instance:
+```cpp
+auto container = di::make_injector(
+    di::bind<Logger>().to<LogWithSpdLog>()
+);
+auto logger1 = container.create<Logger &>();
+auto logger2 = container.create<Logger &>();
+```
+
+In the example above, `logger1` and `logger2` are the same instance of `LogWithSpdLog`.
+
+### Injection
+
+Injection is the process of providing dependencies to an object.
+It is done by the container when it creates an object.
+
+#### Constructor Injection
+
+Constructor injection is the process of providing dependencies to an object through its constructor.
+For instance:
+```cpp
+class A {
+public:
+    A(int i, double d) {}
+};
+
+class B {
+public:
+    B(A a) {}
+};
+
+class C {
+public:
+    C(A a) {}
+};
+
+auto container = di::make_injector();
+auto a = container.create<A &>();
+auto b = container.create<B &>();
+auto c = container.create<C>();
+```
+
+In the example above, the container creates an instance of `A` and injects it into the constructors of `B` and `C`.
+When the container creates an instance of `B`, it creates an instance of `A` and passes it to the constructor of `B`.
+When the container creates an instance of `C`, it creates an instance of `A` and passes it to the constructor of `C`.
+
+#### Field Injection
+
+Field injection is the process of providing dependencies to an object through its fields.
+For instance:
+```cpp
+class A {
+public:
+    int i;
+    double d;
+};
+
+class B {
+public:
+    A &a = inject<A>();
+};
+
+auto container = di::make_injector();
+auto a = container.create<A &>();
+auto b = container.create<B &>();
+B b2{};
+```
+
+In the example above, the container creates an instance of `A` and injects it into the field `a` of `B`.
+When the container creates an instance of `B`, it creates an instance of `A` and assigns it to the field `a` of `B`.
+When we create an instance of `B` manually, we have to call the `inject` function to inject an instance of `A` into the field `a` of `B`.
+
+#### Global Variables
+
+Our code base relies on global variables g_() that behaves like singletons.
+When we moved to DependencyInjection we've migrated those singletons to the container.
+For instance:
+```cpp
+Logger LogWithSpdLog::getInstance() {
+    return inject<Logger>();
+}
+
+constexpr auto g_logger = LogWithSpdLog::getInstance;
+```
+
+In the example above, we've created a provider for the `Logger` interface.
+We've also created a global variable `g_logger` that is initialized with an instance of `Logger` from the container.
+Every time we call `g_logger`, we get the same instance of `Logger`.
+
+They are somewhat softer than the traditional singletons, because we can still create instances of them manually.
+That improves our testability, because we can create stubs of the `Logger` interface and inject it into the container.
+
+
+### Using the Container
+
+To simplify the registration of providers in singleton scope, we've created three auxiliary functions.
+
+#### `DI::create<T>`
+
+This translates directly to container.create<T>() and can return unique or shared instances, depending on the value of T.
+
+#### `DI::get<T>`
+
+This translates directly to container.create<T &>() and will always return the same instance.
+
+#### `inject<T>()`
+
+This is a shortcut for `DI::get<T>()` and is used to inject dependencies into fields of objects that are not created by the container.
+
+
+### Testing
+
+For tests, we allow the setup of a test container via the `DI::setTestContainer` function.
+This function receives an instace of `di::injector` and sets it as the test container.
+When the test container is set, the `DI::create<T>` and `DI::get<T>` functions will return instances from the test container.
+When the test container is not set, the `DI::create<T>` and `DI::get<T>` functions will return instances from the default container.
+
+This gives us the ability to create stubs of interfaces and inject them into the container for testing.
+That way we are able to test the behavior of our code without having to rely on the implementation of the dependencies.
+
+For instance:
+```cpp
+{
+    di::extension::injector<> injector{};
+    DI::setTestContainer(&InMemoryLogger::install(injector));
+
+    auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
+    auto &logger2 = dynamic_cast<InMemoryLogger &>(inject<Logger>());
+    auto &logger3 = g_logger();
+}
+```
+
+In the example above, we've created a test container and registered a provider for the `Logger` interface.
+Because the test container is set, the `DI::create<T>` and `DI::get<T>` functions will return instances from the test container.
+When we call `DI::create<Logger &>()`, we get an instance of `InMemoryLogger`.
+When we call `DI::get<Logger &>()`, we get the same instance of `InMemoryLogger`.
+When we call `g_logger()`, we get the same instance of `InMemoryLogger`.

--- a/src/lib/di/container.hpp
+++ b/src/lib/di/container.hpp
@@ -17,7 +17,7 @@ namespace di = boost::di;
 class DI final {
 private:
 	inline static di::extension::injector<>* testContainer;
-	const inline static auto defaultInjector = di::make_injector(
+	const inline static auto defaultContainer = di::make_injector(
 		di::bind<Logger>().to<LogWithSpdLog>().in(di::singleton)
 	);
 
@@ -33,7 +33,7 @@ public:
 	 */
 	template <class T>
 	inline static T create() {
-		return testContainer ? testContainer->create<T>() : defaultInjector.create<T>();
+		return testContainer ? testContainer->create<T>() : defaultContainer.create<T>();
 	}
 
 	/**

--- a/src/lib/di/soft_singleton.cpp
+++ b/src/lib/di/soft_singleton.cpp
@@ -10,8 +10,8 @@
 #include "lib/di/soft_singleton.hpp"
 #include "utils/tools.hpp"
 
-SoftSingleton::SoftSingleton(Logger &logger, std::string id) :
-	logger(logger), id(std::move(id)) { }
+SoftSingleton::SoftSingleton(std::string id) :
+	id(std::move(id)) { }
 
 void SoftSingleton::increment() {
 	instance_count++;

--- a/src/lib/di/soft_singleton.hpp
+++ b/src/lib/di/soft_singleton.hpp
@@ -9,13 +9,11 @@
 #pragma once
 
 #include <iostream>
+#include "lib/logging/log_with_spd_log.hpp"
 
-/**
- * This
- */
 class SoftSingleton {
 public:
-	SoftSingleton(Logger &logger, std::string id);
+	explicit SoftSingleton(std::string id);
 
 	// non-copyable
 	SoftSingleton(const SoftSingleton &) = delete;
@@ -26,7 +24,7 @@ public:
 	void decrement();
 
 private:
-	Logger &logger;
+	Logger &logger = g_logger();
 	std::string id;
 	int instance_count = 0;
 };

--- a/src/lib/logging/log_with_spd_log.cpp
+++ b/src/lib/logging/log_with_spd_log.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 
 #include "pch.hpp"
+#include "lib/di/container.hpp"
 
 LogWithSpdLog::LogWithSpdLog() {
 	setLevel("debug");

--- a/src/lib/logging/log_with_spd_log.hpp
+++ b/src/lib/logging/log_with_spd_log.hpp
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include "lib/logging/logger.hpp"
+
 class LogWithSpdLog final : public Logger {
 public:
 	LogWithSpdLog();

--- a/src/lib/thread/README.md
+++ b/src/lib/thread/README.md
@@ -1,0 +1,36 @@
+## Thread Pool
+
+The thread pool is a collection of threads that can be used to execute tasks.
+The thread pool is created with a fixed number of threads. By default, the number of threads is the number of cpu cores.
+The use can also specify the number of cores via `DEFAULT_NUMBER_OF_THREADS` environment variable.
+The bigger value between the two is used.
+
+Keep in mind that if the number of threads is too high, the performance will be degraded due to the context switching.
+
+### Usage
+
+The thread pool uses asio for the implementation. 
+Its basic concept is to have a shared asio::io_context and have it run on multiple threads.
+The user can post tasks to the thread pool and the thread pool will execute them on one of its threads.
+
+```cpp
+#include <thread/thread_pool.hpp>
+
+int main() {
+    ThreadPool &pool = inject<ThreadPool>(); // preferrably uses constructor injection or setter injection.
+
+    // Post a task to the thread pool
+    pool.addLoad([]() {
+        std::cout << "Hello from thread " << std::this_thread::get_id() << std::endl;
+    });
+}
+```
+
+### Parallelism
+The load can be executed on any thread in the thread pool, meaning that they are trully asynchronous and parallel (if you have multiple cores).
+This means that you should take care of the thread safety of your code, either with atomic variables or mutexes.
+
+### Lifetime
+We have a centralized thread pool via dependency injection. This means that the thread pool will be destroyed when the dependency injection container is destroyed.
+This also mean that you cannot join threads, you need to rely on signals if you want to acknowledge that the a load executed.
+

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -11,6 +11,10 @@
 #include "lib/thread/thread_pool.hpp"
 #include "utils/tools.hpp"
 
+#ifndef DEFAULT_NUMBER_OF_THREADS
+	#define DEFAULT_NUMBER_OF_THREADS 4
+#endif
+
 ThreadPool::ThreadPool(Logger &logger) :
 	logger(logger) {
 	start();
@@ -25,7 +29,7 @@ void ThreadPool::start() {
 	 * will make processing non-blocking in some way and that would allow
 	 * single core computers to process things concurrently, but not in parallel.
 	 */
-	int nThreads = std::max<int>(static_cast<int>(getNumberOfCores()), 4);
+	int nThreads = std::max<int>(static_cast<int>(getNumberOfCores()), DEFAULT_NUMBER_OF_THREADS);
 
 	for (std::size_t i = 0; i < nThreads; ++i) {
 		threads.emplace_back([this] { ioService.run(); });

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include "lib/logging/logger.hpp"
+
 class ThreadPool {
 public:
 	explicit ThreadPool(Logger &logger);

--- a/src/lua/creature/creatureevent.hpp
+++ b/src/lua/creature/creatureevent.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.hpp"
 #include "lua/scripts/scripts.hpp"
 

--- a/src/lua/modules/modules.hpp
+++ b/src/lua/modules/modules.hpp
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include "lua/global/baseevents.hpp"
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
+#include "lua/global/baseevents.hpp"
 #include "lua/scripts/luascript.hpp"
 #include "server/network/message/networkmessage.hpp"
 

--- a/src/lua/scripts/luascript.hpp
+++ b/src/lua/scripts/luascript.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "lib/logging/log_with_spd_log.hpp"
 #include "lua/functions/lua_functions_loader.hpp"
 #include "lua/scripts/script_environment.hpp"
 

--- a/src/lua/scripts/scripts.hpp
+++ b/src/lua/scripts/scripts.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "lib/di/container.hpp"
 #include "lua/scripts/luascript.hpp"
 
 class Scripts {

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -142,6 +142,4 @@
 #include <eventpp/utilities/scopedremover.h>
 #include <eventpp/eventdispatcher.h>
 
-#include "lib/di/container.hpp"
-
 #include "lua/global/shared_object.hpp"

--- a/src/security/rsa.cpp
+++ b/src/security/rsa.cpp
@@ -9,6 +9,7 @@
 
 #include "pch.hpp"
 
+#include "lib/di/container.hpp"
 #include "security/rsa.hpp"
 
 RSA::RSA(Logger &logger) :
@@ -20,6 +21,10 @@ RSA::RSA(Logger &logger) :
 RSA::~RSA() {
 	mpz_clear(n);
 	mpz_clear(d);
+}
+
+RSA &RSA::getInstance() {
+	return inject<RSA>();
 }
 
 void RSA::start() {

--- a/src/security/rsa.hpp
+++ b/src/security/rsa.hpp
@@ -20,9 +20,7 @@ public:
 	RSA(RSA const &) = delete;
 	void operator=(RSA const &) = delete;
 
-	static RSA &getInstance() {
-		return inject<RSA>();
-	}
+	static RSA &getInstance();
 
 	void start();
 

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lib/di/container.hpp"
 #include "server/network/message/networkmessage.hpp"
 
 static constexpr int32_t CONNECTION_WRITE_TIMEOUT = 30;

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "lib/logging/logger.hpp"
 #include "server/network/connection/connection.hpp"
 #include "server/signals.hpp"
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${PROJECT_NAME}_lib PRIVATE
+    pugicast.cpp
     tools.cpp
     wildcardtree.cpp
 )

--- a/src/utils/pugicast.cpp
+++ b/src/utils/pugicast.cpp
@@ -6,11 +6,11 @@
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.com/
  */
-
 #include "pch.hpp"
-#include "canary_server.hpp"
-#include "lib/di/container.hpp"
+#include "lib/logging/log_with_spd_log.hpp"
 
-int main() {
-	return inject<CanaryServer>().run();
+namespace pugi {
+	void logError(const std::string &str) {
+		g_logger().error(str);
+	}
 }

--- a/src/utils/pugicast.hpp
+++ b/src/utils/pugicast.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 namespace pugi {
+	void logError(const std::string &str);
+
 	template <typename T>
 	// NOTE: std::clamp returns the minimum value if the value is less than the specified minimum value, the maximum value if the value is greater than the specified maximum value, or the value itself if it falls within the range
 	T cast(const pugi::char_t* str) {
@@ -36,13 +38,13 @@ namespace pugi {
 		// If the string could not be parsed as the specified type
 		if (errorCode == std::errc::invalid_argument) {
 			// Throw an exception indicating that the argument is invalid
-			g_logger().error("Invalid argument {}", str);
+			logError(fmt::format("Invalid argument {}", str));
 			throw std::invalid_argument("Invalid argument: " + std::string(str));
 		}
 		// If the parsed value is out of range for the specified type
 		else if (errorCode == std::errc::result_out_of_range) {
 			// Throw an exception indicating that the result is out of range
-			g_logger().error("Result out of range: {}", str);
+			logError(fmt::format("Result out of range: {}", str));
 			throw std::out_of_range("Result out of range: " + std::string(str));
 		}
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,105 @@
+## Testing
+
+### Running tests
+
+To run the tests, you need to compile with the flag `BUILD_TESTS` enabled (`-DBUILD_TESTS:BOOL=ON`).
+This will build all tests within the `tests` directory and generate a `tests` folder in the build directory, which contains the test executable.
+
+Once the executable is generated, you can run the tests with the following command:
+```bash
+cd build/{build_type}/tests
+./canary_ut
+```
+
+### Adding tests
+
+Tests are added in the `tests` folder, in the root of the repository.
+As much as possible, tests should be added in the same folder as the code they are testing:
+
+```
+- src
+    - foo
+        - foo.cpp
+    - bar
+        - bar.cpp
+- tests
+    - foo
+        - foo_test.cpp
+    - bar
+        - bar_test.cpp
+```
+
+### Boost::ut
+
+Tests are written using the Boost::ut framework.  We've chosen this framework because it is simple, macro-free, intuitive, and easy to use.
+In this section, we will go over the basics of the framework, but you can find more information in the [Boost::ut documentation](https://boost-ext.github.io/ut/).
+There are many ways to write tests, and we encourage you to read the documentation to find the way that works best for you.
+
+#### Suites
+
+Tests needs to be encapsulated by suites, which are defined using `suite<>` structure.
+```cpp
+suite<"foo"> test_foo = [] {
+    // Tests go here
+};
+```
+
+This puts all tests within test_foo under the suite "foo".
+You can use declare multiple suites with the same name, and they will be merged together.
+This allows you to declare suites in different files, and they will be merged together, keeping test files clean.
+
+Avoid creating tests directly in the main function, as this will put them in the `global` suite, which is not recommended.
+
+#### Tests
+
+Tests can be defined using the `test()` lambda or the `_test` operator:
+```cpp
+suite<"foo"> test_foo = [] {
+    "test 1"_test = [] {
+        // Test 1
+    };
+
+    test("test 2") = [] {
+        // Test 2
+    };
+};
+```
+
+#### Assertions
+
+Both are equivalent, the received argument is the description of the test.
+The description is used to identify the test in the output, and should be unique within a suite.
+
+Assertions are done using the `expect()` function:
+```cpp
+suite<"foo"> test_foo = [] {
+    "test 1"_test = [] {
+        expect(1_i == 1_i);
+    };
+};
+```
+
+#### Testing against injected dependencies
+
+Testing against injected dependencies is done using the `di::extension::injector<>` class.
+This class is used to create the dependency injection container, and can be used to set up the container for testing.
+For example, to test the `RSA` class, we need to inject a `Logger` class, otherwise it will use the default SpdLog implementation.
+
+```cpp
+suite<"security"> rsaTest = [] {
+	test("RSA::start logs error for missing .pem file") = [] {
+		di::extension::injector<> injector{};
+		DI::setTestContainer(&InMemoryLogger::install(injector));
+
+		DI::create<RSA &>().start();
+
+		auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
+
+        expect(eq(1, logger.logs.size()) >> fatal);
+		expect(
+			eq(std::string{"error"}, logger.logs[0].level) and
+			eq(std::string{"File key.pem not found or have problem on loading... Setting standard rsa key\n"}, logger.logs[0].message)
+        );
+	};
+};
+```

--- a/tests/security/rsa_test.cpp
+++ b/tests/security/rsa_test.cpp
@@ -15,13 +15,12 @@ using namespace boost::ut;
 
 suite<"security"> rsaTest = [] {
 	test("RSA::start logs error for missing .pem file") = [] {
-		di::extension::injector<> injector{di::bind<Logger>.to<InMemoryLogger>().in(di::singleton)};
-		InMemoryLogger::install(injector);
-		DI::setTestContainer(&injector);
+		di::extension::injector<> injector{};
+		DI::setTestContainer(&InMemoryLogger::install(injector));
 
 		DI::create<RSA &>().start();
 
-		auto &logger = dynamic_cast<InMemoryLogger &>(DI::get<Logger &>());
+		auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
 
         expect(eq(1, logger.logs.size()) >> fatal);
 		expect(

--- a/tests/stubs/in_memory_logger.hpp
+++ b/tests/stubs/in_memory_logger.hpp
@@ -12,7 +12,9 @@
 #include <string>
 #include <utility>
 
-#include "lib/logging/logger.hpp"
+#include "lib/di/container.hpp"
+
+namespace di = boost::di;
 
 class InMemoryLogger : public Logger {
 	private:
@@ -24,8 +26,9 @@ class InMemoryLogger : public Logger {
 	public:
 		mutable std::vector<LogEntry> logs;
 
-		static void install(di::extension::injector<> &injector) {
+		static di::extension::injector<> &install(di::extension::injector<> &injector) {
 			injector.install(di::bind<Logger>.to<InMemoryLogger>().in(di::singleton));
+			return injector;
         }
 
 		bool hasLogEntry(const std::string& lvl, const std::string& expectedMsg) const {

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -373,6 +373,7 @@
     <ClCompile Include="..\src\server\network\webhook\webhook.cpp" />
     <ClCompile Include="..\src\server\server.cpp" />
     <ClCompile Include="..\src\server\signals.cpp" />
+    <ClCompile Include="..\src\utils\pugicast.cpp" />
     <ClCompile Include="..\src\utils\tools.cpp" />
     <ClCompile Include="..\src\utils\wildcardtree.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Container DI will eventually have too much internal code, and it won't behave as a library but as a shared container. Thus, moving it out of pch will improve building and reduce chances of cross dependencies.