### PR TITLE
improve: real time timer in dispatcher

### DIFF
--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -125,7 +125,7 @@ void Dispatcher::executeScheduledEvents() {
 	auto it = scheduledTasks.begin();
 	while (it != scheduledTasks.end()) {
 		const auto &task = *it;
-		if (task->getTime() > OTSYS_TIME()) {
+		if (task->getTime() > OTSYS_TIME(true)) {
 			break;
 		}
 
@@ -191,14 +191,14 @@ void Dispatcher::mergeEvents() {
 
 std::chrono::milliseconds Dispatcher::timeUntilNextScheduledTask() const {
 	constexpr auto CHRONO_0 = std::chrono::milliseconds(0);
-	constexpr auto CHRONO_MILI_MAX = std::chrono::milliseconds::max();
+	constexpr auto CHRONO_MILI_MAX = std::chrono::milliseconds(SCHEDULER_MINTICKS);
 
 	if (scheduledTasks.empty()) {
 		return CHRONO_MILI_MAX;
 	}
 
 	const auto &task = *scheduledTasks.begin();
-	const auto timeRemaining = std::chrono::milliseconds(task->getTime() - OTSYS_TIME());
+	const auto timeRemaining = std::chrono::milliseconds(task->getTime() - OTSYS_TIME(true));
 	return std::max<std::chrono::milliseconds>(timeRemaining, CHRONO_0);
 }
 

--- a/src/server/network/message/outputmessage.cpp
+++ b/src/server/network/message/outputmessage.cpp
@@ -13,11 +13,11 @@
 #include "server/network/protocol/protocol.hpp"
 #include "game/scheduling/dispatcher.hpp"
 
-const std::chrono::milliseconds OUTPUTMESSAGE_AUTOSEND_DELAY { 10 };
+constexpr auto OUTPUTMESSAGE_AUTOSEND_DELAY = 10;
 
 void OutputMessagePool::scheduleSendAll() {
 	g_dispatcher().scheduleEvent(
-		OUTPUTMESSAGE_AUTOSEND_DELAY.count(), [this] { sendAll(); }, "OutputMessagePool::sendAll"
+		OUTPUTMESSAGE_AUTOSEND_DELAY, [this] { sendAll(); }, "OutputMessagePool::sendAll"
 	);
 }
 


### PR DESCRIPTION
use the current time, instead of the cache for scheduled tasks, as there may be complex tasks that end up taking aA long time and consequently delaying other tasks, since the team does not count the time it took for that task to be processed.