### PR TITLE
fix: prevent client debug when purchase/sale statistics are missing

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5857,6 +5857,8 @@ void ProtocolGame::sendMarketDetail(uint16_t itemId, uint8_t tier) {
 				msg.add<uint64_t>(purchaseStatistics.highestPrice);
 				msg.add<uint64_t>(purchaseStatistics.lowestPrice);
 			}
+		} else {
+			msg.addByte(0x00);
 		}
 	} else {
 		msg.addByte(0x00); // send to old protocol ?
@@ -5880,6 +5882,8 @@ void ProtocolGame::sendMarketDetail(uint16_t itemId, uint8_t tier) {
 				msg.add<uint64_t>(saleStatistics.highestPrice);
 				msg.add<uint64_t>(saleStatistics.lowestPrice);
 			}
+		} else {
+			msg.addByte(0x00);
 		}
 	} else {
 		msg.addByte(0x00); // send to old protocol ?


### PR DESCRIPTION
This PR introduces a change to ensure proper handling of cases where sale statistics for a specific item with tier are not found in the tierStatsMap.

### Fixes #2656

## Type of change

  - [X ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
