### PR TITLE
fix: potions add flask to player

### DIFF
--- a/data/scripts/actions/items/potions.lua
+++ b/data/scripts/actions/items/potions.lua
@@ -89,10 +89,13 @@ function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHot
 		local deactivatedFlasks = player:kv():get("talkaction.potions.flask") or false
 		if not deactivatedFlasks then
 			local container = Container(item:getParent().uid)
-			local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-
-			if fromPosition.x == CONTAINER_POSITION and container ~= inbox and container:getEmptySlots() ~= 0 then
-				container:addItem(potion.flask, 1)
+			if container then
+				local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
+				if fromPosition.x == CONTAINER_POSITION and container ~= inbox and container:getEmptySlots() ~= 0 then
+					container:addItem(potion.flask, 1)
+				else
+					player:addItem(potion.flask, 1)
+				end
 			else
 				Game.createItem(potion.flask, 1, fromPosition)
 			end

--- a/data/scripts/actions/items/potions.lua
+++ b/data/scripts/actions/items/potions.lua
@@ -90,8 +90,8 @@ function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHot
 		if not deactivatedFlasks then
 			local container = Container(item:getParent().uid)
 			if container then
-				local inbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-				if fromPosition.x == CONTAINER_POSITION and container ~= inbox and container:getEmptySlots() ~= 0 then
+				local storeInbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
+				if fromPosition.x == CONTAINER_POSITION and container ~= storeInbox and container:getEmptySlots() ~= 0 then
 					container:addItem(potion.flask, 1)
 				else
 					player:addItem(potion.flask, 1)


### PR DESCRIPTION
- function **Game.createItem** did not work when the container was full and when it was store inbox. It is only used when there is no container.
- the correct function for when the container is full or the container is a store inbox is **player:addItem.**
