### PR TITLE
fix: adjustments to block move inbox store items to floor

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1102,6 +1102,17 @@ void Game::playerMoveThing(uint32_t playerId, const Position &fromPos, uint16_t 
 			playerMoveCreature(player, movingCreature, movingCreature->getPosition(), tile);
 		}
 	} else if (thing->getItem()) {
+
+		if (thing->getItem()->isStoreItem()) {
+			// '0x40' -> To store inbox.
+			// '0x41' -> To depot.
+			// '0x42:0x50' -> To all depot slot.
+			if (toPos.y < 0x40 || toPos.y > 0x50) {
+				player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+				return;
+			}
+		}
+
 		std::shared_ptr<Cylinder> toCylinder = internalGetCylinder(player, toPos);
 		if (!toCylinder) {
 			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);


### PR DESCRIPTION
# Description

Adjustments to block move store inbox itens to floor, related in this issue: https://github.com/opentibiabr/canary/issues/1855

## Behaviour
### **Actual**

Os itens da Store inbox, tanto os comprados na Store quanto os obtidos via Daily Reward, estão podendo ser movidos para fora da Store Inbox e jogados no chão, podendo assim ser obtidos por outros jogadores.

https://github.com/opentibiabr/canary/assets/17263249/3adb1c59-0b17-49db-8f50-963550c6a164

### **Expected**

Os itens da Store Inbox, devem apenas ser movidos para o depósito, e do depósito para o Store Inbox.

https://github.com/opentibiabr/canary/assets/17263249/8d2694a9-06da-4497-a10e-477348ce37e1

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Comprar um item na Store ou obter na Daily Reward.
Arrastar e soltar o item para o chão.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
