### PR TITLE
fix: opentelemetry linker error

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,6 +18,11 @@
     "spdlog",
     "zlib",
     "bshoshany-thread-pool",
+	{
+		"name": "opentelemetry-cpp",
+		"default-features": true,
+		"features": ["otlp-http", "prometheus"]
+	},
     {
       "name": "libmariadb",
       "features": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,11 +18,11 @@
     "spdlog",
     "zlib",
     "bshoshany-thread-pool",
-	{
-		"name": "opentelemetry-cpp",
-		"default-features": true,
-		"features": ["otlp-http", "prometheus"]
-	},
+    {
+      "name": "opentelemetry-cpp",
+      "default-features": true,
+      "features": ["otlp-http", "prometheus"]
+    },
     {
       "name": "libmariadb",
       "features": [


### PR DESCRIPTION
# Description
I couldn't compile on Windows 10 without including this package in vcpkg.

### Fixes
Fixes linker error #2673 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

It compiles now and it wouldn't compile before.

**Test Configuration**:

  - Server Version: latest
  - Client: 13.32
  - Operating System: Windows 10

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works