### PR TITLE
fix: guild bank withdraw checking against incorrect bankable

### DIFF
--- a/src/game/bank/bank.cpp
+++ b/src/game/bank/bank.cpp
@@ -97,7 +97,7 @@ bool Bank::transferTo(const std::shared_ptr<Bank> destination, uint64_t amount) 
 		return false;
 	}
 	if (destinationBankable->getPlayer() != nullptr) {
-		auto player = bankable->getPlayer();
+		auto player = destinationBankable->getPlayer();
 		auto name = asLowerCaseString(player->getName());
 		replaceString(name, " ", "");
 		if (deniedNames.contains(name)) {


### PR DESCRIPTION
This change fixes the error that closed the server when trying to withdraw values ​​from the guild bank using the guild withdraw command