### PR TITLE
improve: allow saving the player entire stash with just one insert

### DIFF
--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -336,7 +336,11 @@ bool IOLoginDataSave::savePlayerStash(std::shared_ptr<Player> player) {
 			return false;
 		}
 	}
-	return stashQuery.execute();
+
+	if (!stashQuery.execute()) {
+		return false;
+	}
+	return true;
 }
 
 bool IOLoginDataSave::savePlayerSpells(std::shared_ptr<Player> player) {

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -327,17 +327,16 @@ bool IOLoginDataSave::savePlayerStash(std::shared_ptr<Player> player) {
 		return false;
 	}
 
+	query.str("");
+
+	DBInsert stashQuery("INSERT INTO `player_stash` (`player_id`,`item_id`,`item_count`) VALUES ");
 	for (const auto &[itemId, itemCount] : player->getStashItems()) {
-		query.str("");
-		query << "INSERT INTO `player_stash` (`player_id`,`item_id`,`item_count`) VALUES (";
-		query << player->getGUID() << ", ";
-		query << itemId << ", ";
-		query << itemCount << ")";
-		if (!db.executeQuery(query.str())) {
+		query << player->getGUID() << ',' << itemId << ',' << itemCount;
+		if (!stashQuery.addRow(query)) {
 			return false;
 		}
 	}
-	return true;
+	return stashQuery.execute();
 }
 
 bool IOLoginDataSave::savePlayerSpells(std::shared_ptr<Player> player) {


### PR DESCRIPTION
When saving the player's stash, currently each item is inserted individually. With this change, only one insert is executed.