### PR TITLE
fix: boolean_random error

### DIFF
--- a/data/scripts/movements/claw_of_the_noxious_spawn.lua
+++ b/data/scripts/movements/claw_of_the_noxious_spawn.lua
@@ -3,8 +3,8 @@ local clawOfTheNoxiousSpawn = MoveEvent()
 function clawOfTheNoxiousSpawn.onEquip(player, item, slot, isCheck)
 	if not isCheck then
 		if not Tile(player:getPosition()):hasFlag(TILESTATE_PROTECTIONZONE) then
-			doTargetCombat(0, player, COMBAT_PHYSICALDAMAGE, -150, -200, CONST_ME_DRAWBLOOD)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, (math.boolean_random() and "It tightens around your wrist as you take it on." or "Ouch! The serpent claw stabbed you."))
+			doTargetCombatHealth(0, player, COMBAT_PHYSICALDAMAGE, -150, -200, CONST_ME_DRAWBLOOD)
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, (math.random(2) == 1 and "It tightens around your wrist as you take it on." or "Ouch! The serpent claw stabbed you."))
 			return true
 		end
 	end


### PR DESCRIPTION
This pull request addresses an issue in the script claw_of_the_noxious_spawn.lua where the boolean_random function was called but not defined. The correction includes replacing the function call with the appropriate logic for randomized text display.