### PR TITLE
fix: offer for life crystal and white pearls in npcs

### DIFF
--- a/data-otservbr-global/npc/alexander.lua
+++ b/data-otservbr-global/npc/alexander.lua
@@ -40,7 +40,7 @@ local itemsTable = {
 	},
 	["creature products"] = {
 		{ itemName = "crystal ball", clientId = 3076, buy = 530, sell = 190 },
-		{ itemName = "life crystal", clientId = 3061, sell = 83 },
+		{ itemName = "life crystal", clientId = 3061, sell = 85 },
 		{ itemName = "mind stone", clientId = 3062, sell = 170 },
 	},
 	["shields"] = {

--- a/data-otservbr-global/npc/briasol.lua
+++ b/data-otservbr-global/npc/briasol.lua
@@ -161,7 +161,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/chantalle.lua
+++ b/data-otservbr-global/npc/chantalle.lua
@@ -152,7 +152,7 @@ npcConfig.shop = {
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "watermelon tourmaline", clientId = 33780, sell = 230000 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/edmund.lua
+++ b/data-otservbr-global/npc/edmund.lua
@@ -116,7 +116,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/gail.lua
+++ b/data-otservbr-global/npc/gail.lua
@@ -157,7 +157,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/haroun.lua
+++ b/data-otservbr-global/npc/haroun.lua
@@ -117,7 +117,7 @@ npcConfig.shop = {
 	{ itemName = "club ring", clientId = 3093, buy = 500, sell = 100 },
 	{ itemName = "elven amulet", clientId = 3082, buy = 500, sell = 100, count = 50 },
 	{ itemName = "garlic necklace", clientId = 3083, buy = 100, sell = 50 },
-	{ itemName = "life crystal", clientId = 4840, sell = 50 },
+	{ itemName = "life crystal", clientId = 3061, sell = 50 },
 	{ itemName = "magic light wand", clientId = 3046, buy = 120, sell = 35 },
 	{ itemName = "mind stone", clientId = 3062, sell = 100 },
 	{ itemName = "orb", clientId = 3060, sell = 750 },

--- a/data-otservbr-global/npc/ishina.lua
+++ b/data-otservbr-global/npc/ishina.lua
@@ -187,7 +187,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/iwan.lua
+++ b/data-otservbr-global/npc/iwan.lua
@@ -126,7 +126,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/jessica.lua
+++ b/data-otservbr-global/npc/jessica.lua
@@ -151,7 +151,7 @@ npcConfig.shop = {
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "watermelon tourmaline", clientId = 33780, sell = 230000 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/khanna.lua
+++ b/data-otservbr-global/npc/khanna.lua
@@ -103,7 +103,7 @@ local itemsTable = {
 		{ itemName = "goanna meat", clientId = 31560, sell = 190 },
 		{ itemName = "lamassu hoof", clientId = 31441, sell = 330 },
 		{ itemName = "lamassu horn", clientId = 31442, sell = 240 },
-		{ itemName = "life crystal", clientId = 3061, sell = 85 },
+		{ itemName = "life crystal", clientId = 3061, sell = 75 },
 		{ itemName = "lizard heart", clientId = 31340, sell = 530 },
 		{ itemName = "manticore ear", clientId = 31440, sell = 310 },
 		{ itemName = "manticore tail", clientId = 31439, sell = 220 },

--- a/data-otservbr-global/npc/larek.lua
+++ b/data-otservbr-global/npc/larek.lua
@@ -66,7 +66,7 @@ npcConfig.shop = {
 	{ itemName = "small topaz", clientId = 9057, sell = 200 },
 	{ itemName = "vial", clientId = 2874, buy = 20 },
 	{ itemName = "vial of milk", clientId = 2874, buy = 50, count = 9 },
-	{ itemName = "white pearl", clientId = 3026, sell = 160 },
+	{ itemName = "white pearl", clientId = 3026, sell = 160, sell = 160 },
 }
 -- On buy npc shop message
 npcType.onBuyItem = function(npc, player, itemId, subType, amount, ignore, inBackpacks, totalCost)

--- a/data-otservbr-global/npc/larek.lua
+++ b/data-otservbr-global/npc/larek.lua
@@ -66,7 +66,7 @@ npcConfig.shop = {
 	{ itemName = "small topaz", clientId = 9057, sell = 200 },
 	{ itemName = "vial", clientId = 2874, buy = 20 },
 	{ itemName = "vial of milk", clientId = 2874, buy = 50, count = 9 },
-	{ itemName = "white pearl", clientId = 3026, sell = 160, sell = 160 },
+	{ itemName = "white pearl", clientId = 3026, sell = 160 },
 }
 -- On buy npc shop message
 npcType.onBuyItem = function(npc, player, itemId, subType, amount, ignore, inBackpacks, totalCost)

--- a/data-otservbr-global/npc/odemara.lua
+++ b/data-otservbr-global/npc/odemara.lua
@@ -123,7 +123,7 @@ npcConfig.shop = {
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "watermelon tourmaline", clientId = 33780, sell = 230000 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/oiriz.lua
+++ b/data-otservbr-global/npc/oiriz.lua
@@ -116,7 +116,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/tesha.lua
+++ b/data-otservbr-global/npc/tesha.lua
@@ -140,7 +140,7 @@ npcConfig.shop = {
 	{ itemName = "watermelon tourmaline", clientId = 33780, sell = 230000 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 }
 -- On buy npc shop message
 npcType.onBuyItem = function(npc, player, itemId, subType, amount, ignore, inBackpacks, totalCost)

--- a/data-otservbr-global/npc/tezila.lua
+++ b/data-otservbr-global/npc/tezila.lua
@@ -115,7 +115,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/yonan.lua
+++ b/data-otservbr-global/npc/yonan.lua
@@ -87,7 +87,7 @@ npcConfig.shop = {
 	{ itemName = "unicorn figurine", clientId = 30054, sell = 50000 },
 	{ itemName = "violet crystal shard", clientId = 16120, sell = 1500 },
 	{ itemName = "wedding ring", clientId = 3004, buy = 990 },
-	{ itemName = "white pearl", clientId = 3026, buy = 320 },
+	{ itemName = "white pearl", clientId = 3026, buy = 320, sell = 160 },
 	{ itemName = "white silk flower", clientId = 34008, sell = 9000 },
 }
 

--- a/data-otservbr-global/npc/zoltan.lua
+++ b/data-otservbr-global/npc/zoltan.lua
@@ -62,7 +62,7 @@ local function creatureSayCallback(npc, creature, type, message)
 	if MsgContains(message, "yenny the gentle") then
 		npcHandler:say("Ah, Yenny the Gentle was one of the founders of the druid order called Crunor's Caress, that has been originated in her hometown Carlin.", npc, creature)
 		npcHandler:setTopic(playerId, 0)
-	elseif MsgContains(message, "crunors caress") then
+	elseif MsgContains(message, "crunor's caress") then
 		if player:getStorageValue(Storage.Quest.U7_24.TheParadoxTower.TheFearedHugo) == 1 then
 			-- Questlog: The Feared Hugo (Padreia)
 			player:setStorageValue(Storage.Quest.U7_24.TheParadoxTower.TheFearedHugo, 2)


### PR DESCRIPTION
Life crystal buy offers had wrong prices according to Cyclopedia and Wiki. Haroun had wrong life crystal ID.

https://tibia.fandom.com/wiki/Life_Crystal

White pearl buy offer was missing from 13 vendors.

https://tibia.fandom.com/wiki/White_Pearl