### PR TITLE
improve: connection lock-free

### DIFF
--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -326,7 +326,6 @@ void Connection::internalWorker() {
 		return;
 	}
 
-
 	const auto &outputMessage = messageQueue.front();
 	protocol->onSendMessage(outputMessage);
 

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -91,10 +91,6 @@ private:
 	asio::high_resolution_timer readTimer;
 	asio::high_resolution_timer writeTimer;
 
-	std::recursive_mutex connectionLock;
-
-	std::list<OutputMessage_ptr> messageQueue;
-
 	ConstServicePort_ptr service_port;
 	Protocol_ptr protocol;
 
@@ -106,6 +102,45 @@ private:
 
 	std::underlying_type_t<ConnectionState_t> connectionState = CONNECTION_STATE_OPEN;
 	bool receivedFirst = false;
+
+	// deque lockfree for two-threads
+	struct {
+		auto empty() {
+			locked.wait(true);
+			return list.empty();
+		}
+		auto front() {
+			locked.wait(true);
+			return list.front();
+		}
+		auto emplace_back(OutputMessage_ptr obj) {
+			lock();
+			list.emplace_back(obj);
+			unlock();
+		}
+		void pop_front() {
+			lock();
+			list.pop_front();
+			unlock();
+		}
+		void clear() {
+			lock();
+			list.clear();
+			unlock();
+		}
+
+		private:
+			void lock() {
+				locked.wait(true);
+				locked.store(true);
+			}
+			void unlock() {
+				locked.store(false);
+				locked.notify_one();
+			}
+		std::deque<OutputMessage_ptr> list;
+		std::atomic_bool locked = false;
+	} messageQueue;
 
 	friend class ServicePort;
 	friend class ConnectionManager;

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -129,15 +129,15 @@ private:
 			unlock();
 		}
 
-		private:
-			void lock() {
-				locked.wait(true);
-				locked.store(true);
-			}
-			void unlock() {
-				locked.store(false);
-				locked.notify_one();
-			}
+	private:
+		void lock() {
+			locked.wait(true);
+			locked.store(true);
+		}
+		void unlock() {
+			locked.store(false);
+			locked.notify_one();
+		}
 		std::deque<OutputMessage_ptr> list;
 		std::atomic_bool locked = false;
 	} messageQueue;


### PR DESCRIPTION
let's eliminate the use of mutex and just look at messageQueue, as it is used in two different threads, so it needs special attention.