### PR TITLE
fix: imbuement elemental damage only to physical damage

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -649,6 +649,10 @@ CombatDamage Combat::applyImbuementElementalDamage(std::shared_ptr<Player> attac
 			continue;
 		}
 
+		if (damage.primary.type != COMBAT_PHYSICALDAMAGE) {
+			break;
+		}
+
 		float damagePercent = imbuementInfo.imbuement->elementDamage / 100.0;
 
 		damage.secondary.type = imbuementInfo.imbuement->combatType;


### PR DESCRIPTION
## Description
Imbuement Elemental Damage must work only to physical damage.
https://tibia.fandom.com/wiki/Imbuing#Fire_Damage