### PR TITLE
fix: add death event into white deer

### DIFF
--- a/data-otservbr-global/monster/mammals/white_deer.lua
+++ b/data-otservbr-global/monster/mammals/white_deer.lua
@@ -62,6 +62,10 @@ monster.flags = {
 	canWalkOnPoison = false,
 }
 
+monster.events = {
+	"WhiteDeerDeath",
+}
+
 monster.light = {
 	level = 0,
 	color = 0,

--- a/data-otservbr-global/monster/mammals/white_deer.lua
+++ b/data-otservbr-global/monster/mammals/white_deer.lua
@@ -13,6 +13,10 @@ monster.outfit = {
 	lookMount = 0,
 }
 
+monster.events = {
+	"WhiteDeerDeath",
+}
+
 monster.raceId = 720
 monster.Bestiary = {
 	class = "Mammal",
@@ -60,10 +64,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-}
-
-monster.events = {
-	"WhiteDeerDeath",
 }
 
 monster.light = {


### PR DESCRIPTION
When killing the white deer creature, it should reappear as an enraged white deer in case of success and in case of failure, a pair of elves, this addition to the event allows the mechanics that had been lost to be reincorporated


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Test A
  - [x] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
