### PR TITLE
feat: update public and internal server versions

### DIFF
--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -181,12 +181,12 @@ void CanaryServer::setupHousesRent() {
 
 void CanaryServer::logInfos() {
 #if defined(GIT_RETRIEVED_STATE) && GIT_RETRIEVED_STATE
-	logger.debug("{} - Version [{}] dated [{}]", STATUS_SERVER_NAME, STATUS_SERVER_VERSION, GIT_COMMIT_DATE_ISO8601);
+	logger.debug("{} - Version [{}] dated [{}]", STATUS_SERVER_NAME, SERVER_RELEASE_VERSION, GIT_COMMIT_DATE_ISO8601);
 	#if GIT_IS_DIRTY
 	logger.debug("DIRTY - NOT OFFICIAL RELEASE");
 	#endif
 #else
-	logger.info("{} - Version {}", STATUS_SERVER_NAME, STATUS_SERVER_VERSION);
+	logger.info("{} - Version {}", STATUS_SERVER_NAME, SERVER_RELEASE_VERSION);
 #endif
 
 	logger.debug("Compiled with {}, on {} {}, for platform {}\n", getCompiler(), __DATE__, __TIME__, getPlatform());

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -10,12 +10,18 @@
 #pragma once
 
 static constexpr auto STATUS_SERVER_NAME = "Canary";
-static constexpr auto STATUS_SERVER_VERSION = "2.6.1";
+// STATUS_SERVER_VERSION is used for external display purposes, such as listings on otlist.
+// This version should generally only show the major version to avoid frequent changes in otlist categories.
+static constexpr auto STATUS_SERVER_VERSION = "3.0";
+
 static constexpr auto STATUS_SERVER_DEVELOPERS = "OpenTibiaBR Organization";
 
 static constexpr auto AUTHENTICATOR_DIGITS = 6U;
 static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 
+// SERVER_MAJOR_VERSION is the actual full version of the server, including minor and patch numbers.
+// This is intended for internal use to identify the exact state of the server (release) software.
+static constexpr auto SERVER_RELEASE_VERSION = "3.0.0";
 static constexpr auto CLIENT_VERSION = 1321;
 
 #define CLIENT_VERSION_UPPER (CLIENT_VERSION / 100)


### PR DESCRIPTION
# Description:
This adds descriptive comments to clarify the purpose and usage of the version constants STATUS_SERVER_VERSION and SERVER_RELEASE_VERSION.

The STATUS_SERVER_VERSION constant is intended for external displays, like server listings on otlist (otservlist.com), and only shows the major version. This helps to minimize frequent changes in otlist categories.

On the other hand, SERVER_RELEASE_VERSION is the full version of the Canary Server, intended for internal use. It helps in identifying the exact state of the server software.

# Changes:
Added comments to STATUS_SERVER_VERSION explaining its usage for external displays, particularly on otlist.
Added comments to SERVER_RELEASE_VERSION explaining its purpose for internal use to identify the server's exact version.