### PR TITLE
feat: add custom formatter for enum types in FMT

### DIFF
--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -84,6 +84,17 @@
 #include <fmt/format.h>
 #include <fmt/args.h>
 
+// FMT Custom Formatter for Enums
+template <typename E>
+struct fmt::formatter<E, std::enable_if_t<std::is_enum_v<E>, char>> : formatter<std::underlying_type_t<E>> {
+	template <typename FormatContext>
+	auto format(E e, FormatContext &ctx) {
+		return formatter<std::underlying_type_t<E>>::format(
+			static_cast<std::underlying_type_t<E>>(e), ctx
+		);
+	}
+};
+
 // GMP
 #include <gmp.h>
 


### PR DESCRIPTION
Implemented a custom formatter in the FMT library to handle enum types more effectively. This formatter casts enums to their underlying types, enabling seamless integration with FMT's existing formatting capabilities. This enhancement simplifies the process of formatting enums and ensures type-safe handling.

Example of use: g_logger().info("Enum type account gamemaster: {}", ACCOUNT_TYPE_GAMEMASTER)