### PR TITLE
fix: global server save and expBoostCount improvements

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1739,8 +1739,8 @@ function GameStore.processExpBoostPuchase(player)
 	player:setStoreXpBoost(50)
 	player:setExpBoostStamina(currentExpBoostTime + 3600)
 
-	if player:getStorageValue(GameStore.Storages.expBoostCount) == -1 or expBoostCount == 6 then
-		player:setStorageValue(GameStore.Storages.expBoostCount, 1)
+	if expBoostCount == -1 or expBoostCount == 6 then
+		expBoostCount = 1
 	end
 
 	player:setStorageValue(GameStore.Storages.expBoostCount, expBoostCount + 1)

--- a/data/scripts/globalevents/global_server_save.lua
+++ b/data/scripts/globalevents/global_server_save.lua
@@ -5,7 +5,8 @@ local function ServerSave()
 
 	if configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_CLOSE) then
 		Game.setGameState(GAME_STATE_CLOSED)
-	elseif configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_SHUTDOWN) then
+	end
+	if configManager.getBoolean(configKeys.GLOBAL_SERVER_SAVE_SHUTDOWN) then
 		Game.setGameState(GAME_STATE_SHUTDOWN)
 	end
 


### PR DESCRIPTION
# Description

Fixing when the server is configured to shut down and close, the server doesn't shut down, because of this `elseif`.