### PR TITLE
fix: removed error message in console

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2131,7 +2131,7 @@ void Combat::applyExtensions(std::shared_ptr<Creature> caster, std::shared_ptr<C
 	if (player) {
 		chance = player->getSkillLevel(SKILL_CRITICAL_HIT_CHANCE);
 		bonus = player->getSkillLevel(SKILL_CRITICAL_HIT_DAMAGE);
-		if (target) {
+		if (target && target->getMonster()) {
 			uint16_t playerCharmRaceid = player->parseRacebyCharm(CHARM_LOW, false, 0);
 			if (playerCharmRaceid != 0) {
 				const auto mType = g_monsters().getMonsterType(target->getName());


### PR DESCRIPTION
Removed these messages:
![image](https://github.com/opentibiabr/canary/assets/7812282/4f72ed1d-d5ea-4f99-a23c-f393fa00e4dd)
