### PR TITLE
feat: various talkaction upgrades

### DIFF
--- a/data/scripts/talkactions/gm/teleport_to_active_player.lua
+++ b/data/scripts/talkactions/gm/teleport_to_active_player.lua
@@ -1,0 +1,32 @@
+local teleportToCreature = TalkAction("/active")
+
+function teleportToCreature.onSay(player, words, param)
+	-- create log
+	logCommand(player, words, param)
+
+	local players = Game.getPlayers()
+	local activePlayers = {}
+
+	for _, targetPlayer in ipairs(players) do
+		local isGhost = targetPlayer:isInGhostMode()
+		local isTraining = onExerciseTraining[targetPlayer:getId()]
+		local isIdle = targetPlayer:getIdleTime() >= 5 * 60 * 1000
+		local isActive = not isGhost and not isTraining and not isIdle
+		if isActive then
+			table.insert(activePlayers, targetPlayer)
+		end
+	end
+
+	if #activePlayers == 0 then
+		player:sendCancelMessage("There are no active players.")
+		return false
+	end
+
+	local targetPlayer = activePlayers[math.random(#activePlayers)]
+	player:teleportTo(targetPlayer:getPosition())
+	return false
+end
+
+teleportToCreature:separator(" ")
+teleportToCreature:groupType("gamemaster")
+teleportToCreature:register()

--- a/data/scripts/talkactions/god/add_addon.lua
+++ b/data/scripts/talkactions/god/add_addon.lua
@@ -1,0 +1,45 @@
+local addons = TalkAction("/addaddon")
+
+function addons.onSay(player, words, param)
+	-- create log
+	logCommand(player, words, param)
+
+	local target
+	local split = param:split(",")
+	local name = split[1]
+
+	if param == '' then
+		target = player:getTarget()
+		if not target then
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'Gives players the ability to wear addon for a specific outfit. Usage: /addaddon <player name>, <looktype>')
+			return true
+		end
+	else
+		target = Player(name)
+	end
+
+	if not target then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'Player ' .. name .. ' is currently not online.')
+		return false
+	end
+
+	local looktype = tonumber(split[2])
+	if not looktype then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'Invalid looktype.')
+		return false
+	end
+
+	local addons = tonumber(split[3])
+	if not addons or addons < 0 or addons > 3 then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'Invalid addon.')
+		return false
+	end
+
+	target:addOutfitAddon(looktype, addons)
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 'Addon for looktype  ' .. looktype .. 'a for ' .. target:getName() .. ' set to ' .. addons .. '.')
+	return false
+end
+
+addons:separator(" ")
+addons:groupType("god")
+addons:register()

--- a/data/scripts/talkactions/god/add_mount.lua
+++ b/data/scripts/talkactions/god/add_mount.lua
@@ -1,0 +1,39 @@
+--[[
+	/addmount playername, mount
+]]
+
+local printConsole = true
+
+local addOutfit = TalkAction("/addmount")
+
+function addOutfit.onSay(player, words, param)
+	-- create log
+	logCommand(player, words, param)
+
+	if param == "" then
+		player:sendCancelMessage("Command param required.")
+		return true
+	end
+
+	local split = param:split(",")
+	local name = split[1]
+
+	local target = Player(name)
+	if target then
+		local mount = tonumber(split[2])
+		target:addMount(mount)
+		target:sendTextMessage(MESSAGE_ADMINISTRADOR, "" .. player:getName() .. " has been added a new mount for you.")
+		player:sendTextMessage(MESSAGE_ADMINISTRADOR, "You have sucessfull added mount " .. mount .. " to the player " .. target:getName() .. ".")
+		if printConsole then
+			logger.info("[addOutfit.onSay] - Player: {} has been added mount: {} to the player: {}",
+				player:getName(), lookType, target:getName())
+		end
+		return true
+	end
+	player:sendCancelMessage("Player not found.")
+	return true
+end
+
+addOutfit:separator(" ")
+addOutfit:groupType("god")
+addOutfit:register()

--- a/data/scripts/talkactions/god/charms.lua
+++ b/data/scripts/talkactions/god/charms.lua
@@ -1,23 +1,20 @@
 local addCharm = TalkAction("/addcharms")
 
 function addCharm.onSay(player, words, param)
-	-- create log
-	logCommand(player, words, param)
-
 	local usage = "/addcharms PLAYER NAME,AMOUNT"
 	if param == "" then
 		player:sendCancelMessage("Command param required. Usage: " .. usage)
