### PR TITLE
fix: colored text loot in OTC 13.40

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -809,7 +809,7 @@ bool Creature::dropCorpse(std::shared_ptr<Creature> lastHitCreature, std::shared
 				auto monster = getMonster();
 				if (monster && !monster->isRewardBoss()) {
 					std::ostringstream lootMessage;
-					auto collorMessage = player->getProtocolVersion() > 1200 && player->getOperatingSystem() < CLIENTOS_OTCLIENT_LINUX;
+					auto collorMessage = player->getProtocolVersion() > 1200;
 					lootMessage << "Loot of " << getNameDescription() << ": " << corpseContainer->getContentDescription(collorMessage) << ".";
 					auto suffix = corpseContainer->getAttribute<std::string>(ItemAttribute_t::LOOTMESSAGE_SUFFIX);
 					if (!suffix.empty()) {


### PR DESCRIPTION
# Description

in OTC Redemption . PR "feat: full cyclopedia module" was approved today. which includes this feature

1) Otc Redemption 13.40
![image](https://github.com/user-attachments/assets/6ea86f60-e2d3-4aa0-b868-1ad7c7348d2f)
2) Cipsoft 13.40
![image](https://github.com/user-attachments/assets/ac9876b0-a6bc-4621-8bf7-4d38f476de5f)
3) Redemption 11.00
![image](https://github.com/user-attachments/assets/ed92ab76-51df-40fd-a7e2-d5656c9abe21)
4) V8
![image](https://github.com/user-attachments/assets/0ce6f503-ee65-43ce-b929-a1f56be999e6)

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change


  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

kill monster
  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 13.40
  - Client: otcr
  - Operating System:11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
