### PR TITLE
fix: unjustified death

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -630,8 +630,16 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature> &creature, const s
 void Creature::onDeath() {
 	bool lastHitUnjustified = false;
 	bool mostDamageUnjustified = false;
-
+	std::shared_ptr<Creature> mostDamageCreatureMaster = nullptr;
 	std::shared_ptr<Creature> mostDamageCreature = nullptr;
+	if (mostDamageCreature) {
+		mostDamageCreatureMaster = mostDamageCreature->getMaster();
+		mostDamageUnjustified = mostDamageCreature->onKilledCreature(getCreature(), false);
+	}
+	std::shared_ptr<Creature> lastHitCreature = g_game().getCreatureByID(lastHitCreatureId);
+	if (lastHitCreature && lastHitCreature != mostDamageCreature && lastHitCreature != mostDamageCreatureMaster) {
+		lastHitUnjustified = lastHitCreature->onKilledCreature(getCreature(), true);
+	}
 
 	const int64_t timeNow = OTSYS_TIME();
 	const uint32_t inFightTicks = g_configManager().getNumber(PZ_LOCKED);
@@ -669,17 +677,6 @@ void Creature::onDeath() {
 
 	for (const auto &it : experienceMap) {
 		it.first->onGainExperience(it.second, getCreature());
-	}
-
-	std::shared_ptr<Creature> mostDamageCreatureMaster = nullptr;
-	if (mostDamageCreature) {
-		mostDamageCreatureMaster = mostDamageCreature->getMaster();
-		mostDamageUnjustified = mostDamageCreature->onKilledCreature(getCreature(), false);
-	}
-
-	std::shared_ptr<Creature> lastHitCreature = g_game().getCreatureByID(lastHitCreatureId);
-	if (lastHitCreature && lastHitCreature != mostDamageCreature && lastHitCreature != mostDamageCreatureMaster) {
-		lastHitUnjustified = lastHitCreature->onKilledCreature(getCreature(), true);
 	}
 
 	bool droppedCorpse = dropCorpse(lastHitCreature, mostDamageCreature, lastHitUnjustified, mostDamageUnjustified);


### PR DESCRIPTION
The function that clears the attackedSet was being executed before onKilledCreature: https://github.com/opentibiabr/canary/blob/a9c391b4af42f138509826861c986042fb5c20d8/src/creatures/creature.cpp#L651
Which caused the kills/skulls bug.