### PR TITLE
improve: '/pos' command parsing for multiple formats

### DIFF
--- a/data/scripts/talkactions/gm/position.lua
+++ b/data/scripts/talkactions/gm/position.lua
@@ -30,14 +30,14 @@ function position.onSay(player, words, param)
 
 	local x, y, z = extractCoordinates(param)
 	if x and y and z then
-		local position = Position(x, y, z)
-		local tile = Tile(position)
+		local teleportPosition = Position(x, y, z)
+		local tile = Tile(teleportPosition)
 		if not tile then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid tile or position. Send a valid position.")
 			return true
 		end
 
-		player:teleportTo(position)
+		player:teleportTo(teleportPosition)
 		return true
 	else
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid position format. Use one of the following formats: \n/pos {x = ..., y = ..., z = ...}\n/pos Position(..., ..., ...)\n/pos x, y, z.")

--- a/data/scripts/talkactions/gm/position.lua
+++ b/data/scripts/talkactions/gm/position.lua
@@ -1,22 +1,47 @@
 local position = TalkAction("/pos", "!pos")
 
+local function extractCoordinates(input)
+	local patterns = {
+		-- table format
+		"{%s*x%s*=%s*(%d+)%s*,%s*y%s*=%s*(%d+)%s*,%s*z%s*=%s*(%d+)%s*}",
+		-- Position format
+		"Position%s*%((%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)",
+		-- x, y, z format
+		"(%d+)%s*,%s*(%d+)%s*,%s*(%d+)",
+	}
+
+	for _, pattern in ipairs(patterns) do
+		local x, y, z = string.match(input, pattern)
+		if x and y and z then
+			return tonumber(x), tonumber(y), tonumber(z)
+		end
+	end
+end
+
 function position.onSay(player, words, param)
 	-- create log
 	logCommand(player, words, param)
 
-	local param = string.gsub(param, "%s+", "")
-	local tile = load("return " .. param)()
-	local split = param:split(",")
-	if type(tile) == "table" and tile.x and tile.y and tile.z then
-		player:teleportTo(Position(tile.x, tile.y, tile.z))
-	elseif split and param ~= "" then
-		player:teleportTo(Position(split[1], split[2], split[3]))
-	elseif param == "" then
-		local playerPosition = player:getPosition()
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your current position is: \z
-		" .. playerPosition.x .. ", " .. playerPosition.y .. ", " .. playerPosition.z .. ".")
+	if param == "" then
+		local pos = player:getPosition()
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your current position is: " .. pos.x .. ", " .. pos.y .. ", " .. pos.z .. ".")
+		return true
 	end
-	return true
+
+	local x, y, z = extractCoordinates(param)
+	if x and y and z then
+		local position = Position(x, y, z)
+		local tile = Tile(position)
+		if not tile then
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid tile or position. Send a valid position.")
+			return true
+		end
+
+		player:teleportTo(position)
+		return true
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid position format. Use one of the following formats: \n/pos {x = ..., y = ..., z = ...}\n/pos Position(..., ..., ...)\n/pos x, y, z.")
+	end
 end
 
 position:separator(" ")

--- a/data/scripts/talkactions/gm/position.lua
+++ b/data/scripts/talkactions/gm/position.lua
@@ -38,7 +38,6 @@ function position.onSay(player, words, param)
 		end
 
 		player:teleportTo(teleportPosition)
-		return true
 	else
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid position format. Use one of the following formats: \n/pos {x = ..., y = ..., z = ...}\n/pos Position(..., ..., ...)\n/pos x, y, z.")
 	end

--- a/data/scripts/talkactions/gm/position.lua
+++ b/data/scripts/talkactions/gm/position.lua
@@ -25,7 +25,7 @@ function position.onSay(player, words, param)
 	if param == "" then
 		local pos = player:getPosition()
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your current position is: " .. pos.x .. ", " .. pos.y .. ", " .. pos.z .. ".")
-		return true
+		return
 	end
 
 	local x, y, z = extractCoordinates(param)
@@ -34,7 +34,7 @@ function position.onSay(player, words, param)
 		local tile = Tile(teleportPosition)
 		if not tile then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid tile or position. Send a valid position.")
-			return true
+			return
 		end
 
 		player:teleportTo(teleportPosition)


### PR DESCRIPTION
Refactored the '/pos' command in the game's scripting to support multiple input formats more robustly. The command now accurately interprets positions from table format '{x = ..., y = ..., z = ...}', the 'Position(..., ..., ...)' format, and the standard 'x, y, z' coordinate format. The update includes improved error handling and clearer user feedback for invalid inputs.

Resolves #1846