### PR TITLE
Fix: send timeMessage when using boss lever

### DIFF
--- a/data/libs/functions/boss_lever.lua
+++ b/data/libs/functions/boss_lever.lua
@@ -189,7 +189,7 @@ function BossLever:onUse(player)
 					local currentTime = os.time()
 					if lastEncounter and currentTime < lastEncounter then
 						local timeLeft = lastEncounter - currentTime
-						local timeMessage = getTimeInWords(timeLeft) .. " to face " .. monsterName .. " again!"
+						local timeMessage = getTimeInWords(timeLeft) .. " to face " .. self.name .. " again!"
 						local message = "You have to wait " .. timeMessage
 
 						if currentPlayer ~= player then


### PR DESCRIPTION
# Description

After defeating a boss, if you attempt to do it again and pull the lever, an error is generated: "nameMonster (a nil value)."

## Behaviour
### **Actual**

1 - Use the lever for Grand Master Oberon boss, and defeat boss.
2 - Return to lever and attempt to summon boss again.

Note: After trying to use the lever again, an error is detected, as shown below.. (this error does not happen with all lever bosses)

![image](https://github.com/opentibiabr/canary/assets/47985212/746d2de5-0ec1-473b-b045-18eac675e479)

### **Expected**

After using the boss lever to defeat it again, a message is sent to player.

**_"You have to wait 19 hours, 59 minutes and 59 seconds to face Grand Master Oberon again!"_**

  - [x] Bug fix (non-breaking change which fixes an issue)

  - Server Version: Canary - Version 3.1.2
  - Client: tibia-client-13.32.14520
  - Operating System: Windows 10
