### PR TITLE
feat: more robust zone handling

### DIFF
--- a/data/libs/functions/spectators.lua
+++ b/data/libs/functions/spectators.lua
@@ -1,4 +1,5 @@
 ---@author @Glatharth
+---@deprecated Use Zone instead
 Spectators = {}
 setmetatable(Spectators, {
 	__call = function(self)

--- a/data/libs/hazard_lib.lua
+++ b/data/libs/hazard_lib.lua
@@ -108,18 +108,16 @@ function Hazard:register()
 
 	local event = ZoneEvent(self.zone)
 
-	function event.onEnter(zone, creature)
+	function event.afterEnter(zone, creature)
 		local player = creature:getPlayer()
-		if not player then return true end
+		if not player then return end
 		player:setHazardSystemPoints(self:getPlayerCurrentLevel(player))
-		return true
 	end
 
-	function event.onLeave(zone, creature)
+	function event.afterLeave(zone, creature)
 		local player = creature:getPlayer()
-		if not player then return true end
+		if not player then return end
 		player:setHazardSystemPoints(0)
-		return true
 	end
 
 	Hazard.areas[self.name] = self

--- a/data/libs/zones_lib.lua
+++ b/data/libs/zones_lib.lua
@@ -9,10 +9,66 @@
 ---@method getNpcs
 ---@method getItems
 
+function Zone:randomPosition()
+	local positions = self:getPositions()
+	local destination = positions[math.random(1, #positions)]
+	local tile = destination:getTile()
+	while not tile or not tile:isWalkable(false, false, false, false, true) do
+		destination = positions[math.random(1, #positions)]
+		tile = destination:getTile()
+	end
+	return destination
+end
+
+function Zone:sendTextMessage(...)
+	local players = self:getPlayers()
+	for _, player in ipairs(players) do
+		player:sendTextMessage(...)
+	end
+end
+
+function Zone:countMonsters(name)
+	local count = 0
+	for _, monster in ipairs(self:getMonsters()) do
+		if not name or monster:getName():lower() == name:lower() then
+			count = count + 1
+		end
+	end
+	return count
+end
+
+function Zone:countPlayers(notFlag)
+	local players = self:getPlayers()
+	local count = 0
+	for _, player in ipairs(players) do
+		if notFlag then
+			if not player:hasGroupFlag(notFlag) then
+				count = count + 1
+			end
+		else
+			count = count + 1
+		end
+	end
+	return count
+end
+
+function Zone:isInZone(position)
+	local zones = position:getZones()
+	if not zones then return false end
+	for _, zone in ipairs(zones) do
+		if zone == self then
+			return true
+		end
+	end
+	return false
+end
+
 ---@class ZoneEvent
 ---@field public zone Zone
----@field public onEnter function
----@field public onLeave function
+---@field public beforeEnter function
+---@field public beforeLeave function
+---@field public afterEnter function
+---@field public afterLeave function
 ZoneEvent = {}
 
 setmetatable(ZoneEvent, {
@@ -27,34 +83,63 @@ setmetatable(ZoneEvent, {
 	end
 })
 
-
 function ZoneEvent:register()
-	if self.onEnter then
-		local onEnter = EventCallback()
-		function onEnter.zoneOnCreatureEnter(zone, creature)
+	if self.beforeEnter then
+		local beforeEnter = EventCallback()
+		function beforeEnter.zoneBeforeCreatureEnter(zone, creature)
 			if zone ~= self.zone then return true end
-			return self.onEnter(zone, creature)
+			return self.beforeEnter(zone, creature)
 		end
 
-		onEnter:register()
+		beforeEnter:register()
 	end
 
-	if self.onLeave then
-		local onLeave = EventCallback()
-		function onLeave.zoneOnCreatureLeave(zone, creature)
+	if self.beforeLeave then
+		local beforeLeave = EventCallback()
+		function beforeLeave.zoneBeforeCreatureLeave(zone, creature)
 			if zone ~= self.zone then return true end
-			return self.onLeave(zone, creature)
+			return self.beforeLeave(zone, creature)
 		end
 
-		onLeave:register()
+		beforeLeave:register()
+	end
+
+	if self.afterEnter then
+		local afterEnter = EventCallback()
+		function afterEnter.zoneAfterCreatureEnter(zone, creature)
+			if zone ~= self.zone then return true end
+			self.afterEnter(zone, creature)
+		end
+
+		afterEnter:register()
+	end
+
+	if self.afterLeave then
+		local afterLeave = EventCallback()
+		function afterLeave.zoneAfterCreatureLeave(zone, creature)
+			if zone ~= self.zone then return true end
+			self.afterLeave(zone, creature)
+		end
+
+		afterLeave:register()
 	end
 end
 
 function Zone:blockFamiliars()
 	local event = ZoneEvent(self)
-	function event.onEnter(_zone, creature)
+	function event.beforeEnter(_zone, creature)
 		local monster = creature:getMonster()
 		return not (monster and monster:getMaster() and monster:getMaster():isPlayer())
+	end
+
+	event:register()
+end
+
+function Zone:trapMonsters()
+	local event = ZoneEvent(self)
+	function event.beforeLeave(_zone, creature)
+		local monster = creature:getMonster()
+		return not monster
 	end
 
 	event:register()

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9819,7 +9819,7 @@ phmap::parallel_flat_hash_set<T> setDifference(const phmap::parallel_flat_hash_s
 	return setResult;
 }
 
-ReturnValue Game::beforeCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones, bool force /* = false*/) {
+ReturnValue Game::beforeCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones, bool force /* = false*/) const {
 	if (!creature) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -9849,7 +9849,7 @@ ReturnValue Game::beforeCreatureZoneChange(Creature* creature, const phmap::para
 	return RETURNVALUE_NOERROR;
 }
 
-void Game::afterCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones) {
+void Game::afterCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones) const {
 	if (!creature) {
 		return;
 	}

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -634,6 +634,9 @@ public:
 	 */
 	bool tryRetrieveStashItems(Player* player, Item* item);
 
+	ReturnValue beforeCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones, bool force = false);
+	void afterCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones);
+
 	std::unique_ptr<IOWheel> &getIOWheel();
 	const std::unique_ptr<IOWheel> &getIOWheel() const;
 
@@ -851,8 +854,6 @@ private:
 	) const;
 
 	void unwrapItem(Item* item, uint16_t unWrapId, House* house, Player* player);
-
-	ReturnValue onCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones);
 
 	// Variable members (m_)
 	std::unique_ptr<IOWheel> m_IOWheel;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -634,8 +634,8 @@ public:
 	 */
 	bool tryRetrieveStashItems(Player* player, Item* item);
 
-	ReturnValue beforeCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones, bool force = false);
-	void afterCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones);
+	ReturnValue beforeCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones, bool force = false) const;
+	void afterCreatureZoneChange(Creature* creature, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &fromZones, const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &toZones) const;
 
 	std::unique_ptr<IOWheel> &getIOWheel();
 	const std::unique_ptr<IOWheel> &getIOWheel() const;

--- a/src/game/movement/position.hpp
+++ b/src/game/movement/position.hpp
@@ -115,5 +115,14 @@ struct Position {
 	}
 };
 
