### PR TITLE
fix: possibility of stashing items that are far away

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1664,7 +1664,7 @@ void Game::playerMoveItem(std::shared_ptr<Player> player, const Position &fromPo
 	player->cancelPush();
 
 	item->checkDecayMapItemOnMove();
-	
+
 	g_events().eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 	g_callbacks().executeCallback(EventCallback_t::playerOnItemMoved, &EventCallback::playerOnItemMoved, player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1649,7 +1649,12 @@ void Game::playerMoveItem(std::shared_ptr<Player> player, const Position &fromPo
 			return;
 		}
 	}
-
+	
+	if (isTryingToStow(toPos, toCylinder)) {
+		player->stowItem(item, count, false);
+		return;
+	}
+	
 	ReturnValue ret = internalMoveItem(fromCylinder, toCylinder, toIndex, item, count, nullptr, 0, player);
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
@@ -1660,11 +1665,6 @@ void Game::playerMoveItem(std::shared_ptr<Player> player, const Position &fromPo
 
 	item->checkDecayMapItemOnMove();
 	
-	if (isTryingToStow(toPos, toCylinder)) {
-		player->stowItem(item, count, false);
-		return;
-	}
-
 	g_events().eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 	g_callbacks().executeCallback(EventCallback_t::playerOnItemMoved, &EventCallback::playerOnItemMoved, player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1518,11 +1518,6 @@ void Game::playerMoveItem(std::shared_ptr<Player> player, const Position &fromPo
 		return;
 	}
 
-	if (isTryingToStow(toPos, toCylinder)) {
-		player->stowItem(item, count, false);
-		return;
-	}
-
 	if (!item->isPushable() || item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTMOVABLE);
 		return;
@@ -1664,6 +1659,11 @@ void Game::playerMoveItem(std::shared_ptr<Player> player, const Position &fromPo
 	player->cancelPush();
 
 	item->checkDecayMapItemOnMove();
+	
+	if (isTryingToStow(toPos, toCylinder)) {
+		player->stowItem(item, count, false);
+		return;
+	}
 
 	g_events().eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 	g_callbacks().executeCallback(EventCallback_t::playerOnItemMoved, &EventCallback::playerOnItemMoved, player, item, count, fromPos, toPos, fromCylinder, toCylinder);


### PR DESCRIPTION
# Description

Its possible to stash items even if they are distant from the player position.

This PR will block this behaviour.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)


