### PR TITLE
fix: adventurer stone

### DIFF
--- a/data-otservbr-global/scripts/actions/adventurers_guild/adventurers_stone.lua
+++ b/data-otservbr-global/scripts/actions/adventurers_guild/adventurers_stone.lua
@@ -60,7 +60,7 @@ end
 
 function adventurersStone.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local tile = Tile(player:getPosition())
-	if not tile:hasFlag(TILESTATE_PROTECTIONZONE) or tile:hasFlag(TILESTATE_HOUSE) or player:isPzLocked() or player:getCondition(CONDITION_INFIGHT, CONDITIONID_DEFAULT) then
+	if not tile:hasFlag(TILESTATE_PROTECTIONZONE) or tile:hasFlag(TILESTATE_HOUSE) or player:isPzLocked() then
 		doNotTeleport(player)
 		return false
 	end


### PR DESCRIPTION
# Description

Atualmente você não pode usar a stone caso esteja em fight mode, ou seja se voce atacar o dog na frente do templo e tentar usar a pedra não irá conseguir até sair fight mode.
Thanks @elsongabriel 

## Behaviour
### **Actual**

Você tenta usar a pedra em fight mode e não consegue, aparece a mensage: Try to move more to the center of a temple to use the spiritual energy for a teleport.

### **Expected**

Mesmo em fight mode voce consegue usar a pedra, mesmo padrão foi testado no global oficial

### Fixes #2042 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.21
  - Operating System: Windows/Ubuntu 22.04

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
