### PR TITLE
fix: NPCs purchase items without capacity check

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2362,7 +2362,7 @@ std::tuple<ReturnValue, uint32_t, uint32_t> Game::addItemBatch(const std::shared
 				if (item->getContainer()) {
 					containersCreated++;
 				}
-				totalAdded++;
+				totalAdded += item->getItemCount();
 			}
 
 			ret = returnError;


### PR DESCRIPTION
# Description

Ignore Capacity option fix.

## Behaviour

### **Actual**

If you buy using "ignore capacity" more than 1 item, it will cost only 1 item.

### **Expected**

If you buy using "ignore capacity" more than 1 item, it will cost only more than one item.

### Fixes #2737 

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Buy 100 arrows with "ignore capacity".
It will cost 2 gp.


## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
