### PR TITLE
fix: update wrong blessing counting

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3543,7 +3543,7 @@ void ProtocolGame::sendCyclopediaCharacterCombatStats() {
 
 	uint8_t haveBlesses = 0;
 	uint8_t blessings = 8;
-	for (uint8_t i = 1; i < blessings; ++i) {
+	for (uint8_t i = 1; i <= blessings; ++i) {
 		if (player->hasBlessing(i)) {
 			++haveBlesses;
 		}


### PR DESCRIPTION
# Description

Blessings are not being counted at all. Only counts to 7. Currently we need to check 8 blesses.


## Behaviour
### **Actual**

![image](https://github.com/user-attachments/assets/cc2c6afc-b327-46e5-9122-4c4b24c95716)


Blessings are not being counted at all. Only counts to 7. Currently we need to check 8 blesses.

### **Issues**
https://github.com/opentibiabr/canary/issues/2745

### **Expected**

Count and check 8 blesses.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Get all the blesses and look cyclopedia.

**Test Configuration**:

  - Server Version: 13.32
  - Client: 13.32
  - Operating System: NA

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
