### PR TITLE
fix: forge convergence show all items with same class

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5021,7 +5021,7 @@ void ProtocolGame::sendOpenForge() {
 				getForgeInfoMap(item, receiveTierItemMap);
 			}
 			if (itemClassification == 4) {
-				getForgeInfoMap(item, convergenceItemsMap[item->getSlotPosition()]);
+				getForgeInfoMap(item, convergenceItemsMap[item->getClassification()]);
 			}
 		}
 	}


### PR DESCRIPTION
When the forge activated the "convergence" option it did not show all class 4 items, with this modification it will correctly show all class 4 items


# Description

The modification will cause that when the "convergence" option is activated it will show you all the classification 4 items


With the proposed modification, it now correctly teaches all class 4 items

## Behaviour
### **Actual**

Currently, if you check the "convergence" option in the forge it only shows you the items by category, Weapons with Weapons, helmet with helmets, etc.

With the proposed modification, it now correctly teaches all class 4 items

### **Expected**

Not all classification 4 items are shown when the "convergence" option is activated, it only shows items by category, which is not correct.


### Fixes 

Resolves #2511;

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

The forge was tested by activating the "convergence" option for both the fusion and the transfer and in both cases it now shows all the items classification 4 correctly


  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
