### PR TITLE
fix: beds

### DIFF
--- a/src/items/bed.cpp
+++ b/src/items/bed.cpp
@@ -94,12 +94,7 @@ bool BedItem::canUse(std::shared_ptr<Player> player) {
 		return false;
 	}
 
-	auto partName = itemType.name;
-	auto nextPartname = nextBedItem->getName();
-	auto firstPart = keepFirstWordOnly(partName);
-	auto nextPartOf = keepFirstWordOnly(nextPartname);
-	g_logger().debug("First bed part name {}, second part name {}", firstPart, nextPartOf);
-	if (!isMovable() || !nextBedItem->isMovable() || firstPart != nextPartOf) {
+	if (!isMovable() || !nextBedItem->isMovable() || !isBedComplete(nextBedItem)) {
 		return false;
 	}
 
@@ -120,6 +115,18 @@ bool BedItem::canUse(std::shared_ptr<Player> player) {
 		return false;
 	}
 	return true;
+}
+
+bool BedItem::isBedComplete(std::shared_ptr<BedItem> nextBedItem) {
+	const ItemType& it = Item::items[id];
+
+	if (nextBedItem == nullptr) {
+		return false;
+	}
+
+	g_logger().debug("First bed part id {}, second part id {}", it.id, nextBedItem->getID());
+
+	return it.bedPartOf == nextBedItem->getID();
 }
 
 bool BedItem::trySleep(std::shared_ptr<Player> player) {

--- a/src/items/bed.cpp
+++ b/src/items/bed.cpp
@@ -118,7 +118,7 @@ bool BedItem::canUse(std::shared_ptr<Player> player) {
 }
 
 bool BedItem::isBedComplete(std::shared_ptr<BedItem> nextBedItem) {
-	const ItemType& it = Item::items[id];
+	const ItemType &it = Item::items[id];
 
 	if (nextBedItem == nullptr) {
 		return false;

--- a/src/items/bed.cpp
+++ b/src/items/bed.cpp
@@ -124,7 +124,12 @@ bool BedItem::isBedComplete(std::shared_ptr<BedItem> nextBedItem) {
 		return false;
 	}
 
-	g_logger().debug("First bed part id {}, second part id {}", it.id, nextBedItem->getID());
+	auto partName = it.name;
+	auto nextPartname = nextBedItem->getName();
+	auto firstPart = keepFirstWordOnly(partName);
+	auto nextPartOf = keepFirstWordOnly(nextPartname);
+
+	g_logger().debug("First bed part id {} name {}, second part id {} name {}", it.id, firstPart, nextBedItem->getID(), nextPartOf);
 
 	return it.bedPartOf == nextBedItem->getID();
 }

--- a/src/items/bed.hpp
+++ b/src/items/bed.hpp
@@ -39,6 +39,8 @@ public:
 
 	bool canUse(std::shared_ptr<Player> player);
 
+	bool isBedComplete(std::shared_ptr<BedItem> nextBedItem);
+
 	bool trySleep(std::shared_ptr<Player> player);
 	bool sleep(std::shared_ptr<Player> player);
 	void wakeUp(std::shared_ptr<Player> player);


### PR DESCRIPTION
# Description

This PR fixes the way players can be able to sleep in beds.

## Behaviour
### **Actual**

https://github.com/opentibiabr/canary/assets/32341050/da1d883c-51cf-45f9-8e4c-60c549892b64

### **Expected**

https://github.com/opentibiabr/canary/assets/32341050/521b4f29-399b-41e5-a613-a8d807bfb7af

### Fixes #2610 

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Create or buy two parts of a bed item:

- [X] Join then to fullfil and try to sleep (it should be able to sleep);
- [X] Join then with the feet wrong part direction and try to sleep (it should not be able to sleep);
- [X] Repeat the process for other direction.

**Test Configuration**:

  - Server Version: Latest (3.1.2)
  - Client: 13.32
  - Operating System: Windows 11

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
