### PR TITLE
feat: tibia coin item

### DIFF
--- a/data-otservbr-global/scripts/actions/store_coins.lua
+++ b/data-otservbr-global/scripts/actions/store_coins.lua
@@ -1,0 +1,12 @@
+local storeCoin = Action()
+
+function storeCoin.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
+	local count = item:getCount()
+	item:remove()
+	player:addTransferableCoins(count)
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have added " .. count .. " tibia coins to your balance. Your total is now " .. player:getTransferableCoins() .. ".")
+end
+
+storeCoin:id(ITEM_STORE_COIN)
+storeCoin:register()

--- a/src/lua/functions/core/game/lua_enums.cpp
+++ b/src/lua/functions/core/game/lua_enums.cpp
@@ -829,6 +829,7 @@ void LuaEnums::initItemIdEnums(lua_State* L) {
 	registerEnum(L, ITEM_GOLD_COIN);
 	registerEnum(L, ITEM_PLATINUM_COIN);
 	registerEnum(L, ITEM_CRYSTAL_COIN);
+	registerEnum(L, ITEM_STORE_COIN);
 	registerEnum(L, ITEM_REWARD_CHEST);
 	registerEnum(L, ITEM_REWARD_CONTAINER);
 	registerEnum(L, ITEM_AMULETOFLOSS);


### PR DESCRIPTION
This is a tiny little script for the Tibia Coin item. This can be used to create an in-game tradeable Tibia Coin item that players can use to gain TC.
It enables safer trading of items in-game for this currency.
