### PR TITLE
fix: plunder patriarch corpse and sanguine imbuements

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -57620,19 +57620,19 @@
 	<item id="39537" article="a" name="lazyfairy"/>
 	<item id="39538" article="a" name="dead plunder patriarch">
 		<attribute key="containerSize" value="30" />
-		<attribute key="decayTo" value="36539" />
-		<attribute key="duration" value="10" />
+		<attribute key="decayTo" value="39539" />
+		<attribute key="duration" value="300" />
 		<attribute key="fluidSource" value="blood" />
 	</item>
 	<item id="39539" article="a" name="dead plunder patriarch">
 		<attribute key="containerSize" value="30" />
-		<attribute key="decayTo" value="36540" />
+		<attribute key="decayTo" value="39540" />
 		<attribute key="duration" value="300" />
 		<attribute key="fluidSource" value="blood" />
 	</item>
 	<item id="39540" article="a" name="dead plunder patriarch">
 		<attribute key="containerSize" value="15" />
-		<attribute key="decayTo" value="36541" />
+		<attribute key="decayTo" value="39541" />
 		<attribute key="duration" value="300" />
 	</item>
 	<item id="39541" article="a" name="dead plunder patriarch">
@@ -59081,10 +59081,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillsword" value="5"/>
 		<attribute key="weight" value="6100"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost sword" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost sword" value="3"/>
 		</attribute>
 	</item>
 	<item id="43865" article="a" name="grand sanguine blade">
@@ -59095,10 +59096,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillsword" value="5"/>
 		<attribute key="weight" value="6000"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost sword" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost sword" value="3"/>
 		</attribute>
 	</item>
 	<item id="43866" article="a" name="sanguine cudgel">
@@ -59109,10 +59111,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillclub" value="5"/>
 		<attribute key="weight" value="6900"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost club" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost club" value="3"/>
 		</attribute>
 	</item>
 	<item id="43867" article="a" name="grand sanguine cudgel">
@@ -59123,10 +59126,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillclub" value="5"/>
 		<attribute key="weight" value="6800"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost club" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost club" value="3"/>
 		</attribute>
 	</item>
 	<item id="43868" article="a" name="sanguine hatchet">
@@ -59137,10 +59141,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="weight" value="7200"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost axe" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost axe" value="3"/>
 		</attribute>
 	</item>
 	<item id="43869" article="a" name="grand sanguine hatchet">
@@ -59151,10 +59156,11 @@
 		<attribute key="defense" value="32"/>
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="weight" value="7200"/>
-		<attribute key="imbuementslot" value="2">
-			<attribute key="life leech" value="6"/>
+		<attribute key="imbuementslot" value="3">
+			<attribute key="life leech" value="3"/>
 			<attribute key="mana leech" value="3"/>
-			<attribute key="skillboost axe" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost axe" value="3"/>
 		</attribute>
 	</item>
 	<item id="43870" article="a" name="sanguine razor">
@@ -59168,7 +59174,10 @@
 		<attribute key="skillsword" value="5"/>
 		<attribute key="weight" value="8100"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost sword" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost sword" value="3"/>
 		</attribute>
 	</item>
 	<item id="43871" article="a" name="grand sanguine razor">
@@ -59182,7 +59191,10 @@
 		<attribute key="skillsword" value="5"/>
 		<attribute key="weight" value="7900"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost sword" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost sword" value="3"/>
 		</attribute>
 	</item>
 	<item id="43872" article="a" name="sanguine bludgeon">
@@ -59196,7 +59208,10 @@
 		<attribute key="skillclub" value="5"/>
 		<attribute key="weight" value="9300"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost club" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost club" value="3"/>
 		</attribute>
 	</item>
 	<item id="43873" article="a" name="grand sanguine bludgeon">
@@ -59210,7 +59225,10 @@
 		<attribute key="skillclub" value="5"/>
 		<attribute key="weight" value="9100"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost club" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost club" value="3"/>
 		</attribute>
 	</item>
 	<item id="43874" article="a" name="sanguine battleaxe">
