### PR TITLE
fix: login after death and prey window oldprotocol

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4261,12 +4261,10 @@ void ProtocolGame::sendBasicData() {
 	msg.addByte(player->getVocation()->getClientId());
 
 	// Prey window
-	if (!oldProtocol) {
-		if (player->getVocation()->getId() == 0 && player->getGroup()->id < GROUP_TYPE_GAMEMASTER) {
-			msg.addByte(0);
-		} else {
-			msg.addByte(1); // has reached Main (allow player to open Prey window)
-		}
+	if (player->getVocation()->getId() == 0 && player->getGroup()->id < GROUP_TYPE_GAMEMASTER) {
+		msg.addByte(0);
+	} else {
+		msg.addByte(1); // has reached Main (allow player to open Prey window)
 	}
 
 	// Filter only valid ids

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -924,7 +924,7 @@ void ProtocolGame::parsePacket(NetworkMessage &msg) {
 
 void ProtocolGame::parsePacketDead(uint8_t recvbyte) {
 	if (recvbyte == 0x14) {
-		// Remove player from game if click "ok" using otcv8
+		// Remove player from game if click "ok" using otc
 		if (player && isOTC) {
 			g_game().removePlayerUniqueLogin(player->getName());
 		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -473,6 +473,7 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 
 	// Extended opcodes
 	if (operatingSystem >= CLIENTOS_OTCLIENT_LINUX) {
+		isOTC = true;
 		NetworkMessage opcodeMessage;
 		opcodeMessage.addByte(0x32);
 		opcodeMessage.addByte(0x00);
@@ -924,7 +925,7 @@ void ProtocolGame::parsePacket(NetworkMessage &msg) {
 void ProtocolGame::parsePacketDead(uint8_t recvbyte) {
 	if (recvbyte == 0x14) {
 		// Remove player from game if click "ok" using otcv8
-		if (player && otclientV8 > 0) {
+		if (player && isOTC) {
 			g_game().removePlayerUniqueLogin(player->getName());
 		}
 		disconnect();

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -503,6 +503,7 @@ private:
 	bool oldProtocol = false;
 
 	uint16_t otclientV8 = 0;
+	bool isOTC = false;
 
 	void sendInventory();
 	void sendOpenStash();


### PR DESCRIPTION
# Description

this if only integrates v8 , but not redemption. 

![image](https://github.com/user-attachments/assets/b136e1df-c742-4ab6-b22b-b60ae9c82c4b)

incorporated in https://github.com/opentibiabr/canary/pull/1240/ `"fix: click "ok" button clone character using otcv8"`


my proposed solution = a variable called `isOTC` is created . why ? a variable  may be useful in the future

-------------
and revert https://github.com/opentibiabr/canary/pull/2757 

![image](https://github.com/user-attachments/assets/a3ff4b3f-f1eb-4f05-b989-6593cdbad5fb)
also the feature `GamePrey `must match in both otc
![image](https://github.com/user-attachments/assets/01a5ea2e-59c5-4d8f-ac74-55c6ea1d93bd)

in redemption also have to do the undo

## Behaviour
### **Actual**


https://github.com/user-attachments/assets/ce1d2ce3-fbd6-45b8-8226-e170532371ee



### **Expected**

### Clipsoft
![clipsof](https://github.com/user-attachments/assets/db13d52e-96fd-4d92-a1e9-365b32ba87bc)

### mehah 11.00
![vvav](https://github.com/user-attachments/assets/01eb7b94-8436-4589-9046-46e5dbdcf9c9)

### mehah 13.32

![1332-ezgif com-optimize](https://github.com/user-attachments/assets/8892136a-af05-46e8-89ed-0844ce9c5d12)


### Fixes 
Canary: 

#2735  `"players spans in position of death with no corpse after death "`
report by @Aerwix @pasturryx

Redemption : 

https://github.com/mehah/otclient/issues/831 `Login in corpse after death `
@leoddias

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

die for some monster in otc redemption

**Test Configuration**:

  - Server Version: Canary 13.32 allow old protocol
  - Client: mehah 13.32 | 11.00  and clipsof . no test in v8
  - Operating System: Windows 10+1

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


| Client            	| Test 	|
|-------------------	|------	|
| Clipsoft 13.32    	|     ✅  	|
| OTC mehah 13.32   	|    ✅   	|
| OTC Mehah 11.00 * 	|    ✅   	|
| OTCV8 11.00      	|    idk  	|

*need revert this: https://github.com/mehah/otclient/pull/823