### PR TITLE
feat: kv: remove key and list prefix

### DIFF
--- a/src/kv/kv.hpp
+++ b/src/kv/kv.hpp
@@ -32,6 +32,8 @@ public:
 
 	virtual std::shared_ptr<KV> scoped(const std::string &scope) = 0;
 
+	virtual std::unordered_set<std::string> keys(const std::string &prefix = "") = 0;
+
 	void remove(const std::string &key);
 
 	virtual void flush() {
@@ -60,6 +62,7 @@ public:
 	}
 
 	std::shared_ptr<KV> scoped(const std::string &scope) override final;
+	std::unordered_set<std::string> keys(const std::string &prefix = "");
 
 protected:
 	phmap::parallel_flat_hash_map<std::string, std::pair<ValueWrapper, std::list<std::string>::iterator>> getStore() {
@@ -76,6 +79,7 @@ protected:
 
 	virtual std::optional<ValueWrapper> load(const std::string &key) = 0;
 	virtual bool save(const std::string &key, const ValueWrapper &value) = 0;
+	virtual std::vector<std::string> loadPrefix(const std::string &prefix = "") = 0;
 
 private:
 	void setLocked(const std::string &key, const ValueWrapper &value);
@@ -118,8 +122,12 @@ public:
 	}
 
 	std::shared_ptr<KV> scoped(const std::string &scope) override final {
-		logger.debug("ScopedKV::scoped({})", buildKey(scope));
+		logger.trace("ScopedKV::scoped({})", buildKey(scope));
 		return std::make_shared<ScopedKV>(logger, rootKV_, buildKey(scope));
+	}
+
+	std::unordered_set<std::string> keys(const std::string &prefix = "") override {
+		return rootKV_.keys(buildKey(prefix));
 	}
 
 private:

--- a/src/kv/kv_sql.hpp
+++ b/src/kv/kv_sql.hpp
@@ -25,6 +25,7 @@ public:
 	bool saveAll() override;
 
 private:
+	std::vector<std::string> loadPrefix(const std::string &prefix = "") override;
 	std::optional<ValueWrapper> load(const std::string &key) override;
 	bool save(const std::string &key, const ValueWrapper &value) override;
 	bool prepareSave(const std::string &key, const ValueWrapper &value, DBInsert &update);

--- a/src/kv/value_wrapper.cpp
+++ b/src/kv/value_wrapper.cpp
@@ -1,30 +1,31 @@
 #include "kv/value_wrapper.hpp"
+#include "utils/tools.hpp"
 
 ValueWrapper::ValueWrapper(uint64_t timestamp) :
-	timestamp_(timestamp) { }
+	timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(const ValueVariant &value, uint64_t timestamp) :
-	data_(value), timestamp_(timestamp) { }
+	data_(value), timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(const std::string &value, uint64_t timestamp) :
-	data_(value), timestamp_(timestamp) { }
+	data_(value), timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(bool value, uint64_t timestamp) :
-	data_(value), timestamp_(timestamp) { }
+	data_(value), timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(int value, uint64_t timestamp) :
-	data_(value), timestamp_(timestamp) { }
+	data_(value), timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(double value, uint64_t timestamp) :
-	data_(value), timestamp_(timestamp) { }
+	data_(value), timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(const phmap::flat_hash_map<std::string, ValueWrapper> &value, uint64_t timestamp) :
 	data_(createMapFromRange(value.begin(), value.end(), timestamp)),
-	timestamp_(timestamp) { }
+	timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 ValueWrapper::ValueWrapper(const std::initializer_list<std::pair<const std::string, ValueWrapper>> &init_list, uint64_t timestamp) :
 	data_(createMapFromRange(init_list.begin(), init_list.end(), timestamp)),
-	timestamp_(timestamp) { }
+	timestamp_(timestamp == 0 ? getTimeMsNow() : timestamp) { }
 
 std::optional<ValueWrapper> ValueWrapper::get(const std::string &key) const {
 	auto pval = std::get_if<MapType>(&data_);

--- a/src/lua/functions/core/libs/kv_functions.cpp
+++ b/src/lua/functions/core/libs/kv_functions.cpp
@@ -72,10 +72,48 @@ int KVFunctions::luaKVGet(lua_State* L) {
 		valueWrapper = g_kv().get(key, forceLoad);
 	}
 
-	if (valueWrapper) {
+	if (valueWrapper.has_value()) {
 		pushValueWrapper(L, *valueWrapper);
 	} else {
 		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int KVFunctions::luaKVRemove(lua_State* L) {
+	// KV.remove(key) | scopedKV:remove(key)
+	auto key = getString(L, -1);
+	if (isUserdata(L, 1)) {
+		auto scopedKV = getUserdataShared<KV>(L, 1);
+		scopedKV->remove(key);
+	} else {
+		g_kv().remove(key);
+	}
+	lua_pushnil(L);
+	return 1;
+}
+
+int KVFunctions::luaKVKeys(lua_State* L) {
+	// KV.keys([prefix = ""]) | scopedKV:keys([prefix = ""])
+	std::unordered_set<std::string> keys;
+	std::string prefix = "";
+
+	if (isString(L, -1)) {
+		prefix = getString(L, -1);
+	}
+
+	if (isUserdata(L, 1)) {
+		auto scopedKV = getUserdataShared<KV>(L, 1);
+		keys = scopedKV->keys();
+	} else {
+		keys = g_kv().keys(prefix);
+	}
+
+	int index = 0;
+	lua_createtable(L, static_cast<int>(keys.size()), 0);
+	for (const auto &key : keys) {
+		pushString(L, key);
+		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
 }

--- a/src/lua/functions/core/libs/kv_functions.hpp
+++ b/src/lua/functions/core/libs/kv_functions.hpp
@@ -18,17 +18,23 @@ public:
 		registerMethod(L, "kv", "scoped", KVFunctions::luaKVScoped);
 		registerMethod(L, "kv", "set", KVFunctions::luaKVSet);
 		registerMethod(L, "kv", "get", KVFunctions::luaKVGet);
+		registerMethod(L, "kv", "keys", KVFunctions::luaKVKeys);
+		registerMethod(L, "kv", "remove", KVFunctions::luaKVRemove);
 
 		registerClass(L, "KV", "");
 		registerMethod(L, "KV", "scoped", KVFunctions::luaKVScoped);
 		registerMethod(L, "KV", "set", KVFunctions::luaKVSet);
 		registerMethod(L, "KV", "get", KVFunctions::luaKVGet);
+		registerMethod(L, "KV", "keys", KVFunctions::luaKVKeys);
+		registerMethod(L, "KV", "remove", KVFunctions::luaKVRemove);
 	}
 
 private:
 	static int luaKVScoped(lua_State* L);
 	static int luaKVSet(lua_State* L);
 	static int luaKVGet(lua_State* L);
+	static int luaKVKeys(lua_State* L);
+	static int luaKVRemove(lua_State* L);
 
 	static std::optional<ValueWrapper> getValueWrapper(lua_State* L);
 	static void pushStringValue(lua_State* L, const StringType &value);

--- a/tests/fixture/kv/in_memory_kv.hpp
+++ b/tests/fixture/kv/in_memory_kv.hpp
@@ -35,6 +35,9 @@ public:
 	}
 
 protected:
+	std::vector<std::string> loadPrefix(const std::string &prefix = "") override {
+		return {};
+	}
 	std::optional<ValueWrapper> load(const std::string &key) override {
 		return std::nullopt;
 	}


### PR DESCRIPTION
Adds a much needed `:remove()` method to the KV lua interface as well as a `:keys` method to list every key from a prefix.

Fixes #1992 
Related #1979 