### PR TITLE
improve: using parallel_flat_hash on connections

### DIFF
--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -18,7 +18,7 @@
 
 Connection_ptr ConnectionManager::createConnection(asio::io_service &io_service, ConstServicePort_ptr servicePort) {
 	auto connection = std::make_shared<Connection>(io_service, servicePort);
-	connections.insert(connection);
+	connections.emplace(connection);
 	return connection;
 }
 
@@ -27,14 +27,15 @@ void ConnectionManager::releaseConnection(const Connection_ptr &connection) {
 }
 
 void ConnectionManager::closeAll() {
-	for (const auto &connection : connections) {
+	connections.for_each([](const Connection_ptr &connection) {
 		try {
 			std::error_code error;
 			connection->socket.shutdown(asio::ip::tcp::socket::shutdown_both, error);
 		} catch (const std::system_error &systemError) {
 			g_logger().error("[ConnectionManager::closeAll] - Failed to close connection, system error code {}", systemError.what());
 		}
-	}
+	});
+
 	connections.clear();
 }
 

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -17,22 +17,16 @@
 #include "server/server.hpp"
 
 Connection_ptr ConnectionManager::createConnection(asio::io_service &io_service, ConstServicePort_ptr servicePort) {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
-
 	auto connection = std::make_shared<Connection>(io_service, servicePort);
 	connections.insert(connection);
 	return connection;
 }
 
 void ConnectionManager::releaseConnection(const Connection_ptr &connection) {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
-
 	connections.erase(connection);
 }
 
 void ConnectionManager::closeAll() {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
-
 	for (const auto &connection : connections) {
 		try {
 			std::error_code error;

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -42,8 +42,7 @@ public:
 	void closeAll();
 
 private:
-	phmap::flat_hash_set<Connection_ptr> connections;
-	std::mutex connectionManagerLock;
+	phmap::parallel_flat_hash_set_m<Connection_ptr> connections;
 };
 
 class Connection : public std::enable_shared_from_this<Connection> {


### PR DESCRIPTION
The library itself already has a container that supports parallelism, so we'll let it manage these locks.