### PR TITLE
fix: correct table name in loop iteration

### DIFF
--- a/data-otservbr-global/scripts/actions/object/golden_outfit_display.lua
+++ b/data-otservbr-global/scripts/actions/object/golden_outfit_display.lua
@@ -35,7 +35,7 @@ function goldenOutfitDisplay.onUse(player, item, fromPosition, target, toPositio
 	return true
 end
 
-for index, value in pairs(transformDisplay) do
+for index, value in pairs(transformations) do
 	goldenOutfitDisplay:id(index)
 end
 


### PR DESCRIPTION
Fixed an issue where the incorrect table name 'transformDisplay' was used instead of 'transformations' in the loop iteration, causing a 'table expected, got nil' error.