@@ -59224,7 +59242,10 @@
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="weight" value="8500"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost axe" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost axe" value="3"/>
 		</attribute>
 	</item>
 	<item id="43875" article="a" name="grand sanguine battleaxe">
@@ -59238,7 +59259,10 @@
 		<attribute key="skillaxe" value="5"/>
 		<attribute key="weight" value="8300"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost axe" value="5"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost axe" value="3"/>
 		</attribute>
 	</item>
 	<item id="43876" article="a" name="sanguine legs">
@@ -59263,7 +59287,11 @@
 		<attribute key="attack" value="9"/>
 		<attribute key="weight" value="4700"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost distance" value="4"/>
+			<attribute key="elemental damage" value="3"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost distance" value="3"/>
 		</attribute>
 	</item>
 	<item id="43878" article="a" name="grand sanguine bow">
@@ -59279,7 +59307,11 @@
 		<attribute key="attack" value="9"/>
 		<attribute key="weight" value="4700"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost distance" value="4"/>
+			<attribute key="elemental damage" value="3"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost distance" value="3"/>
 		</attribute>
 	</item>
 	<item id="43879" article="a" name="sanguine crossbow">
@@ -59295,7 +59327,11 @@
 		<attribute key="attack" value="10"/>
 		<attribute key="weight" value="4700"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost distance" value="4"/>
+			<attribute key="elemental damage" value="3"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost distance" value="3"/>
 		</attribute>
 	</item>
 	<item id="43880" article="a" name="grand sanguine crossbow">
@@ -59311,7 +59347,11 @@
 		<attribute key="attack" value="10"/>
 		<attribute key="weight" value="4700"/>
 		<attribute key="imbuementslot" value="3">
-			<attribute key="skillboost distance" value="4"/>
+			<attribute key="elemental damage" value="3"/>
+			<attribute key="life leech" value="3"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost distance" value="3"/>
 		</attribute>
 	</item>
 	<item id="43881" article="a" name="sanguine greaves">
@@ -59333,9 +59373,9 @@
 		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="weight" value="2200"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="mana leech" value="1"/>
-			<attribute key="life leech" value="2"/>
-			<attribute key="skillboost magic level" value="5"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost magic level" value="3"/>
 		</attribute>
 	</item>
 	<item id="43883" article="a" name="grand sanguine coil">
@@ -59349,9 +59389,9 @@
 		<attribute key="criticalhitchance" value="10"/>
 		<attribute key="weight" value="2100"/>
 		<attribute key="imbuementslot" value="2">
-			<attribute key="mana leech" value="1"/>
-			<attribute key="life leech" value="2"/>
-			<attribute key="skillboost magic level" value="5"/>
+			<attribute key="mana leech" value="3"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost magic level" value="3"/>
 		</attribute>
 	</item>
 	<item id="43884" name="sanguine boots">
@@ -59378,8 +59418,8 @@
 		<attribute key="weight" value="2500"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
-			<attribute key="life leech" value="6"/>
-			<attribute key="skillboost magic level" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost magic level" value="3"/>
 		</attribute>
 	</item>
 	<item id="43886" article="a" name="grand sanguine rod">
@@ -59394,8 +59434,8 @@
 		<attribute key="weight" value="2400"/>
 		<attribute key="imbuementslot" value="2">
 			<attribute key="mana leech" value="3"/>
-			<attribute key="life leech" value="6"/>
-			<attribute key="skillboost magic level" value="5"/>
+			<attribute key="critical hit" value="3"/>
+			<attribute key="skillboost magic level" value="3"/>
 		</attribute>
 	</item>
 	<item id="43887" article="a" name="sanguine galoshes">


### PR DESCRIPTION
# Description

- Wrong corpse decay ids for plunder patriarch.
- More accurate Imbuements for sanguine items.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] My changes generate no new warnings
