### PR TITLE
fix: Zoltan quest trigger dialogue for "The Paradox Tower Quest"

### DIFF
--- a/data-otservbr-global/npc/zoltan.lua
+++ b/data-otservbr-global/npc/zoltan.lua
@@ -62,7 +62,7 @@ local function creatureSayCallback(npc, creature, type, message)
 	if MsgContains(message, "yenny the gentle") then
 		npcHandler:say("Ah, Yenny the Gentle was one of the founders of the druid order called Crunor's Caress, that has been originated in her hometown Carlin.", npc, creature)
 		npcHandler:setTopic(playerId, 0)
-	elseif MsgContains(message, "crunors caress") then
+	elseif MsgContains(message, "crunor's caress") then
 		if player:getStorageValue(Storage.Quest.U7_24.TheParadoxTower.TheFearedHugo) == 1 then
 			-- Questlog: The Feared Hugo (Padreia)
 			player:setStorageValue(Storage.Quest.U7_24.TheParadoxTower.TheFearedHugo, 2)


### PR DESCRIPTION
Small change to put the quest trigger dialogue in line with the Wiki (and the other quest dialogue).

https://tibia.fandom.com/wiki/The_Paradox_Tower_Quest#Mission_1:_The_Feared_Hugo

![image](https://github.com/user-attachments/assets/1c6212be-23f8-48fe-a46e-7365ef3ce05d)
