### PR TITLE
fix: getRuneSpell making it possible to search by spell id and rune id

### DIFF
--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -184,15 +184,15 @@ std::shared_ptr<Spell> Spells::getSpellByName(const std::string &name) {
 
 std::shared_ptr<RuneSpell> Spells::getRuneSpell(uint16_t id) {
 	auto it = runes.find(id);
-	if (it == runes.end()) {
-		for (auto &rune : runes) {
-			if (rune.second->getRuneItemId() == id) {
-				return rune.second;
-			}
-		}
-		return nullptr;
+	if (it != runes.end()) {
+		return it->second;
 	}
-	return it->second;
+	for (auto &rune : runes) {
+		if (rune.second->getSpellId() == id) {
+			return rune.second;
+		}
+	}
+	return nullptr;
 }
 
 std::shared_ptr<RuneSpell> Spells::getRuneSpellByName(const std::string &name) {


### PR DESCRIPTION
# Description

Currently rune spells are mapped via item id, not spell id, via the `Spells::registerRuneLuaEvent ` function. As it seems to me at first, the function `Spells::getRuneSpell` is intended to search for the rune spell by the id of the rune (item) or by the id of the spell. However, the way it is implemented will only return rune spells by the rune (item) id. These small modifications to this PR aim to allow searching in two scenarios: id of spell, or id of rune item id.

PS: I didn't identify any scenario in which the function was called searching for the spell id.

## Behaviour
### **Actual**

When searching for a rune spell by spell id nullptr is returned

### **Expected**

When searching for a rune spell by spell id, the spell is returned

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

BEFORE implementing the changes:
Open data/scripts/globalevents/server_initalization.lua.
At the end of the serverInitialization.onStartup() function, add:
```
	-- great fireball rune (gfb)
	local gfbSpellId = 16
	local bySpellId = Spell(gfbSpellId)
	if bySpellId then
		print("bySpellId: ", bySpellId:getName())
	else
		print("bySpellId not found")
	end
	local gfbRuneId = 3191
	local byRuneId = Spell(gfbRuneId)
	if byRuneId then
		print("byRuneId: ", byRuneId:getName())
	else
		print("byRuneId not found")
	end
```

Check the output by turning on the server
```
bySpellId not found
byRuneId: great fireball rune
```

AFTER implementing the changes: run the server and check the output:
```
bySpellId: great fireball rune
byRuneId: great fireball rune
```
Clean test code

**Test Configuration**:

  - Server Version: 3.1.2
  - Client:
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
