### PR TITLE
fix: safer zone refreshes

### DIFF
--- a/src/game/zones/zone.cpp
+++ b/src/game/zones/zone.cpp
@@ -35,16 +35,8 @@ std::shared_ptr<Zone> Zone::addZone(const std::string &name) {
 void Zone::addArea(Area area) {
 	for (const Position &pos : area) {
 		positions.insert(pos);
-		std::shared_ptr<Tile> tile = g_game().map.getTile(pos);
-		if (tile) {
-			for (auto item : *tile->getItemList()) {
-				itemAdded(item);
-			}
-			for (auto creature : *tile->getCreatures()) {
-				creatureAdded(creature);
-			}
-		}
 	}
+	refresh();
 }
 
 void Zone::subtractArea(Area area) {
@@ -281,10 +273,18 @@ void Zone::refresh() {
 		if (!tile) {
 			continue;
 		}
-		for (const auto &item : *tile->getItemList()) {
+		const auto &items = tile->getItemList();
+		if (!items) {
+			continue;
+		}
+		for (const auto &item : *items) {
 			itemAdded(item);
 		}
-		for (const auto &creature : *tile->getCreatures()) {
+		const auto &creatures = tile->getCreatures();
+		if (!creatures) {
+			continue;
+		}
+		for (const auto &creature : *creatures) {
 			creatureAdded(creature);
 		}
 	}


### PR DESCRIPTION
On the rare occasion when a zone has an invalid Tile in it, getting an items vector can return null. This adds a check around it to avoid potential crashes.
