### PR TITLE
fix: duplicated daily rewards bug

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -462,14 +462,12 @@ function Player.selectDailyReward(self, msg)
 		local description = ""
 		for k, v in ipairs(items) do
 			if dailyTable.itemCharges then
-				for i = 1, rewardCount do
-					local inboxItem = inbox:addItem(v.itemId, dailyTable.itemCharges) -- adding charges for each item
-					if inboxItem then
-						inboxItem:setAttribute(ITEM_ATTRIBUTE_STORE, systemTime())
-					end
+				local inboxItem = inbox:addItem(v.itemId, dailyTable.itemCharges) -- adding charges for each item
+				if inboxItem then
+					inboxItem:setAttribute(ITEM_ATTRIBUTE_STORE, systemTime())
 				end
 			else
-				local inboxItem = inbox:addItem(v.itemId, rewardCount) -- adding single item w/o charges
+				local inboxItem = inbox:addItem(v.itemId, v.count) -- adding single item w/o charges
 				if inboxItem then
 					inboxItem:setAttribute(ITEM_ATTRIBUTE_STORE, systemTime())
 				end


### PR DESCRIPTION
# Description

Removes the possibility of getting duplicate rewards, both on exercise weapons and normal items.

## Behaviour
### **Actual**

If you try to take the daily reward this will happen (Premium):

If you select 5 mana potions and 5 health potions, you will receive 10 of each.
If you select 1 exercise bow and 1 exercise rod, you will receive 2 of each.

### **Expected**

Correctly distribution of the rewards.

### Fixes  #2500

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)
