### PR TITLE
fix: manage storages talkaction wasn't working properly

### DIFF
--- a/data/scripts/talkactions/god/manage_storage.lua
+++ b/data/scripts/talkactions/god/manage_storage.lua
@@ -28,7 +28,6 @@ function Player.getStorageValueTalkaction(self, param)
 		local storageName = tostring(split[2])
 		local storageValue = target:getStorageValueByName(storageName)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageName .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
-		return true
 	else
 		local storageValue = target:getStorageValue(storageKey)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")

--- a/data/scripts/talkactions/god/manage_storage.lua
+++ b/data/scripts/talkactions/god/manage_storage.lua
@@ -26,13 +26,14 @@ function Player.getStorageValueTalkaction(self, param)
 	if storageKey == nil then
 		-- Get the key for this storage name
 		local storageName = tostring(split[2])
-		local storageValue = self:getStorageValueByName(storageName)
+		local storageValue = target:getStorageValueByName(storageName)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageName .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 		return true
+	else
+		local storageValue = target:getStorageValue(storageKey)
+		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 	end
 
-	local storageValue = self:getStorageValue(storageKey)
-	self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 	return true
 end
 


### PR DESCRIPTION
# Description


## Behaviour
### **Actual**

The /getstorage command aimed self not target.

### **Expected**
Working as expected, getting the right storage from the right player.


## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

