### PR TITLE
chore: remove deprecated functions

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -116,15 +116,6 @@ function Player.getCookiesDelivered(self)
 	return amount
 end
 
-function Player.allowMovement(self, allow)
-	return allow and self:kv():remove("block-movement") or self:kv():set("block-movement", 1)
-end
-
-function Player.hasAllowMovement(self)
-	local blockMovement = self:kv():get("block-movement") or 0
-	return blockMovement ~= 1
-end
-
 function Player.checkGnomeRank(self)
 	if not IsRunningGlobalDatapack() then
 		return true


### PR DESCRIPTION
The functions have been deprecated and are also broken.

Just use the new function and it will work as before:
self:setMoveLocked(true)
self:setMoveLocked(false)

Close #2203