### PR TITLE
fix: empty check and iterator validation in ContainerIterator::advance()

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -969,7 +969,7 @@ void ContainerIterator::advance() {
 
 	++cur;
 
-	if (cur == over.front()->itemlist.end()) {
+	if (!over.empty() && cur == over.front()->itemlist.end()) {
 		over.pop_front();
 		if (!over.empty()) {
 			cur = over.front()->itemlist.begin();


### PR DESCRIPTION
Description:
This PR adds an !over.empty() check in ContainerIterator::advance() to ensure the iterator does not access an empty queue or go out of bounds during container iteration.

Key Changes:

Added validation to prevent accessing over.front() when the over queue is empty.
Ensured the iterator cur is correctly repositioned to the next container, preventing out-of-bounds access to itemlist.
This improves the stability and prevents potential crashes during container iteration.