### PR TITLE
feat: fully async saves

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -738,8 +738,8 @@ bool Creature::dropCorpse(std::shared_ptr<Creature> lastHitCreature, std::shared
 			dropLoot(corpse->getContainer(), lastHitCreature);
 			corpse->startDecaying();
 			bool corpses = corpse->isRewardCorpse() || (corpse->getID() == ITEM_MALE_CORPSE || corpse->getID() == ITEM_FEMALE_CORPSE);
-			if (corpse->getContainer() && mostDamageCreature && mostDamageCreature->getPlayer() && !corpses) {
-				const auto player = mostDamageCreature->getPlayer();
+			const auto player = mostDamageCreature ? mostDamageCreature->getPlayer() : nullptr;
+			if (corpse->getContainer() && player && !corpses) {
 				auto monster = getMonster();
 				if (monster && !monster->isRewardBoss()) {
 					std::ostringstream lootMessage;

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -493,6 +493,7 @@ public:
 	std::shared_ptr<Cylinder> getParent() override final {
 		return getTile();
 	}
+
 	void setParent(std::weak_ptr<Cylinder> cylinder) override final {
 		auto lockedCylinder = cylinder.lock();
 		if (lockedCylinder) {

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -225,6 +225,9 @@ void Monster::onCreatureMove(std::shared_ptr<Creature> creature, std::shared_ptr
 		}
 
 		updateIdleStatus();
+		if (!m_attackedCreature.expired()) {
+			return;
+		}
 
 		if (!isSummon()) {
 			auto followCreature = getFollowCreature();
@@ -792,7 +795,7 @@ void Monster::onThink(uint32_t interval) {
 					// This happens just after a master orders an attack, so lets follow it aswell.
 					setFollowCreature(attackedCreature);
 				}
-			} else if (!targetIDList.empty()) {
+			} else if (!attackedCreature && !targetIDList.empty()) {
 				if (!followCreature || !hasFollowPath) {
 					searchTarget(TARGETSEARCH_NEAREST);
 				} else if (isFleeing()) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7651,7 +7651,6 @@ const std::unique_ptr<PlayerWheel> &Player::wheel() const {
 }
 
 void Player::sendLootMessage(const std::string &message) const {
-	auto party = getParty();
 	if (!party) {
 		sendTextMessage(MESSAGE_LOOT, message);
 		return;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -19,6 +19,7 @@
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"
 #include "game/scheduling/task.hpp"
+#include "game/scheduling/save_manager.hpp"
 #include "grouping/familiars.hpp"
 #include "lua/creature/creatureevent.hpp"
 #include "lua/creature/events.hpp"
@@ -1715,17 +1716,18 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone) {
 
 void Player::onRemoveCreature(std::shared_ptr<Creature> creature, bool isLogout) {
 	Creature::onRemoveCreature(creature, isLogout);
+	auto player = getPlayer();
 
-	if (creature == getPlayer()) {
+	if (creature == player) {
 		if (isLogout) {
 			if (party) {
-				party->leaveParty(static_self_cast<Player>());
+				party->leaveParty(player);
 			}
 			if (guild) {
-				guild->removeMember(static_self_cast<Player>());
+				guild->removeMember(player);
 			}
 
-			g_game().removePlayerUniqueLogin(static_self_cast<Player>());
+			g_game().removePlayerUniqueLogin(player);
 			loginPosition = getPosition();
 			lastLogout = time(nullptr);
 			g_logger().info("{} has logged out", getName());
@@ -1739,16 +1741,12 @@ void Player::onRemoveCreature(std::shared_ptr<Creature> creature, bool isLogout)
 		}
 
 		if (tradePartner) {
-			g_game().internalCloseTrade(static_self_cast<Player>());
+			g_game().internalCloseTrade(player);
 		}
 
 		closeShopWindow();
 
-		for (uint32_t tries = 0; tries < 3; ++tries) {
-			if (IOLoginData::savePlayer(static_self_cast<Player>())) {
-				break;
-			}
-		}
+		g_saveManager().savePlayer(player);
 	}
 
 	if (creature == shopOwner) {
@@ -4048,7 +4046,9 @@ void Player::postRemoveNotification(std::shared_ptr<Thing> thing, std::shared_pt
 		assert(i ? i->getContainer() != nullptr : true);
 
 		if (i) {
-			requireListUpdate = i->getContainer()->getHoldingPlayer() != getPlayer();
+			if (auto container = i->getContainer()) {
+				requireListUpdate = container->getHoldingPlayer() != getPlayer();
+			}
 		} else {
 			requireListUpdate = newParent != getPlayer();
 		}
@@ -7651,6 +7651,7 @@ const std::unique_ptr<PlayerWheel> &Player::wheel() const {
 }
 
 void Player::sendLootMessage(const std::string &message) const {
+	auto party = getParty();
 	if (!party) {
 		sendTextMessage(MESSAGE_LOOT, message);
 		return;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -94,6 +94,23 @@ static constexpr int32_t PLAYER_SOUND_HEALTH_CHANGE = 10;
 
 class Player final : public Creature, public Cylinder, public Bankable {
 public:
+	class PlayerLock {
+	public:
+		explicit PlayerLock(const std::shared_ptr<Player> &p) :
+			player(p) {
+			player->mutex.lock();
+		}
+
+		PlayerLock(const PlayerLock &) = delete;
+
+		~PlayerLock() {
+			player->mutex.unlock();
+		}
+
+	private:
+		const std::shared_ptr<Player> &player;
+	};
+
 	explicit Player(ProtocolGame_ptr p);
 	~Player();
 
@@ -2504,6 +2521,9 @@ public:
 	std::shared_ptr<Container> getLootPouch();
 
 private:
+	friend class PlayerLock;
+	std::mutex mutex;
+
 	static uint32_t playerFirstID;
 	static uint32_t playerLastID;
 
@@ -2862,6 +2882,7 @@ private:
 	void clearCooldowns();
 
 	friend class Game;
+	friend class SaveManager;
 	friend class Npc;
 	friend class PlayerFunctions;
 	friend class NetworkMessageFunctions;

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -849,7 +849,7 @@ void PlayerWheel::saveSlotPointsOnPressSaveButton(NetworkMessage &msg) {
 	initializePlayerData();
 	registerPlayerBonusData();
 
-	g_logger().debug("Player: {} is saved the all slots info in: {} seconds", m_player.getName(), bm_saveSlot.duration());
+	g_logger().debug("Player: {} is saved the all slots info in: {} milliseconds", m_player.getName(), bm_saveSlot.duration());
 }
 
 /*

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -7,5 +7,6 @@ target_sources(${PROJECT_NAME}_lib PRIVATE
     scheduling/events_scheduler.cpp
     scheduling/dispatcher.cpp
     scheduling/task.cpp
+    scheduling/save_manager.cpp
     zones/zone.cpp
 )

--- a/src/game/bank/bank.cpp
+++ b/src/game/bank/bank.cpp
@@ -13,6 +13,7 @@
 #include "game/game.hpp"
 #include "creatures/players/player.hpp"
 #include "io/iologindata.hpp"
+#include "game/scheduling/save_manager.hpp"
 
 Bank::Bank(const std::shared_ptr<Bankable> bankable) :
 	m_bankable(bankable) {
@@ -25,14 +26,14 @@ Bank::~Bank() {
 	}
 	std::shared_ptr<Player> player = bankable->getPlayer();
 	if (player && !player->isOnline()) {
-		IOLoginData::savePlayer(player);
+		g_saveManager().savePlayer(player);
 
 		return;
 	}
 	if (bankable->isGuild()) {
 		const auto guild = static_self_cast<Guild>(bankable);
 		if (guild && !guild->isOnline()) {
-			IOGuild::saveGuild(guild);
+			g_saveManager().saveGuild(guild);
 		}
 	}
 }

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -427,7 +427,6 @@ public:
 
 	GameState_t getGameState() const;
 	void setGameState(GameState_t newState);
-	void saveGameState();
 
 	// Events
 	void checkCreatureWalk(uint32_t creatureId);
@@ -497,7 +496,10 @@ public:
 	const std::map<uint16_t, std::map<uint8_t, uint64_t>> &getItemsPrice() const {
 		return itemsPriceMap;
 	}
-	const phmap::flat_hash_map<uint32_t, std::shared_ptr<Player>> &getPlayers() const {
+	const phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Guild>> &getGuilds() const {
+		return guilds;
+	}
+	const phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> &getPlayers() const {
 		return players;
 	}
 	const std::map<uint32_t, std::shared_ptr<Monster>> &getMonsters() const {
@@ -770,10 +772,11 @@ private:
 	phmap::flat_hash_map<std::string, HighscoreCacheEntry> highscoreCache;
 
 	phmap::flat_hash_map<std::string, std::weak_ptr<Player>> m_uniqueLoginPlayerNames;
-	phmap::flat_hash_map<uint32_t, std::shared_ptr<Player>> players;
+	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> players;
 	phmap::flat_hash_map<std::string, std::weak_ptr<Player>> mappedPlayerNames;
-	phmap::flat_hash_map<uint32_t, std::shared_ptr<Guild>> guilds;
+	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Guild>> guilds;
 	phmap::flat_hash_map<uint16_t, std::shared_ptr<Item>> uniqueItems;
+	phmap::parallel_flat_hash_map<uint32_t, std::string> m_playerNameCache;
 	std::map<uint32_t, uint32_t> stages;
 
 	/* Items stored from the lua scripts positions

--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -1,0 +1,150 @@
+#include "pch.hpp"
+
+#include "game/game.hpp"
+#include "game/scheduling/save_manager.hpp"
+#include "io/iologindata.hpp"
+
+SaveManager::SaveManager(ThreadPool &threadPool, KVStore &kvStore, Logger &logger, Game &game) :
+	threadPool(threadPool), kv(kvStore), logger(logger), game(game) { }
+
+SaveManager &SaveManager::getInstance() {
+	return inject<SaveManager>();
+}
+
+void SaveManager::saveAll() {
+	Benchmark bm_saveAll;
+	logger.info("Saving server...");
+	const auto players = game.getPlayers();
+
+	for (const auto &[_, player] : players) {
+		player->loginPosition = player->getPosition();
+		doSavePlayer(player);
+	}
+
+	auto guilds = game.getGuilds();
+	for (const auto &[_, guild] : guilds) {
+		saveGuild(guild);
+	}
+
+	saveMap();
+	saveKV();
+	logger.info("Server saved in {} milliseconds.", bm_saveAll.duration());
+}
+
+void SaveManager::scheduleAll() {
+	auto scheduledAt = std::chrono::steady_clock::now();
+	m_scheduledAt = scheduledAt;
+
+	addLoad([this, scheduledAt]() {
+		if (m_scheduledAt.load() != scheduledAt) {
+			logger.warn("Skipping save for server because another save has been scheduled.");
+			return;
+		}
+		saveAll();
+	});
+}
+
+void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
+	auto player = playerPtr.lock();
+	if (!player) {
+		logger.debug("Skipping save for player because player is no longer online.");
+		return;
+	}
+	logger.debug("Scheduling player {} for saving.", player->getName());
+	auto scheduledAt = std::chrono::steady_clock::now();
+	m_playerMap[player->getGUID()] = scheduledAt;
+	addLoad([this, playerPtr, scheduledAt]() {
+		auto player = playerPtr.lock();
+		if (!player) {
+			logger.debug("Skipping save for player because player is no longer online.");
+			return;
+		}
+		if (m_playerMap[player->getGUID()] != scheduledAt) {
+			logger.warn("Skipping save for player because another save has been scheduled.");
+			return;
+		}
+		doSavePlayer(player);
+	});
+}
+
+bool SaveManager::doSavePlayer(std::shared_ptr<Player> player) {
+	if (!player) {
+		logger.debug("Failed to save player because player is null.");
+		return false;
+	}
+	Benchmark bm_savePlayer;
+	Player::PlayerLock lock(player);
+	m_playerMap.erase(player->getGUID());
+	logger.debug("Saving player {}...", player->getName());
+	bool saveSuccess = IOLoginData::savePlayer(player);
+	if (!saveSuccess) {
+		logger.error("Failed to save player {}.", player->getName());
+	}
+	auto duration = bm_savePlayer.duration();
+	if (duration > 100) {
+		logger.warn("Saving player {} took {} milliseconds.", player->getName(), duration);
+	} else {
+		logger.debug("Saving player {} took {} milliseconds.", player->getName(), duration);
+	}
+	return saveSuccess;
+}
+
+bool SaveManager::savePlayer(std::shared_ptr<Player> player) {
+	if (player->isOnline()) {
+		schedulePlayer(player);
+		return true;
+	}
+	return doSavePlayer(player);
+}
+
+void SaveManager::saveGuild(std::shared_ptr<Guild> guild) {
+	if (!guild) {
+		logger.debug("Failed to save guild because guild is null.");
+		return;
+	}
+	Benchmark bm_saveGuild;
+	logger.debug("Saving guild {}...", guild->getName());
+	IOGuild::saveGuild(guild);
+	auto duration = bm_saveGuild.duration();
+	if (duration > 100) {
+		logger.warn("Saving guild {} took {} milliseconds.", guild->getName(), duration);
+	} else {
+		logger.debug("Saving guild {} took {} milliseconds.", guild->getName(), duration);
+	}
+}
+
+void SaveManager::saveMap() {
+	Benchmark bm_saveMap;
+	logger.debug("Saving map...");
+	bool saveSuccess = Map::save();
+	if (!saveSuccess) {
+		logger.error("Failed to save map.");
+	}
+	auto duration = bm_saveMap.duration();
+	if (duration > 100) {
+		logger.warn("Map saved in {} milliseconds.", bm_saveMap.duration());
+	} else {
+		logger.debug("Map saved in {} milliseconds.", bm_saveMap.duration());
+	}
+}
+
+void SaveManager::saveKV() {
+	Benchmark bm_saveKV;
+	logger.debug("Saving key-value store...");
+	bool saveSuccess = kv.saveAll();
+	if (!saveSuccess) {
+		logger.error("Failed to save key-value store.");
+	}
+	auto duration = bm_saveKV.duration();
+	if (duration > 100) {
+		logger.warn("Key-value store saved in {} milliseconds.", bm_saveKV.duration());
+	} else {
+		logger.debug("Key-value store saved in {} milliseconds.", bm_saveKV.duration());
+	}
+}
+
+void SaveManager::addLoad(std::function<void(void)> f) {
+	threadPool.addLoad([this, f]() {
+		f();
+	});
+}

--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -53,7 +53,7 @@ void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
 	logger.debug("Scheduling player {} for saving.", playerToSave->getName());
 	auto scheduledAt = std::chrono::steady_clock::now();
 	m_playerMap[playerToSave->getGUID()] = scheduledAt;
-	addLoad([this, playerPtr, scheduledAt]() {
+	threadPool.addLoad([this, playerPtr, scheduledAt]() {
 		auto player = playerPtr.lock();
 		if (!player) {
 			logger.debug("Skipping save for player because player is no longer online.");

--- a/src/game/scheduling/save_manager.hpp
+++ b/src/game/scheduling/save_manager.hpp
@@ -1,0 +1,48 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2022 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#pragma once
+
+#include "lib/thread/thread_pool.hpp"
+#include "kv/kv.hpp"
+
+class SaveManager {
+public:
+	explicit SaveManager(ThreadPool &threadPool, KVStore &kvStore, Logger &logger, Game &game);
+
+	SaveManager(const SaveManager &) = delete;
+	void operator=(const SaveManager &) = delete;
+
+	static SaveManager &getInstance();
+
+	void saveAll();
+	void scheduleAll();
+
+	bool savePlayer(std::shared_ptr<Player> player);
+	void saveGuild(std::shared_ptr<Guild> guild);
+
+private:
+	void saveMap();
+	void saveKV();
+
+	void schedulePlayer(std::weak_ptr<Player> player);
+	bool doSavePlayer(std::shared_ptr<Player> player);
+
+	std::atomic<std::chrono::steady_clock::time_point> m_scheduledAt;
+	phmap::parallel_flat_hash_map<uint32_t, std::chrono::steady_clock::time_point> m_playerMap;
+
+	void addLoad(std::function<void(void)> f);
+
+	ThreadPool &threadPool;
+	KVStore &kv;
+	Logger &logger;
+	Game &game;
+};
+
+constexpr auto g_saveManager = SaveManager::getInstance;

--- a/src/game/scheduling/save_manager.hpp
+++ b/src/game/scheduling/save_manager.hpp
@@ -37,8 +37,6 @@ private:
 	std::atomic<std::chrono::steady_clock::time_point> m_scheduledAt;
 	phmap::parallel_flat_hash_map<uint32_t, std::chrono::steady_clock::time_point> m_playerMap;
 
-	void addLoad(std::function<void(void)> f);
-
 	ThreadPool &threadPool;
 	KVStore &kv;
 	Logger &logger;

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -362,7 +362,9 @@ void IOLoginData::addVIPEntry(uint32_t accountId, uint32_t guid, const std::stri
 
 	std::ostringstream query;
 	query << "INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES (" << accountId << ',' << guid << ',' << db.escapeString(description) << ',' << icon << ',' << notify << ')';
-	db.executeQuery(query.str());
+	if (!db.executeQuery(query.str())) {
+		g_logger().error("Failed to add VIP entry for account %u. QUERY: %s", accountId, query.str().c_str());
+	}
 }
 
 void IOLoginData::editVIPEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) {
@@ -370,7 +372,9 @@ void IOLoginData::editVIPEntry(uint32_t accountId, uint32_t guid, const std::str
 
 	std::ostringstream query;
 	query << "UPDATE `account_viplist` SET `description` = " << db.escapeString(description) << ", `icon` = " << icon << ", `notify` = " << notify << " WHERE `account_id` = " << accountId << " AND `player_id` = " << guid;
-	db.executeQuery(query.str());
+	if (!db.executeQuery(query.str())) {
+		g_logger().error("Failed to edit VIP entry for account %u. QUERY: %s", accountId, query.str().c_str());
+	}
 }
 
 void IOLoginData::removeVIPEntry(uint32_t accountId, uint32_t guid) {

--- a/src/io/iomap.cpp
+++ b/src/io/iomap.cpp
@@ -77,7 +77,7 @@ void IOMap::loadMap(Map* map, const Position &pos) {
 
 	map->flush();
 
-	g_logger().info("Map Loaded {} ({}x{}) in {} seconds", map->path.filename().string(), map->width, map->height, bm_mapLoad.duration());
+	g_logger().info("Map Loaded {} ({}x{}) in {} milliseconds", map->path.filename().string(), map->width, map->height, bm_mapLoad.duration());
 }
 
 void IOMap::parseMapDataAttributes(FileStream &stream, Map* map) {

--- a/src/io/iomapserialize.cpp
+++ b/src/io/iomapserialize.cpp
@@ -49,7 +49,7 @@ void IOMapSerialize::loadHouseItems(Map* map) {
 			loadItem(propStream, tile, true);
 		}
 	} while (result->next());
-	g_logger().info("Loaded house items in {} seconds", bm_context.duration());
+	g_logger().info("Loaded house items in {} milliseconds", bm_context.duration());
 }
 bool IOMapSerialize::saveHouseItems() {
 	bool success = DBTransaction::executeWithinTransaction([]() {
@@ -64,8 +64,6 @@ bool IOMapSerialize::saveHouseItems() {
 }
 
 bool IOMapSerialize::SaveHouseItemsGuard() {
-	Benchmark bm_context;
-
 	Database &db = Database::getInstance();
 	std::ostringstream query;
 
@@ -98,7 +96,6 @@ bool IOMapSerialize::SaveHouseItemsGuard() {
 		return false;
 	}
 
-	g_logger().info("Saved house items in {} seconds", bm_context.duration());
 	return true;
 }
 

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -14,6 +14,7 @@
 #include "io/iologindata.hpp"
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"
+#include "game/scheduling/save_manager.hpp"
 
 uint8_t IOMarket::getTierFromDatabaseTable(const std::string &string) {
 	auto tier = static_cast<uint8_t>(std::atoi(string.c_str()));
@@ -177,7 +178,7 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool) {
 			}
 
 			if (player->isOffline()) {
-				IOLoginData::savePlayer(player);
+				g_saveManager().savePlayer(player);
 			}
 		} else {
 			uint64_t totalPrice = result->getNumber<uint64_t>("price") * amount;

--- a/src/items/bed.cpp
+++ b/src/items/bed.cpp
@@ -13,6 +13,7 @@
 #include "game/game.hpp"
 #include "io/iologindata.hpp"
 #include "game/scheduling/dispatcher.hpp"
+#include "game/scheduling/save_manager.hpp"
 
 BedItem::BedItem(uint16_t id) :
 	Item(id) {
@@ -178,7 +179,7 @@ void BedItem::wakeUp(std::shared_ptr<Player> player) {
 			auto regenPlayer = std::make_shared<Player>(nullptr);
 			if (IOLoginData::loadPlayerById(regenPlayer, sleeperGUID)) {
 				regeneratePlayer(regenPlayer);
-				IOLoginData::savePlayer(regenPlayer);
+				g_saveManager().savePlayer(regenPlayer);
 			}
 		} else {
 			regeneratePlayer(player);

--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<Container> Container::create(std::shared_ptr<Tile> tile) {
 Container::~Container() {
 	if (getID() == ITEM_BROWSEFIELD) {
 		for (std::shared_ptr<Item> item : itemlist) {
-			item->setParent(m_parent);
+			item->setParent(getParent());
 		}
 	}
 }

--- a/src/items/containers/mailbox/mailbox.cpp
+++ b/src/items/containers/mailbox/mailbox.cpp
@@ -12,6 +12,7 @@
 #include "items/containers/mailbox/mailbox.hpp"
 #include "game/game.hpp"
 #include "io/iologindata.hpp"
+#include "game/scheduling/save_manager.hpp"
 #include "map/spectators.hpp"
 
 ReturnValue Mailbox::queryAdd(int32_t, const std::shared_ptr<Thing> &thing, uint32_t, uint32_t, std::shared_ptr<Creature>) {
@@ -107,7 +108,7 @@ bool Mailbox::sendItem(std::shared_ptr<Item> item) const {
 			if (player->isOnline()) {
 				player->onReceiveMail();
 			} else {
-				IOLoginData::savePlayer(player);
+				g_saveManager().savePlayer(player);
 			}
 			return true;
 		}

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -12,6 +12,7 @@
 #include "creatures/interactions/chat.hpp"
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"
+#include "game/scheduling/save_manager.hpp"
 #include "lua/functions/core/game/global_functions.hpp"
 #include "lua/scripts/lua_environment.hpp"
 #include "lua/scripts/script_environment.hpp"
@@ -722,7 +723,7 @@ int GlobalFunctions::luaStopEvent(lua_State* L) {
 }
 
 int GlobalFunctions::luaSaveServer(lua_State* L) {
-	g_game().saveGameState();
+	g_saveManager().scheduleAll();
 	pushBoolean(L, true);
 	return 1;
 }

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -19,6 +19,7 @@
 #include "io/ioprey.hpp"
 #include "items/item.hpp"
 #include "lua/functions/creatures/player/player_functions.hpp"
+#include "game/scheduling/save_manager.hpp"
 #include "map/spectators.hpp"
 
 int PlayerFunctions::luaPlayerSendInventory(lua_State* L) {
@@ -1379,6 +1380,11 @@ int PlayerFunctions::luaPlayerSetVocation(lua_State* L) {
 	}
 
 	player->setVocation(vocation->getId());
+	player->sendSkills();
+	player->sendStats();
+	player->sendBasicData();
+	player->wheel()->sendGiftOfLifeCooldown();
+	g_game().reloadCreature(player);
 	pushBoolean(L, true);
 	return 1;
 }
@@ -2824,10 +2830,7 @@ int PlayerFunctions::luaPlayerSave(lua_State* L) {
 		if (!player->isOffline()) {
 			player->loginPosition = player->getPosition();
 		}
-		pushBoolean(L, IOLoginData::savePlayer(player));
-		if (player->isOffline()) {
-			// avoiding memory leak
-		}
+		pushBoolean(L, g_saveManager().savePlayer(player));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -14,6 +14,7 @@
 #include "game/game.hpp"
 #include "items/item.hpp"
 #include "items/decay/decay.hpp"
+#include "game/scheduling/save_manager.hpp"
 
 class Imbuement;
 

--- a/src/map/house/house.cpp
+++ b/src/map/house/house.cpp
@@ -14,6 +14,7 @@
 #include "io/iologindata.hpp"
 #include "game/game.hpp"
 #include "items/bed.hpp"
+#include "game/scheduling/save_manager.hpp"
 
 House::House(uint32_t houseId) :
 	id(houseId) { }
@@ -285,7 +286,7 @@ bool House::transferToDepot(std::shared_ptr<Player> player) const {
 		g_logger().debug("[{}] moving item '{}' to depot", __FUNCTION__, item->getName());
 		g_game().internalMoveItem(item->getParent(), player->getInbox(), INDEX_WHEREEVER, item, item->getItemCount(), nullptr, FLAG_NOLIMIT);
 	}
-	IOLoginData::savePlayer(player);
+	g_saveManager().savePlayer(player);
 	return true;
 }
 
@@ -821,7 +822,7 @@ void Houses::payHouses(RentPeriod_t rentPeriod) const {
 			}
 		}
 
-		IOLoginData::savePlayer(player);
+		g_saveManager().savePlayer(player);
 	}
 }
 

--- a/src/server/signals.cpp
+++ b/src/server/signals.cpp
@@ -11,6 +11,7 @@
 
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"
+#include "game/scheduling/save_manager.hpp"
 #include "lib/thread/thread_pool.hpp"
 #include "lua/creature/events.hpp"
 #include "lua/scripts/lua_environment.hpp"
@@ -91,7 +92,7 @@ void Signals::sigtermHandler() {
 void Signals::sigusr1Handler() {
 	// Dispatcher thread
 	g_logger().info("SIGUSR1 received, saving the game state...");
-	g_game().saveGameState();
+	g_saveManager().scheduleAll();
 }
 
 void Signals::sighupHandler() {

--- a/src/utils/benchmark.hpp
+++ b/src/utils/benchmark.hpp
@@ -75,7 +75,7 @@ public:
 
 private:
 	int64_t time() const noexcept {
-		return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+		return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 	}
 
 	int64_t startTime = -1;

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -61,6 +61,7 @@
     <ClInclude Include="..\src\game\scheduling\events_scheduler.hpp" />
     <ClInclude Include="..\src\game\scheduling\dispatcher.hpp" />
     <ClInclude Include="..\src\game\scheduling\task.hpp" />
+    <ClInclude Include="..\src\game\scheduling\save_manager.hpp" />
     <ClInclude Include="..\src\io\fileloader.hpp" />
     <ClInclude Include="..\src\io\filestream.hpp" />
     <ClInclude Include="..\src\io\functions\iologindata_load_player.hpp" />
@@ -257,6 +258,7 @@
     <ClCompile Include="..\src\game\game.cpp" />
     <ClCompile Include="..\src\game\bank\bank.cpp" />
     <ClCompile Include="..\src\game\scheduling\task.cpp" />
+    <ClCompile Include="..\src\game\scheduling\save_manager.cpp" />
     <ClCompile Include="..\src\game\zones\zone.cpp" />
     <ClCompile Include="..\src\game\movement\position.cpp" />
     <ClCompile Include="..\src\game\movement\teleport.cpp" />


### PR DESCRIPTION
Credits: @beats-dh. This is highly inspired and done with Beats' help.

Save intervals are pretty frustrating, they lock the server up and no one is excited to see them come. This makes that whole process asynchronous and speeds everything up.

Only saves that happen during the interval will be async, everything else stays the same. This means that logging out, using the market, etc, will still directly save the player. When that happens, the player is then automatically removed from the save queue.
