### PR TITLE
fix: prismatic ring attribute absorb

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -34797,7 +34797,7 @@
 		<attribute key="showduration" value="1"/>
 		<attribute key="showAttributes" value="1"/>
 		<attribute key="absorbpercentphysical" value="10"/>
-		<attribute key="absorbpercentpoison" value="8"/>
+		<attribute key="absorbpercentenergy" value="8"/>
 		<attribute key="duration" value="3600"/>
 		<attribute key="transformdeequipto" value="16114"/>
 		<attribute key="decayTo" value="0"/>


### PR DESCRIPTION
# Description

currently if you have the ring unequipped, it appears that it protects 8% on earth

## Behaviour
### **Actual**

currently if you have the ring unequipped, it appears that it protects 8% on earth


### **Expected**

the ring must protect 8% in energy


### Fixes 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

The ring is checked and it correctly shows the energy protection


  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
