### PR TITLE
fix: quivers not showing attributes

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -61565,6 +61565,7 @@
 	<item id="36666" article="a" name="eldritch quiver">
 		<attribute key="primarytype" value="quivers"/>
 		<attribute key="slotType" value="right-hand"/>
+		<attribute key="showattributes" value="1"/>
 		<attribute key="containersize" value="8"/>
 		<attribute key="weight" value="2200"/>
 		<attribute key="perfectshotdamage" value="20"/>
@@ -65289,6 +65290,7 @@
 	<item id="39150" article="an" name="alicorn quiver">
 		<attribute key="primarytype" value="quivers"/>
 		<attribute key="slotType" value="right-hand"/>
+		<attribute key="showattributes" value="1"/>
 		<attribute key="containersize" value="12"/>
 		<attribute key="weight" value="2000"/>
 		<attribute key="magiclevelpoints" value="1"/>


### PR DESCRIPTION
changes:
- Added showattributes property to alicorn and eldritch quivers in items.xml

# Description

This change make the Alicorn and Eldritch quiver shows the attributes of perfect shot and others attributes.

## Behaviour
### **Actual**

Create an Alicorn or Eldritch quiver and look, it is not showing the attributes perfect shot and magic level.

### **Expected**

Create an Alicorn or Eldritch quiver and look, it is showing the attributes perfect shot and magic level.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Create an alicorn quiver and look
  - [ ] Create an eldritch quiver and look

**Test Configuration**:

  - Server Version: 3.1.1
  - Client: Tibia 13.21.13839
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works

closes #1914 
