### PR TITLE
feat: mirror images improvements

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/soul_war/mirror image - A.lua
+++ b/data-otservbr-global/scripts/actions/quests/soul_war/mirror image - A.lua
@@ -1,0 +1,34 @@
+local MIRROR_ACTION_ID = 50053
+local MIRROR_ITEM_ID = 33784
+local TRANSFORMED_MIRROR_ITEM_ID = 33785
+local TRANSFORMATION_DURATION = 900 * 1000 -- 15 minutos
+
+local mirrored = Action()
+function onUseMirror(player, item, fromPosition, target, toPosition, isHotkey)
+    if not player or not player:isPlayer() then
+        return false
+    end
+
+    if item.actionid == MIRROR_ACTION_ID and item.itemid == MIRROR_ITEM_ID then
+        local mirrorImage = Game.createMonster("Mirror Image", toPosition)
+        if not mirrorImage then
+            return false
+        end
+
+        local mirror = Tile(toPosition):getItemById(MIRROR_ITEM_ID)
+        if mirror then
+            mirror:transform(TRANSFORMED_MIRROR_ITEM_ID)
+            addEvent(function()
+                local revertedMirror = Tile(toPosition):getItemById(TRANSFORMED_MIRROR_ITEM_ID)
+                if revertedMirror then
+                    revertedMirror:transform(MIRROR_ITEM_ID)
+                end
+            end, TRANSFORMATION_DURATION)
+        end
+    end
+    return true
+end
+
+mirrored.onUse = onUseMirror
+mirrored:aid(MIRROR_ACTION_ID)
+mirrored:register()

--- a/data-otservbr-global/scripts/actions/quests/soul_war/mirror image - B.lua
+++ b/data-otservbr-global/scripts/actions/quests/soul_war/mirror image - B.lua
@@ -1,0 +1,34 @@
+local MIRROR_ACTION_ID = 50052
+local MIRROR_ITEM_ID = 33782
+local TRANSFORMED_MIRROR_ITEM_ID = 33783
+local TRANSFORMATION_DURATION = 900 * 1000 -- 15 minutos
+
+local mirrored = Action()
+function onUseMirror(player, item, fromPosition, target, toPosition, isHotkey)
+    if not player or not player:isPlayer() then
+        return false
+    end
+
+    if item.actionid == MIRROR_ACTION_ID and item.itemid == MIRROR_ITEM_ID then
+        local mirrorImage = Game.createMonster("Mirror Image", toPosition)
+        if not mirrorImage then
+            return false
+        end
+
+        local mirror = Tile(toPosition):getItemById(MIRROR_ITEM_ID)
+        if mirror then
+            mirror:transform(TRANSFORMED_MIRROR_ITEM_ID)
+            addEvent(function()
+                local revertedMirror = Tile(toPosition):getItemById(TRANSFORMED_MIRROR_ITEM_ID)
+                if revertedMirror then
+                    revertedMirror:transform(MIRROR_ITEM_ID)
+                end
+            end, TRANSFORMATION_DURATION)
+        end
+    end
+    return true
+end
+
+mirrored.onUse = onUseMirror
+mirrored:aid(MIRROR_ACTION_ID)
+mirrored:register()


### PR DESCRIPTION
Create a monster: **Mirror Image** when uses the mirror.

when player clicks on:
Mirror id 33782 with aid: 50052
Mirror id 33784 with aid: 50053

**The aid need to be added on rme in all mirrors.**
**I don't know how time is correct like global tibia and to prevent trolls i added 15 minutes to revert the wall.**

**I added actionid to prevent exploits on custom maps with mirrors outside of the mirrored nightmare.**

**How to configure in rme:**
![image](https://github.com/opentibiabr/canary/assets/98285577/c72dcdda-72b7-4583-ac59-d7034cbd103d)
