### PR TITLE
fix: issues related to party leadership and leaving a party

### DIFF
--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -187,16 +187,16 @@ bool Party::passPartyLeadership(std::shared_ptr<Player> player) {
 
 	for (auto member : getMembers()) {
 		member->sendPartyCreatureShield(oldLeader);
-		member->sendPartyCreatureShield(leader);
+		member->sendPartyCreatureShield(player);
 	}
 
 	for (auto invitee : getInvitees()) {
 		invitee->sendCreatureShield(oldLeader);
-		invitee->sendCreatureShield(leader);
+		invitee->sendCreatureShield(player);
 	}
 
-	leader->sendPartyCreatureShield(oldLeader);
-	leader->sendPartyCreatureShield(leader);
+	player->sendPartyCreatureShield(oldLeader);
+	player->sendPartyCreatureShield(player);
 
 	player->sendTextMessage(MESSAGE_PARTY_MANAGEMENT, "You are now the leader of the party.");
 	return true;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7736,7 +7736,8 @@ void Game::playerLeaveParty(uint32_t playerId) {
 	}
 
 	std::shared_ptr<Party> party = player->getParty();
-	if (!party || player->hasCondition(CONDITION_INFIGHT)) {
+	if (!party || player->hasCondition(CONDITION_INFIGHT) && !player->getZoneType() == ZONE_PROTECTION) {
+		player->sendTextMessage(TextMessage(MESSAGE_FAILURE, "You cannot leave party, contact the administrator."));
 		return;
 	}
 


### PR DESCRIPTION
• Leadership Transition in Party: Resolved the issue where party leadership was not being passed correctly (Resolves https://github.com/opentibiabr/canary/issues/1830). This fix ensures smooth transition of leadership as intended.

• Leaving Party in Specific Conditions: Addressed a bug where players sometimes couldn't leave a party. The issue was identified in the 'Game::playerLeaveParty' function, which returned prematurely when a player was in a protection zone and in infight mode. This fix includes a check for the protection zone to ensure that players can leave the party as expected.