### PR TITLE
fix: use flask on familiar

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3744,6 +3744,18 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 			return;
 		}
 	}
+
+	if (creature->getMonster() && creature->getMonster()->isFamiliar() && (it.isRune() || it.type == ITEM_TYPE_POTION)) {
+		player->setNextPotionAction(OTSYS_TIME() + g_configManager().getNumber(EX_ACTIONS_DELAY_INTERVAL, __FUNCTION__));
+
+		if (it.isMultiUse()) {
+			player->sendUseItemCooldown(g_configManager().getNumber(EX_ACTIONS_DELAY_INTERVAL, __FUNCTION__));
+		}
+
+		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
+		return;
+	}
+
 	Position toPos = creature->getPosition();
 	Position walkToPos = fromPos;
 	ReturnValue ret = g_actions().canUse(player, fromPos);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3745,7 +3745,8 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 		}
 	}
 
-	if (creature->getMonster() && creature->getMonster()->isFamiliar() && (it.isRune() || it.type == ITEM_TYPE_POTION)) {
+	const std::shared_ptr<Monster> monster = creature->getMonster();
+	if (monster && monster->isFamiliar() && creature->getMaster()->getPlayer() == player && (it.isRune() || it.type == ITEM_TYPE_POTION)) {
 		player->setNextPotionAction(OTSYS_TIME() + g_configManager().getNumber(EX_ACTIONS_DELAY_INTERVAL, __FUNCTION__));
 
 		if (it.isMultiUse()) {


### PR DESCRIPTION
# Description

- [X] Fixes #2507 

This change approaches its maximum in tibia.

In addition to blocking the use of runes and potions on your familiar, you must always update the NextActions and cooldown times, as is the case in Tibia.

The gif below shows that only the owner of the family member is blocked and the other players continue with the same existing features.

https://imgur.com/Lo7Ec2n