### PR TITLE
Fix: shield instead armor effect on blockhit - again

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -997,9 +997,11 @@ BlockType_t Creature::blockHit(std::shared_ptr<Creature> attacker, CombatType_t 
 		attacker->onAttackedCreature(static_self_cast<Creature>());
 		attacker->onAttackedCreatureBlockHit(blockType);
 	}
-
-	mitigateDamage(combatType, blockType, damage);
-
+	
+	if (damage != 0) {
+		mitigateDamage(combatType, blockType, damage);
+	}
+	
 	if (damage != 0) {
 		onTakeDamage(attacker, damage);
 	}


### PR DESCRIPTION
# Description
Sorry for again same changes, but previous PR (https://github.com/opentibiabr/canary/pull/2774) i not able to "fix" clang / ubuntu build check.

## Behaviour

### **Actual**
Equip armor/helmet/legs/boots, spawn rat and should be puff effect, but for now is armor effect

### **Expected**
When blocktype = shield, should be shield puff effect

### Fixes #issuenumber

## Type of change
Additional condition before migiation in blockhit method.
Without condition it always no matter what, it changes blocktype to "armor".

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Equip armor/helmet/legs/boots, spawn rat and now is puff effect.
Character: 8 lv, skills 10, equip ^


**Test Configuration**:

  - Server Version: commit  #fa85e18ff591f136caaea09719a262d818f40919
  - Client: 13.32 | cipsoft client
  - Operating System: Windows (no matter)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
