### PR TITLE
feat: chain improvements for lower range

### DIFF
--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -324,7 +324,8 @@ public:
 
 private:
 	static void doChainEffect(const Position &origin, const Position &pos, uint8_t effect);
-	static void pickChainTargets(Creature* caster, std::vector<Creature*> &targets, std::set<uint32_t> &targetSet, std::set<uint32_t> &visited, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool backtracking, bool aggressive);
+	static std::vector<std::pair<Position, std::vector<uint32_t>>> pickChainTargets(Creature* caster, const CombatParams &params, uint8_t chainDistance, uint8_t maxTargets, bool aggressive, bool backtracking, Creature* initialTarget = nullptr);
+	static bool isValidChainTarget(Creature* caster, Creature* currentTarget, Creature* potentialTarget, const CombatParams &params, bool aggressive);
 
 	static void doCombatDefault(Creature* caster, Creature* target, const CombatParams &params);
 

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -880,12 +880,6 @@ void PlayerWheel::loadDBPlayerSlotPointsOnLogin() {
 bool PlayerWheel::saveDBPlayerSlotPointsOnLogout() const {
 	Database &db = Database::getInstance();
 	std::ostringstream query;
-	query << "DELETE FROM `player_wheeldata` WHERE `player_id` = " << m_player.getGUID();
-	if (!db.executeQuery(query.str())) {
-		return false;
-	}
-	query.str(std::string());
-
 	DBInsert insertWheelData("INSERT INTO `player_wheeldata` (`player_id`, `slot`) VALUES ");
 	insertWheelData.upsert({ "slot" });
 	PropWriteStream stream;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2525,7 +2525,7 @@ void Game::internalQuickLootCorpse(Player* player, Container* corpse) {
 		ss << " (automatic looting)";
 	}
 	ss << ".";
-	player->sendTextMessage(MESSAGE_LOOT, ss.str());
+	player->sendTextMessage(MESSAGE_STATUS, ss.str());
 
 	if (shouldNotifyCapacity) {
 		ss.str(std::string());

--- a/src/game/movement/position.hpp
+++ b/src/game/movement/position.hpp
@@ -62,6 +62,11 @@ struct Position {
 	static int32_t getDiagonalDistance(const Position &p1, const Position &p2) {
 		return std::max(Position::getDistanceX(p1, p2), Position::getDistanceY(p1, p2));
 	}
+	static double getEuclideanDistance(const Position &p1, const Position &p2) {
+		int32_t dx = Position::getDistanceX(p1, p2);
+		int32_t dy = Position::getDistanceY(p1, p2);
+		return std::sqrt(dx * dx + dy * dy);
+	}
 
 	static Direction getRandomDirection();
 


### PR DESCRIPTION
The C++ chain system works well today if the chain ability can hit further than 2 squares. But for 1 tile chaining it tends to pick too few targets and be sub-optimal. This isn't a big issue with the current spells/monsters in the datapack but it poses a limitation to developing chain abilities with shorter range.
This PR fixes that by re-working the chain algorithm to do more efficient backtracking in order to pick a good set of targets to hit.
