### PR TITLE
fix: equipping two-handed distance weapons via action bar removes quiver if equipped

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1925,7 +1925,7 @@ void Player::onWalk(Direction &dir) {
 
 	Creature::onWalk(dir);
 	setNextActionTask(nullptr);
-  
+
 	g_callbacks().executeCallback(EventCallback_t::playerOnWalk, &EventCallback::playerOnWalk, getPlayer(), dir);
 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3199,7 +3199,13 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 		} else {
 			const int32_t &slotPosition = equipItem->getSlotPosition();
 			// Checks if a two-handed item is being equipped in the left slot when the right slot is already occupied and move to backpack
-			if (slotPosition & SLOTP_LEFT && rightItem && (slotPosition & SLOTP_TWO_HAND)) {
+			if (
+				(slotPosition & SLOTP_LEFT)
+				&& (slotPosition & SLOTP_TWO_HAND)
+				&& rightItem
+				&& !(it.weaponType == WEAPON_DISTANCE)
+				&& !rightItem->isQuiver()
+			) {
 				ret = internalCollectManagedItems(player, rightItem, getObjectCategory(rightItem), false);
 			}
 


### PR DESCRIPTION
# Description

When equipping by dragging a two-handed ranged weapon into the inventory, it is possible to equip this weapon without removing the quiver.
However, if the equipment was equipped using the action bar, this removes the equipped quiver.

This PR aims to allow the player to equip a two-handed distance weapon from the action bar without having their equipped quiver removed.
In circumstances other than a two-handed weapon, the behavior remains and the equipped quiver/shield must be removed.

### Fixes #2574 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. With a paladin, configure a two-handed ranged weapon (bow, crossbow, etc.) to be equipped from the action bar. Do the same for some quiver.
2. Equip the quiver.
3. Using the action bar, equip the weapon. 

Both must remain equipped.

4. With a golden axe (two handed axe), check that when equipping it both (ranged weapon and quiver) must be moved to the backpack

Videos:
[Before Example Video](https://github.com/opentibiabr/canary/assets/7812282/7d736f2f-aef7-40fa-96ac-d421c6de75f3)
[After Example Video](https://github.com/opentibiabr/canary/assets/7812282/5241d27e-2799-44e8-a17e-2cb68da8f7ee)

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.32
  - Operating System: Windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