+namespace std {
+	template <>
+	struct hash<Position> {
+		std::size_t operator()(const Position &p) const {
+			return static_cast<std::size_t>(p.x) | (static_cast<std::size_t>(p.y) << 16) | (static_cast<std::size_t>(p.z) << 32);
+		}
+	};
+}
+
 std::ostream &operator<<(std::ostream &, const Position &);
 std::ostream &operator<<(std::ostream &, const Direction &);

--- a/src/game/zones/zone.cpp
+++ b/src/game/zones/zone.cpp
@@ -232,20 +232,14 @@ void Zone::creatureRemoved(Creature* creature) {
 		return;
 	}
 	creaturesCache.erase(creature->getID());
-	if (creature->getPlayer()) {
-		if (playersCache.erase(creature->getID())) {
-			g_logger().trace("Player {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
-		}
+	if (creature->getPlayer() && playersCache.erase(creature->getID())) {
+		g_logger().trace("Player {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
 	}
-	if (creature->getMonster()) {
-		if (monstersCache.erase(creature->getID())) {
-			g_logger().trace("Monster {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
-		}
+	if (creature->getMonster() && monstersCache.erase(creature->getID())) {
+		g_logger().trace("Monster {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
 	}
-	if (creature->getNpc()) {
-		if (npcsCache.erase(creature->getID())) {
-			g_logger().trace("Npc {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
-		}
+	if (creature->getNpc() && npcsCache.erase(creature->getID())) {
+		g_logger().trace("Npc {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
 	}
 }
 

--- a/src/game/zones/zone.cpp
+++ b/src/game/zones/zone.cpp
@@ -14,13 +14,12 @@
 #include "creatures/monsters/monster.hpp"
 #include "creatures/npcs/npc.hpp"
 #include "creatures/players/player.hpp"
+#include "game/scheduling/dispatcher.hpp"
 
-std::map<std::string, std::shared_ptr<Zone>> Zone::zones = {};
-std::mutex Zone::zonesMutex = {};
+phmap::parallel_flat_hash_map<std::string, std::shared_ptr<Zone>> Zone::zones = {};
 const static std::shared_ptr<Zone> nullZone = nullptr;
 
-const std::shared_ptr<Zone> Zone::addZone(const std::string &name) {
-	std::lock_guard lock(zonesMutex);
+std::shared_ptr<Zone> Zone::addZone(const std::string &name) {
 	if (name == "default") {
 		g_logger().error("Zone name {} is reserved", name);
 		return nullZone;
@@ -38,7 +37,27 @@ void Zone::addArea(Area area) {
 		positions.insert(pos);
 		Tile* tile = g_game().map.getTile(pos);
 		if (tile) {
-			tiles.insert(tile);
+			for (auto item : *tile->getItemList()) {
+				itemAdded(item);
+			}
+			for (auto creature : *tile->getCreatures()) {
+				creatureAdded(creature);
+			}
+		}
+	}
+}
+
+void Zone::subtractArea(Area area) {
+	for (const Position &pos : area) {
+		positions.erase(pos);
+		Tile* tile = g_game().map.getTile(pos);
+		if (tile) {
+			for (auto item : *tile->getItemList()) {
+				itemRemoved(item);
+			}
+			for (auto creature : *tile->getCreatures()) {
+				creatureRemoved(creature);
+			}
 		}
 	}
 }
@@ -47,62 +66,114 @@ bool Zone::isPositionInZone(const Position &pos) const {
 	return positions.contains(pos);
 }
 
-const std::shared_ptr<Zone> Zone::getZone(const std::string &name) {
-	std::lock_guard lock(zonesMutex);
+Position Zone::getRemoveDestination(Creature* creature /* = nullptr */) const {
+	if (!creature || !creature->getPlayer()) {
+		return Position();
+	}
+	if (removeDestination != Position()) {
+		return removeDestination;
+	}
+	if (creature->getPlayer()) {
+		return creature->getPlayer()->getTown()->getTemplePosition();
+	}
+	return Position();
+}
+
+std::shared_ptr<Zone> Zone::getZone(const std::string &name) {
 	return zones[name];
 }
 
-const std::set<Position> &Zone::getPositions() const {
+const phmap::parallel_flat_hash_set<Position> &Zone::getPositions() const {
 	return positions;
 }
 
 const phmap::parallel_flat_hash_set<Tile*> &Zone::getTiles() const {
+	static phmap::parallel_flat_hash_set<Tile*> tiles;
+	tiles.clear();
+	for (const auto &position : positions) {
+		Tile* tile = g_game().map.getTile(position);
+		if (tile) {
+			tiles.insert(tile);
+		}
+	}
 	return tiles;
 }
 
 const phmap::parallel_flat_hash_set<Creature*> &Zone::getCreatures() const {
+	static phmap::parallel_flat_hash_set<Creature*> creatures;
+	creatures.clear();
+	for (const auto creatureId : creaturesCache) {
+		auto creature = g_game().getCreatureByID(creatureId);
+		if (creature) {
+			creatures.insert(creature);
+		}
+	}
 	return creatures;
 }
 
 const phmap::parallel_flat_hash_set<Player*> &Zone::getPlayers() const {
+	static phmap::parallel_flat_hash_set<Player*> players;
+	players.clear();
+	for (const auto playerId : playersCache) {
+		auto player = g_game().getPlayerByID(playerId);
+		if (player) {
+			players.insert(player);
+		}
+	}
 	return players;
 }
 
 const phmap::parallel_flat_hash_set<Monster*> &Zone::getMonsters() const {
+	static phmap::parallel_flat_hash_set<Monster*> monsters;
+	monsters.clear();
+	for (const auto monsterId : monstersCache) {
+		auto monster = g_game().getMonsterByID(monsterId);
+		if (monster) {
+			monsters.insert(monster);
+		}
+	}
 	return monsters;
 }
 
 const phmap::parallel_flat_hash_set<Npc*> &Zone::getNpcs() const {
+	static phmap::parallel_flat_hash_set<Npc*> npcs;
+	npcs.clear();
+	for (const auto npcId : npcsCache) {
+		auto npc = g_game().getNpcByID(npcId);
+		if (npc) {
+			npcs.insert(npc);
+		}
+	}
 	return npcs;
 }
 
 const phmap::parallel_flat_hash_set<Item*> &Zone::getItems() const {
-	return items;
+	return itemsCache;
+}
+
+void Zone::removePlayers() const {
+	for (auto player : getPlayers()) {
+		g_game().internalTeleport(player, getRemoveDestination(player));
+	}
 }
 
 void Zone::removeMonsters() const {
-	// copy monsters because removeCreature will remove monster from monsters
-	phmap::parallel_flat_hash_set<Monster*> monstersCopy = monsters;
-	for (auto monster : monstersCopy) {
+	for (auto monster : getMonsters()) {
 		g_game().removeCreature(monster);
 	}
 }
 
 void Zone::removeNpcs() const {
-	// copy npcs because removeCreature will remove npc from npcs
-	phmap::parallel_flat_hash_set<Npc*> npcsCopy = npcs;
-	for (auto npc : npcsCopy) {
+	for (auto npc : getNpcs()) {
 		g_game().removeCreature(npc);
 	}
 }
 
 void Zone::clearZones() {
-	std::lock_guard lock(zonesMutex);
 	zones.clear();
 }
 
-phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> Zone::getZones(const Position &postion) {
-	std::lock_guard lock(zonesMutex);
+phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> Zone::getZones(const Position postion) {
 	phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> zonesSet;
 	for (const auto &[_, zone] : zones) {
 		if (zone && zone->isPositionInZone(postion)) {
@@ -124,35 +195,82 @@ const phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &Zone::getZones() {
 }
 
 void Zone::creatureAdded(Creature* creature) {
-	creatures.insert(creature);
+	if (!creature) {
+		return;
+	}
+
+	uint32_t id = 0;
 	if (creature->getPlayer()) {
-		players.insert(creature->getPlayer());
+		id = creature->getPlayer()->getID();
+		auto [_, playerInserted] = playersCache.insert(id);
+		if (playerInserted) {
+			g_logger().trace("Player {} (ID: {}) added to zone {}", creature->getName(), id, name);
+		}
 	}
 	if (creature->getMonster()) {
-		monsters.insert(creature->getMonster());
+		id = creature->getMonster()->getID();
+		auto [_, monsterInserted] = monstersCache.insert(id);
+		if (monsterInserted) {
+			g_logger().trace("Monster {} (ID: {}) added to zone {}", creature->getName(), id, name);
+		}
 	}
 	if (creature->getNpc()) {
-		npcs.insert(creature->getNpc());
+		id = creature->getNpc()->getID();
+		auto [_, npcInserted] = npcsCache.insert(id);
+		if (npcInserted) {
+			g_logger().trace("Npc {} (ID: {}) added to zone {}", creature->getName(), id, name);
+		}
+	}
+
+	if (id != 0) {
+		creaturesCache.insert(id);
 	}
 }
 
 void Zone::creatureRemoved(Creature* creature) {
-	creatures.erase(creature);
+	if (!creature) {
+		return;
+	}
+	creaturesCache.erase(creature->getID());
 	if (creature->getPlayer()) {
-		players.erase(creature->getPlayer());
+		if (playersCache.erase(creature->getID())) {
+			g_logger().trace("Player {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
+		}
 	}
 	if (creature->getMonster()) {
-		monsters.erase(creature->getMonster());
+		if (monstersCache.erase(creature->getID())) {
+			g_logger().trace("Monster {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
+		}
 	}
 	if (creature->getNpc()) {
-		npcs.erase(creature->getNpc());
+		if (npcsCache.erase(creature->getID())) {
+			g_logger().trace("Npc {} (ID: {}) removed from zone {}", creature->getName(), creature->getID(), name);
+		}
+	}
+}
+
+void Zone::thingAdded(Thing* thing) {
+	if (!thing) {
+		return;
+	}
+
+	if (thing->getItem()) {
+		itemAdded(thing->getItem());
+	} else if (thing->getCreature()) {
+		creatureAdded(thing->getCreature());
 	}
 }
 
 void Zone::itemAdded(Item* item) {
-	items.insert(item);
+	if (!item) {
+		return;
+	}
+	itemsCache.insert(item);
 }
 
 void Zone::itemRemoved(Item* item) {
-	items.erase(item);
+	if (!item) {
+		return;
+	}
+	itemsCache.erase(item);
 }

--- a/src/game/zones/zone.hpp
+++ b/src/game/zones/zone.hpp
@@ -17,6 +17,7 @@ class Monster;
 class Player;
 class Npc;
 class Item;
+class Thing;
 
 struct Area {
 	constexpr Area() = default;
@@ -90,9 +91,14 @@ public:
 		return name;
 	}
 	void addArea(Area area);
+	void subtractArea(Area area);
 	bool isPositionInZone(const Position &position) const;
+	Position getRemoveDestination(Creature* creature = nullptr) const;
+	void setRemoveDestination(const Position &position) {
+		removeDestination = position;
+	}
 
-	const std::set<Position> &getPositions() const;
+	const phmap::parallel_flat_hash_set<Position> &getPositions() const;
 	const phmap::parallel_flat_hash_set<Tile*> &getTiles() const;
 	const phmap::parallel_flat_hash_set<Creature*> &getCreatures() const;
 	const phmap::parallel_flat_hash_set<Player*> &getPlayers() const;
@@ -102,28 +108,30 @@ public:
 
 	void creatureAdded(Creature* creature);
 	void creatureRemoved(Creature* creature);
+	void thingAdded(Thing* thing);
 	void itemAdded(Item* item);
 	void itemRemoved(Item* item);
 
+	void removePlayers() const;
 	void removeMonsters() const;
 	void removeNpcs() const;
 
-	const static std::shared_ptr<Zone> addZone(const std::string &name);
-	const static std::shared_ptr<Zone> getZone(const std::string &name);
-	static phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> getZones(const Position &position);
+	static std::shared_ptr<Zone> addZone(const std::string &name);
+	static std::shared_ptr<Zone> getZone(const std::string &name);
+	static phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> getZones(const Position position);
 	const static phmap::parallel_flat_hash_set<std::shared_ptr<Zone>> &getZones();
 	static void clearZones();
 
 private:
+	Position removeDestination = Position();
 	std::string name;
-	std::set<Position> positions;
-	phmap::parallel_flat_hash_set<Tile*> tiles;
-	phmap::parallel_flat_hash_set<Item*> items;
-	phmap::parallel_flat_hash_set<Creature*> creatures;
-	phmap::parallel_flat_hash_set<Monster*> monsters;
-	phmap::parallel_flat_hash_set<Npc*> npcs;
-	phmap::parallel_flat_hash_set<Player*> players;
+	phmap::parallel_flat_hash_set<Position> positions;
 
-	static std::mutex zonesMutex;
-	static std::map<std::string, std::shared_ptr<Zone>> zones;
+	phmap::parallel_flat_hash_set<Item*> itemsCache;
+	phmap::parallel_flat_hash_set<uint32_t> creaturesCache;
+	phmap::parallel_flat_hash_set<uint32_t> monstersCache;
+	phmap::parallel_flat_hash_set<uint32_t> npcsCache;
+	phmap::parallel_flat_hash_set<uint32_t> playersCache;
+
+	static phmap::parallel_flat_hash_map<std::string, std::shared_ptr<Zone>> zones;
 };

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -347,10 +347,6 @@ void Tile::onAddTileItem(Item* item) {
 
 	setTileFlags(item);
 
-	for (const auto zone : getZones()) {
-		zone->itemAdded(item);
-	}
-
 	const Position &cylinderMapPos = getPosition();
 
 	SpectatorHashSet spectators;
@@ -455,7 +451,6 @@ void Tile::onRemoveTileItem(const SpectatorHashSet &spectators, const std::vecto
 			it->second->removeThing(item, item->getItemCount());
 		}
 	}
-
 	for (const auto zone : getZones()) {
 		zone->itemRemoved(item);
 	}
@@ -1537,6 +1532,9 @@ void Tile::internalAddThing(Thing* thing) {
 void Tile::internalAddThing(uint32_t, Thing* thing) {
 	if (!thing) {
 		return;
+	}
+	for (const auto zone : getZones()) {
+		zone->thingAdded(thing);
 	}
 
 	thing->setParent(this);

--- a/src/lua/callbacks/callbacks_definitions.hpp
+++ b/src/lua/callbacks/callbacks_definitions.hpp
@@ -63,6 +63,8 @@ enum class EventCallback_t : uint16_t {
 	// Npc
 	npcOnSpawn,
 	// Zone
-	zoneOnCreatureEnter,
-	zoneOnCreatureLeave,
+	zoneBeforeCreatureEnter,
+	zoneBeforeCreatureLeave,
+	zoneAfterCreatureEnter,
+	zoneAfterCreatureLeave,
 };

--- a/src/lua/callbacks/event_callback.hpp
+++ b/src/lua/callbacks/event_callback.hpp
@@ -126,8 +126,10 @@ public:
 	void npcOnSpawn(Npc* npc, const Position &position) const;
 
 	// Zone
-	bool zoneOnCreatureEnter(std::shared_ptr<Zone> zone, Creature* creature) const;
-	bool zoneOnCreatureLeave(std::shared_ptr<Zone> zone, Creature* creature) const;
+	bool zoneBeforeCreatureEnter(std::shared_ptr<Zone> zone, Creature* creature) const;
+	bool zoneBeforeCreatureLeave(std::shared_ptr<Zone> zone, Creature* creature) const;
+	void zoneAfterCreatureEnter(std::shared_ptr<Zone> zone, Creature* creature) const;
+	void zoneAfterCreatureLeave(std::shared_ptr<Zone> zone, Creature* creature) const;
 
 	/**
 	 * @note here end the lua binder functions }

--- a/src/lua/functions/core/game/zone_functions.cpp
+++ b/src/lua/functions/core/game/zone_functions.cpp
@@ -47,7 +47,7 @@ int ZoneFunctions::luaZoneGetName(lua_State* L) {
 }
 
 int ZoneFunctions::luaZoneAddArea(lua_State* L) {
-	// Zone:addArea(area, fromPos, toPos)
+	// Zone:addArea(fromPos, toPos)
 	auto zone = getUserdataShared<Zone>(L, 1);
 	if (!zone) {
 		reportErrorFunc(getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
@@ -59,6 +59,45 @@ int ZoneFunctions::luaZoneAddArea(lua_State* L) {
 	auto area = Area(fromPos, toPos);
 	zone->addArea(area);
 	pushBoolean(L, true);
+	return 1;
+}
+
+int ZoneFunctions::luaZoneSubtractArea(lua_State* L) {
+	// Zone:subtractArea(fromPos, toPos)
+	auto zone = getUserdataShared<Zone>(L, 1);
+	if (!zone) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
+		pushBoolean(L, false);
+		return 1;
+	}
+	auto fromPos = getPosition(L, 2);
+	auto toPos = getPosition(L, 3);
+	auto area = Area(fromPos, toPos);
+	zone->subtractArea(area);
+	pushBoolean(L, true);
+	return 1;
+}
+
+int ZoneFunctions::luaZoneGetRemoveDestination(lua_State* L) {
+	// Zone:getRemoveDestination()
+	auto zone = getUserdataShared<Zone>(L, 1);
+	if (!zone) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
+		return 1;
+	}
+	pushPosition(L, zone->getRemoveDestination());
+	return 1;
+}
+
+int ZoneFunctions::luaZoneSetRemoveDestination(lua_State* L) {
+	// Zone:setRemoveDestination(pos)
+	auto zone = getUserdataShared<Zone>(L, 1);
+	if (!zone) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
+		return 1;
+	}
+	auto pos = getPosition(L, 2);
+	zone->setRemoveDestination(pos);
 	return 1;
 }
 
@@ -208,6 +247,19 @@ int ZoneFunctions::luaZoneGetItems(lua_State* L) {
 	return 1;
 }
 
+int ZoneFunctions::luaZoneRemovePlayers(lua_State* L) {
+	// Zone:removePlayers()
+	auto zone = getUserdataShared<Zone>(L, 1);
+	if (!zone) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	zone->removePlayers();
+	return 1;
+}
+
 int ZoneFunctions::luaZoneRemoveMonsters(lua_State* L) {
 	// Zone:removeMonsters()
 	auto zone = getUserdataShared<Zone>(L, 1);
@@ -217,7 +269,7 @@ int ZoneFunctions::luaZoneRemoveMonsters(lua_State* L) {
 		return 1;
 	}
 	zone->removeMonsters();
-	return 0;
+	return 1;
 }
 
 int ZoneFunctions::luaZoneRemoveNpcs(lua_State* L) {
@@ -229,7 +281,7 @@ int ZoneFunctions::luaZoneRemoveNpcs(lua_State* L) {
 		return 1;
 	}
 	zone->removeNpcs();
-	return 0;
+	return 1;
 }
 
 int ZoneFunctions::luaZoneGetByName(lua_State* L) {

--- a/src/lua/functions/core/game/zone_functions.hpp
+++ b/src/lua/functions/core/game/zone_functions.hpp
@@ -12,6 +12,9 @@ public:
 
 		registerMethod(L, "Zone", "getName", ZoneFunctions::luaZoneGetName);
 		registerMethod(L, "Zone", "addArea", ZoneFunctions::luaZoneAddArea);
+		registerMethod(L, "Zone", "subtractArea", ZoneFunctions::luaZoneSubtractArea);
+		registerMethod(L, "Zone", "getRemoveDestination", ZoneFunctions::luaZoneGetRemoveDestination);
+		registerMethod(L, "Zone", "setRemoveDestination", ZoneFunctions::luaZoneSetRemoveDestination);
 		registerMethod(L, "Zone", "getPositions", ZoneFunctions::luaZoneGetPositions);
 		registerMethod(L, "Zone", "getTiles", ZoneFunctions::luaZoneGetTiles);
 		registerMethod(L, "Zone", "getCreatures", ZoneFunctions::luaZoneGetCreatures);
@@ -20,6 +23,7 @@ public:
 		registerMethod(L, "Zone", "getNpcs", ZoneFunctions::luaZoneGetNpcs);
 		registerMethod(L, "Zone", "getItems", ZoneFunctions::luaZoneGetItems);
 
+		registerMethod(L, "Zone", "removePlayers", ZoneFunctions::luaZoneRemovePlayers);
 		registerMethod(L, "Zone", "removeMonsters", ZoneFunctions::luaZoneRemoveMonsters);
 		registerMethod(L, "Zone", "removeNpcs", ZoneFunctions::luaZoneRemoveNpcs);
 
@@ -35,6 +39,10 @@ private:
 
 	static int luaZoneGetName(lua_State* L);
 	static int luaZoneAddArea(lua_State* L);
+	static int luaZoneSubtractArea(lua_State* L);
+	static int luaZoneGetRemoveDestination(lua_State* L);
+	static int luaZoneSetRemoveDestination(lua_State* L);
+	static int luaZoneRefresh(lua_State* L);
 	static int luaZoneGetPositions(lua_State* L);
 	static int luaZoneGetTiles(lua_State* L);
 	static int luaZoneGetCreatures(lua_State* L);
@@ -43,6 +51,7 @@ private:
 	static int luaZoneGetNpcs(lua_State* L);
 	static int luaZoneGetItems(lua_State* L);
 
+	static int luaZoneRemovePlayers(lua_State* L);
 	static int luaZoneRemoveMonsters(lua_State* L);
 	static int luaZoneRemoveNpcs(lua_State* L);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -14,6 +14,7 @@
 
 #include "creatures/monsters/monster.hpp"
 #include "game/game.hpp"
+#include "game/zones/zone.hpp"
 #include "io/iomap.hpp"
 #include "io/iomapserialize.hpp"
 
@@ -282,6 +283,12 @@ void Map::moveCreature(Creature &creature, Tile &newTile, bool forceTeleport /* 
 	Position oldPos = oldTile.getPosition();
 	Position newPos = newTile.getPosition();
 
+	auto fromZones = oldTile.getZones();
+	auto toZones = newTile.getZones();
+	if (auto ret = g_game().beforeCreatureZoneChange(&creature, fromZones, toZones); ret != RETURNVALUE_NOERROR) {
+		return;
+	}
+
 	bool teleport = forceTeleport || !newTile.getGround() || !Position::areInRange<1, 1, 0>(oldPos, newPos);
 
 	SpectatorHashSet spectators;
@@ -347,6 +354,7 @@ void Map::moveCreature(Creature &creature, Tile &newTile, bool forceTeleport /* 
 
 	oldTile.postRemoveNotification(&creature, &newTile, 0);
 	newTile.postAddNotification(&creature, &oldTile, 0);
+	g_game().afterCreatureZoneChange(&creature, fromZones, toZones);
 }
 
 void Map::getSpectatorsInternal(SpectatorHashSet &spectators, const Position &centerPos, int32_t minRangeX, int32_t maxRangeX, int32_t minRangeY, int32_t maxRangeY, int32_t minRangeZ, int32_t maxRangeZ, bool onlyPlayers) const {


### PR DESCRIPTION
This adds a lot of safety to how we handle Zones. Making it so dealing with the contents of a zone is never going to respond with creatures that have already been deleted.

This also migrated the `bosslever.lua` to use zones, and deprectes the Spectators library. Zones are a more flexible way to achieve the same thing, and more. This should also fix a potential crazy with the removal of players from a bosslever room since that was previously done with an unsafe call to `addEvent`.
