### PR TITLE
fix: wrong params in creatureSetIcon function

### DIFF
--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -1024,7 +1024,7 @@ int CreatureFunctions::luaCreatureSetIcon(lua_State* L) {
 	auto count = getNumber<uint16_t>(L, 5, 0);
 	CreatureIcon creatureIcon;
 	if (category == CreatureIconCategory_t::Modifications) {
-		auto icon = getNumber<CreatureIconModifications_t>(L, 5);
+		auto icon = getNumber<CreatureIconModifications_t>(L, 4);
 		creatureIcon = CreatureIcon(icon, count);
 	} else {
 		auto icon = getNumber<CreatureIconQuests_t>(L, 4);

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -1020,8 +1020,8 @@ int CreatureFunctions::luaCreatureSetIcon(lua_State* L) {
 		return 1;
 	}
 	const auto key = getString(L, 2);
-	auto category = getNumber<CreatureIconCategory_t>(L, 3);
-	auto count = getNumber<uint16_t>(L, 5, 0);
+	const auto category = getNumber<CreatureIconCategory_t>(L, 3);
+	const auto count = getNumber<uint16_t>(L, 5, 0);
 	CreatureIcon creatureIcon;
 	if (category == CreatureIconCategory_t::Modifications) {
 		auto icon = getNumber<CreatureIconModifications_t>(L, 4);


### PR DESCRIPTION
# Description

The setIcon function does not work when used in the "Modifications" category, this problem has existed since the creation of the function in PR #1585

## Behaviour
### **Actual**

Test with the above command and it will not work without changing this PR.

### **Expected**

Use the setIcon function with the "Modifications" category and the correct category icon appears.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

You can test with the script below:

```lua
local icons = TalkAction("!icon")

function icons.onSay(player, words, param)
	player:setIcon("test", CreatureIconCategory_Modifications, CreatureIconModifications_Influenced, 3)
	return true
end

icons:groupType("normal")
icons:register()
```

**Test Configuration**:

  - Server Version: Canary Main
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
