### PR TITLE
fix: reward collect crash

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2695,9 +2695,9 @@ ReturnValue Game::internalCollectLootItems(Player* player, Item* item, ObjectCat
 ReturnValue Game::collectRewardChestItems(Player* player, uint32_t maxMoveItems /* = 0*/) {
 	// Check if have item on player reward chest
 	RewardChest* rewardChest = player->getRewardChest();
-	if (!rewardChest || rewardChest->empty()) {
-		g_logger().debug("Reward chest is wrong or empty");
-		return RETURNVALUE_NOTPOSSIBLE;
+	if (rewardChest->empty()) {
+		g_logger().debug("Reward chest is empty");
+		return RETURNVALUE_REWARDCHESTISEMPTY;
 	}
 
 	auto rewardItemsVector = player->getRewardsFromContainer(rewardChest->getContainer());
@@ -9822,15 +9822,15 @@ void Game::playerRewardChestCollect(uint32_t playerId, const Position &pos, uint
 	}
 
 	// Updates the parent of the reward chest and reward containers to avoid memory usage after cleaning
-	RewardChest* myRewardChest = player->getRewardChest();
-	if (myRewardChest->size() == 0) {
+	RewardChest* playerRewardChest = player->getRewardChest();
+	if (playerRewardChest->empty()) {
 		player->sendCancelMessage(RETURNVALUE_REWARDCHESTISEMPTY);
 		return;
 	}
 
-	myRewardChest->setParent(item->getContainer()->getParent()->getTile());
+	playerRewardChest->setParent(item->getContainer()->getParent()->getTile());
 	for (const auto &[mapRewardId, reward] : player->rewardMap) {
-		reward->setParent(myRewardChest);
+		reward->setParent(playerRewardChest);
 	}
 
 	std::lock_guard<std::mutex> lock(player->quickLootMutex);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9821,6 +9821,18 @@ void Game::playerRewardChestCollect(uint32_t playerId, const Position &pos, uint
 		return;
 	}
 
+	// Updates the parent of the reward chest and reward containers to avoid memory usage after cleaning
+	RewardChest* myRewardChest = player->getRewardChest();
+	if (myRewardChest->size() == 0) {
+		player->sendCancelMessage(RETURNVALUE_REWARDCHESTISEMPTY);
+		return;
+	}
+
+	myRewardChest->setParent(item->getContainer()->getParent()->getTile());
+	for (const auto &[mapRewardId, reward] : player->rewardMap) {
+		reward->setParent(myRewardChest);
+	}
+
 	std::lock_guard<std::mutex> lock(player->quickLootMutex);
 
 	ReturnValue returnValue = collectRewardChestItems(player, maxMoveItems);

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -310,17 +310,17 @@ ReturnValue Actions::internalUseItem(Player* player, const Position &pos, uint8_
 
 		// reward chest
 		if (container->getRewardChest() != nullptr && container->getParent()) {
-			RewardChest* myRewardChest = player->getRewardChest();
-			if (myRewardChest->size() == 0) {
+			RewardChest* playerRewardChest = player->getRewardChest();
+			if (playerRewardChest->empty()) {
 				return RETURNVALUE_REWARDCHESTISEMPTY;
 			}
 
-			myRewardChest->setParent(container->getParent()->getTile());
+			playerRewardChest->setParent(container->getParent()->getTile());
 			for (const auto &[mapRewardId, reward] : player->rewardMap) {
-				reward->setParent(myRewardChest);
+				reward->setParent(playerRewardChest);
 			}
 
-			openContainer = myRewardChest;
+			openContainer = playerRewardChest;
 		}
 
 		auto rewardId = container->getAttribute<time_t>(ItemAttribute_t::DATE);


### PR DESCRIPTION
After discovering how to reproduce the crash, it became easier to fix.

```cpp
>    otbr.exe!Item::getTopParent() Linha 337    C++
     otbr.exe!Item::getTile() Linha 369    C++
     otbr.exe!Game::internalMoveItem(Cylinder * fromCylinder, Cylinder * toCylinder, int index, Item * item, unsigned int count, Item * * _moveItem, unsigned int flags, Creature * actor, Item * tradeItem) Linha 2464    C++
     otbr.exe!Game::processMoveOrAddItemToLootContainer(Item * item, Container * lootContainer, unsigned int & remainderCount, Player * player) Linha 3470    C++
     otbr.exe!Game::processLootItems(Player * player, Container * lootContainer, Item * item, bool & fallbackConsumed) Linha 3487    C++
     otbr.exe!Game::internalCollectLootItems(Player * player, Item * item, ObjectCategory_t category) Linha 3534    C++
     otbr.exe!Game::collectRewardChestItems(Player * player, unsigned int maxMoveItems) Linha 3555    C++
     otbr.exe!Game::playerRewardChestCollect(unsigned int playerId, const Position & pos, unsigned short itemId, unsigned char stackPos, unsigned int maxMoveItems) Linha 10442    C++
     [Código Externo]    
     [Quadro Embutido] otbr.exe!std::_Func_class<void>::operator()() Linha 883    C++
     [Quadro Embutido] otbr.exe!Task::operator()() Linha 40    C++
     otbr.exe!Dispatcher::threadMain() Linha 62    C++
     [Código Externo]    
```
The crash occurred in very difficult scenarios, when the object's parent had been removed (for example, due to the decay of the boss's original body), which caused the reward container to lose the parent, but still remain in memory. From now on, we will set a new parent (the reward chest and the tile).

Fixes #994
Fixes #1147 