### PR TITLE
fix: disable map async load

### DIFF
--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -62,13 +62,7 @@ int CanaryServer::run() {
 			initializeDatabase();
 			loadModules();
 			setWorldType();
-
-			std::unique_lock lock(mapLoaderLock);
-			mapSignal.wait(lock, [this] { return loaderMapDone; });
-
-			if (!threadFailMsg.empty()) {
-				throw FailedToInitializeCanary(threadFailMsg);
-			}
+			loadMaps();
 
 			logger.info("Initializing gamestate...");
 			g_game().setGameState(GAME_STATE_INIT);
@@ -146,11 +140,15 @@ void CanaryServer::setWorldType() {
 }
 
 void CanaryServer::loadMaps() const {
-	g_game().loadMainMap(g_configManager().getString(MAP_NAME));
+	try {
+		g_game().loadMainMap(g_configManager().getString(MAP_NAME));
 
-	// If "mapCustomEnabled" is true on config.lua, then load the custom map
-	if (g_configManager().getBoolean(TOGGLE_MAP_CUSTOM)) {
-		g_game().loadCustomMaps(g_configManager().getString(DATA_DIRECTORY) + "/world/custom/");
+		// If "mapCustomEnabled" is true on config.lua, then load the custom map
+		if (g_configManager().getBoolean(TOGGLE_MAP_CUSTOM)) {
+			g_game().loadCustomMaps(g_configManager().getString(DATA_DIRECTORY) + "/world/custom/");
+		}
+	} catch (const std::exception &err) {
+		throw FailedToInitializeCanary(err.what());
 	}
 }
 
@@ -323,16 +321,6 @@ void CanaryServer::loadModules() {
 	// Load items dependencies
 	modulesLoadHelper((g_game().loadAppearanceProtobuf(coreFolder + "/items/appearances.dat") == ERROR_NONE), "appearances.dat");
 	modulesLoadHelper(Item::items.loadFromXml(), "items.xml");
-
-	inject<ThreadPool>().addLoad([this] {
-		try {
-			loadMaps();
-		} catch (const std::exception &err) {
-			threadFailMsg = err.what();
-		}
-		loaderMapDone = true;
-		mapSignal.notify_one();
-	});
 
 	auto datapackFolder = g_configManager().getString(DATA_DIRECTORY);
 	logger.debug("Loading core scripts on folder: {}/", coreFolder);

--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -362,8 +362,6 @@ void CanaryServer::loadModules() {
 	g_game().loadBoostedCreature();
 	g_ioBosstiary().loadBoostedBoss();
 	g_ioprey().InitializeTaskHuntOptions();
-	// Spawn monsters and npcs
-	g_game().map.spawnCreatures();
 }
 
 void CanaryServer::modulesLoadHelper(bool loaded, std::string moduleName) {

--- a/src/canary_server.hpp
+++ b/src/canary_server.hpp
@@ -45,7 +45,6 @@ private:
 	ServiceManager &serviceManager;
 
 	std::mutex loaderLock;
-	std::mutex mapLoaderLock;
 	std::condition_variable loaderSignal;
 	std::condition_variable mapSignal;
 	std::unique_lock<std::mutex> loaderUniqueLock;

--- a/src/canary_server.hpp
+++ b/src/canary_server.hpp
@@ -50,7 +50,6 @@ private:
 	std::unique_lock<std::mutex> loaderUniqueLock;
 	std::string threadFailMsg;
 
-	bool loaderMapDone = false;
 	bool loaderDone = false;
 	bool loadFailed = false;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -441,7 +441,7 @@ bool Game::loadItemsPrice() {
 void Game::loadMainMap(const std::string &filename) {
 	Monster::despawnRange = g_configManager().getNumber(DEFAULT_DESPAWNRANGE);
 	Monster::despawnRadius = g_configManager().getNumber(DEFAULT_DESPAWNRADIUS);
-	map.loadMap(g_configManager().getString(DATA_DIRECTORY) + "/world/" + filename + ".otbm", true, true, false, false);
+	map.loadMap(g_configManager().getString(DATA_DIRECTORY) + "/world/" + filename + ".otbm", true, true, true, true);
 }
 
 void Game::loadCustomMaps(const std::filesystem::path &customMapPath) {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -119,11 +119,6 @@ void Map::loadHouseInfo() {
 	IOMapSerialize::loadHouseItems(this);
 }
 
-void Map::spawnCreatures() {
-	IOMap::loadNpcs(this);
-	IOMap::loadMonsters(this);
-}
-
 bool Map::save() {
 	bool saved = false;
 	for (uint32_t tries = 0; tries < 6; tries++) {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -64,7 +64,6 @@ public:
 	void loadMapCustom(const std::string &mapName, bool loadHouses, bool loadMonsters, bool loadNpcs, const int customMapIndex);
 
 	void loadHouseInfo();
-	void spawnCreatures();
 
 	/**
 	 * Save a map.


### PR DESCRIPTION
There is a race between getting to laoding all the NPC/Monster lua files and spawning them via the map.
Previously, on #1507 we attempted to fix that by only spawning them after everything was already loaded.

This fixed the problem in some cases, but created a second race: the map loader prepares to load a custom map after its down, and because its a singleton class with internal state it no longer "knows" where the monster/npc spawn files are.

This PR here reverts the async part of map loading to make it deterministic again, at the expense of the speed up we previously got.
