### PR TITLE
fix: house_lists version column in database with wrong type

### DIFF
--- a/data-otservbr-global/migrations/40.lua
+++ b/data-otservbr-global/migrations/40.lua
@@ -8,7 +8,6 @@ function onUpdateDatabase()
 			ADD PRIMARY KEY (`house_id`, `listid`);
 		]])
 
-
 	db.query([[
 		ALTER TABLE house_lists 
 		CHANGE version version BIGINT(20) 

--- a/data-otservbr-global/migrations/40.lua
+++ b/data-otservbr-global/migrations/40.lua
@@ -1,8 +1,5 @@
 function onUpdateDatabase()
 	logger.info("Updating database to version 41 (optimize house_lists)")
-	db.query([[
-			ALTER TABLE `house_lists` DROP COLUMN `id`;
-		]])
 
 	db.query([[
 			ALTER TABLE `house_lists`
@@ -10,5 +7,12 @@ function onUpdateDatabase()
 			ADD INDEX `version` (`version`),
 			ADD PRIMARY KEY (`house_id`, `listid`);
 		]])
+
+
+	db.query([[
+		ALTER TABLE house_lists 
+		CHANGE version version BIGINT(20) 
+		NOT NULL DEFAULT '0';
+	]])
 	return true
 end

--- a/data-otservbr-global/migrations/40.lua
+++ b/data-otservbr-global/migrations/40.lua
@@ -12,6 +12,6 @@ function onUpdateDatabase()
 		ALTER TABLE `house_lists` 
 		MODIFY `version` bigint(20) NOT NULL DEFAULT '0';
 	]])
-	
+
 	return true
 end

--- a/data-otservbr-global/migrations/40.lua
+++ b/data-otservbr-global/migrations/40.lua
@@ -9,9 +9,9 @@ function onUpdateDatabase()
 		]])
 
 	db.query([[
-		ALTER TABLE house_lists 
-		CHANGE version version BIGINT(20) 
-		NOT NULL DEFAULT '0';
+		ALTER TABLE `house_lists` 
+		MODIFY `version` bigint(20) NOT NULL DEFAULT '0';
 	]])
+	
 	return true
 end

--- a/schema.sql
+++ b/schema.sql
@@ -438,7 +438,7 @@ DELIMITER ;
 CREATE TABLE IF NOT EXISTS `house_lists` (
   `house_id` int NOT NULL,
   `listid` int NOT NULL,
-  `version` int NOT NULL DEFAULT '0',
+  `version` bigint NOT NULL DEFAULT '0',
   `list` text NOT NULL,
   PRIMARY KEY (`house_id`, `listid`),
   KEY `house_id_index` (`house_id`),

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
     CONSTRAINT `server_config_pk` PRIMARY KEY (`config`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '40'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '41'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 -- Table structure `accounts`
 CREATE TABLE IF NOT EXISTS `accounts` (

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
     CONSTRAINT `server_config_pk` PRIMARY KEY (`config`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '38'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '40'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 -- Table structure `accounts`
 CREATE TABLE IF NOT EXISTS `accounts` (


### PR DESCRIPTION
# Description

The column is defined with the type int, which receives a maximum value of 4.294.967.295. Therefore, it was showing an error when saving the database table. The solution I found was to change the type of the version column from INT to BIGINT.


## Behaviour

### **Actual**

Unable to save house lists.
Showing error in console: "Query: INSERT INTO `house_lists` (`house_id` , `listid` , `list`, `version`) VALUES ...."

### **Expected**

Normally saving the houses.


### Fixes #issuenumber

## Type of change

  - [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

I've changed the type in database and run /save with GOD account. The save is now working as expected.

[2023-19-10 09:21:17.403] [info] The server will save all accounts within 60 seconds. You might lag or freeze for 5 seconds, please find a safe place.
[2023-19-10 09:22:17.409] [info] CLEAN: Removed 7 items from 7 tiles in 0 seconds
[2023-19-10 09:22:17.409] [info] Saving server...
[2023-19-10 09:22:18.126] [info] Saved house items in 0.454 seconds
[2023-19-10 09:22:18.205] [info] Server save complete. Next save in 1 hour!

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ x] My code follows the style guidelines of this project
  - [ x] I have performed a self-review of my own code
  - [ x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [ x] I have added tests that prove my fix is effective or that my feature works
