### PR TITLE
fix: paladin speed on sharpshooter and swift foot

### DIFF
--- a/data-canary/scripts/spells/support/sharpshooter.lua
+++ b/data-canary/scripts/spells/support/sharpshooter.lua
@@ -12,7 +12,7 @@ combat:addCondition(skill)
 
 local speed = Condition(CONDITION_PARALYZE)
 speed:setParameter(CONDITION_PARAM_TICKS, 10000)
-speed:setFormula(-0.73, 0, -0.73, 0)
+speed:setFormula(0.7, 0, 0.7, 0)
 combat:addCondition(speed)
 
 local exhaustHealGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)

--- a/data-canary/scripts/spells/support/sharpshooter.lua
+++ b/data-canary/scripts/spells/support/sharpshooter.lua
@@ -10,7 +10,7 @@ skill:setParameter(CONDITION_PARAM_DISABLE_DEFENSE, true)
 skill:setParameter(CONDITION_PARAM_BUFF_SPELL, true)
 combat:addCondition(skill)
 
-local speed = Condition(CONDITION_PARALYZE)
+local speed = Condition(CONDITION_HASTE)
 speed:setParameter(CONDITION_PARAM_TICKS, 10000)
 speed:setFormula(0.7, 0, 0.7, 0)
 combat:addCondition(speed)

--- a/data-canary/scripts/spells/support/swift_foot.lua
+++ b/data-canary/scripts/spells/support/swift_foot.lua
@@ -8,7 +8,7 @@ combat:addCondition(exhaust)
 
 local condition = Condition(CONDITION_HASTE)
 condition:setParameter(CONDITION_PARAM_TICKS, 10000)
-condition:setFormula(0.8, -72, 0.8, -72)
+condition:setFormula(1.8, 72, 1.8, 72)
 combat:addCondition(condition)
 
 local exhaustAttackGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)

--- a/data-otservbr-global/scripts/spells/support/sharpshooter.lua
+++ b/data-otservbr-global/scripts/spells/support/sharpshooter.lua
@@ -4,7 +4,7 @@ local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 
-local speed = Condition(CONDITION_PARALYZE)
+local speed = Condition(CONDITION_HASTE)
 speed:setParameter(CONDITION_PARAM_TICKS, spellDuration)
 speed:setFormula(0.7, 0, 0.7, 0)
 combat:addCondition(speed)

--- a/data-otservbr-global/scripts/spells/support/sharpshooter.lua
+++ b/data-otservbr-global/scripts/spells/support/sharpshooter.lua
@@ -6,7 +6,7 @@ combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 
 local speed = Condition(CONDITION_PARALYZE)
 speed:setParameter(CONDITION_PARAM_TICKS, spellDuration)
-speed:setFormula(-0.7, 56, -0.7, 56)
+speed:setFormula(0.7, 0, 0.7, 0)
 combat:addCondition(speed)
 
 local exhaustHealGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)

--- a/data-otservbr-global/scripts/spells/support/swift_foot.lua
+++ b/data-otservbr-global/scripts/spells/support/swift_foot.lua
@@ -6,7 +6,7 @@ combat:setParameter(COMBAT_PARAM_AGGRESSIVE, 0)
 
 local condition = Condition(CONDITION_HASTE)
 condition:setParameter(CONDITION_PARAM_TICKS, spellDuration)
-condition:setFormula(0.8, -72, 0.8, -72)
+condition:setFormula(1.8, 72, 1.8, 72)
 combat:addCondition(condition)
 
 local spell = Spell("instant")


### PR DESCRIPTION
The changes to speed didnt take into account the paladin spells.