### PR TITLE
feat: add sound for open and close doors

### DIFF
--- a/data-otservbr-global/scripts/actions/door/custom_door.lua
+++ b/data-otservbr-global/scripts/actions/door/custom_door.lua
@@ -18,12 +18,14 @@ function customDoor.onUse(player, item, fromPosition, target, toPosition, isHotk
 	for index, value in ipairs(CustomDoorTable) do
 		if value.closedDoor == item.itemid then
 			item:transform(value.openDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_OPEN_DOOR)
 			return true
 		end
 	end
 	for index, value in ipairs(CustomDoorTable) do
 		if value.openDoor == item.itemid then
 			item:transform(value.closedDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_CLOSE_DOOR)
 			return true
 		end
 	end

--- a/data-otservbr-global/scripts/actions/door/key_door.lua
+++ b/data-otservbr-global/scripts/actions/door/key_door.lua
@@ -37,6 +37,7 @@ function keyDoor.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	for index, value in ipairs(KeyDoorTable) do
 		if value.closedDoor == item.itemid then
 			item:transform(value.openDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_OPEN_DOOR)
 			return true
 		end
 	end
@@ -46,6 +47,7 @@ function keyDoor.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				return false
 			end
 			item:transform(value.closedDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_CLOSE_DOOR)
 			return true
 		end
 	end
@@ -60,8 +62,12 @@ function keyDoor.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			if item.actionid == target.actionid then
 				if value.lockedDoor == target.itemid then
 					target:transform(value.openDoor)
+					item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_OPEN_DOOR)
 					return true
 				elseif table.contains({ value.openDoor, value.closedDoor }, target.itemid) then
+					if value.openDoor == item.itemid then
+						item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_CLOSE_DOOR)
+					end
 					target:transform(value.lockedDoor)
 					return true
 				end

--- a/data-otservbr-global/scripts/actions/door/level_door.lua
+++ b/data-otservbr-global/scripts/actions/door/level_door.lua
@@ -15,6 +15,7 @@ function levelDoor.onUse(player, item, fromPosition, target, toPosition, isHotke
 		if value.closedDoor == item.itemid then
 			if item.actionid > 0 and player:getLevel() >= item.actionid - 1000 then
 				item:transform(value.openDoor)
+				item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_OPEN_DOOR)
 				player:teleportTo(toPosition, true)
 				return true
 			else

--- a/data-otservbr-global/scripts/actions/door/quest_door.lua
+++ b/data-otservbr-global/scripts/actions/door/quest_door.lua
@@ -15,6 +15,7 @@ function questDoor.onUse(player, item, fromPosition, target, toPosition, isHotke
 		if value.closedDoor == item.itemid then
 			if item.actionid > 0 and player:getStorageValue(item.actionid) ~= -1 then
 				item:transform(value.openDoor)
+				item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_OPEN_DOOR)
 				player:teleportTo(toPosition, true)
 				return true
 			else

--- a/data-otservbr-global/scripts/movements/others/closing_door.lua
+++ b/data-otservbr-global/scripts/movements/others/closing_door.lua
@@ -103,11 +103,13 @@ function closingDoor.onStepOut(creature, item, position, fromPosition)
 	for index, value in ipairs(LevelDoorTable) do
 		if value.openDoor == item.itemid then
 			item:transform(value.closedDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_CLOSE_DOOR)
 		end
 	end
 	for index, value in ipairs(QuestDoorTable) do
 		if value.openDoor == item.itemid then
 			item:transform(value.closedDoor)
+			item:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ACTION_CLOSE_DOOR)
 		end
 	end
 	return true


### PR DESCRIPTION
changes:
- Added open sound to custom/normal doors
- Added open sound to key doors
- Added open sound to level doors
- Added open sound to quest doors


# Description

Addition of open and close doors sound to all type of doors.

## Behaviour
### **Actual**

Opens or closes a door and there's no sound.

### **Expected**

Opens or closes a door and the open or close door sound should be heard.

## Type of change

  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

All the tests below should cast a sound for all spectators.
  - [ ] Opens a common door
  - [ ] Opens a quest door
  - [ ] Opens a level door
  - [ ] Opens a locked door
  - [ ] Closes a common door
  - [ ] Closes a quest door
  - [ ] Closes a level door
  - [ ] Closes a locked door

**Test Configuration**:

  - Server Version: 3.1.1
  - Client: 13.21.13839
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
