### PR TITLE
improve: AreaCombat::areas to array

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1770,13 +1770,15 @@ bool ChainPickerCallback::onChainCombat(std::shared_ptr<Creature> creature, std:
 //**********************************************************//
 
 void AreaCombat::clear() {
-	areas.clear();
+	std::ranges::fill(areas, nullptr);
 }
 
 AreaCombat::AreaCombat(const AreaCombat &rhs) {
 	hasExtArea = rhs.hasExtArea;
-	for (const auto &it : rhs.areas) {
-		areas[it.first] = it.second->clone();
+	for (uint_fast8_t i = 0; i <= Direction::DIRECTION_LAST; ++i) {
+		if (const auto &area = rhs.areas[i]) {
+			areas[i] = area->clone();
+		}
 	}
 }
 

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -21,8 +21,6 @@ class Spell;
 class Player;
 class MatrixArea;
 
-static const std::unique_ptr<MatrixArea> &MatrixAreaNull {};
-
 // for luascript callback
 class ValueCallback final : public CallBack {
 public:
@@ -247,15 +245,10 @@ private:
 			}
 		}
 
-		auto it = areas.find(dir);
-		if (it == areas.end()) {
-			return MatrixAreaNull;
-		}
-
-		return it->second;
+		return areas[dir];
 	}
 
-	std::map<Direction, std::unique_ptr<MatrixArea>> areas;
+	std::array<std::unique_ptr<MatrixArea>, Direction::DIRECTION_LAST + 1> areas {};
 	bool hasExtArea = false;
 };
 


### PR DESCRIPTION
Accessing the array index is almost ~2x faster than using a std::map. There would only be advantages to using std::map if there were a large number of records, which is not the case.

Memory consumption may be a little higher with an array, as it will allocate memory to directions that may not be used, but it is irrelevant compared to the performance gain.


Benchmark:
![image](https://github.com/opentibiabr/canary/assets/2267386/e409577f-bbae-4c1b-91ea-18063296fe62)

<details>

	struct Teste {
		bool any = false;
	};

	std::array<std::unique_ptr<Teste>, 8> arrayTest;
	std::map<int, std::unique_ptr<Teste>> mapTest;
	arrayTest[3] = std::make_unique<Teste>();
	arrayTest[4] = std::make_unique<Teste>();
	arrayTest[5] = std::make_unique<Teste>();
	arrayTest[6] = std::make_unique<Teste>();

	Benchmark bm;
	for (size_t i = 0; i < 999999999; ++i) {
		const auto &v = arrayTest[3 + (rand() % 6)];
	}
	g_logger().info("Array: " + std::to_string(bm.duration()) + "ms");

	bm.reset();
	bm.start();
	for (size_t i = 0; i < 999999999; ++i) {
		const auto &v = mapTest[3 + (rand() % 6)];
	}
	g_logger().info("Map: " + std::to_string(bm.duration()) + "ms");
</details>