### PR TITLE
ci: disable sonar in draft prs and main branch

### DIFF
--- a/.github/workflows/analysis-sonarcloud.yml
+++ b/.github/workflows/analysis-sonarcloud.yml
@@ -3,19 +3,14 @@ name: Analysis - SonarCloud
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/**'
-  push:
-    paths:
-      - 'src/**'
-    branches:
-      - main
+      - "src/**"
 
 env:
   VCPKG_BUILD_TYPE: debug
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  MAKEFLAGS: '-j 2'
+  MAKEFLAGS: "-j 2"
   VCPKG_BINARY_SOURCES: clear;default,readwrite
 
 jobs:


### PR DESCRIPTION
We don't look at sonar on main/drafts. And it's a _very_ heavy build that takes a really long time. Disabling it here is sensible to allow merges to be worked on quicker.
