### PR TITLE
fix: monsters bestiary class

### DIFF
--- a/data-otservbr-global/monster/reptiles/boar_man.lua
+++ b/data-otservbr-global/monster/reptiles/boar_man.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2339
 monster.Bestiary = {
-	class = "Hybrids",
+	class = "Humanoid",
 	race = BESTY_RACE_HUMANOID,
 	toKill = 2500,
 	FirstUnlock = 100,

--- a/data-otservbr-global/monster/reptiles/crape_man.lua
+++ b/data-otservbr-global/monster/reptiles/crape_man.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2337
 monster.Bestiary = {
-	class = "Hybrids",
+	class = "Humanoid",
 	race = BESTY_RACE_HUMANOID,
 	toKill = 2500,
 	FirstUnlock = 100,

--- a/data-otservbr-global/monster/reptiles/liodile.lua
+++ b/data-otservbr-global/monster/reptiles/liodile.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2338
 monster.Bestiary = {
-	class = "Hybrids",
+	class = "Humanoid",
 	race = BESTY_RACE_HUMANOID,
 	toKill = 2500,
 	FirstUnlock = 100,

--- a/data-otservbr-global/monster/reptiles/rhindeer.lua
+++ b/data-otservbr-global/monster/reptiles/rhindeer.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2342
 monster.Bestiary = {
-	class = "Hybrids",
+	class = "Humanoid",
 	race = BESTY_RACE_HUMANOID,
 	toKill = 2500,
 	FirstUnlock = 100,


### PR DESCRIPTION
# Description

When opening the bestiary window in the Tibia client, the Hybrids category appeared instead of Humanoid. And besides, there were only four monsters inside.

## Behaviour
### **Actual**

Show monsters of the (non-existent) hybrids class.

![Captura de tela 2023-11-24 175237](https://github.com/opentibiabr/canary/assets/104323065/4d05e97e-4838-49a2-b805-4b483f03449f)
![Captura de tela 2023-11-24 175248](https://github.com/opentibiabr/canary/assets/104323065/091efba2-de6e-4470-a794-43aa1f05db56)

### **Expected**

Show humanoid class monsters.

![Captura de tela 2023-11-24 180342](https://github.com/opentibiabr/canary/assets/104323065/d288225d-639c-4104-9a58-9d4c59de3c79)
![Captura de tela 2023-11-24 180357](https://github.com/opentibiabr/canary/assets/104323065/4adbb794-47e3-4906-8c80-a1a8c3bf6ce8)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Just open the bestiary window and see the monsters.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
