### PR TITLE
fix: transform item logic crash

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2616,12 +2616,10 @@ std::shared_ptr<Item> Game::transformItem(std::shared_ptr<Item> item, uint16_t n
 
 			auto decaying = item->getDecaying();
 			// If the item is decaying, we need to transform it to the new item
-			if (decaying > DECAYING_FALSE && item->getDuration() <= 1) {
+			if (decaying > DECAYING_FALSE && item->getDuration() <= 1 && newType.decayTo) {
 				g_logger().debug("Decay duration old type {}, transformEquipTo {}, transformDeEquipTo {}", curType.decayTo, curType.transformEquipTo, curType.transformDeEquipTo);
-				g_logger().debug("Decay duration new type, decayTo {}, transformEquipTo {}, transformDeEquipTo {}", newType.decayTo, newType.transformEquipTo, newType.transformDeEquipTo);
-				if (newType.decayTo) {
-					itemId = newType.decayTo;
-				}
+				g_logger().debug("Decay duration new type decayTo {}, transformEquipTo {}, transformDeEquipTo {}", newType.decayTo, newType.transformEquipTo, newType.transformDeEquipTo);
+				itemId = newType.decayTo;
 			} else if (curType.id != newType.id) {
 				if (newType.group != curType.group) {
 					item->setDefaultSubtype();


### PR DESCRIPTION
Resolves #2516

Related to: #2419

In the updated version of the code, we streamlined the condition for item decay by integrating an additional check directly into the initial if statement. Previously, we had a separate check inside the if block to determine if the newType.decayTo value was present, which then set the itemId accordingly. However, this approach had the potential risk of creating unnecessary complexity and possibly leading to a loop if the conditions weren't met as expected.

To address this and enhance clarity, we've moved the check for newType.decayTo into the condition of the if statement itself. This adjustment ensures that all necessary conditions are evaluated upfront, making the code more straightforward and preventing the execution from entering the if block unless all criteria are satisfied. This change not only simplifies the logic but also ensures that we avoid any unintended loops by making the transition to the else if statement more predictable when the initial conditions are not met.