### PR TITLE
fix: adjust handling of null variable in Player.addAchievementProgress

### DIFF
--- a/data/scripts/lib/register_achievements.lua
+++ b/data/scripts/lib/register_achievements.lua
@@ -641,14 +641,17 @@ function Player.addAchievementProgress(self, achievement, totalProgress)
 		return
 	end
 
-	local progressNumber = self:kv():scoped("achievements"):get("progress")
-	if progressNumber and progressNumber <= totalProgress then
-		if progressNumber == totalProgress then
-			self:addAchievement(foundAchievement.id)
-			self:kv():scoped("achievements"):remove("progress")
-			return
-		end
+	local achievScope = self:kv():scoped("achievements")
+	local achievScopeName = tostring(foundAchievement.name .. "-progress")
+	local progressNumber = achievScope:get(achievScopeName) or 0
 
-		self:kv():scoped("achievements"):set("progress", progressNumber)
+	if progressNumber + 1 == totalProgress then
+		self:addAchievement(foundAchievement.id)
+		logger.debug("[Player.addAchievementProgress] - Achievement '{}' completed", foundAchievement.name)
+		achievScope:remove(achievScopeName)
+		return
 	end
+
+	logger.debug("[Player.addAchievementProgress] - Achievement '{}' progress updated to '{}', total progress '{}'", foundAchievement.name, progressNumber + 1, totalProgress)
+	achievScope:set(achievScopeName, progressNumber + 1)
 end


### PR DESCRIPTION
This pull request addresses an issue where the Player.addAchievementProgress function was not properly handling null values, leading to arithmetic errors. The fix ensures that the function behaves as expected and correctly increments the achievement progress. Additionally, adjustments were made to the logic to enhance the overall functionality.
