### PR TITLE
fix: removed duplicated achievement

### DIFF
--- a/data/libs/achievements_lib.lua
+++ b/data/libs/achievements_lib.lua
@@ -570,10 +570,6 @@ achievements = {
 	[475] = { name = "Taskmaster", grade = 1, points = 2, description = "Having hunted and bested them all, you live for the thrill of the hunt!" },
 	[476] = { name = "Verminbane", grade = 1, points = 2, description = "And so it begins!" },
 
-	--12.60
-	[480] = { name = "Honorary Rascoohan", grade = 1, points = 2, description = "When in Rascacoon, do as the Rascoohans do!" },
-	[481] = { name = "Release the Kraken", grade = 1, points = 3, description = "Riding around on this squishy companion gives you the feeling of flying through the air... uhm... swimming through the seven seas!" },
-
 	--Custom
 	[477] = { name = "Waypoint Explorer", grade = 1, points = 1, description = "You've explored all the towns of Tibia and discovered each town's waypoint." },
 	[478] = { name = "Up the Molehill", grade = 1, points = 3, description = "Putting this candle stump on your new mount was kind of a waiting game. You're even tempted to call it whack-a-mole. But in the end you found a loyal companion for your journeys into the depths." },


### PR DESCRIPTION
# Description

Removed duplicated achievements
- Honorary Rascoohan
- Release the Kraken