### PR TITLE
fix: start server with visual studio solution

### DIFF
--- a/src/game/scheduling/task.hpp
+++ b/src/game/scheduling/task.hpp
@@ -14,12 +14,12 @@ public:
 	// DO NOT allocate this class on the stack
 	Task(std::function<void(void)> &&f, std::string context) :
 		context(std::move(context)), func(std::move(f)) {
-		assert(!context.empty() && "Context cannot be empty!");
+		assert(!this->context.empty() && "Context cannot be empty!");
 	}
 
 	Task(std::function<void(void)> &&f, std::string context, uint32_t delay) :
 		delay(delay), context(std::move(context)), func(std::move(f)) {
-		assert(!context.empty() && "Context cannot be empty!");
+		assert(!this->context.empty() && "Context cannot be empty!");
 	}
 
 	virtual ~Task() = default;


### PR DESCRIPTION
The default behavior when moving an object to another property is for the old property to lose the object reference, but with clang, it seems that this only happens after a while, as if there was a garbage collector.