### PR TITLE
fix: creatures walking snow console error

### DIFF
--- a/data/scripts/movements/snow.lua
+++ b/data/scripts/movements/snow.lua
@@ -9,7 +9,7 @@ function snow.onStepOut(creature, item, position, fromPosition)
 	else
 		item:transform(item.itemid + 15)
 	end
-	
+
 	local player = creature:getPlayer()
 	if player and player:isPlayer() then
 		player:addAchievementProgress("Snowbunny", 10000)

--- a/data/scripts/movements/snow.lua
+++ b/data/scripts/movements/snow.lua
@@ -2,11 +2,7 @@ local snow = MoveEvent()
 
 function snow.onStepOut(creature, item, position, fromPosition)
 	local player = creature:getPlayer()
-	if not player then
-		return true
-	end
-
-	if player:isInGhostMode() then
+	if not player or player:isInGhostMode() then
 		return true
 	end
 

--- a/data/scripts/movements/snow.lua
+++ b/data/scripts/movements/snow.lua
@@ -1,18 +1,19 @@
 local snow = MoveEvent()
 
 function snow.onStepOut(creature, item, position, fromPosition)
-	local player = creature:getPlayer()
-	if player and player:isInGhostMode() then
+	if creature:isInGhostMode() then
 		return true
 	end
-
 	if item.itemid == 799 then
 		item:transform(6594)
 	else
 		item:transform(item.itemid + 15)
 	end
-
-	player:addAchievementProgress("Snowbunny", 10000)
+	
+	local player = creature:getPlayer()
+	if player and player:isPlayer() then
+		player:addAchievementProgress("Snowbunny", 10000)
+	end
 	item:decay()
 	return true
 end

--- a/data/scripts/movements/snow.lua
+++ b/data/scripts/movements/snow.lua
@@ -1,19 +1,22 @@
 local snow = MoveEvent()
 
 function snow.onStepOut(creature, item, position, fromPosition)
-	if creature:isInGhostMode() then
+	local player = creature:getPlayer()
+	if not player then
 		return true
 	end
+
+	if player:isInGhostMode() then
+		return true
+	end
+
 	if item.itemid == 799 then
 		item:transform(6594)
 	else
 		item:transform(item.itemid + 15)
 	end
 
-	local player = creature:getPlayer()
-	if player and player:isPlayer() then
-		player:addAchievementProgress("Snowbunny", 10000)
-	end
+	player:addAchievementProgress("Snowbunny", 10000)
 	item:decay()
 	return true
 end

--- a/data/scripts/movements/snow.lua
+++ b/data/scripts/movements/snow.lua
@@ -2,7 +2,11 @@ local snow = MoveEvent()
 
 function snow.onStepOut(creature, item, position, fromPosition)
 	local player = creature:getPlayer()
-	if not player or player:isInGhostMode() then
+	if not player then
+		return true
+	end
+
+	if player:isInGhostMode() then
 		return true
 	end
 


### PR DESCRIPTION
Resolves #2398
Resolves #2366

This is my possible solution to avoid console error mentioned here: https://github.com/opentibiabr/canary/issues/2398

Snow is now working fine in the next way:
1. Only players are generating steps in the snow.
2. Ghost mode won't generate steps.
3. Creatures won't generate steps (and no more no sense error)


