### PR TITLE
fix: check nil storage key from setStorageValue

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -824,7 +824,7 @@ bool Creature::dropCorpse(std::shared_ptr<Creature> lastHitCreature, std::shared
 
 				auto isReachable = g_game().map.getPathMatching(player->getPosition(), dirList, FrozenPathingConditionCall(corpse->getPosition()), fpp);
 
-				if (player->checkAutoLoot(monster->isRewardBoss()) && corpseContainer && mostDamageCreature->getPlayer() && isReachable) {
+				if (player->checkAutoLoot(monster->isRewardBoss()) && isReachable) {
 					g_dispatcher().addEvent([player, corpseContainer, corpsePosition = corpse->getPosition()] {
 						g_game().playerQuickLootCorpse(player, corpseContainer, corpsePosition);
 					},

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -1744,6 +1744,11 @@ int PlayerFunctions::luaPlayerSetStorageValue(lua_State* L) {
 		return 1;
 	}
 
+	if (key == 0) {
+		reportErrorFunc("Storage key is nil");
+		return 1;
+	}
+
 	if (player) {
 		player->addStorageValue(key, value);
 		pushBoolean(L, true);


### PR DESCRIPTION
When a key from Lua is nil, it is automatically transformed into 0 without being checked. Consequently, even with a nil key, no error is thrown, and the code continues as if everything had occurred normally, resulting in the storage not being set.

Removed two duplicated checks in creature.cpp; they are already verified in the if statement above.