### PR TITLE
fix: adjust target reach assumption immediately after setting

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -1064,7 +1064,7 @@ bool Creature::setFollowCreature(std::shared_ptr<Creature> creature) {
 			onWalkAborted();
 		}
 
-		hasFollowPath = false;
+		hasFollowPath = true;
 		forceUpdateFollowPath = false;
 		m_followCreature = creature;
 		isUpdatingPath = true;


### PR DESCRIPTION
This is a pretty subtle bug, but it prevents the `challenge` spell from working most of the time. This is what occurs:

1. Monster attacks someone, it's their only option for a target when they do, so whether or not they can reach it, it sets it; it keeps trying to set it until it works
2. Someone challenges it; it sets its target to the new person (which runs the code above)
3. `onThink` runs, `hasFollowPath` is still `false` because we haven't had time to run the path finding algo yet; we think it's unreachable and switch away to the other target (with we already had a path for)

Solution: by "assuming" we have a path, we let the pathfinding algo run, in the meantime `onThink` assumes everything is OK.

