### PR TITLE
fix: inverted panel and shrine in daily reward

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -241,7 +241,7 @@ DailyReward.loadDailyReward = function(playerId, target)
 	end
 
 	target = REWARD_FROM_PANEL
-	if target ~= 0 then
+	if target == 0 then
 		target = REWARD_FROM_SHRINE
 	end
 

--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -240,9 +240,8 @@ DailyReward.loadDailyReward = function(playerId, target)
 		return false
 	end
 
-	target = REWARD_FROM_PANEL
-	if target == 0 then
-		target = REWARD_FROM_SHRINE
+	if target ~= 0 then
+		target = REWARD_FROM_PANEL
 	end
 
 	player:sendCollectionResource(ClientPackets.JokerResource, player:getJokerTokens())


### PR DESCRIPTION
# Description

When entering, clicking on the shrine, the "instant reward access" was being requested, as in the panel option.

I performed the test with print(target) and confirmed return 0 for REWARD_FROM_SHRINE and return 1 for REWARD_FROM_PANEL

close: #1537

**Test Configuration**:

  - Server Version: Canary Main
  - Client: 13.20
  - Operating System: Windows
