### PR TITLE
fix: spectral bolts attack and raid draptor update

### DIFF
--- a/data-otservbr-global/raids/farmine/draptor.xml
+++ b/data-otservbr-global/raids/farmine/draptor.xml
@@ -10,6 +10,7 @@
 	<singlespawn delay="120000" name="Draptor" x="33338" y="31197" z="7"/>
 	<singlespawn delay="120000" name="Draptor" x="33256" y="31158" z="7"/>
 	<singlespawn delay="120000" name="Draptor" x="33234" y="31185" z="7"/>
+	<singlespawn delay="20000" name="Grand Mother Foulscale" x="33311" y="31177" z="7"/>
 	<areaspawn delay="20000" fromx="33213" fromy="31160" fromz="7" tox="33352" toy="31237" toz="7">
 		<monster name="Dragon" amount="70"/>
 	</areaspawn>

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -37654,6 +37654,7 @@
 		<attribute key="showduration" value="1"/>
 		<attribute key="maxhitchance" value="100"/>
 		<attribute key="duration" value="3600"/>
+		<attribute key="attack" value="78"/>
 		<attribute key="weight" value="90"/>
 	</item>
 	<item id="25759" article="a" name="royal star">


### PR DESCRIPTION
# Description

- Missing attack attribute in conjured spectral bolts.
- Added Grand Mother Foulscale to her raid.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] My changes generate no new warnings