### PR TITLE
fix: send correct tier data

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4857,7 +4857,7 @@ void ProtocolGame::sendForgingData() {
 	// Exalted core table per tier
 	msg.addByte(static_cast<uint8_t>(tierCorePrices.size()));
 	for (const auto &[tier, cores] : tierCorePrices) {
-		msg.addByte(tier);
+		msg.addByte(tier + 1);
 		msg.addByte(cores);
 	}
 


### PR DESCRIPTION
## Behaviour
### **Actual**

In Exaltation Forge's Transfer window: clicking tier 10 item crashes client; exalted core costs differ from tibia.fandom.com data.

### **Expected**

In Exaltation Forge's Transfer window: clicking tier 10 item shows costs; exalted core costs are the same as on tibia.fandom.com.

### Fixes #2090 

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Tested transfers on all tiers of class 2 and 3. 
Tested 10->9 and 2->1 for class 4.

**Test Configuration**:

  - Server Version: up to 6ae7aec48c5e2920faf35d8c23959bbc56e16347
  - Client: 13.21.13839
  - Operating System: Win10

