### PR TITLE
refactor: duplicated check of condition rooted

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1543,10 +1543,6 @@ ReturnValue Game::internalMoveCreature(const std::shared_ptr<Creature> &creature
 		return ret;
 	}
 
-	if (creature->hasCondition(CONDITION_ROOTED)) {
-		return RETURNVALUE_NOTPOSSIBLE;
-	}
-
 	if (creature->hasCondition(CONDITION_FEARED)) {
 		std::shared_ptr<MagicField> field = toTile->getFieldItem();
 		if (field && !field->isBlocking() && field->getDamage() != 0) {


### PR DESCRIPTION
# Description

There is a condition duplicated, it was already verified in the beggining of the function Game::internalMoveCreature

## Behaviour
### **Actual**

Not applicable

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Duplicated lines in the code, the second one would never be reached, no test needed.

**Test Configuration**:

N/A

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
