### PR TITLE
fix: block gold pouch using in the obtain method

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5384,6 +5384,11 @@ void Game::playerSetManagedContainer(uint32_t playerId, ObjectCategory_t categor
 		return;
 	}
 
+	if (container->getID() == ITEM_GOLD_POUCH && !isLootContainer) {
+        player->sendTextMessage(MESSAGE_FAILURE, "You can only set the gold pouch as a loot container.");
+        return;
+    }
+
 	if (container->getHoldingPlayer() != player) {
 		player->sendCancelMessage("You must be holding the container to set it as a loot container.");
 		return;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5385,9 +5385,9 @@ void Game::playerSetManagedContainer(uint32_t playerId, ObjectCategory_t categor
 	}
 
 	if (container->getID() == ITEM_GOLD_POUCH && !isLootContainer) {
-        player->sendTextMessage(MESSAGE_FAILURE, "You can only set the gold pouch as a loot container.");
-        return;
-    }
+		player->sendTextMessage(MESSAGE_FAILURE, "You can only set the gold pouch as a loot container.");
+		return;
+	}
 
 	if (container->getHoldingPlayer() != player) {
 		player->sendCancelMessage("You must be holding the container to set it as a loot container.");


### PR DESCRIPTION
# Description

Players are using this behavior to store items in this pouch.
![image](https://github.com/opentibiabr/canary/assets/25832677/427cec56-a5a5-45bd-a5b1-7da76c28741b)


## Behaviour
### **Actual**

Able to select in the Obtain (Manage Container)

### **Expected**

Not be able to add in Obtain, only in Loot Container.
