### PR TITLE
fix: experience formula

### DIFF
--- a/data/scripts/talkactions/god/add_skill.lua
+++ b/data/scripts/talkactions/god/add_skill.lua
@@ -17,8 +17,7 @@ local function getSkillId(skillName)
 end
 
 local function getExpForLevel(level)
-	level = level - 1
-	return ((50 * level * level * level) - (150 * level * level) + (400 * level)) / 3
+	return math.floor((((level - 6) * level + 17) * level - 12) / 6) * 100
 end
 
 local addSkill = TalkAction("/addskill")

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -220,9 +220,8 @@ public:
 	void addList() override;
 	void removePlayer(bool displayEffect, bool forced = true);
 
-	static uint64_t getExpForLevel(int32_t lv) {
-		lv--;
-		return ((50ULL * lv * lv * lv) - (150ULL * lv * lv) + (400ULL * lv)) / 3ULL;
+	static uint64_t getExpForLevel(uint64_t lv) {
+		return (((lv - 6ULL) * lv + 17ULL) * lv - 12ULL) / 6ULL * 100ULL;
 	}
 
 	uint16_t getStaminaMinutes() const {


### PR DESCRIPTION
CipSoft formula have less multiplication which should make it a little faster.
Because it have less multiplication it also don't overflow as often, with CipSoft formula it is possible to reach 1034406 level instead of 717217 with Open-Tibia formula.