### PR TITLE
Fix: change class name "Iks" to "Undead"

### DIFF
--- a/data-otservbr-global/monster/undeads/iks_ahpututu.lua
+++ b/data-otservbr-global/monster/undeads/iks_ahpututu.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2349
 monster.Bestiary = {
-	class = "Iks",
+	class = "Undead",
 	race = BESTY_RACE_UNDEAD,
 	toKill = 5,
 	FirstUnlock = 1,

--- a/data-otservbr-global/monster/undeads/iks_aucar.lua
+++ b/data-otservbr-global/monster/undeads/iks_aucar.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2344
 monster.Bestiary = {
-	class = "Iks",
+	class = "Undead",
 	race = BESTY_RACE_UNDEAD,
 	toKill = 1000,
 	FirstUnlock = 50,

--- a/data-otservbr-global/monster/undeads/iks_chuka.lua
+++ b/data-otservbr-global/monster/undeads/iks_chuka.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2345
 monster.Bestiary = {
-	class = "Iks",
+	class = "Undead",
 	race = BESTY_RACE_UNDEAD,
 	toKill = 1000,
 	FirstUnlock = 50,

--- a/data-otservbr-global/monster/undeads/iks_churrascan.lua
+++ b/data-otservbr-global/monster/undeads/iks_churrascan.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2350
 monster.Bestiary = {
-	class = "Iks",
+	class = "Undead",
 	race = BESTY_RACE_UNDEAD,
 	toKill = 1000,
 	FirstUnlock = 50,

--- a/data-otservbr-global/monster/undeads/iks_pututu.lua
+++ b/data-otservbr-global/monster/undeads/iks_pututu.lua
@@ -15,7 +15,7 @@ monster.outfit = {
 
 monster.raceId = 2343
 monster.Bestiary = {
-	class = "Iks",
+	class = "Undead",
 	race = BESTY_RACE_UNDEAD,
 	toKill = 1000,
 	FirstUnlock = 50,


### PR DESCRIPTION
# Description

This is a change in the class names of the "Iks" monsters from "Iks" to "Undead". I did this because the current class name breaks the Bestiary.

## Behaviour
### **Actual**

Opening the Bestiary does not display the category "Undead". It displays "Iks" instead, saying that it has 70+ entries, but only the entries with the class name "Iks" are shown. Monsters with the class name "Undead" are hidden.

### **Expected**

The monster class "Undead" should be visible in the Bestiary.

Due to the fact that the monsters that currently have the class name "Iks" also have the race "BESTY_RACE_UNDEAD" and all monsters with the class name "Undead" also have this race, I assume that this is unintentional.

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I tested this in the game, and the Bestiary now works as expected.

**Test Configuration**:

  - Latest canary commit with the otservbr-global data pack, 
  - Client 13.32 by dudantas
  - Windows 10

