### PR TITLE
fix: lua getNumber overflow

### DIFF
--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -62,7 +62,7 @@ public:
 	getNumber(lua_State* L, int32_t arg) {
 		return static_cast<T>(static_cast<int64_t>(lua_tonumber(L, arg)));
 	}
-	template<typename T>
+	template <typename T>
 	static typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value, T>::type getNumber(lua_State* L, int32_t arg) {
 		auto number = lua_tonumber(L, arg);
 		// If there is overflow, we return the value 0

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -66,7 +66,7 @@ public:
 	static typename std::enable_if<std::is_integral<T>::value || std::is_floating_point<T>::value, T>::type getNumber(lua_State* L, int32_t arg) {
 		auto number = lua_tonumber(L, arg);
 		// If there is overflow, we return the value 0
-		if constexpr (std::is_integral<T>::value && std::is_unsigned<T>::value) {
+		if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
 			if (number < 0) {
 				g_logger().warn("[{}] overflow, setting to default signed value (0)", __FUNCTION__);
 				number = T(0);


### PR DESCRIPTION
Converting Lua numbers to unsigned integer types in C++ can be problematic due to Lua's lua_tonumber function defaulting to -1 when no explicit integer is defined. This poses an overflow risk when casting to unsigned types like uint32_t or uint16_t in C++, as negative values translate to large positive numbers.

This pull request addresses the issue by implementing a check in the Lua-to-C++ conversion function. If lua_tonumber returns a negative value, we adjust the value to 0 for unsigned types. This ensures safe and accurate conversion of Lua values to C++ unsigned integers, avoiding unexpected overflow and maintaining data integrity.