### PR TITLE
fix: change weapon log type

### DIFF
--- a/src/items/weapons/weapons.cpp
+++ b/src/items/weapons/weapons.cpp
@@ -221,9 +221,10 @@ void Weapon::internalUseWeapon(std::shared_ptr<Player> player, std::shared_ptr<I
 		} else {
 			damage.origin = ORIGIN_MELEE;
 		}
+
 		damage.primary.type = params.combatType;
 		damage.primary.value = (getWeaponDamage(player, target, item) * damageModifier) / 100;
-		g_logger().info("[1] Weapon::internalUseWeapon - primary damage: {}", damage.primary.value);
+		g_logger().debug("[1] Weapon::internalUseWeapon - primary damage: {}", damage.primary.value);
 		damage.secondary.type = getElementType();
 
 		// Cleave damage
@@ -250,6 +251,7 @@ void Weapon::internalUseWeapon(std::shared_ptr<Player> player, std::shared_ptr<I
 		} else {
 			Combat::doCombatHealth(player, target, damage, params);
 		}
+
 		g_logger().debug("Weapon::internalUseWeapon - cpp callback executed.");
 	}
 


### PR DESCRIPTION
change the log type when using a chain weapon, thus avoiding unnecessary console spam.

Close #2370