### PR TITLE
fix: loot message typo

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -754,7 +754,7 @@ bool Creature::dropCorpse(std::shared_ptr<Creature> lastHitCreature, std::shared
 				auto monster = getMonster();
 				if (monster && !monster->isRewardBoss()) {
 					std::ostringstream lootMessage;
-					lootMessage << "Loot of " << getNameDescription() << ": " << corpse->getContainer()->getContentDescription(player->getProtocolVersion() < 1200);
+					lootMessage << "Loot of " << getNameDescription() << ": " << corpse->getContainer()->getContentDescription(player->getProtocolVersion() < 1200) << ".";
 					auto suffix = corpse->getContainer()->getAttribute<std::string>(ItemAttribute_t::LOOTMESSAGE_SUFFIX);
 					if (!suffix.empty()) {
 						lootMessage << suffix;


### PR DESCRIPTION
![image](https://github.com/opentibiabr/canary/assets/98285577/7fb8aa03-5d7b-4bf6-8e83-800b476aaab8)
![image](https://github.com/opentibiabr/canary/assets/98285577/f2cd1984-9690-4320-bac7-38d246052c2f)

Correção da falta de pontuação ao final da mensagem de loot.
Igual no Tibia Global.