### PR TITLE
improve: safety when getting a tile

### DIFF
--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -107,6 +107,8 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::unique_ptr<F
 		return floor->getTile(x, y);
 	}
 
+	std::unique_lock l(floor->mutex);
+
 	const uint8_t z = floor->getZ();
 
 	auto map = static_cast<Map*>(this);

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -107,7 +107,7 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::unique_ptr<F
 		return floor->getTile(x, y);
 	}
 
-	std::unique_lock l(floor->mutex);
+	std::unique_lock l(floor->getMutex());
 
 	const uint8_t z = floor->getZ();
 

--- a/src/map/mapcache.hpp
+++ b/src/map/mapcache.hpp
@@ -86,18 +86,22 @@ struct Floor {
 		z(z) {};
 
 	std::shared_ptr<Tile> getTile(uint16_t x, uint16_t y) const {
+		std::shared_lock sl(mutex);
 		return tiles[x & FLOOR_MASK][y & FLOOR_MASK].first;
 	}
 
 	void setTile(uint16_t x, uint16_t y, std::shared_ptr<Tile> tile) {
+		std::unique_lock l(mutex);
 		tiles[x & FLOOR_MASK][y & FLOOR_MASK].first = tile;
 	}
 
 	std::shared_ptr<BasicTile> getTileCache(uint16_t x, uint16_t y) const {
+		std::shared_lock sl(mutex);
 		return tiles[x & FLOOR_MASK][y & FLOOR_MASK].second;
 	}
 
 	void setTileCache(uint16_t x, uint16_t y, const std::shared_ptr<BasicTile> &newTile) {
+		std::unique_lock l(mutex);
 		tiles[x & FLOOR_MASK][y & FLOOR_MASK].second = newTile;
 	}
 
@@ -107,6 +111,7 @@ struct Floor {
 
 private:
 	std::pair<std::shared_ptr<Tile>, std::shared_ptr<BasicTile>> tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
+	mutable std::shared_mutex mutex;
 	uint8_t z { 0 };
 };
 

--- a/src/map/mapcache.hpp
+++ b/src/map/mapcache.hpp
@@ -107,10 +107,13 @@ struct Floor {
 		return z;
 	}
 
-	mutable std::shared_mutex mutex;
+	auto &getMutex() const {
+		return mutex;
+	}
 
 private:
 	std::pair<std::shared_ptr<Tile>, std::shared_ptr<BasicTile>> tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
+	mutable std::shared_mutex mutex;
 	uint8_t z { 0 };
 };
 

--- a/src/map/mapcache.hpp
+++ b/src/map/mapcache.hpp
@@ -91,7 +91,6 @@ struct Floor {
 	}
 
 	void setTile(uint16_t x, uint16_t y, std::shared_ptr<Tile> tile) {
-		std::unique_lock l(mutex);
 		tiles[x & FLOOR_MASK][y & FLOOR_MASK].first = tile;
 	}
 
@@ -101,7 +100,6 @@ struct Floor {
 	}
 
 	void setTileCache(uint16_t x, uint16_t y, const std::shared_ptr<BasicTile> &newTile) {
-		std::unique_lock l(mutex);
 		tiles[x & FLOOR_MASK][y & FLOOR_MASK].second = newTile;
 	}
 
@@ -109,9 +107,10 @@ struct Floor {
 		return z;
 	}
 
+	mutable std::shared_mutex mutex;
+
 private:
 	std::pair<std::shared_ptr<Tile>, std::shared_ptr<BasicTile>> tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
-	mutable std::shared_mutex mutex;
 	uint8_t z { 0 };
 };
 


### PR DESCRIPTION
This PR brings a crash fix with the implementation of the pathfinder multithreading, as it is now possible to get/create a Tile simultaneously, so we need to maintain this acquisition safely.