### PR TITLE
fix: transcendence applies correct status without unlocked stages

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6688,7 +6688,7 @@ void Player::triggerTranscendance() {
 		outfit.lookType = getVocation()->getAvatarLookType();
 		outfitCondition->setOutfit(outfit);
 		addCondition(outfitCondition);
-		wheel()->setOnThinkTimer(WheelOnThink_t::AVATAR, OTSYS_TIME() + duration);
+		wheel()->setOnThinkTimer(WheelOnThink_t::AVATAR_FORGE, OTSYS_TIME() + duration);
 		g_game().addMagicEffect(getPosition(), CONST_ME_AVATAR_APPEAR);
 		sendTextMessage(MESSAGE_ATTENTION, "Transcendance was triggered.");
 		sendSkills();

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -2410,21 +2410,25 @@ int32_t PlayerWheel::checkBattleHealingAmount() const {
 }
 
 int32_t PlayerWheel::checkAvatarSkill(WheelAvatarSkill_t skill) const {
-	if (skill == WheelAvatarSkill_t::NONE || getOnThinkTimer(WheelOnThink_t::AVATAR) <= OTSYS_TIME()) {
+	if (skill == WheelAvatarSkill_t::NONE || (getOnThinkTimer(WheelOnThink_t::AVATAR_SPELL) <= OTSYS_TIME() && getOnThinkTimer(WheelOnThink_t::AVATAR_FORGE) <= OTSYS_TIME())) {
 		return 0;
 	}
 
 	uint8_t stage = 0;
-	if (getInstant("Avatar of Light")) {
-		stage = getStage(WheelStage_t::AVATAR_OF_LIGHT);
-	} else if (getInstant("Avatar of Steel")) {
-		stage = getStage(WheelStage_t::AVATAR_OF_STEEL);
-	} else if (getInstant("Avatar of Nature")) {
-		stage = getStage(WheelStage_t::AVATAR_OF_NATURE);
-	} else if (getInstant("Avatar of Storm")) {
-		stage = getStage(WheelStage_t::AVATAR_OF_STORM);
+	if (getOnThinkTimer(WheelOnThink_t::AVATAR_SPELL) > OTSYS_TIME()) {
+		if (getInstant("Avatar of Light")) {
+			stage = getStage(WheelStage_t::AVATAR_OF_LIGHT);
+		} else if (getInstant("Avatar of Steel")) {
+			stage = getStage(WheelStage_t::AVATAR_OF_STEEL);
+		} else if (getInstant("Avatar of Nature")) {
+			stage = getStage(WheelStage_t::AVATAR_OF_NATURE);
+		} else if (getInstant("Avatar of Storm")) {
+			stage = getStage(WheelStage_t::AVATAR_OF_STORM);
+		} else {
+			return 0;
+		}
 	} else {
-		return 0;
+		stage = 3;
 	}
 
 	if (skill == WheelAvatarSkill_t::DAMAGE_REDUCTION) {

--- a/src/creatures/players/wheel/wheel_definitions.hpp
+++ b/src/creatures/players/wheel/wheel_definitions.hpp
@@ -105,9 +105,10 @@ enum class WheelOnThink_t : uint8_t {
 	FOCUS_MASTERY = 4,
 	GIFT_OF_LIFE = 5,
 	DIVINE_EMPOWERMENT = 6,
-	AVATAR = 7,
+	AVATAR_SPELL = 7,
+	AVATAR_FORGE = 8,
 
-	TOTAL_COUNT = 8
+	TOTAL_COUNT = 9
 };
 
 enum class WheelStat_t : uint8_t {

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -3997,9 +3997,9 @@ int PlayerFunctions::luaPlayerAvatarTimer(lua_State* L) {
 	}
 
 	if (lua_gettop(L) == 1) {
-		lua_pushnumber(L, (lua_Number)player->wheel()->getOnThinkTimer(WheelOnThink_t::AVATAR));
+		lua_pushnumber(L, (lua_Number)player->wheel()->getOnThinkTimer(WheelOnThink_t::AVATAR_SPELL));
 	} else {
-		player->wheel()->setOnThinkTimer(WheelOnThink_t::AVATAR, getNumber<int64_t>(L, 2));
+		player->wheel()->setOnThinkTimer(WheelOnThink_t::AVATAR_SPELL, getNumber<int64_t>(L, 2));
 		pushBoolean(L, true);
 	}
 	return 1;


### PR DESCRIPTION
# Description

When you are using a legs with tier and the transcendence happens, if the player do not have any kind of stage unlocked in the wheel of destiny, the proper status like damage reduction, critical damage chance 100% and critical damage of 15% it's not applied. This PR fix the logic and remove early return that prevents the code from running and considering the case of no avatar stage unlocked.

thanks @luanluciano93 for the discussion and proposing new changes to the code.

## Behaviour
### **Actual**

1. When transcendence is applied and player have no stage in avatar wheel, the proper status are not applied;
2. When transcendence occurs, the status are not visually presented correctly to client (always stays in 0);

### **Expected**

Transcendence is a special effect that triggers a shorter version of the [Avatar spell](https://tibia.fandom.com/wiki/Avatar) (Stage 3). Which will grant all the bonuses from the spell, but last for only 7 seconds.

![image](https://github.com/opentibiabr/canary/assets/87909998/ef47b001-f69e-4c72-8d64-31721f4b52c7)

### Fixes #2499
### Fixes #2169

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Transform without any point applied in the avatar wheel tree;
  - [x] Check if the status are displayed properly on the skills window and the damages changes;
  
![Imagem do WhatsApp de 2024-04-20 à(s) 23 56 19_95532c74](https://github.com/opentibiabr/canary/assets/87909998/7fc6b5ef-7509-419a-a181-ac36e3dcf2ba)


**Test Configuration**:
  - Server Version: latest
  - Client: 13.32.14520
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
