### PR TITLE
fix loot pouch as quick loot

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5285,7 +5285,7 @@ void Game::playerSetManagedContainer(uint32_t playerId, ObjectCategory_t categor
 	}
 
 	std::shared_ptr<Container> container = thing->getContainer();
-	auto allowConfig = !g_configManager().getBoolean(TOGGLE_GOLD_POUCH_ALLOW_ANYTHING, __FUNCTION__) || !g_configManager().getBoolean(TOGGLE_GOLD_POUCH_QUICKLOOT_ONLY, __FUNCTION__);
+	auto allowConfig = g_configManager().getBoolean(TOGGLE_GOLD_POUCH_ALLOW_ANYTHING, __FUNCTION__) || g_configManager().getBoolean(TOGGLE_GOLD_POUCH_QUICKLOOT_ONLY, __FUNCTION__);
 	if (!container || (container->getID() == ITEM_GOLD_POUCH && category != OBJECTCATEGORY_GOLD) && !allowConfig) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;


### PR DESCRIPTION
# Description

Currently, it is not possible to equip the loot pouch (gold pouch) with it activated in the config.lua, as there is a reversal in logic where it accepts it as a loot pouch.

I compared it with the old code, and indeed, the logic was inverted in a recent commit.

I have already tested this modification, and everything occurs correctly.

## Behaviour
### **Actual**

It doesnt allow you to equip loot pouch on quick looting (Manage loot container window).

### **Expected**

It should accept loot pouch as quickloot (when activated on config.lua)

### Fixes #2402

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

I built the new change and tested on a character with loot pouch. I also, tested the quicklooting system. Everything worked.

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.32
  - Operating System: Linux

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
