### PR TITLE
fix: inverted bit in daily reward

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -243,7 +243,7 @@ DailyReward.loadDailyReward = function(playerId, target)
 	if target == REWARD_FROM_SHRINE then -- if you receive 0 (shrine) send 1
 		target = 1
 	else
-		target = 2 -- if you receive 1 (panel) send 0
+		target = 0 -- if you receive 1 (panel) send 0
 	end
 
 	player:sendCollectionResource(ClientPackets.JokerResource, player:getJokerTokens())

--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -240,8 +240,10 @@ DailyReward.loadDailyReward = function(playerId, target)
 		return false
 	end
 
-	if target ~= 0 then
-		target = REWARD_FROM_PANEL
+	if target == REWARD_FROM_SHRINE then -- if you receive 0 (shrine) send 1
+		target = 1
+	else
+		target = 2 -- if you receive 1 (panel) send 0
 	end
 
 	player:sendCollectionResource(ClientPackets.JokerResource, player:getJokerTokens())


### PR DESCRIPTION
# Description

if the "loadDailyReward" function receives 0 (used from the shrine) it must return 1, and if it receives 1 (used from the panel) it must return 0.