### PR TITLE
fix: gem atelier critical extra damage not being applied

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1925,7 +1925,7 @@ void Player::onWalk(Direction &dir) {
 
 	Creature::onWalk(dir);
 	setNextActionTask(nullptr);
-	
+
 	g_callbacks().executeCallback(EventCallback_t::playerOnWalk, &EventCallback::playerOnWalk, getPlayer(), dir);
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1925,7 +1925,7 @@ void Player::onWalk(Direction &dir) {
 
 	Creature::onWalk(dir);
 	setNextActionTask(nullptr);
-  
+	
 	g_callbacks().executeCallback(EventCallback_t::playerOnWalk, &EventCallback::playerOnWalk, getPlayer(), dir);
 }
 
@@ -5371,6 +5371,7 @@ uint16_t Player::getSkillLevel(skills_t skill) const {
 	} else if (skill == SKILL_MANA_LEECH_AMOUNT) {
 		skillLevel += m_wheelPlayer->getStat(WheelStat_t::MANA_LEECH);
 	} else if (skill == SKILL_CRITICAL_HIT_DAMAGE) {
+		skillLevel += m_wheelPlayer->getStat(WheelStat_t::CRITICAL_DAMAGE);
 		skillLevel += m_wheelPlayer->getMajorStatConditional("Combat Mastery", WheelMajor_t::CRITICAL_DMG_2);
 		skillLevel += m_wheelPlayer->getMajorStatConditional("Ballistic Mastery", WheelMajor_t::CRITICAL_DMG);
 		skillLevel += m_wheelPlayer->checkAvatarSkill(WheelAvatarSkill_t::CRITICAL_DAMAGE);


### PR DESCRIPTION
changes:
- Added gem stat to critical extra damage player skill level


# Description

Fixes the gems applied in gem atelier that wasn't applying the critical extra damage to player.

## Behaviour
### **Actual**

When placing a gem into a vessel that contains a modifier with critical extra damage it does not apply to player and not display in combat stats cyclopedia and in skills window

### **Expected**

When placing a gem into a vessel that contains a modifier with critical extra damage it should apply to player and display in combat stats cyclopedia and in skills window

### Fixes #2550 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Apply a gem in vessel that contains a critical extra damage
  - [ ] Open player combat stats cyclopedia and skills window and the information should be there

**Test Configuration**:

  - Server Version: Current
  - Client: 13.32.14520
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
