### PR TITLE
Fix Potions Issue

### DIFF
--- a/data-otservbr-global/scripts/actions/other/potions.lua
+++ b/data-otservbr-global/scripts/actions/other/potions.lua
@@ -270,18 +270,19 @@ function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHot
 		target:say("Aaaah...", MESSAGE_POTION)
 		local deactivatedFlasks = player:kv():get("talkaction.potions.flask") or false
 		if not deactivatedFlasks then
-			if fromPosition.x == CONTAINER_POSITION then
-				local container = Container(item:getParent().uid)
-				container:addItem(potion.flask, 1)
-			else
-				player:addItem(potion.flask, 1)
-			end
+		if fromPosition.x == CONTAINER_POSITION and not container == STORE_INBOX then
+			local container = Container(item:getParent().uid)
+			container:addItem(potion.flask, 1)
+		else
+			player:addItem(potion.flask, 1)
 		end
 		player:addCondition(exhaust)
 		player:setStorageValue(38412, player:getStorageValue(38412) + 1)
 	end
+end
 
 	player:getPosition():sendSingleSoundEffect(SOUND_EFFECT_TYPE_ITEM_USE_POTION, player:isInGhostMode() and nil or player)
+
 	-- Delay potion
 	_G.PlayerDelayPotion[player:getId()] = systemTime() + 500
 


### PR DESCRIPTION
**Antes ao usar uma potion com a BP cheia, reportava um errro e não gerava a potion vazia.**

potions.lua:callback
Function: ContainerFunctions::luaContainerAddItem
Error Description: Cannot add item to container, error code: 'You cannot put more objects in this container.'
Stack Trace:
Cannot add item to container, error code: 'You cannot put more objects in this container.'
stack traceback:
        [C]: in function 'addItem'
        
Agora caso não haja espaço cairá no chão.


De forma adicional Potions utilizadas na store inbox não criarão potions vazias na mesma.
![image](https://github.com/Mirkaanks/canary/assets/98285577/12196181-1942-4ebd-a1db-87e666b08f52)