### PR TITLE
fix: added check for type 'two-handed'

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -22329,7 +22329,7 @@
 			<attribute key="unproperly" value="true"/>
 			<attribute key="weaponType" value="axe"/>
 			<attribute key="slot" value="hand"/>
-			<attribute key="chain" value="1"/>
+			<attribute key="chain" value="0.9"/>
 		</attribute>
 	</item>
 	<item id="8097" article="a" name="solar axe">

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -22329,7 +22329,7 @@
 			<attribute key="unproperly" value="true"/>
 			<attribute key="weaponType" value="axe"/>
 			<attribute key="slot" value="hand"/>
-			<attribute key="chain" value="0.9"/>
+			<attribute key="chain" value="1"/>
 		</attribute>
 	</item>
 	<item id="8097" article="a" name="solar axe">

--- a/src/items/functions/item/item_parse.cpp
+++ b/src/items/functions/item/item_parse.cpp
@@ -1026,7 +1026,7 @@ void ItemParse::createAndRegisterScript(ItemType &itemType, pugi::xml_node attri
 		auto stringKey = asLowerCaseString(subKeyAttribute.as_string());
 		if (stringKey == "slot") {
 			auto slotName = asLowerCaseString(subValueAttribute.as_string());
-			if (moveevent && slotName != "two-handed" && (moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP)) {
+			if (moveevent && (moveevent->getEventType() == MOVE_EVENT_EQUIP || moveevent->getEventType() == MOVE_EVENT_DEEQUIP)) {
 				if (slotName == "head") {
 					moveevent->setSlot(SLOTP_HEAD);
 				} else if (slotName == "necklace") {

--- a/src/items/functions/item/item_parse.cpp
+++ b/src/items/functions/item/item_parse.cpp
@@ -1049,6 +1049,8 @@ void ItemParse::createAndRegisterScript(ItemType &itemType, pugi::xml_node attri
 					moveevent->setSlot(SLOTP_RING);
 				} else if (slotName == "ammo") {
 					moveevent->setSlot(SLOTP_AMMO);
+				} else if (slotName == "two-handed") {
+					moveevent->setSlot(SLOTP_TWO_HAND);
 				} else {
 					g_logger().warn("[{}] unknown slot type '{}'", __FUNCTION__, slotName);
 				}


### PR DESCRIPTION
# Description

Warnings when starting the server. 

![image](https://github.com/opentibiabr/canary/assets/4534564/5dba71f5-e0d0-4fe2-99c6-61e27662cba6)


## Behaviour

### **Actual**

When starting the server warning messages are occuring.

### **Expected**

Start without warnings

![image](https://github.com/opentibiabr/canary/assets/4534564/bb678b40-4a40-452b-a674-f1f1478f8dae)


### Fixes

## Type of change

Please delete options that are not relevant.

  - [ X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

Tested by cloneing the main repo and building a fresh binary

  - [ X] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ X] My code follows the style guidelines of this project
  - [ X] I have performed a self-review of my own code

