### PR TITLE
fix: missing function loadPlayerInstantSpellList in IOLoginData

### DIFF
--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -172,7 +172,7 @@ bool IOLoginData::loadPlayer(std::shared_ptr<Player> player, DBResult_ptr result
 		// Load task hunting class
 		IOLoginDataLoad::loadPlayerTaskHuntingClass(player, result);
 
-		// Load instant spells class
+		// Load instant spells list
 		IOLoginDataLoad::loadPlayerInstantSpellList(player, result);
 
 		if (disableIrrelevantInfo) {

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -172,6 +172,9 @@ bool IOLoginData::loadPlayer(std::shared_ptr<Player> player, DBResult_ptr result
 		// Load task hunting class
 		IOLoginDataLoad::loadPlayerTaskHuntingClass(player, result);
 
+		// Load instant spells class
+		IOLoginDataLoad::loadPlayerInstantSpellList(player, result);
+
 		if (disableIrrelevantInfo) {
 			return true;
 		}


### PR DESCRIPTION
# Description

When the player learn the spell by the NPC and logout, he will forget it and will need to buy it again because the respective spells entries will be deleted from the database (player_spells).

## Behaviour
### **Actual**

Learn a spell via npc, try to cast it (you will succeed) then logout.
Login again and try to cast the spell, you will fail and receive the cancel message: you need to learn the spell.

### **Expected**

The player always can cast the spell after learning it.

## Type of change

  - [ X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
