### PR TITLE
improve: added monster count to create monster talkaction

### DIFF
--- a/data/scripts/talkactions/god/create_monster.lua
+++ b/data/scripts/talkactions/god/create_monster.lua
@@ -1,7 +1,7 @@
 local function createCreaturesAround(player, maxRadius, creatureName, creatureCount, creatureForge, boolForceCreate)
 	local position = player:getPosition()
 	local createdCount = 0
-	local sendMessage
+	local sendMessage = false
 	local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(creatureForge, player)
 	for radius = 1, maxRadius do
 		if createdCount >= creatureCount then

--- a/data/scripts/talkactions/god/create_monster.lua
+++ b/data/scripts/talkactions/god/create_monster.lua
@@ -1,3 +1,48 @@
+local function createCreaturesAround(player, maxRadius, creatureName, creatureCount, creatureForge, mustBeReachable)
+	local position = player:getPosition()
+	local createdCount = 0
+	local sendMessage = false
+	local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(creatureForge, player)
+	for radius = 1, maxRadius do
+		if createdCount >= creatureCount then
+			break
+		end
+
+		local minX = position.x - radius
+		local maxX = position.x + radius
+		local minY = position.y - radius
+		local maxY = position.y + radius
+		for dx = minX, maxX do
+			for dy = minY, maxY do
+				if (dx == minX or dx == maxX or dy == minY or dy == maxY) and createdCount < creatureCount then
+					local checkPosition = Position(dx, dy, position.z)
+					local tile = Tile(checkPosition)
+					if tile and tile:getCreatureCount() == 0 and not tile:hasProperty(CONST_PROP_IMMOVABLEBLOCKSOLID) and (not mustBeReachable or player:getPathTo(checkPosition)) then
+						local monster = Game.createMonster(creatureName, checkPosition)
+						if monster then
+							createdCount = createdCount + 1
+							monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+							position:sendMagicEffect(CONST_ME_MAGIC_RED)
+							if creatureForge ~= nil and monster:isForgeable() then
+								local monsterType = monster:getType()
+								if canSetFiendish then
+									SetFiendish(monsterType, position, player, monster)
+								end
+								if canSetInfluenced then
+									SetInfluenced(monsterType, monster, player, influencedLevel)
+								end
+							elseif notSendMessage then
+								sendMessage = true
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+	player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
+end
+
 local createMonster = TalkAction("/m")
 
 function createMonster.onSay(player, words, param)
@@ -12,25 +57,36 @@ function createMonster.onSay(player, words, param)
 		return true
 	end
 
+	local position = player:getPosition()
+
 	local split = param:split(",")
 	local monsterName = split[1]
-	local monsterForge = nil
+	local monsterCount = 0
 	if split[2] then
 		split[2] = split[2]:gsub("^%s*(.-)$", "%1") --Trim left
-		monsterForge = split[2]
+		monsterCount = tonumber(split[2])
+	end
+
+	local monsterForge = nil
+	if split[3] then
+		split[3] = split[3]:gsub("^%s*(.-)$", "%1") --Trim left
+		monsterForge = split[3]
 	end
 	-- Check dust level
-	local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(monsterForge, player)
+	if monsterCount > 1 then
+		createCreaturesAround(player, 20, monsterName, monsterCount, monsterForge, true)
+		return true
+	end
 
-	local position = player:getPosition()
 	local monster = Game.createMonster(monsterName, position)
 	if monster then
-		if not monster:isForgeable() then
+		local canSetFiendish, canSetInfluenced, influencedLevel = CheckDustLevel(monsterForge, player)
+		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+		position:sendMagicEffect(CONST_ME_MAGIC_RED)
+		if monsterForge ~= nil and not monster:isForgeable() then
 			player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
 			return true
 		end
-		monster:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-		position:sendMagicEffect(CONST_ME_MAGIC_RED)
 
 		local monsterType = monster:getType()
 		if canSetFiendish then

--- a/data/scripts/talkactions/god/create_monster.lua
+++ b/data/scripts/talkactions/god/create_monster.lua
@@ -43,7 +43,7 @@ local function createCreaturesAround(player, maxRadius, creatureName, creatureCo
 	if sendMessage == true then
 		player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
 	end
-	
+
 	logger.info("Created '{}' monsters", createdCount)
 end
 

--- a/data/scripts/talkactions/god/create_monster.lua
+++ b/data/scripts/talkactions/god/create_monster.lua
@@ -44,7 +44,7 @@ local function createCreaturesAround(player, maxRadius, creatureName, creatureCo
 		player:sendCancelMessage("Only allowed monsters can be fiendish or influenced.")
 	end
 
-	logger.info("Created '{}' monsters", createdCount)
+	logger.info("Player {} created '{}' monsters", player:getName(), createdCount)
 end
 
 local createMonster = TalkAction("/m")


### PR DESCRIPTION
This introduces an improved algorithm for spawning monsters around the player. The enhanced function `createCreaturesAround` now generates creatures in a concentric pattern, starting from the player's position and expanding outwards up to a specified radius. This mechanism ensures a more balanced and controlled distribution of monsters.

Key Features:
- Monsters are spawned in a pattern that expands from 1x1 to a maximum of defined tiles around the player.
- The function supports customization of the monster type, count, and specific forge options.
- Incorporates an option to force spawn monsters, even on occupied tiles.
- Ensures game playability by respecting immovable and solid property checks on tiles.

This update aims to provide a more dynamic and better testing environment.