### PR TITLE
fix: solves the problem when combining zone pvp and no-logout tiles

### DIFF
--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -190,13 +190,12 @@ public:
 			return ZONE_PROTECTION;
 		} else if (hasFlag(TILESTATE_NOPVPZONE)) {
 			return ZONE_NOPVP;
-		} else if (hasFlag(TILESTATE_NOLOGOUT)) {
-			return ZONE_NOLOGOUT;
 		} else if (hasFlag(TILESTATE_PVPZONE)) {
 			return ZONE_PVP;
-		} else {
-			return ZONE_NORMAL;
+		} else if (hasFlag(TILESTATE_NOLOGOUT)) {
+			return ZONE_NOLOGOUT;
 		}
+		return ZONE_NORMAL;
 	}
 
 	bool hasHeight(uint32_t n) const;


### PR DESCRIPTION
fecha https://github.com/opentibiabr/remeres-map-editor/issues/60 e #1765

Como informado no primeiro issue mencionado: quando existia a junção dos tiles zones de pvp e no-logout, o zone pvp não funcionava.

- ❌ No-logout + pvp zone = no-logout funciona e pvp zone não.
- ✅ No-logout + protection zone = os dois funcionam.
- ✅ No-logout + no-pvp zone = os dois funcionam.

O problema estava na posição das condicionais em #557. Com este PR resolve o problema.