### PR TITLE
fix: chat channels message based on player group

### DIFF
--- a/data/chatchannels/scripts/advertising-rook.lua
+++ b/data/chatchannels/scripts/advertising-rook.lua
@@ -1,5 +1,5 @@
 function canJoin(player)
-	return player:getVocation():getId() == VOCATION_NONE or player:getAccountType() >= ACCOUNT_TYPE_SENIORTUTOR
+	return player:getVocation():getId() == VOCATION_NONE or player:getGroup():getId() >= GROUP_TYPE_SENIORTUTOR
 end
 
 local CHANNEL_ADVERTISING_ROOK = 6
@@ -9,7 +9,7 @@ muted:setParameter(CONDITION_PARAM_SUBID, CHANNEL_ADVERTISING_ROOK)
 muted:setParameter(CONDITION_PARAM_TICKS, 120000)
 
 function onSpeak(player, type, message)
-	if player:getAccountType() >= ACCOUNT_TYPE_GAMEMASTER then
+	if player:getGroup():getId() >= GROUP_TYPE_GAMEMASTER then
 		if type == TALKTYPE_CHANNEL_Y then
 			return TALKTYPE_CHANNEL_O
 		end
@@ -28,7 +28,7 @@ function onSpeak(player, type, message)
 	player:addCondition(muted)
 
 	if type == TALKTYPE_CHANNEL_O then
-		if player:getAccountType() < ACCOUNT_TYPE_GAMEMASTER then
+		if player:getGroup():getId() < GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then

--- a/data/chatchannels/scripts/advertising.lua
+++ b/data/chatchannels/scripts/advertising.lua
@@ -1,5 +1,5 @@
 function canJoin(player)
-	return player:getVocation():getId() ~= VOCATION_NONE or player:getAccountType() >= ACCOUNT_TYPE_SENIORTUTOR
+	return player:getVocation():getId() ~= VOCATION_NONE or player:getGroup():getId() >= GROUP_TYPE_SENIORTUTOR
 end
 
 local CHANNEL_ADVERTISING = 5
@@ -9,7 +9,7 @@ muted:setParameter(CONDITION_PARAM_SUBID, CHANNEL_ADVERTISING)
 muted:setParameter(CONDITION_PARAM_TICKS, 120000)
 
 function onSpeak(player, type, message)
-	if player:getAccountType() >= ACCOUNT_TYPE_GAMEMASTER then
+	if player:getGroup():getId() >= GROUP_TYPE_GAMEMASTER then
 		if type == TALKTYPE_CHANNEL_Y then
 			return TALKTYPE_CHANNEL_O
 		end
@@ -28,7 +28,7 @@ function onSpeak(player, type, message)
 	player:addCondition(muted)
 
 	if type == TALKTYPE_CHANNEL_O then
-		if player:getAccountType() < ACCOUNT_TYPE_GAMEMASTER then
+		if player:getGroup():getId() < GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then

--- a/data/chatchannels/scripts/english_chat.lua
+++ b/data/chatchannels/scripts/english_chat.lua
@@ -4,17 +4,17 @@ function onSpeak(player, type, message)
 		return false
 	end
 
-	local playerAccountType = player:getAccountType()
+	local playerGroupType = player:getGroup():getId()
 	if type == TALKTYPE_CHANNEL_Y then
-		if playerAccountType >= ACCOUNT_TYPE_GAMEMASTER then
+		if playerGroupType >= GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_O
 		end
 	elseif type == TALKTYPE_CHANNEL_O then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	end

--- a/data/chatchannels/scripts/help.lua
+++ b/data/chatchannels/scripts/help.lua
@@ -6,8 +6,8 @@ muted:setParameter(CONDITION_PARAM_SUBID, CHANNEL_HELP)
 muted:setParameter(CONDITION_PARAM_TICKS, 3600000)
 
 function onSpeak(player, type, message)
-	local playerAccountType = player:getAccountType()
-	if player:getLevel() == 1 and playerAccountType == ACCOUNT_TYPE_NORMAL then
+	local playerGroupType = player:getGroup():getId()
+	if player:getLevel() == 1 and playerGroupType == GROUP_TYPE_NORMAL then
 		player:sendCancelMessage("You may not speak into channels as long as you are on level 1.")
 		return false
 	end
@@ -17,12 +17,12 @@ function onSpeak(player, type, message)
 		return false
 	end
 
