### PR TITLE
fix: load the XML folder first

### DIFF
--- a/data-canary/monster/demons/fury.lua
+++ b/data-canary/monster/demons/fury.lua
@@ -7,9 +7,9 @@ monster.outfit = {
 	lookType = 149,
 	lookHead = 94,
 	lookBody = 77,
-	lookLegs = 96,
-	lookFeet = 0,
-	lookAddons = 3,
+	lookLegs = 78,
+	lookFeet = 79,
+	lookAddons = 1,
 	lookMount = 0,
 }
 
@@ -23,8 +23,8 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Pits of Inferno (Apocalypse's Throne Room), The Inquisition Quest \z
-		(The Shadow Nexus, Battlefield), Vengoth, Fury Dungeon, Oramond Fury Dungeon, The Extension Site.",
+	Locations = "Pits of Inferno (Apocalypse's Throne Room), The Inquisition Quest (The Shadow Nexus, Battlefield), \z
+	Vengoth, Fury Dungeon, Oramond Fury Dungeon, The Extension Site, Grounds of Destruction and Halls of Ascension.",
 }
 
 monster.health = 4100
@@ -50,7 +50,7 @@ monster.flags = {
 	convinceable = false,
 	pushable = false,
 	rewardBoss = false,
-	illusionable = true,
+	illusionable = false,
 	canPushItems = true,
 	canPushCreatures = true,
 	staticAttackChance = 70,
@@ -59,9 +59,8 @@ monster.flags = {
 	healthHidden = false,
 	isBlockable = false,
 	canWalkOnEnergy = false,
-	canWalkOnFire = false,
+	canWalkOnFire = true,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {
@@ -80,40 +79,41 @@ monster.voices = {
 
 monster.loot = {
 	{ id = 3007, chance = 410 }, -- crystal ring
-	{ id = 3031, chance = 30000, maxCount = 100 }, -- gold coin
-	{ id = 3031, chance = 30000, maxCount = 100 }, -- gold coin
-	{ id = 3031, chance = 38000, maxCount = 69 }, -- gold coin
-	{ id = 3035, chance = 2800, maxCount = 4 }, -- platinum coin
-	{ id = 3065, chance = 20000 }, -- terra rod
-	{ id = 3364, chance = 130 }, -- golden legs
-	{ id = 3554, chance = 790 }, -- steel boots
-	{ id = 5021, chance = 1500, maxCount = 4 }, -- orichalcum pearl
-	{ id = 5911, chance = 4000 }, -- red piece of cloth
-	{ id = 5944, chance = 21500 }, -- soul orb
-	{ id = 5944, chance = 50 }, -- soul orb
+	{ name = "gold coin", chance = 30000, maxCount = 100 },
+	{ name = "gold coin", chance = 30000, maxCount = 100 },
+	{ name = "gold coin", chance = 38000, maxCount = 69 },
+	{ name = "platinum coin", chance = 2800, maxCount = 4 },
+	{ name = "terra rod", chance = 20000 },
+	{ name = "golden legs", chance = 130 },
+	{ name = "steel boots", chance = 790 },
+	{ name = "orichalcum pearl", chance = 1500, maxCount = 4 },
+	{ name = "red piece of cloth", chance = 4000 },
+	{ name = "soul orb", chance = 21500 },
+	{ name = "soul orb", chance = 50 },
 	{ id = 6300, chance = 60 }, -- death ring
-	{ id = 6499, chance = 22500 }, -- demonic essence
-	{ id = 6558, chance = 35000, maxCount = 3 }, -- concentrated demonic blood
-	{ id = 7404, chance = 660 }, -- assassin dagger
-	{ id = 7456, chance = 2000 }, -- noble axe
-	{ id = 239, chance = 10500 }, -- great health potion
-	{ id = 8016, chance = 29280, maxCount = 4 }, -- jalapeno pepper
+	{ name = "demonic essence", chance = 22500 },
+	{ name = "flask of demonic blood", chance = 35000, maxCount = 3 },
+	{ name = "assassin dagger", chance = 660 },
+	{ name = "noble axe", chance = 2000 },
+	{ name = "great health potion", chance = 10500 },
+	{ name = "jalapeno pepper", chance = 29280, maxCount = 4 },
 }
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -510 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -300, length = 8, spread = 3, effect = CONST_ME_EXPLOSIONAREA, target = false },
-	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_DEATHDAMAGE, minDamage = -120, maxDamage = -700, length = 8, spread = 3, target = false },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -120, maxDamage = -300, radius = 4, target = false },
-	-- {name ="fury skill reducer", interval = 2000, chance = 5, target = false},
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_DEATHDAMAGE, minDamage = -120, maxDamage = -700, length = 8, spread = 3, effect = CONST_ME_DRAWBLOOD, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -120, maxDamage = -300, radius = 4, effect = CONST_ME_DRAWBLOOD, target = false },
+	{ name = "fury skill reducer", interval = 2000, chance = 5, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -120, maxDamage = -300, radius = 3, effect = CONST_ME_HITAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -125, maxDamage = -250, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
-	{ name = "speed", interval = 2000, chance = 15, speedChange = -100, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false, duration = 30000 },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = -800, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false, duration = 30000 },
 }
 
 monster.defenses = {
 	defense = 20,
-	armor = 20,
+	armor = 35,
+	mitigation = 1.32,
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 800, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
 }
 

