### PR TITLE
fix: npc clone items and buy in shopping bag

### DIFF
--- a/data/XML/imbuements.xml
+++ b/data/XML/imbuements.xml
@@ -201,7 +201,7 @@
 		<attribute key="item" value="17823" count="25" />
 		<attribute key="item" value="9694" count="20" />
 	</imbuement>
-	<imbuement name="Snake Skin" base="3" category="5" iconid="30" premium="1" storage="50492">
+	<imbuement name="Snake Skin" base="3" category="5" iconid="28" premium="1" storage="50492">
 		<attribute key="description" value="Reduces earth damage by 15%." />
 		<attribute key="effect" type="reduction" combat="earth" value="15" />
 		<attribute key="item" value="17823" count="25" />

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -405,24 +405,23 @@ void Npc::onPlayerSellItem(std::shared_ptr<Player> player, uint16_t itemId, uint
 		}
 	}
 
-	if (toRemove != 0) {
-		g_logger().error("[Npc::onPlayerSellItem] - Problem while removing items from player {} amount {} of items with id {} on shop for npc {}, the payment will be made based on amount of removed items.", player->getName(), toRemove, itemId, getName());
-	}
-
 	auto totalRemoved = amount - toRemove;
 	auto totalCost = static_cast<uint64_t>(sellPrice * totalRemoved);
-	if (getCurrency() == ITEM_GOLD_COIN) {
-		totalPrice += totalCost;
-		if (g_configManager().getBoolean(AUTOBANK, __FUNCTION__)) {
-			player->setBankBalance(player->getBankBalance() + totalCost);
+	g_logger().debug("[Npc::onPlayerSellItem] - Removing items from player {} amount {} of items with id {} on shop for npc {}", player->getName(), toRemove, itemId, getName());
+	if (totalRemoved > 0 && totalCost > 0) {
+		if (getCurrency() == ITEM_GOLD_COIN) {
+			totalPrice += totalCost;
+			if (g_configManager().getBoolean(AUTOBANK, __FUNCTION__)) {
+				player->setBankBalance(player->getBankBalance() + totalCost);
+			} else {
+				g_game().addMoney(player, totalCost);
+			}
+			g_metrics().addCounter("balance_increase", totalCost, { { "player", player->getName() }, { "context", "npc_sale" } });
 		} else {
-			g_game().addMoney(player, totalCost);
-		}
-		g_metrics().addCounter("balance_increase", totalCost, { { "player", player->getName() }, { "context", "npc_sale" } });
-	} else {
-		std::shared_ptr<Item> newItem = Item::CreateItem(getCurrency(), totalCost);
-		if (newItem) {
-			g_game().internalPlayerAddItem(player, newItem, true);
+			std::shared_ptr<Item> newItem = Item::CreateItem(getCurrency(), totalCost);
+			if (newItem) {
+				g_game().internalPlayerAddItem(player, newItem, true);
+			}
 		}
 	}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7023,6 +7023,11 @@ bool Player::saySpell(
 
 // Forge system
 void Player::forgeFuseItems(ForgeAction_t actionType, uint16_t firstItemId, uint8_t tier, uint16_t secondItemId, bool success, bool reduceTierLoss, bool convergence, uint8_t bonus, uint8_t coreCount) {
+	if (getFreeBackpackSlots() == 0) {
+		sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+		return;
+	}
+
 	ForgeHistory history;
 	history.actionType = actionType;
 	history.tier = tier;
@@ -7261,6 +7266,11 @@ void Player::forgeFuseItems(ForgeAction_t actionType, uint16_t firstItemId, uint
 }
 
 void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemId, uint8_t tier, uint16_t receiveItemId, bool convergence) {
+	if (getFreeBackpackSlots() == 0) {
+		sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
+		return;
+	}
+
 	ForgeHistory history;
 	history.actionType = actionType;
 	history.tier = tier;


### PR DESCRIPTION
• Fixed cloning items with currency custom and imbued items • Fixed imbuement "Snake Skin" icon
• Fixed npc buying in shopping bags conflicting with "obtain container"
• Check free backpack slots on forge fuse and transfer items
• When equipping an item when another item is already equipped (using the equip hotkey), the item that will be removed will now go to the main backpack, as it is in global

Resolves #2161
