### PR TITLE
fix: players can't claim rewards after killing bosses

### DIFF
--- a/data-otservbr-global/scripts/creaturescripts/quests/dark_trails/kill_the_ravager.lua
+++ b/data-otservbr-global/scripts/creaturescripts/quests/dark_trails/kill_the_ravager.lua
@@ -7,7 +7,7 @@ local function removeTeleport(position)
 end
 
 local theRavager = CreatureEvent("TheRavagerDeath")
-function theRavager.onDeath(player, creature)
+function theRavager.onDeath(creature)
 	local position = creature:getPosition()
 	position:sendMagicEffect(CONST_ME_TELEPORT)
 	local item = Game.createItem(1949, 1, { x = 33496, y = 32070, z = 8 })

--- a/data-otservbr-global/scripts/creaturescripts/quests/liquid_black/deepling_boss_kill.lua
+++ b/data-otservbr-global/scripts/creaturescripts/quests/liquid_black/deepling_boss_kill.lua
@@ -5,12 +5,11 @@ local bosses = {
 }
 
 local deeplingBosses = CreatureEvent("DeeplingBossDeath")
-function deeplingBosses.onDeath(player, creature)
+function deeplingBosses.onDeath(creature)
 	local bossConfig = bosses[creature:getName():lower()]
 	if not bossConfig then
 		return true
 	end
-
 	onDeathForDamagingPlayers(creature, function(creature, player)
 		if player:getStorageValue(Storage.DeeplingBosses.DeeplingStatus) < bossConfig.status then
 			player:setStorageValue(Storage.DeeplingBosses.DeeplingStatus, bossConfig.status)


### PR DESCRIPTION
# Description

This PR will fix the deepling's  reward chests behaviour.
## Behaviour
### **Actual**

Kill the boss (Ex. Jaul) and try to get the reward in the chest. You will fail :(

### **Expected**

Kill the boss, go to the chest and take your reward.

## Type of change

  - [ X] Bug fix (non-breaking change which fixes an issue)
