### PR TITLE
feature: update tame mounts

### DIFF
--- a/data-otservbr-global/scripts/actions/mounts/gryphon_mount.lua
+++ b/data-otservbr-global/scripts/actions/mounts/gryphon_mount.lua
@@ -1,0 +1,43 @@
+local config = {
+    maskId = 31369,
+    tamedId = 31576, 31561,
+    monsterName = "Gryphon",
+    achievement = "Gryphon Rider",
+    mountId = 144,
+    chance = 100
+}
+
+local action = Action()
+
+function action.onUse(player, item, fromPos, target, toPos, isHotkey)
+    if not target or not target:isMonster() or target:getName() ~= config.monsterName then
+        return true
+    end
+
+    if player:hasMount(config.mountId) then
+        player:sendCancelMessage("You already have this mount.")
+        return true
+    end
+
+    local mask = player:getSlotItem(CONST_SLOT_HEAD)
+    if not mask or mask:getId() ~= config.maskId then
+        player:sendCancelMessage("You must have the mask equipped.")
+        return true
+    end
+
+    item:remove(1)
+
+    if config.chance >= math.random(1, 100) then
+        target:remove()
+        toPos:sendMagicEffect(CONST_ME_MAGIC_GREEN)
+        player:addMount(config.mountId)
+        doCreatureSay(player, "The gryphon will now accompany you as a friend and ally.", TALKTYPE_ORANGE_1)
+    else
+        player:sendCancelMessage("Taming has failed, try again.")
+        toPos:sendMagicEffect(CONST_ME_POFF)
+    end
+    return true
+end
+
+action:id(config.tamedId)
+action:register()

--- a/data-otservbr-global/scripts/actions/mounts/gryphon_mount.lua
+++ b/data-otservbr-global/scripts/actions/mounts/gryphon_mount.lua
@@ -1,42 +1,43 @@
 local config = {
-    maskId = 31369,
-    tamedId = 31576, 31561,
-    monsterName = "Gryphon",
-    achievement = "Gryphon Rider",
-    mountId = 144,
-    chance = 100
+	maskId = 31369,
+	tamedId = 31576,
+	31561,
+	monsterName = "Gryphon",
+	achievement = "Gryphon Rider",
+	mountId = 144,
+	chance = 100,
 }
 
 local action = Action()
 
 function action.onUse(player, item, fromPos, target, toPos, isHotkey)
-    if not target or not target:isMonster() or target:getName() ~= config.monsterName then
-        return true
-    end
+	if not target or not target:isMonster() or target:getName() ~= config.monsterName then
+		return true
+	end
 
-    if player:hasMount(config.mountId) then
-        player:sendCancelMessage("You already have this mount.")
-        return true
-    end
+	if player:hasMount(config.mountId) then
+		player:sendCancelMessage("You already have this mount.")
+		return true
+	end
 
-    local mask = player:getSlotItem(CONST_SLOT_HEAD)
-    if not mask or mask:getId() ~= config.maskId then
-        player:sendCancelMessage("You must have the mask equipped.")
-        return true
-    end
+	local mask = player:getSlotItem(CONST_SLOT_HEAD)
+	if not mask or mask:getId() ~= config.maskId then
+		player:sendCancelMessage("You must have the mask equipped.")
+		return true
+	end
 
-    item:remove(1)
+	item:remove(1)
 
-    if config.chance >= math.random(1, 100) then
-        target:remove()
-        toPos:sendMagicEffect(CONST_ME_MAGIC_GREEN)
-        player:addMount(config.mountId)
-        doCreatureSay(player, "The gryphon will now accompany you as a friend and ally.", TALKTYPE_ORANGE_1)
-    else
-        player:sendCancelMessage("Taming has failed, try again.")
-        toPos:sendMagicEffect(CONST_ME_POFF)
-    end
-    return true
+	if config.chance >= math.random(1, 100) then
+		target:remove()
+		toPos:sendMagicEffect(CONST_ME_MAGIC_GREEN)
+		player:addMount(config.mountId)
+		doCreatureSay(player, "The gryphon will now accompany you as a friend and ally.", TALKTYPE_ORANGE_1)
+	else
+		player:sendCancelMessage("Taming has failed, try again.")
+		toPos:sendMagicEffect(CONST_ME_POFF)
+	end
+	return true
 end
 
 action:id(config.tamedId)

--- a/data-otservbr-global/scripts/actions/mounts/haze_mount.lua
+++ b/data-otservbr-global/scripts/actions/mounts/haze_mount.lua
@@ -1,24 +1,24 @@
- local config = {
-        [32629] = {mountId = 162, message = "You are now versed to ride the haze!"},
-    }
+local config = {
+	[32629] = { mountId = 162, message = "You are now versed to ride the haze!" },
+}
 
 local hazemount = Action()
 
 function hazemount.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-    local mount = config[item.itemid]
+	local mount = config[item.itemid]
 
-    if not mount then
-        return true
-    end
+	if not mount then
+		return true
+	end
 
-    if not player:hasMount(mount.mountId) then
-        player:addMount(mount.mountId)
-        player:say(mount.message, TALKTYPE_MONSTER_SAY)
-        item:remove(1)
-    else
-        player:sendTextMessage(19, "You already have this mount")
-    end
-    return true
+	if not player:hasMount(mount.mountId) then
+		player:addMount(mount.mountId)
+		player:say(mount.message, TALKTYPE_MONSTER_SAY)
+		item:remove(1)
+	else
+		player:sendTextMessage(19, "You already have this mount")
+	end
+	return true
 end
 
 hazemount:id(32629)

--- a/data-otservbr-global/scripts/actions/mounts/haze_mount.lua
+++ b/data-otservbr-global/scripts/actions/mounts/haze_mount.lua
@@ -1,0 +1,25 @@
+ local config = {
+        [32629] = {mountId = 162, message = "You are now versed to ride the haze!"},
+    }
+
+local hazemount = Action()
+
+function hazemount.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    local mount = config[item.itemid]
+
+    if not mount then
+        return true
+    end
+
+    if not player:hasMount(mount.mountId) then
+        player:addMount(mount.mountId)
+        player:say(mount.message, TALKTYPE_MONSTER_SAY)
+        item:remove(1)
+    else
+        player:sendTextMessage(19, "You already have this mount")
+    end
+    return true
+end
+
+hazemount:id(32629)
+hazemount:register()


### PR DESCRIPTION
# Description

Incluído os tame das mounts haze e gryphon, feito todos os testes em linux e windows.

Obs: Todos os itens para montar o the Regalia of Suon(id: 31576) estão presentes no servidor, porém o NPC Yonan não tem ainda a logica implementada para juntar as partes e fazer esse item, gostaria de saber a possibilidade de isso ser feito, pois infelizmente nao faço ideia de como fazer.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Para conseguir a mount Haze basta dar use no item Spectral Scrap of Cloth que dropa no boss the pale worm.
Para conseguir a mount gryphon basta dar use no item the regalia of suon e depois usar em um gryphon, voce deve estar com gryphon mask equipada.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Testado na mais nova versão do repositório canary em windows e linux ubuntu 22.04.
  - [ ] Test B

**Test Configuration**:

  - Server Version: 
  - Client: 13.21
  - Operating System: Linux Ubuntu 22.04 e Windows.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
