### PR TITLE
Update power_burn.lua

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/the_outlaw_camp/power_burn.lua
+++ b/data-otservbr-global/scripts/actions/quests/the_outlaw_camp/power_burn.lua
@@ -16,5 +16,5 @@ function theOutlawPower.onUse(player, item, fromPosition, target, toPosition, is
 	return true
 end
 
-theOutlawPower:id(1491)
+theOutlawPower:uid(1491)
 theOutlawPower:register()


### PR DESCRIPTION
# Description

missing 'u' from line 19 calling a item id instead of a unique id.

## Behaviour
Lever broken.

### **Expected**
Pull lever to continue quest, instead does nothing.

## Type of change
Lua change.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Ran through quest and verified it was broken, changed code to reflect apropriate unique id call.

**Test Configuration**:

  - Server Version: 3.1.1
  - Client: 3121
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
