### PR TITLE
fix: container:addLoot warnings

### DIFF
--- a/data-canary/scripts/actions/other/cask_kegs.lua
+++ b/data-canary/scripts/actions/other/cask_kegs.lua
@@ -35,7 +35,7 @@ local targetIdList = {
 local flasks = Action()
 
 function flasks.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target or not player:getTile():getHouse() then
+	if not target or not target:getItem() then
 		return false
 	end
 

--- a/data-canary/scripts/actions/other/potions.lua
+++ b/data-canary/scripts/actions/other/potions.lua
@@ -159,7 +159,7 @@ local setting = {
 local potions = Action()
 
 function potions.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if type(target) == "userdata" and not target:isPlayer() then
+	if not target or type(target) == "userdata" and not target:isPlayer() then
 		return false
 	end
 

--- a/data-otservbr-global/monster/demons/true_frost_flower_asura.lua
+++ b/data-otservbr-global/monster/demons/true_frost_flower_asura.lua
@@ -29,7 +29,7 @@ monster.Bestiary = {
 monster.health = 4000
 monster.maxHealth = 4000
 monster.race = "blood"
-monster.corpse = 28668
+monster.corpse = 28667
 monster.speed = 150
 monster.manaCost = 0
 

--- a/data-otservbr-global/scripts/actions/other/cask_kegs.lua
+++ b/data-otservbr-global/scripts/actions/other/cask_kegs.lua
@@ -35,7 +35,7 @@ local targetIdList = {
 local flasks = Action()
 
 function flasks.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target then
+	if not target or not target:getItem() then
 		return false
 	end
 

--- a/data-otservbr-global/scripts/actions/other/potions.lua
+++ b/data-otservbr-global/scripts/actions/other/potions.lua
@@ -222,7 +222,7 @@ local potions = {
 local flaskPotion = Action()
 
 function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if type(target) == "userdata" and not target:isPlayer() then
+	if not target or type(target) == "userdata" and not target:isPlayer() then
 		return false
 	end
 

--- a/data-otservbr-global/scripts/creaturescripts/quests/forgotten_knowledge/dragon_egg.lua
+++ b/data-otservbr-global/scripts/creaturescripts/quests/forgotten_knowledge/dragon_egg.lua
@@ -22,7 +22,13 @@ local function revertHorror()
 end
 
 local function changeHorror()
-	local melting = Tile(Position(32267, 31071, 14)):getTopCreature()
+	local meltingTile = Tile(Position(32267, 31071, 14))
+	if not meltingTile then
+		logger.error("Tile not exist on position '{}'", Position(32267, 31071, 14):toString())
+		return
+	end
+
+	local meltingCreature = meltingTile:getTopCreature()
 	local pos = 0
 	local specs, spec = Game.getSpectators(Position(32269, 31091, 14), false, false, 12, 12, 12, 12)
 	for i = 1, #specs do
@@ -30,7 +36,7 @@ local function changeHorror()
 		if spec:isMonster() and spec:getName():lower() == "solid frozen horror" then
 			pos = spec:getPosition()
 			spec:teleportTo(Position(32267, 31071, 14))
-			melting:teleportTo(pos)
+			meltingCreature:teleportTo(pos)
 		end
 	end
 	addEvent(revertHorror, 20 * 1000)

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -48715,13 +48715,13 @@
 		<attribute key="fluidsource" value="blood"/>
 		<attribute key="duration" value="10"/>
 		<attribute key="decayTo" value="28664"/>
-		<attribute key="containersize" value="20"/>
+		<attribute key="containersize" value="32"/>
 	</item>
 	<item id="28664" article="a" name="dead true dawnfire asura">
 		<attribute key="fluidsource" value="blood"/>
 		<attribute key="duration" value="300"/>
 		<attribute key="decayTo" value="28665"/>
-		<attribute key="containersize" value="20"/>
+		<attribute key="containersize" value="32"/>
 	</item>
 	<item id="28665" article="a" name="dead true dawnfire asura">
 		<attribute key="duration" value="300"/>
@@ -48736,13 +48736,13 @@
 		<attribute key="fluidsource" value="blood"/>
 		<attribute key="duration" value="10"/>
 		<attribute key="decayTo" value="28668"/>
-		<attribute key="containersize" value="20"/>
+		<attribute key="containersize" value="32"/>
 	</item>
 	<item id="28668" article="a" name="dead true frost flower asura">
 		<attribute key="fluidsource" value="blood"/>
 		<attribute key="duration" value="300"/>
 		<attribute key="decayTo" value="28669"/>
-		<attribute key="containersize" value="20"/>
+		<attribute key="containersize" value="32"/>
 	</item>
 	<item id="28669" article="a" name="dead true frost flower asura">
 		<attribute key="duration" value="300"/>

--- a/data/libs/functions/container.lua
+++ b/data/libs/functions/container.lua
@@ -32,7 +32,7 @@ function Container:addLoot(loot)
 				tmpItem:setText(item.text)
 			end
 		else
-			Spdlog.warn(("Container:addLoot: failed to add item: %s"):format(ItemType(itemId):getName()))
+			logger.warn("Container:addLoot: failed to add item: {}, to corpse {} with id {}", ItemType(itemId):getName(), self:getName(), self:getId())
 		end
 
 		::continue::

--- a/data/libs/functions/container.lua
+++ b/data/libs/functions/container.lua
@@ -8,7 +8,7 @@ end
 function Container:addLoot(loot)
 	for itemId, item in pairs(loot) do
 		logger.debug("[Container:addLoot] - Adding loot item id: {} to container id: {}", itemId, self:getId())
-		local tmpItem = self:addItem(itemId, item.count)
+		local tmpItem = self:addItem(itemId, item.count, INDEX_WHEREEVER, FLAG_NOLIMIT)
 		if tmpItem then
 			if tmpItem:isContainer() and item.childLoot then
 				if not tmpItem:addLoot(item.childLoot) then

--- a/data/libs/functions/game.lua
+++ b/data/libs/functions/game.lua
@@ -131,5 +131,11 @@ function Game.getStorageValue(key)
 end
 
 function Game.setStorageValue(key, value)
-	globalStorageTable[key] = value
+	local addedValue = globalStorageTable[key]
+	if addedValue == nil then
+		logger.error("[Game.setStorageValue] Key is nil")
+		return
+	end
+
+	addedValue = value
 end

--- a/data/libs/functions/game.lua
+++ b/data/libs/functions/game.lua
@@ -131,8 +131,7 @@ function Game.getStorageValue(key)
 end
 
 function Game.setStorageValue(key, value)
-	local addedValue = globalStorageTable[key]
-	if addedValue == nil then
+	if key == nil then
 		logger.error("[Game.setStorageValue] Key is nil")
 		return
 	end

--- a/data/libs/functions/game.lua
+++ b/data/libs/functions/game.lua
@@ -137,5 +137,5 @@ function Game.setStorageValue(key, value)
 		return
 	end
 
-	addedValue = value
+	globalStorageTable[key] = value
 end

--- a/src/lua/functions/items/container_functions.cpp
+++ b/src/lua/functions/items/container_functions.cpp
@@ -117,6 +117,7 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 	Container* container = getUserdata<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
+		reportErrorFunc("Container is nullptr");
 		return 1;
 	}
 
@@ -127,6 +128,7 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 		itemId = Item::items.getItemIdByName(getString(L, 2));
 		if (itemId == 0) {
 			lua_pushnil(L);
+			reportErrorFunc("Item id is wrong");
 			return 1;
 		}
 	}
@@ -140,6 +142,7 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 	Item* item = Item::CreateItem(itemId, count);
 	if (!item) {
 		lua_pushnil(L);
+		reportErrorFunc("Item is nullptr");
 		return 1;
 	}
 
@@ -151,6 +154,7 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 		pushUserdata<Item>(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
+		reportErrorFunc(fmt::format("Cannot add item to container, error code: '{}'", getReturnMessage(ret)));
 		delete item;
 		lua_pushnil(L);
 	}


### PR DESCRIPTION
The error occurred because the corpse had less capacity than the amount of loot.

I improved the log, so we know which corpse has a problem and what error is returned. I also made some small improvements to other scripts.

Fix: https://github.com/opentibiabr/canary/issues/1596 (warning only)

It's likely that other monsters also have the same error, we'll have to check the logs and fix it.