-		return true
+		return false
 	end
 	local split = param:split(",")
 	if not split[2] then
 		player:sendCancelMessage("Insufficient parameters. Usage: " .. usage)
-		return true
+		return false
 	end
 	local target = Player(split[1])
 	if not target then
 		player:sendCancelMessage("A player with that name is not online.")
-		return true
+		return false
 	end
 	--trim left
 	split[2] = split[2]:gsub("^%s*(.-)$", "%1")

--- a/data/scripts/talkactions/god/close_server.lua
+++ b/data/scripts/talkactions/god/close_server.lua
@@ -8,6 +8,23 @@ function closeServer.onSay(player, words, param)
 		Game.setGameState(GAME_STATE_SHUTDOWN)
 		Webhook.sendMessage("Server Shutdown", "Server was shutdown by: " .. player:getName(),
 			WEBHOOK_COLOR_WARNING, announcementChannels["serverAnnouncements"])
+	elseif param == "save" then
+		if configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_CLEAN_MAP) then
+			cleanMap()
+		end
+		if configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_CLOSE) then
+			Game.setGameState(GAME_STATE_CLOSED, true)
+		end
+		if configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_SHUTDOWN) then
+			Game.setGameState(GAME_STATE_SHUTDOWN, true)
+		end
+		-- Updating daily reward next server save.
+		UpdateDailyRewardGlobalStorage(DailyReward.storages.lastServerSave, os.time())
+		-- Reset gamestore exp boost count.
+		db.query('UPDATE `player_storage` SET `value` = 0 WHERE `player_storage`.`key` = 51052')
+	elseif param == "maintainance" then
+		Game.setGameState(GAME_STATE_MAINTAIN)
+		player:sendTextMessage(MESSAGE_ADMINISTRADOR, "Server is set to maintenance mode.")
 	else
 		Game.setGameState(GAME_STATE_CLOSED)
 		player:sendTextMessage(MESSAGE_ADMINISTRADOR, "Server is now closed.")

--- a/data/scripts/talkactions/god/inbox_command.lua
+++ b/data/scripts/talkactions/god/inbox_command.lua
@@ -1,0 +1,36 @@
+local inboxCommand = TalkAction("/inbox")
+
+function inboxCommand.onSay(player, words, param)
+	param = param:split(',')
+	player:getPosition():sendMagicEffect(CONST_ME_TUTORIALSQUARE)
+	local target = Creature(param[1])
+	if target then
+		local inbox = target:getSlotItem(CONST_SLOT_STORE_INBOX)
+		local inboxSize = inbox:getSize()
+		if inbox and inboxSize > 0 then
+			if param[2] == 'remove' then
+				for i = 0, inboxSize do
+					local item = inbox:getItem(i)
+					if item and item:getId() == tonumber(param[3]) then
+						local itemToDelete = Item(item.uid)
+						if itemToDelete then
+							itemToDelete:remove()
+							player:say(item:getId() .. ' removed')
+						end
+					end
+				end
+			elseif param[2] == 'add' then
+				inbox:addItem(tonumber(param[3]), 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
+				player:say(tonumber(param[3]) .. ' added')
+			end
+		end
+	else
+		player:sendCancelMessage("Creature not found.")
+	end
+
+	return false
+end
+
+inboxCommand:separator(" ")
+inboxCommand:groupType("god")
+inboxCommand:register()

--- a/data/scripts/talkactions/god/zones.lua
+++ b/data/scripts/talkactions/god/zones.lua
@@ -58,11 +58,7 @@ function zones.onSay(player, words, param)
 			player:sendTextMessage(MESSAGE_HEALED, "Zone " .. zone:getName() .. " NPCs: " .. #npcs .. ".")
 		end,
 		kickPlayers = function(zone)
-			local players = zone:getPlayers()
-			for _, player in ipairs(players) do
-				player:teleportTo(player:getTown():getTemplePosition())
-				player:sendTextMessage(MESSAGE_HEALED, "You have been kicked from " .. zone:getName() .. ".")
-			end
+			zone:removePlayers()
 			player:sendTextMessage(MESSAGE_HEALED, "Players kicked from " .. zone:getName() .. ".")
 		end,
 		listPlayers = function(zone)


### PR DESCRIPTION
New talkactions:
- `/active`: allows GMs to teleport to a player who is not idle or training
- `/addaddon`: allow Gods to add addons to a player
- `/addmount`: addlow Gods to add a mount to a player

Fixes:
- Reviewed most talkactions so that they won't get sent as a message when the command is executed
