### PR TITLE
ci: enable merge_group in key builds for merge-queue

### DIFF
--- a/.github/workflows/analysis-reviewdog-cppcheck.yml
+++ b/.github/workflows/analysis-reviewdog-cppcheck.yml
@@ -4,13 +4,12 @@ name: Analysis - Review Dog
 on:
   pull_request:
     paths:
-      - 'src/**'
+      - "src/**"
   push:
     paths:
-      - 'src/**'
+      - "src/**"
 
 jobs:
-
   cppcheck:
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +17,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         uses: fkirc/skip-duplicate-actions@master
         with:
-          concurrent_skipping: 'same_content'
+          concurrent_skipping: "same_content"
           cancel_others: true
 
       - name: Check out code.

--- a/.github/workflows/analysis-reviewdog.yml
+++ b/.github/workflows/analysis-reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         uses: fkirc/skip-duplicate-actions@master
         with:
-          concurrent_skipping: 'same_content'
+          concurrent_skipping: "same_content"
           cancel_others: true
 
       - name: Check out code.
@@ -32,11 +32,9 @@ jobs:
           luac -v
           reviewdog -reporter=github-pr-check -runners=luac
 
-
   luacheck:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code.
         uses: actions/checkout@main
 
@@ -54,11 +52,9 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           reviewdog -reporter=github-pr-check -runners=luacheck
 
-
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code.
         uses: actions/checkout@main
 
@@ -67,14 +63,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
-          pattern: '*.sh'
-          exclude: './.git/*'
-
+          pattern: "*.sh"
+          exclude: "./.git/*"
 
   xmllint:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code.
         uses: actions/checkout@main
 
@@ -92,11 +86,9 @@ jobs:
           xmllint --version
           reviewdog -reporter=github-pr-check -runners=xmllint
 
-
   yamllint:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code.
         uses: actions/checkout@main
 
@@ -106,11 +98,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
 
-
   hadolint:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code
         uses: actions/checkout@main
 
@@ -122,7 +112,6 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check out code
         uses: actions/checkout@main
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/**'
+      - "src/**"
+  merge_group:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
     branches:
       - main
 
@@ -18,10 +19,10 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   build_docker_x86:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
@@ -35,7 +36,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.15
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine Version
         id: gitversion
@@ -93,7 +94,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         uses: fkirc/skip-duplicate-actions@master
         with:
-          concurrent_skipping: 'same_content'
+          concurrent_skipping: "same_content"
           cancel_others: true
 
       - name: Checkout
@@ -104,7 +105,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.15
         with:
-          versionSpec: '5.x'
+          versionSpec: "5.x"
 
       - name: Determine Version
         id: gitversion

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -6,26 +6,27 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/**'
+      - "src/**"
+  merge_group:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
     branches:
       - main
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  MAKEFLAGS: '-j 2'
+  MAKEFLAGS: "-j 2"
 
 jobs:
   cancel-runs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -5,24 +5,25 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/**'
+      - "src/**"
+  merge_group:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
     branches:
       - main
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  MAKEFLAGS: '-j 2'
+  MAKEFLAGS: "-j 2"
 jobs:
   cancel-runs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/build-windows-solution.yml
+++ b/.github/workflows/build-windows-solution.yml
@@ -6,26 +6,27 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'src/**'
+      - "src/**"
+  merge_group:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
     branches:
       - main
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  MAKEFLAGS: '-j 2'
+  MAKEFLAGS: "-j 2"
 
 jobs:
   cancel-runs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -3,19 +3,20 @@ name: Clang-format
 on:
   pull_request:
     paths:
-      - 'src/**'
+      - "src/**"
+  merge_group:
   push:
     paths:
-      - 'src/**'
+      - "src/**"
 jobs:
   cancel-runs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -1,18 +1,18 @@
 ---
-name: 'Cron - Stale issues and PRs'
+name: "Cron - Stale issues and PRs"
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 jobs:
   cancel-runs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
   stale:
     runs-on: ubuntu-latest
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/stale@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is stale because it has been open 120 days with no activity.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
+          stale-issue-message: "This issue is stale because it has been open 120 days with no activity."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity."
           days-before-issue-stale: 90
           days-before-pr-stale: 30
           days-before-issue-close: -1

--- a/.github/workflows/lua-format.yml
+++ b/.github/workflows/lua-format.yml
@@ -3,10 +3,11 @@ name: Lua-format
 on:
   pull_request:
     paths:
-      - 'data*/**'
+      - "data*/**"
+  merge_group:
   push:
     paths:
-      - 'data*/**'
+      - "data*/**"
 jobs:
   lua-formatter:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,5 +1,5 @@
 ---
-name: 'PR - Labeler'
+name: "PR - Labeler"
 on:
   - pull_request_target
 
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/labeler@main
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/tests-lua.yml
+++ b/.github/workflows/tests-lua.yml
@@ -3,6 +3,7 @@ name: Tests - Lua
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
We want to try to use github's merge-queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
Which requires builds to be configured this way first.
