### PR TITLE
fix: throwing magic wall in invisible enemies

### DIFF
--- a/data/scripts/runes/magic_wall.lua
+++ b/data/scripts/runes/magic_wall.lua
@@ -1,4 +1,7 @@
 function onCreateMagicWall(creature, tile)
+	if tile:getTopCreature() then
+		return false
+	end
 	local magicWall
 	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
 		magicWall = ITEM_MAGICWALL_SAFE

--- a/data/scripts/runes/wild_growth.lua
+++ b/data/scripts/runes/wild_growth.lua
@@ -1,4 +1,7 @@
 function onCreateWildGrowth(creature, tile)
+	if tile:getTopCreature() then
+		return false
+	end
 	local wildGrowth
 	if Game.getWorldType() == WORLD_TYPE_NO_PVP then
 		wildGrowth = ITEM_WILDGROWTH_SAFE


### PR DESCRIPTION
# Description

irregularity regarding the magic walls/wild growths runes, when there is a monster and it becomes invisible you can throw runes (mws/wild growths) in that place!!

## Behaviour
### **Actual**

irregularity regarding the magic walls/wild growths runes, when there is a monster and it becomes invisible you can throw runes (mws/wild growths) in that place!!

https://drive.google.com/file/d/1n3aE4sfyLWvbN8_4YHX8-yJapFEGeYVc/view?usp=drive_link

### **Expected**

Check if have a creature in the tile, if so, does nothing.

https://drive.google.com/file/d/1nnPSN2BwMk_aQdW1E5CLvAlm_4plnkwp/view?usp=drive_link

### Fixes #2789

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Throw a Magic wall in a invisible enemy
  - [x] Throw a Wild Growth Rune in a invisible enemy.

**Test Configuration**:

  - Server Version: 13.32
  - Client: 13.32
  - Operating System: NA

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
