### PR TITLE
fix value prismatic ring

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -34167,7 +34167,7 @@
 		<attribute key="showduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentphysical" value="10"/>
-		<attribute key="absorbpercentenergy" value="8"/>
+		<attribute key="absorbpercentpoison" value="8"/>
 		<attribute key="transformequipto" value="16264"/>
 		<attribute key="weight" value="105"/>
 		<attribute key="script" value="moveevent">


### PR DESCRIPTION
The prismatic ring showed an erroneous value as it was not equipped, with this modification it would be fine.


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

Currently the ring shows that it has 8% energy protection.


### **Expected**

with the modification, the ring shows the correct value


### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

It was tested by reviewing the statistics of the energy ring before equipping it and after equipping it and that they both maintain the correct value.


  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
