### PR TITLE
fix: looktype and setkv talkactions

### DIFF
--- a/data/scripts/talkactions/gm/looktype.lua
+++ b/data/scripts/talkactions/gm/looktype.lua
@@ -373,15 +373,22 @@ function looktype.onSay(player, words, param)
 		return true
 	end
 
-	local lookType = tonumber(param)
-	if lookType >= 0 and lookType < 1469 and not table.contains(invalidTypes, lookType) then
-		local playerOutfit = player:getOutfit()
-		playerOutfit.lookType = lookType
-		player:setOutfit(playerOutfit)
+	-- Test if supplied parameter is actually a numerical value to ensure there is no nil value passed.
+	if param:match("%d") then
+		local lookType = tonumber(param)
+		if lookType >= 0 and lookType < 1469 and not table.contains(invalidTypes, lookType) then
+			local playerOutfit = player:getOutfit()
+			playerOutfit.lookType = lookType
+			player:setOutfit(playerOutfit)
+		else
+			player:sendCancelMessage("A look type with that id does not exist.")
+		end
+		return true
 	else
-		player:sendCancelMessage("A look type with that id does not exist.")
+		-- return message if supplied param is not numerical.
+		player:sendCancelMessage("Looktype must be a numerical value.")
+		return true
 	end
-	return true
 end
 
 looktype:separator(" ")

--- a/data/scripts/talkactions/god/manage_kv.lua
+++ b/data/scripts/talkactions/god/manage_kv.lua
@@ -16,7 +16,7 @@ get:register()
 local set = TalkAction("/setkv")
 
 function set.onSay(player, words, param)
-	local key, value = string.splitFirst(param, " ")
+	local key, value = string.splitFirst(param, ",") -- With a space some KV's are not able to be edited due to spaces within the key names, changed to a comma (,) to overcome this issue
 	value = load("return " .. value)()
 	kv.set(key, value)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "kv[" .. key .. "] = " .. PrettyString(value))


### PR DESCRIPTION
# Description

This fix includes two small changes to talkactions (Looktype and setkv)

## Behaviour
### **Actual**
```
/setkv player[number].achievements.Some Achievement-progress [number]
```
The above results in nothing changing as "Some Achievement" contains a space which the default command splits at a space.

---
```
/looktype SomeString
```
If a string is supplied on accident there is an error of nil value as it cannot be converted to a numerical value.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
