### PR TITLE
fix: phantasmal jade items

### DIFF
--- a/data-otservbr-global/scripts/actions/quests/soul_war/reward_soul_war.lua
+++ b/data-otservbr-global/scripts/actions/quests/soul_war/reward_soul_war.lua
@@ -66,7 +66,7 @@ function phantasmalJadeMount.onUse(player, item, fromPosition, target, toPositio
 
 	if table.contains({ 34072, 34073, 34074 }, item.itemid) then
 		-- check items
-		if player:getItemCount(34072) >= 4 and player:getItemCount(34073) == 1 and player:getItemCount(34074) == 1 then
+		if player:getItemCount(34072) >= 4 and player:getItemCount(34073) >= 1 and player:getItemCount(34074) >= 1 then
 			player:removeItem(34072, 4)
 			player:removeItem(34073, 1)
 			player:removeItem(34074, 1)


### PR DESCRIPTION
# Description

If you have more then one item with id 34073 or id 34074, you will not be able to get the mount.

## Behaviour
### **Actual**

Put 4  or more Spectral Horseshoes in your inventory.
Put more then 1 Spectral Horse Tack in your inventory.
Put more then 1 Spectral Saddle in your inventory.

When using any of the items you will receive an error message, even though you have the necessary items.

### **Expected**

Use any of the items, the required amount will be consumed and you will receive the mount. Extra items will not be consumed

  - [X] Bug fix (non-breaking change which fixes an issue)
