### PR TITLE
fix: premium time update shouldn't change last day

### DIFF
--- a/src/account/account.cpp
+++ b/src/account/account.cpp
@@ -46,6 +46,8 @@ namespace account {
 			return ERROR_NO;
 		}
 
+		updatePremiumTime();
+
 		return ERROR_LOADING_ACCOUNT;
 	}
 
@@ -167,11 +169,16 @@ namespace account {
 		return password;
 	}
 
-	error_t Account::addPremiumDays(const int32_t &days) {
-		return setPremiumDays(m_account.premiumRemainingDays + days);
+	void Account::addPremiumDays(const int32_t &days) {
+		uint32_t timeLeft = static_cast<int>((m_account.premiumLastDay - getTimeNow()) % 86400);
+		setPremiumDays(m_account.premiumRemainingDays + days);
+
+		if (timeLeft > 0) {
+			m_account.premiumLastDay += timeLeft;
+		}
 	}
 
-	error_t Account::setPremiumDays(const int32_t &days) {
+	void Account::setPremiumDays(const int32_t &days) {
 		m_account.premiumRemainingDays = days;
 		m_account.premiumLastDay = getTimeNow() + (days * 86400);
 
@@ -179,8 +186,6 @@ namespace account {
 			m_account.premiumLastDay = 0;
 			m_account.premiumRemainingDays = 0;
 		}
-
-		return ERROR_NO;
 	}
 
 	error_t Account::setAccountType(const AccountType &accountType) {
@@ -197,7 +202,7 @@ namespace account {
 		uint32_t daysLeft = static_cast<int>((lastDay - currentTime) / 86400);
 		uint32_t timeLeft = static_cast<int>((lastDay - currentTime) % 86400);
 
-		setPremiumDays(daysLeft > 0 ? daysLeft : 1);
+		m_account.premiumRemainingDays = daysLeft > 0 ? daysLeft : 0;
 
 		if (daysLeft == 0 && timeLeft == 0) {
 			setPremiumDays(0);
@@ -207,7 +212,7 @@ namespace account {
 			setPremiumDays(0);
 		}
 
-		if (remainingDays == m_account.premiumRemainingDays && lastDay == m_account.premiumLastDay) {
+		if (remainingDays == m_account.premiumRemainingDays) {
 			return;
 		}
 

--- a/src/account/account.hpp
+++ b/src/account/account.hpp
@@ -103,8 +103,8 @@ namespace account {
 
 		std::string getPassword();
 
-		error_t addPremiumDays(const int32_t &days);
-		error_t setPremiumDays(const int32_t &days);
+		void addPremiumDays(const int32_t &days);
+		void setPremiumDays(const int32_t &days);
 		[[nodiscard]] inline uint32_t getPremiumRemainingDays() const {
 			return m_account.premiumRemainingDays;
 		}

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2402,9 +2402,7 @@ int PlayerFunctions::luaPlayerAddPremiumDays(lua_State* L) {
 		return 1;
 	}
 
-	if (player->getAccount()->addPremiumDays(addDays) != account::ERROR_NO) {
-		return 1;
-	}
+	player->getAccount()->addPremiumDays(addDays);
 
 	if (player->getAccount()->save() != account::ERROR_NO) {
 		return 1;
@@ -2433,9 +2431,7 @@ int PlayerFunctions::luaPlayerRemovePremiumDays(lua_State* L) {
 		return 1;
 	}
 
-	if (player->getAccount()->addPremiumDays(-removeDays) != account::ERROR_NO) {
-		return 1;
-	}
+	player->getAccount()->addPremiumDays(-removeDays);
 
 	if (player->getAccount()->save() != account::ERROR_NO) {
 		return 1;

--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -47,9 +47,6 @@ void ProtocolLogin::getCharacterList(const std::string &accountDescriptor, const
 		return;
 	}
 
-	// Update premium days
-	account.updatePremiumTime();
-
 	auto output = OutputMessagePool::getOutputMessage();
 	const std::string &motd = g_configManager().getString(SERVER_MOTD);
 	if (!motd.empty()) {

--- a/tests/unit/account/account_test.cpp
+++ b/tests/unit/account/account_test.cpp
@@ -453,19 +453,18 @@ suite<"account"> accountTest = [] {
 
 	test("Account::addPremiumDays sets premium remaining days") = [] {
 		Account acc { 1 };
-		expect(
-			eq(acc.addPremiumDays(100), Errors::ERROR_NO) and
-			eq(acc.getPremiumRemainingDays(), 100)
-		);
+		acc.addPremiumDays(100);
+
+		expect(eq(acc.getPremiumRemainingDays(), 100));
 	};
 
 	test("Account::addPremiumDays can increase premium") = [] {
 		Account acc { 1 };
 
 		acc.setPremiumDays(50);
+		acc.addPremiumDays(50);
 
 		expect(
-			eq(acc.addPremiumDays(50), Errors::ERROR_NO) and
 			approx(acc.getPremiumLastDay(), getTimeNow() + (100 * 86400), 60 * 60 * 1000) and
 			eq(acc.getPremiumRemainingDays(), 100)
 		);
@@ -475,9 +474,9 @@ suite<"account"> accountTest = [] {
 		Account acc { 1 };
 
 		acc.setPremiumDays(50);
+		acc.addPremiumDays(-30);
 
 		expect(
-			eq(acc.addPremiumDays(-30), Errors::ERROR_NO) and
 			approx(acc.getPremiumLastDay(), getTimeNow() - (20 * 86400), 60 * 60 * 1000) and
 			eq(acc.getPremiumRemainingDays(), 20)
 		);
@@ -507,12 +506,14 @@ suite<"account"> accountTest = [] {
 		acc.setPremiumDays(-10);
 		acc.updatePremiumTime();
 		expect(eq(acc.getPremiumRemainingDays(), 0));
+		expect(eq(acc.getPremiumLastDay(), 0));
 	};
 
 	test("Account::updatePremiumTime sets premium remaining days to 0 if last day is 0") = [] {
 		Account acc { 1 };
 		acc.setPremiumDays(0);
 		acc.updatePremiumTime();
+		expect(eq(acc.getPremiumLastDay(), 0));
 		expect(eq(acc.getPremiumRemainingDays(), 0));
 	};
 
@@ -520,6 +521,9 @@ suite<"account"> accountTest = [] {
 		Account acc { 1 };
 		acc.setPremiumDays(8);
 		acc.updatePremiumTime();
+
+		auto remainingTime = (acc.getPremiumLastDay() - getTimeNow()) / 86400;
+		expect(approx(remainingTime, 8, 0.1));
 		expect(eq(acc.getPremiumRemainingDays(), 8));
 	};
 
@@ -527,6 +531,9 @@ suite<"account"> accountTest = [] {
 		Account acc { 1 };
 		acc.setPremiumDays(1);
 		acc.updatePremiumTime();
+
+		auto remainingTime = (acc.getPremiumLastDay() - getTimeNow()) / 86400;
+		expect(approx(remainingTime, 1, 0.1));
 		expect(eq(acc.getPremiumRemainingDays(), 1));
 	};
 


### PR DESCRIPTION
# Description

Premium time update shouldn't change last day and should always try to update on account load.