### PR TITLE
fix: webhook race condition crash

### DIFF
--- a/src/server/network/webhook/webhook.cpp
+++ b/src/server/network/webhook/webhook.cpp
@@ -121,11 +121,11 @@ std::string Webhook::getPayload(const std::string title, const std::string messa
 }
 
 void Webhook::sendWebhook() {
+	std::scoped_lock lock { taskLock };
 	if (webhooks.empty()) {
 		return;
 	}
 
-	std::scoped_lock lock { taskLock };
 	auto task = webhooks.front();
 
 	std::string response_body;


### PR DESCRIPTION
Solves #1522 

When sending webhooks there is a small chance that the webhooks.empty() if passes but when it gets the task the webhooks deque is already empty.

That causes task to be a nullptr and accessing it causes a segmentation fault.

There are two ways to solve if: place the lock in the beginning of the function or check if task exists before proceeding, we are adopting the first.