### PR TITLE
fix: setHouseOwner in server initialization and Husky occurrence

### DIFF
--- a/data-otservbr-global/monster/mammals/husky.lua
+++ b/data-otservbr-global/monster/mammals/husky.lua
@@ -26,7 +26,7 @@ monster.Bestiary = {
 	SecondUnlock = 10,
 	CharmsPoints = 1,
 	Stars = 0,
-	Occurence = 1,
+	Occurrence = 1,
 	Locations = "Svargrond and Nibelor.",
 }
 

--- a/data/scripts/globalevents/server_initialization.lua
+++ b/data/scripts/globalevents/server_initialization.lua
@@ -39,7 +39,7 @@ local function processHouseAuctions()
 				local lastBid = Result.getNumber(resultId, "last_bid")
 				if balance >= lastBid then
 					db.query("UPDATE `players` SET `balance` = " .. (balance - lastBid) .. " WHERE `id` = " .. highestBidder)
-					house:setOwnerGuid(highestBidder)
+					house:setHouseOwner(highestBidder)
 				end
 
 				db.asyncQuery("UPDATE `houses` SET `last_bid` = 0, `bid_end` = 0, `highest_bidder` = 0, `bid` = 0 " .. "WHERE `id` = " .. house:getId())


### PR DESCRIPTION
# Description

setHouseOwner in server initialization and Husky occurrence

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

**Test Configuration**:

  - Server Version: Canary Main
  - Client: 13.32
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