--- a/data-canary/monster/familiars/sorcerer_familiar.lua
+++ b/data-canary/monster/familiars/sorcerer_familiar.lua
@@ -66,8 +66,8 @@ monster.voices = {
 monster.loot = {}
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200 },
-	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_LIFEDRAIN, minDamage = -90, maxDamage = -150, length = 2, spread = 0, target = false },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -280 },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_LIFEDRAIN, minDamage = -90, maxDamage = -150, length = 2, spread = 0, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -190, maxDamage = -210, length = 2, spread = 0, effect = CONST_ME_ENERGYHIT, target = false },
 	{ name = "summon challenge", interval = 2000, chance = 40, target = false },
 }

--- a/data-canary/monster/magicals/frazzlemaw.lua
+++ b/data-canary/monster/magicals/frazzlemaw.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {
@@ -74,49 +73,49 @@ monster.light = {
 monster.voices = {
 	interval = 5000,
 	chance = 10,
-	{ text = "Mwaaaahnducate youuuuuu *gurgle*, mwaaah!", yell = false },
 	{ text = "Mwaaahgod! Overmwaaaaah! *gurgle*", yell = false },
-	{ text = "MMMWAHMWAHMWAHMWAAAAH!", yell = false },
+	{ text = "Mwaaaahnducate youuuuuu *gurgle*, mwaaah!", yell = false },
+	{ text = "MMMWAHMWAHMWAHMWAAAAH!", yell = true },
 	{ text = "Mmmwhamwhamwhah, mwaaah!", yell = false },
 }
 
 monster.loot = {
-	{ id = 3031, chance = 100000, maxCount = 100 }, -- gold coin
-	{ id = 3035, chance = 100000, maxCount = 7 }, -- platinum coin
-	{ id = 3104, chance = 9500 }, -- banana skin
-	{ id = 3110, chance = 10400 }, -- piece of iron
-	{ id = 3111, chance = 10000 }, -- fishbone
+	{ name = "gold coin", chance = 100000, maxCount = 100 },
+	{ name = "platinum coin", chance = 100000, maxCount = 7 },
+	{ name = "banana skin", chance = 9500 },
+	{ name = "piece of iron", chance = 10400 },
+	{ name = "fishbone", chance = 10000 },
 	{ id = 3114, chance = 12680 }, -- skull
 	{ id = 3115, chance = 10000 }, -- bone
 	{ id = 3116, chance = 5500 }, -- big bone
-	{ id = 3265, chance = 3200 }, -- two handed sword
+	{ name = "two handed sword", chance = 3200 },
 	{ id = 3578, chance = 6750, maxCount = 3 }, -- fish
-	{ id = 3582, chance = 6000, maxCount = 2 }, -- ham
-	{ id = 5880, chance = 3000 }, -- iron ore
-	{ id = 5895, chance = 4700 }, -- fish fin
-	{ id = 5925, chance = 5000 }, -- hardened bone
+	{ name = "ham", chance = 6000, maxCount = 2 },
+	{ name = "iron ore", chance = 3000 },
+	{ name = "fish fin", chance = 4700 },
+	{ name = "hardened bone", chance = 5000 },
 	{ id = 5951, chance = 10800 }, -- fish tail
-	{ id = 7404, chance = 1000 }, -- assassin dagger
-	{ id = 7407, chance = 2240 }, -- haunted blade
-	{ id = 7418, chance = 1100 }, -- nightmare blade
-	{ id = 238, chance = 15000, maxCount = 3 }, -- great mana potion
-	{ id = 239, chance = 15000, maxCount = 2 }, -- great health potion
-	{ id = 9058, chance = 2300 }, -- gold ingot
-	{ id = 10389, chance = 1460 }, -- sai
-	{ id = 16120, chance = 3000 }, -- violet crystal shard
-	{ id = 16123, chance = 16000 }, -- brown crystal splinter
-	{ id = 16126, chance = 7600 }, -- red crystal fragment
+	{ name = "assassin dagger", chance = 1000 },
+	{ name = "haunted blade", chance = 2240 },
+	{ name = "nightmare blade", chance = 1100 },
+	{ name = "great mana potion", chance = 15000, maxCount = 3 },
+	{ name = "great health potion", chance = 15000, maxCount = 2 },
+	{ name = "gold ingot", chance = 2300 },
+	{ name = "sai", chance = 1460 },
+	{ name = "violet crystal shard", chance = 3000 },
+	{ name = "brown crystal splinter", chance = 16000 },
+	{ name = "red crystal fragment", chance = 7600 },
 	{ id = 16279, chance = 10000 }, -- crystal rubbish
-	{ id = 20062, chance = 450 }, -- cluster of solace
-	{ id = 20198, chance = 18760 }, -- frazzle tongue
-	{ id = 20199, chance = 16000 }, -- frazzle skin
+	{ name = "cluster of solace", chance = 4450 },
+	{ name = "frazzle tongue", chance = 18760 },
+	{ name = "frazzle skin", chance = 16000 },
 }
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
 	-- bleed
-	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 10, minDamage = -300, maxDamage = -400, radius = 3, target = false },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -700, length = 5, spread = 3, effect = CONST_ME_EXPLOSIONAREA, target = false },
+	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 10, minDamage = -300, maxDamage = -400, radius = 3, effect = CONST_ME_DRAWBLOOD, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -700, length = 5, spread = 0, effect = CONST_ME_EXPLOSIONAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -600, radius = 5, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -80, maxDamage = -150, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
@@ -124,12 +123,13 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 30,
+	armor = 74,
+	mitigation = 2.31,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 250, maxDamage = 425, effect = CONST_ME_HITBYPOISON, target = false },
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 20 },
 	{ type = COMBAT_FIREDAMAGE, percent = 10 },
