### PR TITLE
chore: remove warning logs, keep only debug logs

### DIFF
--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -72,20 +72,19 @@ bool SaveManager::doSavePlayer(std::shared_ptr<Player> player) {
 		logger.debug("Failed to save player because player is null.");
 		return false;
 	}
+
 	Benchmark bm_savePlayer;
 	Player::PlayerLock lock(player);
 	m_playerMap.erase(player->getGUID());
 	logger.debug("Saving player {}...", player->getName());
+
 	bool saveSuccess = IOLoginData::savePlayer(player);
 	if (!saveSuccess) {
 		logger.error("Failed to save player {}.", player->getName());
 	}
+
 	auto duration = bm_savePlayer.duration();
-	if (duration > 100) {
-		logger.warn("Saving player {} took {} milliseconds.", player->getName(), duration);
-	} else {
-		logger.debug("Saving player {} took {} milliseconds.", player->getName(), duration);
-	}
+	logger.debug("Saving player {} took {} milliseconds.", player->getName(), duration);
 	return saveSuccess;
 }
 
@@ -102,15 +101,13 @@ void SaveManager::saveGuild(std::shared_ptr<Guild> guild) {
 		logger.debug("Failed to save guild because guild is null.");
 		return;
 	}
+
 	Benchmark bm_saveGuild;
 	logger.debug("Saving guild {}...", guild->getName());
 	IOGuild::saveGuild(guild);
+
 	auto duration = bm_saveGuild.duration();
-	if (duration > 100) {
-		logger.warn("Saving guild {} took {} milliseconds.", guild->getName(), duration);
-	} else {
-		logger.debug("Saving guild {} took {} milliseconds.", guild->getName(), duration);
-	}
+	logger.debug("Saving guild {} took {} milliseconds.", guild->getName(), duration);
 }
 
 void SaveManager::saveMap() {
@@ -120,12 +117,9 @@ void SaveManager::saveMap() {
 	if (!saveSuccess) {
 		logger.error("Failed to save map.");
 	}
+
 	auto duration = bm_saveMap.duration();
-	if (duration > 100) {
-		logger.warn("Map saved in {} milliseconds.", bm_saveMap.duration());
-	} else {
-		logger.debug("Map saved in {} milliseconds.", bm_saveMap.duration());
-	}
+	logger.debug("Map saved in {} milliseconds.", duration);
 }
 
 void SaveManager::saveKV() {
@@ -135,10 +129,7 @@ void SaveManager::saveKV() {
 	if (!saveSuccess) {
 		logger.error("Failed to save key-value store.");
 	}
+
 	auto duration = bm_saveKV.duration();
-	if (duration > 100) {
-		logger.warn("Key-value store saved in {} milliseconds.", bm_saveKV.duration());
-	} else {
-		logger.debug("Key-value store saved in {} milliseconds.", bm_saveKV.duration());
-	}
+	logger.debug("Key-value store saved in {} milliseconds.", duration);
 }


### PR DESCRIPTION
Remove warning logs, keep only debug logs

This commit refactors the logging statements in the codebase related to saving key-value stores, maps, guilds, and players. It removes warning logs and retains only debug logs for better clarity and consistency. The changes ensure that log messages are consistently logged as debug messages, irrespective of the duration thresholds. This cleanup enhances the code readability and maintains a more uniform and focused logging approach.
