### PR TITLE
fix: quiver bugs

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -1147,6 +1147,10 @@ Item::getDescriptions(const ItemType &it, std::shared_ptr<Item> item /*= nullptr
 			descriptions.emplace_back("Description", it.description);
 		}
 
+		if (item->getContainer()) {
+			descriptions.emplace_back("Capacity", std::to_string(item->getContainer()->capacity()));
+		}
+
 		if (it.showCharges) {
 			auto charges = item->getAttribute<int32_t>(ItemAttribute_t::CHARGES);
 			if (charges != 0) {
@@ -1403,10 +1407,6 @@ Item::getDescriptions(const ItemType &it, std::shared_ptr<Item> item /*= nullptr
 			descriptions.emplace_back("Tier", std::to_string(item->getTier()));
 		}
 
-		if (item->getContainer()) {
-			descriptions.emplace_back("Capacity", std::to_string(item->getContainer()->capacity()));
-		}
-
 		std::string slotName;
 		if (item->getImbuementSlot() > 0) {
 			for (uint8_t i = 0; i < item->getImbuementSlot(); ++i) {
@@ -1560,6 +1560,10 @@ Item::getDescriptions(const ItemType &it, std::shared_ptr<Item> item /*= nullptr
 	} else {
 		if (!it.description.empty()) {
 			descriptions.emplace_back("Description", it.description);
+		}
+
+		if (it.isContainer()) {
+			descriptions.emplace_back("Capacity", std::to_string(it.maxItems));
 		}
 
 		int32_t attack = it.attack;
@@ -1779,10 +1783,6 @@ Item::getDescriptions(const ItemType &it, std::shared_ptr<Item> item /*= nullptr
 				ss << "Mana Shield";
 				descriptions.emplace_back("Skill Boost", ss.str());
 			}
-		}
-
-		if (it.isContainer()) {
-			descriptions.emplace_back("Capacity", std::to_string(it.maxItems));
 		}
 
 		if (it.imbuementSlot > 0) {
@@ -2075,13 +2075,18 @@ std::string Item::parseShowDuration(std::shared_ptr<Item> item) {
 std::string Item::parseShowAttributesDescription(std::shared_ptr<Item> item, const uint16_t itemId) {
 	std::ostringstream itemDescription;
 	const ItemType &itemType = Item::items[itemId];
+
 	if (itemType.armor != 0 || (item && item->getArmor() != 0) || itemType.showAttributes) {
-		bool begin = true;
+		bool begin = itemType.isQuiver() ? false : true;
 
 		int32_t armor = (item ? item->getArmor() : itemType.armor);
 		if (armor != 0) {
-			itemDescription << " (Arm:" << armor;
-			begin = false;
+			if (begin) {
+				itemDescription << " (Arm:" << armor;
+				begin = false;
+			} else {
+				itemDescription << ", Arm:" << armor;
+			}
 		}
 
 		if (itemType.abilities) {
@@ -2167,7 +2172,7 @@ std::string Item::parseShowAttributesDescription(std::shared_ptr<Item> item, con
 					itemDescription << ", ";
 				}
 
-				itemDescription << "Perfect Shot " << std::showpos << itemType.abilities->perfectShotDamage << std::noshowpos << " at range " << unsigned(itemType.abilities->perfectShotRange);
+				itemDescription << "perfect shot " << std::showpos << itemType.abilities->perfectShotDamage << std::noshowpos << " at range " << unsigned(itemType.abilities->perfectShotRange);
 			}
 
 			if (itemType.abilities->reflectFlat[0] != 0) {
@@ -2869,8 +2874,10 @@ std::string Item::getDescription(const ItemType &it, int32_t lookDistance, std::
 			}
 		}
 
-		if (volume != 0) {
+		if (volume != 0 && !it.isQuiver()) {
 			s << " (Vol:" << volume << ')';
+		} else if (volume != 0 && it.isQuiver()) {
+			s << " (Vol:" << volume;
 		}
 	} else {
 		bool found = true;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5643,7 +5643,7 @@ void ProtocolGame::sendMarketDetail(uint16_t itemId, uint8_t tier) {
 
 			if (it.abilities->perfectShotDamage > 0) {
 				string.clear();
-				string << std::showpos << it.abilities->perfectShotDamage << std::noshowpos << " at " << it.abilities->perfectShotRange << "%";
+				string << std::showpos << it.abilities->perfectShotDamage << std::noshowpos << " at range " << unsigned(it.abilities->perfectShotRange);
 				msg.addString(string.str(), "ProtocolGame::sendMarketDetail - string.str()");
 			} else {
 				msg.add<uint16_t>(0x00);


### PR DESCRIPTION
# Description

This PR fixes the quiver incorrect look, market description and description order on market and cyclopedia.

## Behaviour
### **Actual**

![image](https://github.com/opentibiabr/canary/assets/32341050/37ced17d-012c-449a-9250-3ee4816178ae)

![image](https://github.com/opentibiabr/canary/assets/32341050/6e1e7801-1d13-4e82-ad06-bf0202964171)

![image](https://github.com/opentibiabr/canary/assets/32341050/377e810b-d9ac-40f5-a67c-9dfec457f4ab)

### **Expected**

![image](https://github.com/opentibiabr/canary/assets/32341050/d1937f5b-48da-4262-b9bb-fc1f09e86add)

![image](https://github.com/opentibiabr/canary/assets/32341050/e42b93a7-d26e-4f8a-bbbd-54e6ede3e991)

![image](https://github.com/opentibiabr/canary/assets/32341050/081a76da-b49c-4215-83a1-dc3645be1824)

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Open cyclopedia and check the alicorn or eldritch quiver (it should display capacity before the item abilities);
  - [x] Open the market and check the details of alicorn or eldritch quiver (it should display the at range without emojis - string issues);
  - [x] Look at alicorn or eldritch quiver (it should display the abilities inside the volume parenthesis);
  - [x] Look at a backpack to check if the changes have affected;
  - [x] Look at a helmet to check if the changes have affected;
  - [x] Look at a armor to check if the changes have affected;
  - [x] Look at a weapon (sword, rods, etc) to check if the changes have affected;
  - [x] Look at a shield to check if the changes have affected;
  - [x] Look at a legs to check if the changes have affected;
  - [x] Look at a boots to check if the changes have affected;

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.32
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
