### PR TITLE
fix: remove non-existent 'pet' flag from monsters

### DIFF
--- a/data-canary/monster/demons/demon.lua
+++ b/data-canary/monster/demons/demon.lua
@@ -67,7 +67,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/demons/destroyer.lua
+++ b/data-canary/monster/demons/destroyer.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/demons/hellhound.lua
+++ b/data-canary/monster/demons/hellhound.lua
@@ -64,7 +64,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/demons/hellspawn.lua
+++ b/data-canary/monster/demons/hellspawn.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/demons/juggernaut.lua
+++ b/data-canary/monster/demons/juggernaut.lua
@@ -64,7 +64,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/dragons/dragon.lua
+++ b/data-canary/monster/dragons/dragon.lua
@@ -68,7 +68,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = true,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/dragons/dragon_lord.lua
+++ b/data-canary/monster/dragons/dragon_lord.lua
@@ -69,7 +69,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/dragons/hydra.lua
+++ b/data-canary/monster/dragons/hydra.lua
@@ -68,7 +68,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/dragons/ice_dragon.lua
+++ b/data-canary/monster/dragons/ice_dragon.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/dragons/wyrm.lua
+++ b/data-canary/monster/dragons/wyrm.lua
@@ -64,7 +64,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/giants/behemoth.lua
+++ b/data-canary/monster/giants/behemoth.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/giants/cyclops_drone.lua
+++ b/data-canary/monster/giants/cyclops_drone.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/giants/cyclops_smith.lua
+++ b/data-canary/monster/giants/cyclops_smith.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humanoids/frost_troll.lua
+++ b/data-canary/monster/humanoids/frost_troll.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humanoids/goblin.lua
+++ b/data-canary/monster/humanoids/goblin.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humanoids/island_troll.lua
+++ b/data-canary/monster/humanoids/island_troll.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humanoids/troll.lua
+++ b/data-canary/monster/humanoids/troll.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/amazon.lua
+++ b/data-canary/monster/humans/amazon.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/assassin.lua
+++ b/data-canary/monster/humans/assassin.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/bandit.lua
+++ b/data-canary/monster/humans/bandit.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/hunter.lua
+++ b/data-canary/monster/humans/hunter.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/monk.lua
+++ b/data-canary/monster/humans/monk.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/humans/valkyrie.lua
+++ b/data-canary/monster/humans/valkyrie.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/mammals/bat.lua
+++ b/data-canary/monster/mammals/bat.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/mammals/cave_rat.lua
+++ b/data-canary/monster/mammals/cave_rat.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/mammals/winter_wolf.lua
+++ b/data-canary/monster/mammals/winter_wolf.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/mammals/wolf.lua
+++ b/data-canary/monster/mammals/wolf.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/reptiles/crocodile.lua
+++ b/data-canary/monster/reptiles/crocodile.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/reptiles/snake.lua
+++ b/data-canary/monster/reptiles/snake.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/reptiles/tortoise.lua
+++ b/data-canary/monster/reptiles/tortoise.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/slimes/defiler.lua
+++ b/data-canary/monster/slimes/defiler.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/slimes/slime.lua
+++ b/data-canary/monster/slimes/slime.lua
@@ -66,7 +66,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/undeads/ghoul.lua
+++ b/data-canary/monster/undeads/ghoul.lua
@@ -67,7 +67,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/undeads/mummy.lua
+++ b/data-canary/monster/undeads/mummy.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/undeads/skeleton.lua
+++ b/data-canary/monster/undeads/skeleton.lua
@@ -62,7 +62,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/vermins/poison_spider.lua
+++ b/data-canary/monster/vermins/poison_spider.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/vermins/sandcrawler.lua
+++ b/data-canary/monster/vermins/sandcrawler.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/vermins/spider.lua
+++ b/data-canary/monster/vermins/spider.lua
@@ -61,7 +61,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = false,
-	pet = false,
 }
 
 monster.light = {

--- a/data-canary/monster/vermins/wasp.lua
+++ b/data-canary/monster/vermins/wasp.lua
@@ -63,7 +63,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/event_creatures/memory_creatures/memory_of_a_carnisylvan.lua
+++ b/data-otservbr-global/monster/event_creatures/memory_creatures/memory_of_a_carnisylvan.lua
@@ -47,7 +47,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_blue.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_blue.lua
@@ -55,7 +55,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_green.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_green.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_purple.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnar's_megalomania_purple.lua
@@ -48,7 +48,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnars_cruelty.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnars_cruelty.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnars_greed.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnars_greed.lua
@@ -59,7 +59,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnars_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnars_hatred.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnars_malice.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnars_malice.lua
@@ -60,7 +60,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/goshnars_spite.lua
+++ b/data-otservbr-global/monster/quests/soul_war/goshnars_spite.lua
@@ -59,7 +59,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/ashes_of_burning_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/ashes_of_burning_hatred.lua
@@ -49,7 +49,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/blaze_of_burning_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/blaze_of_burning_hatred.lua
@@ -49,7 +49,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/flame_of_burning_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/flame_of_burning_hatred.lua
@@ -49,7 +49,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/spark_of_burning_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/spark_of_burning_hatred.lua
@@ -49,7 +49,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/symbol_of_hatred.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/burning_hatred/symbol_of_hatred.lua
@@ -42,7 +42,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/furious_crater/a_greedy_eye.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/furious_crater/a_greedy_eye.lua
@@ -48,7 +48,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/furious_crater/poor_soul.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/furious_crater/poor_soul.lua
@@ -51,7 +51,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/greater_splinter_of_madness.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/greater_splinter_of_madness.lua
@@ -51,7 +51,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/lesser_splinter_of_madness.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/lesser_splinter_of_madness.lua
@@ -51,7 +51,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/mighty_splinter_of_madness.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/mighty_splinter_of_madness.lua
@@ -51,7 +51,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/necromantic_focus.lua
+++ b/data-otservbr-global/monster/quests/soul_war/normal_monsters/megalomania_room/necromantic_focus.lua
@@ -46,7 +46,6 @@ monster.flags = {
 	canWalkOnEnergy = false,
 	canWalkOnFire = false,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/quests/soul_war/weeping_soul.lua
+++ b/data-otservbr-global/monster/quests/soul_war/weeping_soul.lua
@@ -51,7 +51,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {

--- a/data-otservbr-global/monster/undeads/ahau.lua
+++ b/data-otservbr-global/monster/undeads/ahau.lua
@@ -55,7 +55,6 @@ monster.flags = {
 	canWalkOnEnergy = true,
 	canWalkOnFire = true,
 	canWalkOnPoison = true,
-	pet = false,
 }
 
 monster.light = {


### PR DESCRIPTION
# Description
Removed the non-existent 'pet' flag from monsters to avoid unnecessary errors and improve data consistency. No other changes were made to the monster configurations.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
