### PR TITLE
feat: stronger influenced/fiendish monsters

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -850,9 +850,9 @@ void Monster::doAttacking(uint32_t interval) {
 
 				float multiplier;
 				if (maxCombatValue > 0) { // Defense
-					multiplier = mType->getDefenseMultiplier();
+					multiplier = getDefenseMultiplier();
 				} else { // Attack
-					multiplier = mType->getAttackMultiplier();
+					multiplier = getAttackMultiplier();
 				}
 
 				minCombatValue = spellBlock.minCombatValue * multiplier;
@@ -1924,9 +1924,9 @@ bool Monster::getCombatValues(int32_t &min, int32_t &max) {
 
 	float multiplier;
 	if (maxCombatValue > 0) { // Defense
-		multiplier = mType->getDefenseMultiplier();
+		multiplier = getDefenseMultiplier();
 	} else { // Attack
-		multiplier = mType->getAttackMultiplier();
+		multiplier = getAttackMultiplier();
 	}
 
 	min = minCombatValue * multiplier;

--- a/src/creatures/monsters/monster.hpp
+++ b/src/creatures/monsters/monster.hpp
@@ -156,6 +156,9 @@ public:
 	bool challengeCreature(Creature* creature, int targetChangeCooldown) override;
 
 	bool changeTargetDistance(int32_t distance, uint32_t duration = 12000);
+	bool isChallenged() const {
+		return challengeFocusDuration > 0;
+	}
 
 	CreatureIcon getIcon() const override {
 		if (creatureIcon.isSet()) {
@@ -410,4 +413,14 @@ private:
 	void doRandomStep(Direction &nextDirection, bool &result);
 
 	void onConditionStatusChange(const ConditionType_t &type);
+
+	float getAttackMultiplier() const {
+		float multiplier = mType->getAttackMultiplier();
+		return multiplier * std::pow(1.03f, getForgeStack());
+	}
+
+	float getDefenseMultiplier() const {
+		float multiplier = mType->getAttackMultiplier();
+		return multiplier * std::pow(1.01f, getForgeStack());
+	}
 };


### PR DESCRIPTION
Small change that more accuratly buffs fiends/influenced monsters. In retail Tibia these get stronger with every stack, but we didn't have that feature.
A follow up improvement to this system here would be to make the buff configurable. It currently just tries to emulate what happens in retail.
