### PR TITLE
fix: fluid clamp

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -185,7 +185,8 @@ Item::Item(const uint16_t itemId, uint16_t itemCount /*= 0*/) :
 	const ItemType &it = items[id];
 	auto itemCharges = it.charges;
 	if (it.isFluidContainer() || it.isSplash()) {
-		setAttribute(ItemAttribute_t::FLUIDTYPE, itemCount * (itemCount < sizeof(Fluids_t)));
+		auto fluidType = std::clamp<uint16_t>(itemCount, 1, FLUID_INK);
+		setAttribute(ItemAttribute_t::FLUIDTYPE, fluidType);
 	} else if (it.stackable) {
 		if (itemCount != 0) {
 			setItemCount(static_cast<uint8_t>(itemCount));


### PR DESCRIPTION
Previous PR did some math on fluids that didn't work when dropping splashes, this fixes it to be more deterministic.
