### PR TITLE
fix: change creature from checkCreatures from reference to copy

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5797,7 +5797,7 @@ void Game::checkCreatures() {
 	auto &checkCreatureList = checkCreatureLists[index];
 	size_t it = 0, end = checkCreatureList.size();
 	while (it < end) {
-		const auto &creature = checkCreatureList[it];
+		auto creature = checkCreatureList[it];
 		if (creature && creature->creatureCheck) {
 			if (creature->getHealth() > 0) {
 				creature->onThink(EVENT_CREATURE_THINK_INTERVAL);


### PR DESCRIPTION
Ensures that the Creature's shared_ptr is handled properly and prevents a crash from occurring due to the creature being prematurely removed.

Resolves #1896 