### PR TITLE
Update power_burn.lua

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/the_outlaw_camp/power_burn.lua
+++ b/data-otservbr-global/scripts/actions/quests/the_outlaw_camp/power_burn.lua
@@ -16,5 +16,5 @@ function theOutlawPower.onUse(player, item, fromPosition, target, toPosition, is
 	return true
 end
 
-theOutlawPower:id(1491)
+theOutlawPower:uid(3402)
 theOutlawPower:register()


### PR DESCRIPTION
# Description

Currently the outlaw camp quest will not work due to 2 factors. 1.) The map indicates a unique id of 3402 for the lever which does not reflect the value in the script and 2.) The action is an id instead of a unique id.

## Behaviour
You can not continue the quest due to broken script.

### **Expected**
Pull lever and create flames and open passage.

### Fixes
correct call id to a unique id and change the value of the unique id to match that of the map.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: 3.1.1
  - Client: 1321
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
