### PR TITLE
fix: players healing when attacked

### DIFF
--- a/data-otservbr-global/scripts/creaturescripts/others/login_events.lua
+++ b/data-otservbr-global/scripts/creaturescripts/others/login_events.lua
@@ -10,7 +10,6 @@ function loginEvents.onLogin(player)
 		"FamiliarAdvance",
 		--Quests
 		--Cults Of Tibia Quest
-		"LeidenHeal",
 		"HealthPillar",
 		"YalahariHealth",
 	}


### PR DESCRIPTION
# Description

Removed event 'LeidenHeal' from the player login.