### PR TITLE
fix: critical damage and message log

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2054,8 +2054,8 @@ void Combat::applyExtensions(std::shared_ptr<Creature> caster, std::shared_ptr<C
 
 	if (chance != 0 && uniform_random(1, 100) <= chance) {
 		damage.critical = true;
-		damage.primary.value *= multiplier;
-		damage.secondary.value *= multiplier;
+		damage.primary.value += (damage.primary.value * caster->getPlayer()->getSkillLevel(SKILL_CRITICAL_HIT_DAMAGE)) / 100;
+		damage.secondary.value += (damage.secondary.value * caster->getPlayer()->getSkillLevel(SKILL_CRITICAL_HIT_DAMAGE)) / 100;
 	}
 
 	if (player) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6565,6 +6565,9 @@ bool Game::combatChangeHealth(std::shared_ptr<Creature> attacker, std::shared_pt
 					int32_t totalDamage = damageX;
 					if (distanceX != distanceY) {
 						totalDamage += damageY;
+						if (damage.critical) {
+							totalDamage += (totalDamage * attackerPlayer->getSkillLevel(SKILL_CRITICAL_HIT_DAMAGE));
+						}
 					}
 					damage.primary.value += totalDamage;
 					if (!damage.exString.empty()) {
@@ -6971,6 +6974,10 @@ void Game::buildMessageAsAttacker(
 	}
 	if (damage.fatal) {
 		ss << " (Onslaught)";
+	}
+	if (damage.critical) {
+		ss.str("");
+		ss << ucfirst(target->getNameDescription()) << " loses " << damageString << " due to your critical attack.";
 	}
 	message.type = MESSAGE_DAMAGE_DEALT;
 	message.text = ss.str();


### PR DESCRIPTION
Fix Critical hit multiplier and server log message

resolves https://github.com/opentibiabr/canary/issues/1893
resolves https://github.com/opentibiabr/canary/issues/1888

*please test it*

**Test Configuration**:

  - Server Version: canary 13.21
  - Client: 13.21
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
