### PR TITLE
fix: bestiary occurrence

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2962,6 +2962,7 @@ void ProtocolGame::parseBestiarysendCreatures(NetworkMessage &msg) {
 		newmsg.add<uint16_t>(raceid_);
 
 		uint8_t progress = 0;
+		uint8_t occurrence = 0;
 		for (const auto &_it : creaturesKilled) {
 			if (_it.first == raceid_) {
 				const auto tmpType = g_monsters().getMonsterType(it_.second);
@@ -2969,11 +2970,13 @@ void ProtocolGame::parseBestiarysendCreatures(NetworkMessage &msg) {
 					return;
 				}
 				progress = g_iobestiary().getKillStatus(tmpType, _it.second);
+				occurrence = tmpType->info.bestiaryOccurrence;
 			}
 		}
 
 		if (progress > 0) {
-			newmsg.add<uint16_t>(static_cast<uint16_t>(progress));
+			newmsg.addByte(progress);
+			newmsg.addByte(occurrence);
 		} else {
 			newmsg.addByte(0);
 		}


### PR DESCRIPTION
# Description

the progress was sent alone, the correct thing is to send the progress and the occurrence

If the occurrence is of maximum level (3), the icon should appear, as shown in the image.

![image](https://github.com/user-attachments/assets/2618151e-cde2-4ea6-906b-1a21cdba50e2)

![image](https://github.com/user-attachments/assets/44f13a17-85a3-4992-8cad-e81453e4eef7)

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)

**Test Configuration**:

  - Server Version: Canary Main
  - Client: 13.32
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