@@ -137,8 +137,8 @@ monster.elements = {
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 5 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
 }
 
 monster.immunities = {

--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -341,8 +341,17 @@ void CanaryServer::loadModules() {
 	}
 
 	auto coreFolder = g_configManager().getString(CORE_DIRECTORY, __FUNCTION__);
-	// Load items dependencies
+	// Load appearances.dat first
 	modulesLoadHelper((g_game().loadAppearanceProtobuf(coreFolder + "/items/appearances.dat") == ERROR_NONE), "appearances.dat");
+
+	// Load XML folder dependencies (order matters)
+	modulesLoadHelper(g_vocations().loadFromXml(), "XML/vocations.xml");
+	modulesLoadHelper(g_eventsScheduler().loadScheduleEventFromXml(), "XML/events.xml");
+	modulesLoadHelper(Outfits::getInstance().loadFromXml(), "XML/outfits.xml");
+	modulesLoadHelper(Familiars::getInstance().loadFromXml(), "XML/familiars.xml");
+	modulesLoadHelper(g_imbuements().loadFromXml(), "XML/imbuements.xml");
+	modulesLoadHelper(g_storages().loadFromXML(), "XML/storages.xml");
+
 	modulesLoadHelper(Item::items.loadFromXml(), "items.xml");
 
 	const auto datapackFolder = g_configManager().getString(DATA_DIRECTORY, __FUNCTION__);
@@ -351,17 +360,10 @@ void CanaryServer::loadModules() {
 	modulesLoadHelper((g_luaEnvironment().loadFile(coreFolder + "/core.lua", "core.lua") == 0), "core.lua");
 	modulesLoadHelper(g_scripts().loadScripts(coreFolder + "/scripts/lib", true, false), coreFolder + "/scripts/libs");
 	modulesLoadHelper(g_scripts().loadScripts(coreFolder + "/scripts", false, false), coreFolder + "/scripts");
-
-	// Second XML scripts
-	modulesLoadHelper(g_vocations().loadFromXml(), "XML/vocations.xml");
-	modulesLoadHelper(g_eventsScheduler().loadScheduleEventFromXml(), "XML/events.xml");
-	modulesLoadHelper(Outfits::getInstance().loadFromXml(), "XML/outfits.xml");
-	modulesLoadHelper(Familiars::getInstance().loadFromXml(), "XML/familiars.xml");
-	modulesLoadHelper(g_imbuements().loadFromXml(), "XML/imbuements.xml");
-	modulesLoadHelper(g_storages().loadFromXML(), "XML/storages.xml");
-	modulesLoadHelper(g_modules().loadFromXml(), "modules/modules.xml");
-	modulesLoadHelper(g_events().loadFromXml(), "events/events.xml");
 	modulesLoadHelper((g_npcs().load(true, false)), "npclib");
+
+	modulesLoadHelper(g_events().loadFromXml(), "events/events.xml");
+	modulesLoadHelper(g_modules().loadFromXml(), "modules/modules.xml");
 
 	logger.debug("Loading datapack scripts on folder: {}/", datapackName);
 	// Load scripts

--- a/src/creatures/combat/spells.hpp
+++ b/src/creatures/combat/spells.hpp
@@ -192,6 +192,7 @@ public:
 		return vocSpellMap;
 	}
 	void addVocMap(uint16_t n, bool b) {
+		g_logger().trace("Adding spell: {} to voc id: {}", getName(), n);
 		vocSpellMap[n] = b;
 	}
 

--- a/src/creatures/combat/spells.hpp
+++ b/src/creatures/combat/spells.hpp
@@ -191,9 +191,14 @@ public:
 	[[nodiscard]] const VocSpellMap &getVocMap() const {
 		return vocSpellMap;
 	}
-	void addVocMap(uint16_t n, bool b) {
-		g_logger().trace("Adding spell: {} to voc id: {}", getName(), n);
-		vocSpellMap[n] = b;
+	void addVocMap(uint16_t vocationId, bool b) {
+		if (vocationId == 0XFFFF) {
+			g_logger().error("Vocation overflow for spell: {}", getName());
+			return;
+		}
+
+		g_logger().trace("Adding spell: {} to voc id: {}", getName(), vocationId);
+		vocSpellMap[vocationId] = b;
 	}
 
 	SpellGroup_t getGroup() {


### PR DESCRIPTION
The XML folder was being loaded after the "data", so the vocation id was overflowing when loading spells and no one was able to use spells.

Fixed some console errors in the data-canary.

Resolves #2311 