### PR TITLE
fix: quest trigger "symbol" for Children of the Revolution Mission 4 to the stairs

### DIFF
--- a/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/symbol.lua
+++ b/data-otservbr-global/scripts/movements/quests/children_of_the_revolution/symbol.lua
@@ -16,5 +16,5 @@ function symbol.onStepIn(creature, item, position, fromPosition)
 end
 
 symbol:type("stepin")
-symbol:position({ x = 33349, y = 31123, z = 5 })
+symbol:position({ x = 33357, y = 31123, z = 5 })
 symbol:register()


### PR DESCRIPTION
# Description

The trigger was on one of the levers instead of in front of the stairs, so I moved it to the stairs.

The left red box is the old location. The right red box is the new one.
![image](https://github.com/user-attachments/assets/b93465cd-caaa-42f5-8d44-8cd89b00af8a)

Relevant image from the Wiki:
![image](https://static.wikia.nocookie.net/tibia/images/8/8a/Strange_symbols.jpg/revision/latest?cb=20091213152519&path-prefix=en)

## Behaviour
### **Actual**

The trigger coordinates were on one of the levers. It was impossible to trigger this quest state.

### **Expected**

The trigger should be next to the stairs.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I checked the position in the game with !pos and confirmed that the fix works.

**Test Configuration**:

Latest canary commit with the otservbr-global data pack,
Client 13.32 by dudantas
Windows 10
