### PR TITLE
fix: float precision in config retrieval

### DIFF
--- a/src/config/configmanager.hpp
+++ b/src/config/configmanager.hpp
@@ -39,34 +39,6 @@ public:
 	[[nodiscard]] const std::string &getString(const ConfigKey_t &key, std::string_view context) const;
 	[[nodiscard]] int32_t getNumber(const ConfigKey_t &key, std::string_view context) const;
 	[[nodiscard]] bool getBoolean(const ConfigKey_t &key, std::string_view context) const;
-
-	/**
-	 * @brief Retrieves a float configuration value from the configuration manager, with an optional rounding.
-	 *
-	 * This function is a Lua binding used to get a float value from the configuration manager. It requires
-	 * a key as the first argument, which should be a valid enumeration. An optional second boolean argument
-	 * specifies whether the retrieved float should be rounded to two decimal places.
-	 *
-	 * @param L Pointer to the Lua state. The first argument must be a valid enum key, and the second argument (optional)
-	 * can be a boolean indicating whether to round the result.
-	 *
-	 * @return Returns 1 after pushing the result onto the Lua stack, indicating the number of return values.
-	 *
-	 * @exception reportErrorFunc Throws an error if the first argument is not a valid enum.
-	 *
-	 * Usage:
-	 *  local result = ConfigManager.getFloat(ConfigKey.SomeKey)
-	 *  local result_rounded = ConfigManager.getFloat(ConfigKey.SomeKey, false)
-	 *
-	 * Detailed behavior:
-	 * 1. Extracts the key from the first Lua stack argument as an enumeration of type `ConfigKey_t`.
-	 * 2. Checks if the second argument is provided; if not, defaults to true for rounding.
-	 * 3. Retrieves the float value associated with the key from the configuration manager.
-	 * 4. If rounding is requested, rounds the value to two decimal places.
-	 * 5. Logs the method call and the obtained value using the debug logger.
-	 * 6. Pushes the final value (rounded or original) back onto the Lua stack.
-	 * 7. Returns 1 to indicate a single return value.
-	 */
 	[[nodiscard]] float getFloat(const ConfigKey_t &key, std::string_view context) const;
 
 private:

--- a/src/config/configmanager.hpp
+++ b/src/config/configmanager.hpp
@@ -39,6 +39,34 @@ public:
 	[[nodiscard]] const std::string &getString(const ConfigKey_t &key, std::string_view context) const;
 	[[nodiscard]] int32_t getNumber(const ConfigKey_t &key, std::string_view context) const;
 	[[nodiscard]] bool getBoolean(const ConfigKey_t &key, std::string_view context) const;
+
+	/**
+	 * @brief Retrieves a float configuration value from the configuration manager, with an optional rounding.
+	 *
+	 * This function is a Lua binding used to get a float value from the configuration manager. It requires
+	 * a key as the first argument, which should be a valid enumeration. An optional second boolean argument
+	 * specifies whether the retrieved float should be rounded to two decimal places.
+	 *
+	 * @param L Pointer to the Lua state. The first argument must be a valid enum key, and the second argument (optional)
+	 * can be a boolean indicating whether to round the result.
+	 *
+	 * @return Returns 1 after pushing the result onto the Lua stack, indicating the number of return values.
+	 *
+	 * @exception reportErrorFunc Throws an error if the first argument is not a valid enum.
+	 *
+	 * Usage:
+	 *  local result = ConfigManager.getFloat(ConfigKey.SomeKey)
+	 *  local result_rounded = ConfigManager.getFloat(ConfigKey.SomeKey, false)
+	 *
+	 * Detailed behavior:
+	 * 1. Extracts the key from the first Lua stack argument as an enumeration of type `ConfigKey_t`.
+	 * 2. Checks if the second argument is provided; if not, defaults to true for rounding.
+	 * 3. Retrieves the float value associated with the key from the configuration manager.
+	 * 4. If rounding is requested, rounds the value to two decimal places.
+	 * 5. Logs the method call and the obtained value using the debug logger.
+	 * 6. Pushes the final value (rounded or original) back onto the Lua stack.
+	 * 7. Returns 1 to indicate a single return value.
+	 */
 	[[nodiscard]] float getFloat(const ConfigKey_t &key, std::string_view context) const;
 
 private:

--- a/src/lua/functions/core/game/config_functions.cpp
+++ b/src/lua/functions/core/game/config_functions.cpp
@@ -70,12 +70,21 @@ int ConfigFunctions::luaConfigManagerGetBoolean(lua_State* L) {
 }
 
 int ConfigFunctions::luaConfigManagerGetFloat(lua_State* L) {
-	auto key = getNumber<ConfigKey_t>(L, -1);
+	// configManager.getFloat(key, shouldRound = true)
+
+	// Ensure the first argument (key) is provided and is a valid enum
+	auto key = getNumber<ConfigKey_t>(L, 1);
 	if (!key) {
 		reportErrorFunc("Wrong enum");
 		return 1;
 	}
 
-	lua_pushnumber(L, g_configManager().getFloat(key, __FUNCTION__));
+	// Check if the second argument (shouldRound) is provided and is a boolean; default to true if not provided
+	bool shouldRound = getBoolean(L, 2, true);
+	float value = g_configManager().getFloat(key, __FUNCTION__);
+	double finalValue = shouldRound ? static_cast<double>(std::round(value * 100.0) / 100.0) : value;
+
+	g_logger().debug("[{}] key: {}, finalValue: {}, shouldRound: {}", __METHOD_NAME__, magic_enum::enum_name(key), finalValue, shouldRound);
+	lua_pushnumber(L, finalValue);
 	return 1;
 }

