### PR TITLE
fix: dockerfile

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -11,12 +11,13 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 WORKDIR /opt
 COPY vcpkg.json /opt
-RUN vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ') \
-	&& echo "vcpkg commit ID: $vcpkgCommitId" \
-	&& git clone https://github.com/Microsoft/vcpkg.git \
-	&& cd vcpkg \
-	&& git checkout "$vcpkgCommitId" \
-	&& ./bootstrap-vcpkg.sh
+RUN vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ' | tr -d '\r\n') \
+    && echo "vcpkg commit ID: '$vcpkgCommitId'" \
+    && git clone https://github.com/microsoft/vcpkg.git \
+    && cd vcpkg \
+    && git fetch origin \
+    && git checkout "$vcpkgCommitId" \
+    && ./bootstrap-vcpkg.sh
 
 WORKDIR /opt/vcpkg
 COPY vcpkg.json /opt/vcpkg/


### PR DESCRIPTION
This PR fixes an issue in the Dockerfile where the extraction of the vcpkg commit ID from vcpkg.json was including extra characters, causing the git checkout command to fail.

The issue was caused by the command used to extract the vcpkg commit ID from vcpkg.json. The extracted ID contained extra characters, such as whitespace and newline characters, leading to the following error:

`error: pathspec '095ee06e7f60dceef7d713e3f8b1c2eb10d650d7?' did not match any file(s) known to git
`
To resolve this issue, the command was modified to ensure that only the commit ID is captured without any extra characters. Specifically, the following changes were made:

- Used tr -d '," ' to remove any commas, double quotes, and spaces.
- Added tr -d '\r\n' to remove any carriage return and newline characters.

Changes
- Updated the Dockerfile to properly extract the vcpkg commit ID without extra characters.