### PR TITLE
fix: fire axe quest

### DIFF
--- a/data-otservbr-global/startup/tables/chest.lua
+++ b/data-otservbr-global/startup/tables/chest.lua
@@ -653,7 +653,7 @@ ChestUnique = {
 		itemId = 2472,
 		itemPos = { x = 33078, y = 31656, z = 11 },
 		container = 2853,
-		reward = { { 3098, 1 }, { 3085, 200 }, { 3028, 7 }, { 3320, 1} },
+		reward = { { 3098, 1 }, { 3085, 200 }, { 3028, 7 }, { 3320, 1 } },
 		weight = 27,
 		storage = Storage.Quest.U6_4.FireAxe.Rewards.Bag,
 	},

--- a/data-otservbr-global/startup/tables/chest.lua
+++ b/data-otservbr-global/startup/tables/chest.lua
@@ -653,7 +653,7 @@ ChestUnique = {
 		itemId = 2472,
 		itemPos = { x = 33078, y = 31656, z = 11 },
 		container = 2853,
-		reward = { { 3098, 1 }, { 3085, 200 }, { 3028, 7 } },
+		reward = { { 3098, 1 }, { 3085, 200 }, { 3028, 7 }, { 3320, 1} },
 		weight = 27,
 		storage = Storage.Quest.U6_4.FireAxe.Rewards.Bag,
 	},


### PR DESCRIPTION
# Description

Na fire axe quest voce abre a chest e vem uma bag, nessa bag vem 1 dragon necklace, 1 fire axe, 1 ring of healing e 7 small diamonds, porem estava vindo todos os itens menos o fire axe.

## Behaviour
### **Actual**

Vem todos os itens menos o fire axe

### **Expected**

Vir o fire axe

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: atual
  - Client: 13.21
  - Operating System: windows/ubuntu

## Checklist

  - [ x] My code follows the style guidelines of this project
  - [x ] I have performed a self-review of my own code
  - [ x] I checked the PR checks reports
  - [x ] I have commented my code, particularly in hard-to-understand areas
  - [x ] I have made corresponding changes to the documentation
  - [ x] My changes generate no new warnings
  - [x ] I have added tests that prove my fix is effective or that my feature works
