### PR TITLE
fix: wild growth

### DIFF
--- a/data-canary/scripts/lib/register_actions.lua
+++ b/data-canary/scripts/lib/register_actions.lua
@@ -1,5 +1,5 @@
 local holeId = { 294, 369, 370, 385, 394, 411, 412, 413, 432, 433, 435, 482, 483, 594, 595, 609, 610, 615, 868, 874, 1156, 4824, 7515, 7516, 7517, 7518, 7519, 7520, 7521, 7522, 7737, 7755, 7762, 7767, 7768, 8144, 8690, 8709, 12203, 12961, 17239, 19220, 23364 } -- usable rope holes, for rope spots see global.lua
-local wildGrowth = { 3635, 30224 } -- wild growth destroyable by machete
+local wildGrowth = { 2130, 3635, 30224 } -- wild growth destroyable by machete
 local jungleGrass = { -- grass destroyable by machete
 	[3696] = 3695,
 	[3702] = 3701,

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -5,7 +5,7 @@ local itemsGrinder = {
 }
 local holes = { 593, 606, 608, 867, 21341 }
 local jungleGrass = { 3696, 3702, 17153 }
-local wildGrowth = { 3635, 30224 }
+local wildGrowth = { 2130, 3635, 30224 }
 local fruits = { 3584, 3585, 3586, 3587, 3588, 3589, 3590, 3591, 3592, 3593, 3595, 3596, 5096, 8011, 8012, 8013 }
 local lava = {
 	Position(32808, 32336, 11),


### PR DESCRIPTION
I just put the item ID in a table to allow using tools to destroy the wild.
I used as a reference the ID created when using the rune, which is defined in the [ITEM_WILDGROWTH](https://github.com/opentibiabr/canary/blob/b330a33d90d114eb383ecab1c389aed4e7a2131a/src/utils/utils_definitions.hpp#L527) variable.