--- a/src/lua/functions/core/game/config_functions.hpp
+++ b/src/lua/functions/core/game/config_functions.hpp
@@ -18,18 +18,31 @@ public:
 
 private:
 	/**
-	 * @brief Pushes a potentially rounded floating-point configuration value to Lua.
+	 * @brief Retrieves a float configuration value from the configuration manager, with an optional rounding.
 	 *
-	 * This function retrieves a configuration value based on the specified key,
-	 * optionally rounds it to two decimal places to address floating-point precision issues,
-	 * and then pushes this value to the Lua stack depending on the rounding flag provided.
+	 * This function is a Lua binding used to get a float value from the configuration manager. It requires
+	 * a key as the first argument, which should be a valid enumeration. An optional second boolean argument
+	 * specifies whether the retrieved float should be rounded to two decimal places.
 	 *
-	 * @param L Pointer to the Lua state.
-	 * @param roundFlag A boolean value to determine if rounding should be applied.
-	 * @return Returns 1, the number of values pushed onto the Lua stack.
+	 * @param L Pointer to the Lua state. The first argument must be a valid enum key, and the second argument (optional)
+	 * can be a boolean indicating whether to round the result.
 	 *
-	 * @note If roundFlag is true, the function rounds the float to two decimal places,
-	 * reducing typical floating-point representation errors.
+	 * @return Returns 1 after pushing the result onto the Lua stack, indicating the number of return values.
+	 *
+	 * @exception reportErrorFunc Throws an error if the first argument is not a valid enum.
+	 *
+	 * Usage:
+	 *  local result = ConfigManager.getFloat(ConfigKey.SomeKey)
+	 *  local result_rounded = ConfigManager.getFloat(ConfigKey.SomeKey, false)
+	 *
+	 * Detailed behavior:
+	 * 1. Extracts the key from the first Lua stack argument as an enumeration of type `ConfigKey_t`.
+	 * 2. Checks if the second argument is provided; if not, defaults to true for rounding.
+	 * 3. Retrieves the float value associated with the key from the configuration manager.
+	 * 4. If rounding is requested, rounds the value to two decimal places.
+	 * 5. Logs the method call and the obtained value using the debug logger.
+	 * 6. Pushes the final value (rounded or original) back onto the Lua stack.
+	 * 7. Returns 1 to indicate a single return value.
 	 */
 	static int luaConfigManagerGetFloat(lua_State* L);
 	static int luaConfigManagerGetBoolean(lua_State* L);

--- a/src/lua/functions/core/game/config_functions.hpp
+++ b/src/lua/functions/core/game/config_functions.hpp
@@ -17,6 +17,20 @@ public:
 	static void init(lua_State* L);
 
 private:
+	/**
+	 * @brief Pushes a potentially rounded floating-point configuration value to Lua.
+	 *
+	 * This function retrieves a configuration value based on the specified key,
+	 * optionally rounds it to two decimal places to address floating-point precision issues,
+	 * and then pushes this value to the Lua stack depending on the rounding flag provided.
+	 *
+	 * @param L Pointer to the Lua state.
+	 * @param roundFlag A boolean value to determine if rounding should be applied.
+	 * @return Returns 1, the number of values pushed onto the Lua stack.
+	 *
+	 * @note If roundFlag is true, the function rounds the float to two decimal places,
+	 * reducing typical floating-point representation errors.
+	 */
 	static int luaConfigManagerGetFloat(lua_State* L);
 	static int luaConfigManagerGetBoolean(lua_State* L);
 	static int luaConfigManagerGetNumber(lua_State* L);


### PR DESCRIPTION
# Description
This pull request addresses the issue where floating point values retrieved from the configuration were not being rounded properly, leading to slight inaccuracies. This fix ensures that all float values are correctly rounded to two decimal places before being passed to Lua, thereby ensuring consistent behavior and data accuracy.

## Behaviour
### **Actual**
Previously, when retrieving floating point values from the configuration, the values were subject to floating point precision issues, which resulted in values like `1.1499999761581` being returned instead of `1.15`.

### **Expected**
With the implemented changes, when floating point values are retrieved, they will now be rounded to two decimal places. For example, a configured value of `1.15` will correctly be returned as `1.15` in Lua scripts.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
### Test Configuration:
- **Operating System:** Windows 10
- **Test type:** Integration

The changes were tested by:
- Modifying the configuration values and observing the returned values in Lua.
- Running existing integration tests that verify configuration value retrieval.

Example of test: 
At the config.lua, set ```combatChainSkillFormulaSword = 1.15```: https://github.com/opentibiabr/canary/blob/5bcbc39e5f8cb06c7af774dae86294ed73e7cf26/config.lua.dist#L457
Use this script
```lua
local multiplier = configManager.getFloat(configKeys.COMBAT_CHAIN_SKILL_FORMULA_SWORD)
local multiplierFloat = configManager.getFloat(configKeys.COMBAT_CHAIN_SKILL_FORMULA_SWORD, false)
logger.info("Multiplier is set to: {}, float: {}", multiplier, multiplierFloat)
```
Final result is:
```lua
Multiplier is set to: 1.15, float: 1.1499999761581
```
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