-	if playerAccountType >= ACCOUNT_TYPE_TUTOR then
+	if playerGroupType >= GROUP_TYPE_TUTOR then
 		if string.sub(message, 1, 6) == "!mute " then
 			local targetName = string.sub(message, 7)
 			local target = Player(targetName)
 			if target then
-				if playerAccountType > target:getAccountType() then
+				if playerGroupType > target:getAccountType() then
 					if not target:getCondition(CONDITION_CHANNELMUTEDTICKS, CONDITIONID_DEFAULT, CHANNEL_HELP) then
 						target:addCondition(muted)
 						target:setStorageValue(storage, os.time() + 180)
@@ -41,7 +41,7 @@ function onSpeak(player, type, message)
 			local targetName = string.sub(message, 9)
 			local target = Player(targetName)
 			if target then
-				if playerAccountType > target:getAccountType() then
+				if playerGroupType > target:getAccountType() then
 					if target:getStorageValue(storage) > os.time() then
 						target:removeCondition(CONDITION_CHANNELMUTEDTICKS, CONDITIONID_DEFAULT, CHANNEL_HELP)
 						sendChannelMessage(CHANNEL_HELP, TALKTYPE_CHANNEL_R1, target:getName() .. " has been unmuted.")
@@ -60,16 +60,16 @@ function onSpeak(player, type, message)
 	end
 
 	if type == TALKTYPE_CHANNEL_Y then
-		if playerAccountType >= ACCOUNT_TYPE_TUTOR or player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
+		if playerGroupType >= GROUP_TYPE_TUTOR or player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
 			type = TALKTYPE_CHANNEL_O
 		end
 	elseif type == TALKTYPE_CHANNEL_O then
-		if playerAccountType < ACCOUNT_TYPE_TUTOR and not player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
+		if playerGroupType < GROUP_TYPE_TUTOR and not player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
-			if playerAccountType >= ACCOUNT_TYPE_TUTOR or player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
+			if playerGroupType >= GROUP_TYPE_TUTOR or player:hasFlag(PlayerFlag_TalkOrangeHelpChannel) then
 				type = TALKTYPE_CHANNEL_O
 			else
 				type = TALKTYPE_CHANNEL_Y

--- a/data/chatchannels/scripts/tutor.lua
+++ b/data/chatchannels/scripts/tutor.lua
@@ -1,19 +1,19 @@
 function canJoin(player)
-	return player:getAccountType() >= ACCOUNT_TYPE_TUTOR
+	return player:getGroup():getId() >= GROUP_TYPE_TUTOR
 end
 
 function onSpeak(player, type, message)
-	local playerAccountType = player:getAccountType()
+	local playerGroupType = player:getGroup():getId()
 	if type == TALKTYPE_CHANNEL_Y then
-		if playerAccountType >= ACCOUNT_TYPE_SENIORTUTOR then
+		if playerGroupType >= GROUP_TYPE_SENIORTUTOR then
 			type = TALKTYPE_CHANNEL_O
 		end
 	elseif type == TALKTYPE_CHANNEL_O then
-		if playerAccountType < ACCOUNT_TYPE_SENIORTUTOR then
+		if playerGroupType < GROUP_TYPE_SENIORTUTOR then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	end

--- a/data/chatchannels/scripts/world_chat.lua
+++ b/data/chatchannels/scripts/world_chat.lua
@@ -1,20 +1,20 @@
 function onSpeak(player, type, message)
-	local playerAccountType = player:getAccountType()
-	if player:getLevel() == 1 and playerAccountType < ACCOUNT_TYPE_GAMEMASTER then
+	local playerGroupType = player:getGroup():getId()
+	if player:getLevel() == 1 and playerGroupType < GROUP_TYPE_GAMEMASTER then
 		player:sendCancelMessage("You may not speak into channels as long as you are on level 1.")
 		return false
 	end
 
 	if type == TALKTYPE_CHANNEL_Y then
-		if playerAccountType >= ACCOUNT_TYPE_GAMEMASTER then
+		if playerGroupType >= GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_O
 		end
 	elseif type == TALKTYPE_CHANNEL_O then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	elseif type == TALKTYPE_CHANNEL_R1 then
-		if playerAccountType < ACCOUNT_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
+		if playerGroupType < GROUP_TYPE_GAMEMASTER and not player:hasFlag(PlayerFlag_CanTalkRedChannel) then
 			type = TALKTYPE_CHANNEL_Y
 		end
 	end


### PR DESCRIPTION
Currently messages are based on the player's account, which causes a character on the god account to speak in orange. With this modification, chats will be based on the player's group and not on the account type.