### PR TITLE
fix: correct bed system behaviour

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -46155,6 +46155,7 @@
 		<attribute key="partnerdirection" value="south"/>
 		<attribute key="femaletransformto" value="26092"/>
 		<attribute key="maletransformto" value="26088"/>
+		<attribute key="rotateTo" value="23398"/>
 		<attribute key="wrapableTo" value="23398"/>
 	</item>
 	<item id="26097" article="a" name="verdant bed">
@@ -46164,6 +46165,7 @@
 		<attribute key="partnerdirection" value="north"/>
 		<attribute key="femaletransformto" value="26093"/>
 		<attribute key="maletransformto" value="26089"/>
+		<attribute key="rotateTo" value="23399"/>
 		<attribute key="wrapableTo" value="23398"/>
 	</item>
 	<item id="26098" article="a" name="verdant bed">
@@ -46173,6 +46175,7 @@
 		<attribute key="partnerdirection" value="east"/>
 		<attribute key="femaletransformto" value="26094"/>
 		<attribute key="maletransformto" value="26090"/>
+		<attribute key="rotateTo" value="23396"/>
 		<attribute key="wrapableTo" value="23398"/>
 	</item>
 	<item id="26099" article="a" name="verdant bed">
@@ -46182,6 +46185,7 @@
 		<attribute key="partnerdirection" value="west"/>
 		<attribute key="femaletransformto" value="26095"/>
 		<attribute key="maletransformto" value="26091"/>
+		<attribute key="rotateTo" value="23397"/>
 		<attribute key="wrapableTo" value="23398"/>
 	</item>
 	<item id="26100" article="a" name="bath tub">

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3956,7 +3956,7 @@ std::shared_ptr<Item> Game::wrapItem(std::shared_ptr<Item> item, std::shared_ptr
 	auto itemName = item->getName();
 	std::shared_ptr<Item> newItem = transformItem(item, ITEM_DECORATION_KIT);
 	newItem->setCustomAttribute("unWrapId", static_cast<int64_t>(oldItemID));
-	item->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + itemName + ">.");
+	newItem->setAttribute(ItemAttribute_t::DESCRIPTION, "Unwrap it in your own house to create a <" + itemName + ">.");
 	if (hiddenCharges > 0) {
 		newItem->setAttribute(DATE, hiddenCharges);
 	}

--- a/src/items/bed.cpp
+++ b/src/items/bed.cpp
@@ -84,11 +84,22 @@ bool BedItem::canUse(std::shared_ptr<Player> player) {
 		return false;
 	}
 
-	if (getNextBedItem() == nullptr) {
+	auto nextBedItem = getNextBedItem();
+	if (nextBedItem == nullptr) {
 		return false;
 	}
 
-	if (Item::items[id].bedPart != BED_PILLOW_PART) {
+	const auto &itemType = Item::items[id];
+	if (itemType.bedPart != BED_PILLOW_PART) {
+		return false;
+	}
+
+	auto partName = itemType.name;
+	auto nextPartname = nextBedItem->getName();
+	auto firstPart = keepFirstWordOnly(partName);
+	auto nextPartOf = keepFirstWordOnly(nextPartname);
+	g_logger().debug("First bed part name {}, second part name {}", firstPart, nextPartOf);
+	if (!isMoveable() || !nextBedItem->isMoveable() || firstPart != nextPartOf) {
 		return false;
 	}
 

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -257,6 +257,15 @@ void trim_left(std::string &source, char t) {
 	source.erase(0, source.find_first_not_of(t));
 }
 
+std::string keepFirstWordOnly(std::string &str) {
+	size_t spacePos = str.find(' ');
+	if (spacePos != std::string::npos) {
+		str.erase(spacePos);
+	}
+
+	return str;
+}
+
 void toLowerCaseString(std::string &source) {
 	std::transform(source.begin(), source.end(), source.begin(), tolower);
 }

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -25,6 +25,8 @@ std::string generateToken(const std::string &secret, uint32_t ticks);
 void replaceString(std::string &str, const std::string &sought, const std::string &replacement);
 void trim_right(std::string &source, char t);
 void trim_left(std::string &source, char t);
+std::string keepFirstWordOnly(std::string &str);
+
 void toLowerCaseString(std::string &source);
 std::string asLowerCaseString(std::string source);
 std::string asUpperCaseString(std::string source);


### PR DESCRIPTION
• Fixed a bug that prevented the item's name from appearing when looking at it after wrapping.
• Implemented a special check that only removes beds that are non-movable and do not have anyone sleeping in them.
• Fixed issue where the player could not "sleep" if the two parts of the bed were not "identical". What I did was use the "name" of the bed as a basis, using only the first word to compare the item name. I noticed that all beds have the first words in common, so this was used as a standard.
• Fixed rotate to from "verdant bed"