### PR TITLE
fix: incorrect pricing for enchant/recharge with silver tokens

### DIFF
--- a/data-otservbr-global/npc/cledwyn.lua
+++ b/data-otservbr-global/npc/cledwyn.lua
@@ -97,6 +97,8 @@ end
 
 local charge = {}
 
+local chargePrice = {}
+
 local chargeItem = {
 	["pendulet"] = { noChargeID = 29429, ChargeID = 30344 },
 	["sleep shawl"] = { noChargeID = 29428, ChargeID = 30342 },
@@ -137,18 +139,20 @@ local function creatureSayCallback(npc, creature, type, message)
 	elseif table.contains({ "pendulet", "sleep shawl", "blister ring", "theurgic amulet", "ring of souls", "turtle amulet" }, message:lower()) and npcHandler:getTopic(playerId) == 1 then
 		npcHandler:say("Should I enchant the item " .. message .. " for 2 " .. ItemType(npc:getCurrency()):getPluralName():lower() .. "?", npc, creature)
 		charge = message:lower()
+		chargePrice = 2
 		npcHandler:setTopic(playerId, 2)
 	elseif table.contains({ "spiritthorn ring", "alicorn ring", "arcanomancer sigil", "arboreal ring" }, message:lower()) and npcHandler:getTopic(playerId) == 1 then
 		npcHandler:say("Should I enchant the item " .. message .. " for 5 " .. ItemType(npc:getCurrency()):getPluralName():lower() .. "?", npc, creature)
 		charge = message:lower()
+		chargePrice = 5
 		npcHandler:setTopic(playerId, 2)
 	elseif npcHandler:getTopic(playerId) == 2 then
 		if MsgContains(message, "yes") then
 			if not chargeItem[charge] then
 				npcHandler:say("Sorry, you don't have an unenchanted " .. charge .. ".", npc, creature)
 			else
-				if (player:getItemCount(npc:getCurrency()) >= 2) and (player:getItemCount(chargeItem[charge].noChargeID) >= 1) then
-					player:removeItem(npc:getCurrency(), 2)
+				if (player:getItemCount(npc:getCurrency()) >= chargePrice) and (player:getItemCount(chargeItem[charge].noChargeID) >= 1) then
+					player:removeItem(npc:getCurrency(), chargePrice)
 					player:removeItem(chargeItem[charge].noChargeID, 1)
 					local itemAdd = player:addItem(chargeItem[charge].ChargeID, 1)
 					npcHandler:say("Ah, excellent. Here is your " .. itemAdd:getName():lower() .. ".", npc, creature)


### PR DESCRIPTION
# Description

The NPC Cledwyn, who performs enchant/recharge of various items in exchange for silver tokens is ALWAYS charging 2 silver tokens for each operation. However, some of them should cost 5 silver tokens.

## Behaviour
### **Actual**
If you request a recharge for an Arboreal Ring, for example, you will be charged 2 silver tokens.

### **Expected**
Items like Arboreal Ring, Spiritthorn Ring should cost 5 silver tokens for recharge.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
You can simply take an Arboreal Ring without charge and request an enchant from NPC Cledwyn. He will say that the operation costs 5 silver tokens, but will only charge 2.

**Test Configuration**:

  - Server Version: Canary 3.1.2
  - Client: 13.32
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
