### PR TITLE
perf: EventCallback optimization

### DIFF
--- a/src/lua/callbacks/events_callbacks.cpp
+++ b/src/lua/callbacks/events_callbacks.cpp
@@ -29,24 +29,8 @@ EventsCallbacks &EventsCallbacks::getInstance() {
 }
 
 void EventsCallbacks::addCallback(const std::shared_ptr<EventCallback> callback) {
-	m_callbacks.push_back(callback);
-}
-
-std::vector<std::shared_ptr<EventCallback>> EventsCallbacks::getCallbacks() const {
-	return m_callbacks;
-}
-
-std::vector<std::shared_ptr<EventCallback>> EventsCallbacks::getCallbacksByType(EventCallback_t type) const {
-	std::vector<std::shared_ptr<EventCallback>> eventCallbacks;
-	for (auto callback : getCallbacks()) {
-		if (callback->getType() != type) {
-			continue;
-		}
-
-		eventCallbacks.push_back(callback);
-	}
-
-	return eventCallbacks;
+	const auto &it = m_callbacks.find(callback->getType());
+	(it == m_callbacks.end() ? m_callbacks.emplace(callback->getType(), std::vector<std::shared_ptr<EventCallback>>()).first : it)->second.emplace_back(callback);
 }
 
 void EventsCallbacks::clear() {

--- a/src/lua/callbacks/events_callbacks.hpp
+++ b/src/lua/callbacks/events_callbacks.hpp
@@ -64,7 +64,7 @@ public:
 	 */
 	template <typename CallbackFunc, typename... Args>
 	void executeCallback(EventCallback_t eventType, CallbackFunc callbackFunc, Args &&... args) {
-		auto it = m_callbacks.find(eventType);
+		const auto &it = m_callbacks.find(eventType);
 		if (it == m_callbacks.end()) {
 			return;
 		}
@@ -91,7 +91,7 @@ public:
 	template <typename CallbackFunc, typename... Args>
 	ReturnValue checkCallbackWithReturnValue(EventCallback_t eventType, CallbackFunc callbackFunc, Args &&... args) {
 		ReturnValue res = RETURNVALUE_NOERROR;
-		auto it = m_callbacks.find(eventType);
+		const auto &it = m_callbacks.find(eventType);
 		if (it == m_callbacks.end()) {
 			return res;
 		}
@@ -123,7 +123,7 @@ public:
 	template <typename CallbackFunc, typename... Args>
 	bool checkCallback(EventCallback_t eventType, CallbackFunc callbackFunc, Args &&... args) {
 		bool allCallbacksSucceeded = true;
-		auto it = m_callbacks.find(eventType);
+		const auto &it = m_callbacks.find(eventType);
 		if (it == m_callbacks.end()) {
 			return allCallbacksSucceeded;
 		}

--- a/src/lua/callbacks/events_callbacks.hpp
+++ b/src/lua/callbacks/events_callbacks.hpp
@@ -70,8 +70,8 @@ public:
 		}
 
 		for (const auto &callback : (*it).second) {
-			auto argsCopy = std::make_tuple(args...);
 			if (callback && callback->isLoadedCallback()) {
+				auto argsCopy = std::make_tuple(args...);
 				std::apply(
 					[&callback, &callbackFunc](auto &&... args) {
 						((*callback).*callbackFunc)(std::forward<decltype(args)>(args)...);
@@ -97,8 +97,8 @@ public:
 		}
 
 		for (const auto &callback : (*it).second) {
-			auto argsCopy = std::make_tuple(args...);
 			if (callback && callback->isLoadedCallback()) {
+				auto argsCopy = std::make_tuple(args...);
 				ReturnValue callbackResult = std::apply(
 					[&callback, &callbackFunc](auto &&... args) {
 						return ((*callback).*callbackFunc)(std::forward<decltype(args)>(args)...);
@@ -129,8 +129,8 @@ public:
 		}
 
 		for (const auto &callback : (*it).second) {
-			auto argsCopy = std::make_tuple(args...);
 			if (callback && callback->isLoadedCallback()) {
+				auto argsCopy = std::make_tuple(args...);
 				bool callbackResult = std::apply(
 					[&callback, &callbackFunc](auto &&... args) {
 						return ((*callback).*callbackFunc)(std::forward<decltype(args)>(args)...);


### PR DESCRIPTION
use flat_hash_map instead of std::vector, thus avoiding having to create a vector with the requested types every time the eventCallback is called.