### PR TITLE
feat: include day count in getTimeInWords function

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -67,17 +67,28 @@ end
 
 function getTimeInWords(secsParam)
 	local secs = tonumber(secsParam)
+	local days = math.floor(secs / (24 * 3600))
+	secs = secs - (days * 24 * 3600)
 	local hours, minutes, seconds = getHours(secs), getMinutes(secs), getSeconds(secs)
 	local timeStr = ""
 
+	if days > 0 then
+		timeStr = days .. (days > 1 and " days" or " day")
+	end
+
 	if hours > 0 then
-		timeStr = hours .. (hours > 1 and " hours" or " hour")
+		if timeStr ~= "" then
+			timeStr = timeStr .. ", "
+		end
+
+		timeStr = timeStr .. hours .. (hours > 1 and " hours" or " hour")
 	end
 
 	if minutes > 0 then
 		if timeStr ~= "" then
 			timeStr = timeStr .. ", "
 		end
+
 		timeStr = timeStr .. minutes .. (minutes > 1 and " minutes" or " minute")
 	end
 
@@ -85,9 +96,9 @@ function getTimeInWords(secsParam)
 		if timeStr ~= "" then
 			timeStr = timeStr .. " and "
 		end
+
 		timeStr = timeStr .. seconds .. (seconds > 1 and " seconds" or " second")
 	end
-
 	return timeStr
 end
 


### PR DESCRIPTION
Implemented the functionality to include days in the getTimeInWords function, providing more precise time representation in the message outputs.

![image](https://github.com/opentibiabr/canary/assets/26801045/ceca0dfb-ab8a-4e92-9814-5dad07425670)
