### PR TITLE
fix: reroll monsters grid prey slot on prey expired

### DIFF
--- a/src/io/ioprey.cpp
+++ b/src/io/ioprey.cpp
@@ -276,6 +276,7 @@ void IOPrey::checkPlayerPreys(std::shared_ptr<Player> player, uint8_t amount) co
 
 					player->sendTextMessage(MESSAGE_STATUS, "You don't have enought prey cards to lock monster and bonus when the slot expire.");
 				} else {
+					slot->reloadMonsterGrid(player->getPreyBlackList(), player->getLevel());
 					player->sendTextMessage(MESSAGE_STATUS, "Your prey bonus has expired.");
 				}
 


### PR DESCRIPTION
# Description
Starting the function of rerolling mobs when the prey ends without using the card function

## Behaviour
### **Actual**
On ends prey, grid with mobs have one less monster
![image](https://github.com/user-attachments/assets/da20519b-9260-4461-8200-2e76860cc3c7)


### **Expected**
On ends prey, slot should have new list mosters
![image](https://github.com/user-attachments/assets/1b6fb925-81aa-4211-b16f-f8ad1aafac35)


Do this and that happens
Pick prey, change time to 1 in database, attack/kill any monster, and see this

## Type of change
  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
  - [X] Pick any monster from prey slot, login character, change in database prey time to 1 seconds, save, login on character and kill any monster. - do it once again for sure

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.32
  - Operating System: W10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
