### PR TITLE
fix: CPU overload when loading many nested containers

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -3160,16 +3160,17 @@ void Item::addUniqueId(uint16_t uniqueId) {
 }
 
 bool Item::canDecay() {
-	if (isRemoved() || isDecayDisabled()) {
-		return false;
-	}
-
 	const ItemType &it = Item::items[id];
-	if (it.decayTo < 0 || it.decayTime == 0) {
+	if (it.decayTo < 0 || it.decayTime == 0 || isDecayDisabled()) {
 		return false;
 	}
 
 	if (hasAttribute(ItemAttribute_t::UNIQUEID)) {
+		return false;
+	}
+
+	// In certain conditions, such as depth nested containers, this can overload the CPU, so it is left last.
+	if (isRemoved()) {
 		return false;
 	}
 


### PR DESCRIPTION
# Description

This PR addresses an issue where excessive CPU load occurs when dealing with deeply nested containers due to repeated calls to the `isRemoved` function in the `canDecay` method. To mitigate this, the order of checks in `canDecay` has been changed to evaluate the decay conditions first, and only check for removal status (`isRemoved`) as the last step.

## Behaviour

### **Actual**

When the game contains deeply nested containers (e.g., a backpack within a backpack, repeatedly), logging in or performing operations causes significant CPU load, resulting in delays and performance degradation. The issue is particularly noticeable when there are thousands of nested containers, as the `isRemoved` function is called frequently in `canDecay` checks.

### **Expected**

The `canDecay` method should first check the decay conditions (`decayTo`, `decayTime`, `isDecayDisabled`) and the `UNIQUEID` attribute. Only after these checks should it call `isRemoved`. This change reduces the number of `isRemoved` calls and improves performance when there are many nested containers.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

  - [x] Created 5000 nested containers and logged in with the character, verifying the reduction in login time and CPU usage.
  - [x] Monitored CPU usage during operations that involve item decay checks.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings