### PR TITLE
fix: improvements on remove empty parcel script

### DIFF
--- a/data/scripts/creaturescripts/others/remove_empty_parcel.lua
+++ b/data/scripts/creaturescripts/others/remove_empty_parcel.lua
@@ -1,18 +1,25 @@
 local removeEmptyParcelsEvent = CreatureEvent("RemoveEmptyParcelsOnLogin")
 
 function removeEmptyParcelsEvent.onLogin(player)
-	local emptyParcelsToRemove = {}
-	for _, parcel in ipairs(player:getStoreInbox():getItems(true)) do
-		if parcel:getId() == ITEM_PARCEL_STAMPED and parcel:getEmptySlots() == 10 then
-			table.insert(emptyParcelsToRemove, parcel)
+	local inbox = player:getInbox()
+	if not inbox then
+		logger.warn("[RemoveEmptyParcelsOnLogin] Inbox not found for player {}.", player:getName())
+		return true
+	end
+
+	local parcelsToRemove = {}
+	for _, item in ipairs(inbox:getItems(true)) do
+		if item:getId() == ITEM_PARCEL_STAMPED and item:getEmptySlots() == 10 then
+			table.insert(parcelsToRemove, item)
 		end
 	end
 
-	if #emptyParcelsToRemove > 0 then
-		for _, parcel in pairs(emptyParcelsToRemove) do
+	if #parcelsToRemove > 0 then
+		for _, parcel in ipairs(parcelsToRemove) do
 			parcel:remove()
 		end
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, #emptyParcelsToRemove .. " empty parcels were removed from your store inbox!")
+
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, #parcelsToRemove .. " empty parcels were removed from your store inbox.")
 	end
 	return true
 end


### PR DESCRIPTION
# Description
Adding a check to access the player's store inbox and a small improvement in the variable names.
Fixes the following error when it is not possible to access the store inbox:

```
Interface: Scripts Interface
Script ID: C:\Users\blitt\Downloads\canary-main(1)\canary-main\data/scripts\creaturescripts\others\remove_empty_parcel1.lua:callback
Error Description: .../scripts\creaturescripts\others\remove_empty_parcel1.lua:5: attempt to call method 'getStoreInbox' (a nil value)
stack traceback:
        [C]: in function 'getStoreInbox'
        .../scripts\creaturescripts\others\remove_empty_parcel1.lua:5: in function <.../scripts\creaturescripts\others\remove_empty_parcel1.lua:
```

Also fixes an issue where store inbox was called instead of inbox.