### PR TITLE
feat: possibility to persist NPC on map with /n talkaction

### DIFF
--- a/data/scripts/talkactions/god/create_npc.lua
+++ b/data/scripts/talkactions/god/create_npc.lua
@@ -1,57 +1,57 @@
 local createNpc = TalkAction("/n")
 
 function createNpc.onSay(player, words, param)
-    -- create log
-    logCommand(player, words, param)
+	-- create log
+	logCommand(player, words, param)
 
-    if param == "" then
-        player:sendCancelMessage("Command param required.")
-        return true
-    end
+	if param == "" then
+		player:sendCancelMessage("Command param required.")
+		return true
+	end
 
-    local split = param:split(",")
-    local name = split[1]
-    local permanentStr = split[2]
+	local split = param:split(",")
+	local name = split[1]
+	local permanentStr = split[2]
 
-    local position = player:getPosition()
-    local npc = Game.createNpc(name, position)
-    if npc then
-        npc:setMasterPos(position)
-        position:sendMagicEffect(CONST_ME_MAGIC_RED)
+	local position = player:getPosition()
+	local npc = Game.createNpc(name, position)
+	if npc then
+		npc:setMasterPos(position)
+		position:sendMagicEffect(CONST_ME_MAGIC_RED)
 
-        if permanentStr and permanentStr == "true" then
-            local mapName = configManager.getString(configKeys.MAP_NAME) 
-            local mapNpcsPath = mapName .. "-npc.xml"
-            local filePath = string.format("%s/world/%s", DATA_DIRECTORY, mapNpcsPath)
-            local npcsFile = io.open(filePath, "r")
-            if not npcsFile then
-                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. NPC File not found.")
-                return true
-            end
-            local fileContent = npcsFile:read("*all")
-            npcsFile:close()
-            local endTag = "</npcs>"
-            if not fileContent:find(endTag, 1, true) then
-                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. The NPC file format is incorrect. Missing end tag " .. endTag .. ".")
-                return true
-            end
-            local textToAdd = string.format("\t<npc centerx=\"%i\" centery=\"%i\" centerz=\"%i\" radius=\"1\">\n\t\t<npc name=\"%s\" x=\"0\" y=\"0\" z=\"%i\" spawntime=\"60\" />\n\t</npc>", position.x, position.y, position.z, name, position.z)
-            local newFileContent = fileContent:gsub(endTag, textToAdd .. "\n" .. endTag)
-            npcsFile = io.open(filePath, "w")
-            if not npcsFile then
-                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to write to the NPC file.")
-                return true
-            end
-            npcsFile:write(newFileContent)
-            npcsFile:close()
+		if permanentStr and permanentStr == "true" then
+			local mapName = configManager.getString(configKeys.MAP_NAME)
+			local mapNpcsPath = mapName .. "-npc.xml"
+			local filePath = string.format("%s/world/%s", DATA_DIRECTORY, mapNpcsPath)
+			local npcsFile = io.open(filePath, "r")
+			if not npcsFile then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. NPC File not found.")
+				return true
+			end
+			local fileContent = npcsFile:read("*all")
+			npcsFile:close()
+			local endTag = "</npcs>"
+			if not fileContent:find(endTag, 1, true) then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. The NPC file format is incorrect. Missing end tag " .. endTag .. ".")
+				return true
+			end
+			local textToAdd = string.format('\t<npc centerx="%i" centery="%i" centerz="%i" radius="1">\n\t\t<npc name="%s" x="0" y="0" z="%i" spawntime="60" />\n\t</npc>', position.x, position.y, position.z, name, position.z)
+			local newFileContent = fileContent:gsub(endTag, textToAdd .. "\n" .. endTag)
+			npcsFile = io.open(filePath, "w")
+			if not npcsFile then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to write to the NPC file.")
+				return true
+			end
+			npcsFile:write(newFileContent)
+			npcsFile:close()
 
-            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Permanent NPC added successfully.")
-        end
-    else
-        player:sendCancelMessage("There is not enough room.")
-        position:sendMagicEffect(CONST_ME_POFF)
-    end
-    return true
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Permanent NPC added successfully.")
+		end
+	else
+		player:sendCancelMessage("There is not enough room.")
+		position:sendMagicEffect(CONST_ME_POFF)
+	end
+	return true
 end
 
 createNpc:separator(" ")

