### PR TITLE
fix: disable irrelevant informations

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -988,7 +988,7 @@ std::shared_ptr<Player> Game::getPlayerByName(const std::string &s, bool allowOf
 			return nullptr;
 		}
 		std::shared_ptr<Player> tmpPlayer = std::make_shared<Player>(nullptr);
-		if (!IOLoginData::loadPlayerByName(tmpPlayer, s)) {
+		if (!IOLoginData::loadPlayerByName(tmpPlayer, s, allowOffline)) {
 			if (!isNewName) {
 				g_logger().error("Failed to load player {} from database", s);
 			} else {

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -123,6 +123,10 @@ bool IOLoginData::loadPlayer(std::shared_ptr<Player> player, DBResult_ptr result
 		// Experience load
 		IOLoginDataLoad::loadPlayerExperience(player, result);
 
+		if (disableIrrelevantInfo) {
+			return true;
+		}
+
 		// Blessings load
 		IOLoginDataLoad::loadPlayerBlessings(player, result);
 
@@ -179,10 +183,6 @@ bool IOLoginData::loadPlayer(std::shared_ptr<Player> player, DBResult_ptr result
 
 		// Load instant spells list
 		IOLoginDataLoad::loadPlayerInstantSpellList(player, result);
-
-		if (disableIrrelevantInfo) {
-			return true;
-		}
 
 		// load forge history
 		IOLoginDataLoad::loadPlayerForgeHistory(player, result);


### PR DESCRIPTION
# Description

The "PlayerBadge" was loading a lot of unnecessary information for all players on the account. I moved the if statement up, ensuring that only the preload and level are properly loaded, which are actually relevant information.

If more information is identified that should be loaded in the preload, we should move it to the loadPlayerFirst function.

## Behaviour
### **Actual**
When PlayerBadge calls the function to load all characters on the account, there is unnecessary overhead as it loads a lot of information that will never be used for offline players.

### **Expected**
Only actually necessary information is loaded.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
