### PR TITLE
fix: destroy field is working inside pz

### DIFF
--- a/data/scripts/runes/destroy_field_rune.lua
+++ b/data/scripts/runes/destroy_field_rune.lua
@@ -4,6 +4,13 @@ local fields = { 105, 2118, 2119, 2120, 2121, 2122, 2123, 2124, 2125, 2126, 2132
 local rune = Spell("rune")
 
 function rune.onCastSpell(creature, variant, isHotkey)
+	local inPz = creature:getTile():hasFlag(TILESTATE_PROTECTIONZONE)
+    if inPz then
+        creature:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
+
 	local position = Variant.getPosition(variant)
 	local tile = Tile(position)
 	local field = tile and tile:getItemByType(ITEM_TYPE_MAGICFIELD)

--- a/data/scripts/runes/destroy_field_rune.lua
+++ b/data/scripts/runes/destroy_field_rune.lua
@@ -5,11 +5,11 @@ local rune = Spell("rune")
 
 function rune.onCastSpell(creature, variant, isHotkey)
 	local inPz = creature:getTile():hasFlag(TILESTATE_PROTECTIONZONE)
-    if inPz then
-        creature:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-        creature:getPosition():sendMagicEffect(CONST_ME_POFF)
-        return false
-    end
+	if inPz then
+		creature:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		creature:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
 
 	local position = Variant.getPosition(variant)
 	local tile = Tile(position)


### PR DESCRIPTION
# Description

The player can use destroy field rune in PZ.

## Behaviour

### **Expected**

Block the usage.