--- a/data/scripts/talkactions/god/create_npc.lua
+++ b/data/scripts/talkactions/god/create_npc.lua
@@ -1,3 +1,6 @@
+-- To summon a temporary npc use /n npcname
+-- To summon a permanent npc use /n npcname,true
+
 local createNpc = TalkAction("/n")
 
 function createNpc.onSay(player, words, param)

--- a/data/scripts/talkactions/god/create_npc.lua
+++ b/data/scripts/talkactions/god/create_npc.lua
@@ -1,24 +1,57 @@
 local createNpc = TalkAction("/n")
 
 function createNpc.onSay(player, words, param)
-	-- create log
-	logCommand(player, words, param)
+    -- create log
+    logCommand(player, words, param)
 
-	if param == "" then
-		player:sendCancelMessage("Command param required.")
-		return true
-	end
+    if param == "" then
+        player:sendCancelMessage("Command param required.")
+        return true
+    end
 
-	local position = player:getPosition()
-	local npc = Game.createNpc(param, position)
-	if npc then
-		npc:setMasterPos(position)
-		position:sendMagicEffect(CONST_ME_MAGIC_RED)
-	else
-		player:sendCancelMessage("There is not enough room.")
-		position:sendMagicEffect(CONST_ME_POFF)
-	end
-	return true
+    local split = param:split(",")
+    local name = split[1]
+    local permanentStr = split[2]
+
+    local position = player:getPosition()
+    local npc = Game.createNpc(name, position)
+    if npc then
+        npc:setMasterPos(position)
+        position:sendMagicEffect(CONST_ME_MAGIC_RED)
+
+        if permanentStr and permanentStr == "true" then
+            local mapName = configManager.getString(configKeys.MAP_NAME) 
+            local mapNpcsPath = mapName .. "-npc.xml"
+            local filePath = string.format("%s/world/%s", DATA_DIRECTORY, mapNpcsPath)
+            local npcsFile = io.open(filePath, "r")
+            if not npcsFile then
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. NPC File not found.")
+                return true
+            end
+            local fileContent = npcsFile:read("*all")
+            npcsFile:close()
+            local endTag = "</npcs>"
+            if not fileContent:find(endTag, 1, true) then
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to add permanent NPC. The NPC file format is incorrect. Missing end tag " .. endTag .. ".")
+                return true
+            end
+            local textToAdd = string.format("\t<npc centerx=\"%i\" centery=\"%i\" centerz=\"%i\" radius=\"1\">\n\t\t<npc name=\"%s\" x=\"0\" y=\"0\" z=\"%i\" spawntime=\"60\" />\n\t</npc>", position.x, position.y, position.z, name, position.z)
+            local newFileContent = fileContent:gsub(endTag, textToAdd .. "\n" .. endTag)
+            npcsFile = io.open(filePath, "w")
+            if not npcsFile then
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There was an error when trying to write to the NPC file.")
+                return true
+            end
+            npcsFile:write(newFileContent)
+            npcsFile:close()
+
+            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Permanent NPC added successfully.")
+        end
+    else
+        player:sendCancelMessage("There is not enough room.")
+        position:sendMagicEffect(CONST_ME_POFF)
+    end
+    return true
 end
 
 createNpc:separator(" ")


### PR DESCRIPTION
# Description
Sometimes, we need to add a NPC to the map, and we can do this in two ways: 
We can add it via RME or we can add it in the XML directly.

This PR will give the possibility to persist the recently spawned NPC on the map, just using a command with GOD character.
It will be placed in GOD's position.

USAGE:
Add the param **true** after the NPC Name.

`/n NpcName,true`

This will add the NPC tag to the npcs xml file.

## Behaviour
### **Actual**

Use /n npcName, the NPC will be spawned and removed after the server closes.

### **Expected**

Use /n npcName when you want to add a temporary NPC to the map.
Use /n npcName,true when you want to add a persistent NPC to the map.

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Join the game with GOD, spawn a npc with the following command: 
`/n npcName,true`

Close and reopen the server. The NPC will spawn in the same position.
