### PR TITLE
fix: refresh bosstiary tracker kills on boss death

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1654,9 +1654,6 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin) {
 			}
 		}
 
-		// Reload bestiary tracker
-		refreshCyclopediaMonsterTracker();
-
 		g_game().checkPlayersRecord();
 		IOLoginData::updateOnlineStatus(guid, true);
 		if (getLevel() < g_configManager().getNumber(ADVENTURERSBLESSING_LEVEL)) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1655,7 +1655,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin) {
 		}
 
 		// Reload bestiary tracker
-		refreshBestiaryMonsterTracker();
+		refreshCyclopediaMonsterTracker();
 
 		g_game().checkPlayersRecord();
 		IOLoginData::updateOnlineStatus(guid, true);

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -303,8 +303,8 @@ public:
 		}
 	}
 
-	void refreshBestiaryMonsterTracker() const {
-		refreshCyclopediaMonsterTracker(getCyclopediaMonsterTrackerSet(false), false);
+	void refreshCyclopediaMonsterTracker(bool isBoss = false) const {
+		refreshCyclopediaMonsterTracker(getCyclopediaMonsterTrackerSet(isBoss), isBoss);
 	}
 
 	void refreshCyclopediaMonsterTracker(const phmap::parallel_flat_hash_set<std::shared_ptr<MonsterType>> &trackerList, bool isBoss) const {

--- a/src/io/io_bosstiary.cpp
+++ b/src/io/io_bosstiary.cpp
@@ -176,6 +176,7 @@ void IOBosstiary::addBosstiaryKill(Player* player, const std::shared_ptr<Monster
 
 	auto oldBossLevel = getBossCurrentLevel(player, bossId);
 	player->addBestiaryKillCount(bossId, amount);
+	player->refreshCyclopediaMonsterTracker(true);
 	auto newBossLevel = getBossCurrentLevel(player, bossId);
 	if (oldBossLevel == newBossLevel) {
 		return;

--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -237,12 +237,8 @@ void IOBestiary::addBestiaryKill(Player* player, const std::shared_ptr<MonsterTy
 		}
 	}
 
-	const auto &trackerUnorderedSet = player->getCyclopediaMonsterTrackerSet(false);
-	for (const auto mType : trackerUnorderedSet) {
-		if (raceid == mType->info.raceid) {
-			player->refreshCyclopediaMonsterTracker(trackerUnorderedSet, false);
-		}
-	}
+	// Reload bestiary tracker
+	player->refreshCyclopediaMonsterTracker();
 }
 
 charmRune_t IOBestiary::getCharmFromTarget(Player* player, const std::shared_ptr<MonsterType> mtype) {


### PR DESCRIPTION
I wasn't updating the deaths on the tracker when a new one was killed