### PR TITLE
Use phmap::parallel_flat_hash_map instead map with mutex

### DIFF
--- a/src/creatures/players/management/ban.cpp
+++ b/src/creatures/players/management/ban.cpp
@@ -15,8 +15,6 @@
 #include "utils/tools.hpp"
 
 bool Ban::acceptConnection(uint32_t clientIP) {
-	std::scoped_lock<std::recursive_mutex> lockClass(lock);
-
 	uint64_t currentTime = OTSYS_TIME();
 
 	auto it = ipConnectMap.find(clientIP);

--- a/src/creatures/players/management/ban.hpp
+++ b/src/creatures/players/management/ban.hpp
@@ -24,15 +24,12 @@ struct ConnectBlock {
 	uint32_t count;
 };
 
-using IpConnectMap = std::map<uint32_t, ConnectBlock>;
-
 class Ban {
 public:
 	bool acceptConnection(uint32_t clientIP);
 
 private:
-	IpConnectMap ipConnectMap;
-	std::recursive_mutex lock;
+	phmap::parallel_flat_hash_map<uint32_t, ConnectBlock> ipConnectMap;
 };
 
 class IOBan {

--- a/src/server/network/protocol/protocolstatus.cpp
+++ b/src/server/network/protocol/protocolstatus.cpp
@@ -31,7 +31,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage &msg) {
 		std::string ipStr = convertIPToString(ip);
 		if (ipStr != g_configManager().getString(IP, __FUNCTION__)) {
 			auto it = ipConnectMap.find(ip);
-			if (it != ipConnectMap.end() && OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT, __FUNCTION__))) {
+			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT, __FUNCTION__)))) {
 				disconnect();
 				return;
 			}

--- a/src/server/network/protocol/protocolstatus.cpp
+++ b/src/server/network/protocol/protocolstatus.cpp
@@ -22,7 +22,7 @@ std::string ProtocolStatus::SERVER_NAME = "Canary";
 std::string ProtocolStatus::SERVER_VERSION = "3.0";
 std::string ProtocolStatus::SERVER_DEVELOPERS = "OpenTibiaBR Organization";
 
-std::map<uint32_t, int64_t> ProtocolStatus::ipConnectMap;
+phmap::parallel_flat_hash_map<uint32_t, int64_t> ProtocolStatus::ipConnectMap;
 const uint64_t ProtocolStatus::start = OTSYS_TIME();
 
 void ProtocolStatus::onRecvFirstMessage(NetworkMessage &msg) {
@@ -30,8 +30,8 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage &msg) {
 	if (ip != 0x0100007F) {
 		std::string ipStr = convertIPToString(ip);
 		if (ipStr != g_configManager().getString(IP, __FUNCTION__)) {
-			std::map<uint32_t, int64_t>::const_iterator it = ipConnectMap.find(ip);
-			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT, __FUNCTION__)))) {
+			auto it = ipConnectMap.find(ip);
+			if (it != ipConnectMap.end() && OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT, __FUNCTION__))) {
 				disconnect();
 				return;
 			}

--- a/src/server/network/protocol/protocolstatus.hpp
+++ b/src/server/network/protocol/protocolstatus.hpp
@@ -37,5 +37,5 @@ public:
 	static std::string SERVER_DEVELOPERS;
 
 private:
-	static std::map<uint32_t, int64_t> ipConnectMap;
+	static phmap::parallel_flat_hash_map<uint32_t, int64_t> ipConnectMap;
 };


### PR DESCRIPTION
# Description

If I'm not mistaken, we bypass **std::map** with **mutex** with **phmap**.
Remove std::map of Ban and ProtocolStatus class.

### Fixes #issuenumber

## Type of change
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
