### PR TITLE
fix: conjuring spectral bolt wrong id

### DIFF
--- a/data-canary/scripts/spells/conjuring/Conjure_Spectral_Bolt.lua
+++ b/data-canary/scripts/spells/conjuring/Conjure_Spectral_Bolt.lua
@@ -1,7 +1,7 @@
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, variant)
-	return creature:conjureItem(0, 25758, 100, CONST_ME_MAGIC_BLUE)
+	return creature:conjureItem(0, 35902, 100, CONST_ME_MAGIC_BLUE)
 end
 
 spell:group("support")

--- a/data-otservbr-global/scripts/spells/conjuring/Conjure_Spectral_Bolt.lua
+++ b/data-otservbr-global/scripts/spells/conjuring/Conjure_Spectral_Bolt.lua
@@ -1,7 +1,7 @@
 local spell = Spell("instant")
 
 function spell.onCastSpell(creature, variant)
-	return creature:conjureItem(0, 25758, 100, CONST_ME_MAGIC_BLUE)
+	return creature:conjureItem(0, 35902, 100, CONST_ME_MAGIC_BLUE)
 end
 
 spell:group("support")


### PR DESCRIPTION
It was conjuring the old id (with duration) instead of the correct id.