### PR TITLE
fix: container:addItem missing return

### DIFF
--- a/data-otservbr-global/monster/reptiles/two-headed_turtle.lua
+++ b/data-otservbr-global/monster/reptiles/two-headed_turtle.lua
@@ -70,7 +70,7 @@ monster.loot = {
 	{ name = "two-headed turtle heads", chance = 8700 },
 	{ name = "strong mana potion", chance = 13373 },
 	{ name = "hydrophytes", chance = 11000 },
-	{ id = 1047, chance = 6388 }, -- bone
+	{ id = 3115, chance = 6388 }, -- bone
 	{ name = "glacier shoes", chance = 4650 },
 	{ id = 281, chance = 3582 }, -- giant shimmering pearl (green)
 	{ name = "small tropical fish", chance = 3582 },

--- a/data/libs/functions/container.lua
+++ b/data/libs/functions/container.lua
@@ -20,7 +20,7 @@ function Container:addLoot(loot)
 				local countToAdd = math.min(remainingCount, stackSize)
 				local tmpItem = self:addItem(itemId, countToAdd, INDEX_WHEREEVER, FLAG_NOLIMIT)
 				if not tmpItem then
-					logger.warn("Container:addLoot: failed to add stackable item: {}, to corpse {} with id {}", ItemType(itemId):getName(), self:getName(), self:getId())
+					logger.warn("Container:addLoot: failed to add stackable item: {} with id {}, to corpse {} with id {}", ItemType(itemId):getName(), itemId, self:getName(), self:getId())
 					goto continue
 				end
 				remainingCount = remainingCount - countToAdd
@@ -28,13 +28,13 @@ function Container:addLoot(loot)
 		elseif iType:getCharges() ~= 0 then
 			local tmpItem = self:addItem(itemId, item.count, INDEX_WHEREEVER, FLAG_NOLIMIT)
 			if not tmpItem then
-				logger.warn("Container:addLoot: failed to add charge item: {}, to corpse {} with id {}", ItemType(itemId):getName(), self:getName(), self:getId())
+				logger.warn("Container:addLoot: failed to add charge item: {} with id {}, to corpse {} with id {}", ItemType(itemId):getName(), itemId, self:getName(), self:getId())
 			end
 		else
 			for i = 1, item.count do
 				local tmpItem = self:addItem(itemId, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 				if not tmpItem then
-					logger.warn("Container:addLoot: failed to add item: {}, to corpse {} with id {}", ItemType(itemId):getName(), self:getName(), self:getId())
+					logger.warn("Container:addLoot: failed to add item: {} with id {}, to corpse {} with id {}", ItemType(itemId):getName(), itemId, self:getName(), self:getId())
 					goto continue
 				end
 

--- a/src/lua/functions/items/container_functions.cpp
+++ b/src/lua/functions/items/container_functions.cpp
@@ -166,6 +166,7 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 		setItemMetatable(L, -1, item);
 	} else {
 		reportErrorFunc(fmt::format("Cannot add item to container, error code: '{}'", getReturnMessage(ret)));
+		pushBoolean(L, false);
 	}
 	return 1;
 }


### PR DESCRIPTION
# Description

Invalid item correction.
When dropping an invalid monster yesterday, a strange error returned in the server console, it did not show which monster it was or what the item ID was. 

With this correction now it shows the invalid item id and ooo shows that the item is unpacking.

Fix for the two Headed Turtle monster that was dropping an invalid item 

## Behavior
### **Real**

Does not show strange error in the console

### **Expected**

shows invalid id and shows it in the console

## Type of change

  - [x] Bug fix (rolling change that fixes a problem)

**Test Setup**:

  - Server Version: Latest Main
  - Client: 13.40
  - Operating system: Win 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I performed a self-review of my own code
  - [x] I checked the PR checks reports

  - [x] I made corresponding changes to the documentation
  - [x] My changes do not generate new warnings
  - [x] I added tests that prove my fix is effective or that my feature works