### PR TITLE
fix: unable to get promotion

### DIFF
--- a/data/npclib/npc_system/modules.lua
+++ b/data/npclib/npc_system/modules.lua
@@ -96,7 +96,7 @@ if Modules == nil then
 
 		if player:isPremium() or not parameters.premium then
 			local promotion = player:getVocation():getPromotion()
-			if player:getStorageValue(STORAGEVALUE_PROMOTION) == 1 then
+			if player:isPromoted() or not promotion then
 				npcHandler:say("You are already promoted!", npc, player)
 			elseif player:getLevel() < parameters.level then
 				npcHandler:say(string.format("I am sorry, but I can only promote you once you have reached level %d.", parameters.level), npc, player)
@@ -105,7 +105,6 @@ if Modules == nil then
 			else
 				npcHandler:say(parameters.text, npc, player)
 				player:setVocation(promotion)
-				player:setStorageValue(STORAGEVALUE_PROMOTION, 1)
 			end
 		else
 			npcHandler:say("You need a premium account in order to get promoted.", npc, player)

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -957,7 +957,7 @@ bool PlayerWheel::canOpenWheel() const {
 		return false;
 	}
 
-	if (m_player.getVocation()->getId() <= 4 && m_player.getStorageValue(STORAGEVALUE_PROMOTION) == -1) {
+	if (!m_player.isPromoted()) {
 		return false;
 	}
 

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -1382,6 +1382,17 @@ int PlayerFunctions::luaPlayerSetVocation(lua_State* L) {
 	return 1;
 }
 
+int PlayerFunctions::luaPlayerIsPromoted(lua_State* L) {
+	// player:isPromoted()
+	std::shared_ptr<Player> player = getUserdataShared<Player>(L, 1);
+	if (player) {
+		pushBoolean(L, player->isPromoted());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int PlayerFunctions::luaPlayerGetSex(lua_State* L) {
 	// player:getSex()
 	std::shared_ptr<Player> player = getUserdataShared<Player>(L, 1);

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -130,6 +130,7 @@ private:
 
 		registerMethod(L, "Player", "getVocation", PlayerFunctions::luaPlayerGetVocation);
 		registerMethod(L, "Player", "setVocation", PlayerFunctions::luaPlayerSetVocation);
+		registerMethod(L, "Player", "isPromoted", PlayerFunctions::luaPlayerIsPromoted);
 
 		registerMethod(L, "Player", "getSex", PlayerFunctions::luaPlayerGetSex);
 		registerMethod(L, "Player", "setSex", PlayerFunctions::luaPlayerSetSex);
@@ -469,6 +470,7 @@ private:
 
 	static int luaPlayerGetVocation(lua_State* L);
 	static int luaPlayerSetVocation(lua_State* L);
+	static int luaPlayerIsPromoted(lua_State* L);
 
 	static int luaPlayerGetSex(lua_State* L);
 	static int luaPlayerSetSex(lua_State* L);

--- a/src/utils/const.hpp
+++ b/src/utils/const.hpp
@@ -26,7 +26,6 @@ static constexpr int32_t EVENT_IMBUEMENT_INTERVAL = 1000;
 static constexpr uint8_t IMBUEMENT_MAX_TIER = 3;
 
 static constexpr int32_t STORAGEVALUE_EMOTE = 30008;
-static constexpr int32_t STORAGEVALUE_PROMOTION = 30018;
 static constexpr int32_t STORAGEVALUE_PODIUM = 30020;
 static constexpr int32_t STORAGEVALUE_AUTO_LOOT = 30063;
 static constexpr int32_t STORAGEVALUE_DAILYREWARD = 14898;


### PR DESCRIPTION
Supersedes #1674

This changes how promotion is tracked to trust the characters vocation instead of a bespoke storage. Also adds some utility functions to the lua interface to make this easier to handle.

