### PR TITLE
fix: auto loot reachable corpses only

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -813,7 +813,17 @@ bool Creature::dropCorpse(std::shared_ptr<Creature> lastHitCreature, std::shared
 					player->sendLootMessage(lootMessage.str());
 				}
 
-				if (player->checkAutoLoot(monster->isRewardBoss()) && corpseContainer && mostDamageCreature->getPlayer()) {
+				stdext::arraylist<Direction> dirList(128);
+				FindPathParams fpp;
+				fpp.minTargetDist = 0;
+				fpp.maxTargetDist = 1;
+				fpp.fullPathSearch = true;
+				fpp.clearSight = true;
+				fpp.maxSearchDist = 0;
+
+				auto isReachable = g_game().map.getPathMatching(player->getPosition(), dirList, FrozenPathingConditionCall(corpse->getPosition()), fpp);
+
+				if (player->checkAutoLoot(monster->isRewardBoss()) && corpseContainer && mostDamageCreature->getPlayer() && isReachable ) {
 					g_dispatcher().addEvent(
 						std::bind(&Game::playerQuickLootCorpse, &g_game(), player, corpseContainer, corpse->getPosition()),
 						"Game::playerQuickLootCorpse"


### PR DESCRIPTION
# Description

Updates the auto loot system so the player need to have a clear path to the corpse in order to loot it.

## Behaviour
### **Actual**

Players can auto loot unreachable monsters, like annihilation demons.

### **Expected**

Players shouldn't loot corpses they cannot walk into.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Just created monsters inside a room with windows and a door, killed the monsters through the window and with the door opened.

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
