### PR TITLE
fix: stop loop on internalDecayItem function

### DIFF
--- a/src/items/decay/decay.cpp
+++ b/src/items/decay/decay.cpp
@@ -138,6 +138,17 @@ void Decay::checkDecay() {
 
 void Decay::internalDecayItem(std::shared_ptr<Item> item) {
 	const ItemType &it = Item::items[item->getID()];
+	// Remove the item and halt the decay process if a player triggers a bug where the item's decay ID matches its equip or de-equip transformation ID
+	if (it.id == it.transformEquipTo || it.id == it.transformDeEquipTo) {
+		g_game().internalRemoveItem(item);
+		auto player = item->getHoldingPlayer();
+		if (player) {
+			g_logger().error("[{}] - internalDecayItem failed to player {}, item id is same from transform equip/deequip, "
+							 " item id: {}, equip to id: '{}', deequip to id '{}'", __FUNCTION__, player->getName(), it.id, it.transformEquipTo, it.transformDeEquipTo);
+		}
+		return;
+	}
+
 	if (it.decayTo != 0) {
 		std::shared_ptr<Player> player = item->getHoldingPlayer();
 		if (player) {

--- a/src/items/decay/decay.cpp
+++ b/src/items/decay/decay.cpp
@@ -144,7 +144,8 @@ void Decay::internalDecayItem(std::shared_ptr<Item> item) {
 		auto player = item->getHoldingPlayer();
 		if (player) {
 			g_logger().error("[{}] - internalDecayItem failed to player {}, item id is same from transform equip/deequip, "
-							 " item id: {}, equip to id: '{}', deequip to id '{}'", __FUNCTION__, player->getName(), it.id, it.transformEquipTo, it.transformDeEquipTo);
+							 " item id: {}, equip to id: '{}', deequip to id '{}'",
+							 __FUNCTION__, player->getName(), it.id, it.transformEquipTo, it.transformDeEquipTo);
 		}
 		return;
 	}

--- a/src/items/functions/item/item_parse.cpp
+++ b/src/items/functions/item/item_parse.cpp
@@ -385,8 +385,7 @@ void ItemParse::parseTransform(const std::string &tmpStrValue, pugi::xml_attribu
 	if (stringValue == "transformequipto") {
 		itemType.transformEquipTo = pugi::cast<uint16_t>(valueAttribute.value());
 		if (itemType.transformEquipTo == itemType.decayTo) {
-			g_logger().warn("[{}] item with id {} is transforming on equip to the same id of decay to '{}'", 
-						 __FUNCTION__, itemType.id, itemType.decayTo);
+			g_logger().warn("[{}] item with id {} is transforming on equip to the same id of decay to '{}'", __FUNCTION__, itemType.id, itemType.decayTo);
 			itemType.decayTo = 0;
 		}
 		if (ItemType &transform = Item::items.getItemType(itemType.transformEquipTo);
@@ -395,8 +394,7 @@ void ItemParse::parseTransform(const std::string &tmpStrValue, pugi::xml_attribu
 		}
 	} else if (stringValue == "transformdeequipto") {
 		if (itemType.transformDeEquipTo == itemType.decayTo) {
-			g_logger().warn("[{}] item with id {} is transforming on de-equip to the same id of decay to '{}'", 
-						 __FUNCTION__, itemType.id, itemType.decayTo);
+			g_logger().warn("[{}] item with id {} is transforming on de-equip to the same id of decay to '{}'", __FUNCTION__, itemType.id, itemType.decayTo);
 			itemType.decayTo = 0;
 		}
 

--- a/src/items/functions/item/item_parse.cpp
+++ b/src/items/functions/item/item_parse.cpp
@@ -384,11 +384,22 @@ void ItemParse::parseTransform(const std::string &tmpStrValue, pugi::xml_attribu
 	std::string stringValue = tmpStrValue;
 	if (stringValue == "transformequipto") {
 		itemType.transformEquipTo = pugi::cast<uint16_t>(valueAttribute.value());
+		if (itemType.transformEquipTo == itemType.decayTo) {
+			g_logger().warn("[{}] item with id {} is transforming on equip to the same id of decay to '{}'", 
+						 __FUNCTION__, itemType.id, itemType.decayTo);
+			itemType.decayTo = 0;
+		}
 		if (ItemType &transform = Item::items.getItemType(itemType.transformEquipTo);
 			transform.type == ITEM_TYPE_NONE) {
 			transform.type = itemType.type;
 		}
 	} else if (stringValue == "transformdeequipto") {
+		if (itemType.transformDeEquipTo == itemType.decayTo) {
+			g_logger().warn("[{}] item with id {} is transforming on de-equip to the same id of decay to '{}'", 
+						 __FUNCTION__, itemType.id, itemType.decayTo);
+			itemType.decayTo = 0;
+		}
+
 		itemType.transformDeEquipTo = pugi::cast<uint16_t>(valueAttribute.value());
 	} else if (stringValue == "transformto") {
 		itemType.transformToFree = pugi::cast<uint16_t>(valueAttribute.value());


### PR DESCRIPTION
This fixes a critical issue where an infinite loop is triggered if an item attempts to decay to an ID that matches its equip or unequip transformation ID. Previously, this scenario would lead to an endless loop, causing performance degradation and potentially leading to application instability.

The fix involves adding a conditional check to identify this edge case and take appropriate action, such as removing the item and logging an error, thereby breaking the loop, and maintaining application performance.

Includes:
- Additional conditional checks in the decay logic
- Enhanced logging for debugging