### PR TITLE
fix: adjusting bundle offers for household items

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1630,21 +1630,24 @@ function GameStore.processHouseRelatedPurchase(player, offer)
 
 	local inbox = player:getStoreInbox()
 	if inbox then
-		for _, itemId in ipairs(itemIds) do
-			local decoKit = inbox:addItem(ITEM_DECORATION_KIT, 1)
-			if decoKit then
-				decoKit:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "You bought this item in the Store.\nUnwrap it in your own house to create a <" .. ItemType(itemId):getName() .. ">.")
-				decoKit:setCustomAttribute("unWrapId", itemId)
-				if isCaskItem(itemId) then
-					decoKit:setAttribute(ITEM_ATTRIBUTE_DATE, offer.count)
-				end
+		for offerIndex = 1, offer.count do
+			for _, itemId in ipairs(itemIds) do
+				local decoKit = inbox:addItem(ITEM_DECORATION_KIT, 1)
+				if decoKit then
+					decoKit:setAttribute(ITEM_ATTRIBUTE_DESCRIPTION, "You bought this item in the Store.\nUnwrap it in your own house to create a <" .. ItemType(itemId):getName() .. ">.")
+					decoKit:setCustomAttribute("unWrapId", itemId)
+					if isCaskItem(itemId) then
+						decoKit:setAttribute(ITEM_ATTRIBUTE_DATE, offer.count)
+					end
 
-				if offer.movable ~= true then
-					decoKit:setAttribute(ITEM_ATTRIBUTE_STORE, systemTime())
+					if offer.movable ~= true then
+						decoKit:setAttribute(ITEM_ATTRIBUTE_STORE, systemTime())
+					end
 				end
 			end
+
+			player:sendUpdateContainer(inbox)
 		end
-		player:sendUpdateContainer(inbox)
 	end
 end
 


### PR DESCRIPTION
Ao definir um item de house com a quantidade `> 1` o item só era entregue uma única vez.
Com a adição desse `for` o problema é resolvido.