### PR TITLE
fix: skill duplication on equip item

### DIFF
--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -524,17 +524,17 @@ uint32_t MoveEvent::EquipItem(const std::shared_ptr<MoveEvent> moveEvent, std::s
 		return 1;
 	}
 
+	const ItemType &it = Item::items[item->getID()];
+	if (it.transformEquipTo != 0) {
+		g_game().transformItem(item, it.transformEquipTo);
+	}
+
 	if (player->isItemAbilityEnabled(slot)) {
 		g_logger().debug("[{}] item ability is already enabled", __FUNCTION__);
 		return 1;
 	}
 
 	player->setItemAbility(slot, true);
-
-	const ItemType &it = Item::items[item->getID()];
-	if (it.transformEquipTo != 0) {
-		g_game().transformItem(item, it.transformEquipTo);
-	}
 
 	for (uint8_t slotid = 0; slotid < item->getImbuementSlot(); slotid++) {
 		player->updateImbuementTrackerStats();


### PR DESCRIPTION
Revert send mistake from: https://github.com/opentibiabr/canary/commit/c6895eb063d564a479e4a42e4c1d15f241f9aa9e