### PR TITLE
fix: nomad bestiary race id

### DIFF
--- a/data-otservbr-global/monster/humans/nomad_blue.lua
+++ b/data-otservbr-global/monster/humans/nomad_blue.lua
@@ -18,7 +18,7 @@ monster.events = {
 	"NomadDeath",
 }
 
-monster.raceId = 777
+monster.raceId = 776
 monster.Bestiary = {
 	class = "Human",
 	race = BESTY_RACE_HUMAN,

--- a/data-otservbr-global/monster/humans/nomad_female.lua
+++ b/data-otservbr-global/monster/humans/nomad_female.lua
@@ -18,7 +18,7 @@ monster.events = {
 	"NomadDeath",
 }
 
-monster.raceId = 776
+monster.raceId = 777
 monster.Bestiary = {
 	class = "Human",
 	race = BESTY_RACE_HUMAN,


### PR DESCRIPTION
# Description

Fixes nomad bestiary kill data.

## Behaviour
When killing a blue nomad it counts as a female nomad kill and vice versa, when you kill a female nomad it counts as a blue nomad.

### **Expected**
When killing a blue nomad it counts as a blue nomad kill and vice versa, when killing a female nomad it counts as a female nomad kill.

### Fixes 
Update monster.raceID to correct ID's

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
Verified/tested.

**Test Configuration**:

  - Server Version: 3.1.1
  - Client: 1321
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
