### PR TITLE
fix: change mana shield limit (wrong uint16 to uint32)

### DIFF
--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -760,8 +760,8 @@ protected:
 	int32_t health = 1000;
 	int32_t healthMax = 1000;
 
-	uint16_t manaShield = 0;
-	uint16_t maxManaShield = 0;
+	uint32_t manaShield = 0;
+	uint32_t maxManaShield = 0;
 	int32_t varBuffs[BUFF_LAST + 1] = { 100, 100, 100 };
 
 	std::array<int32_t, COMBAT_COUNT> reflectPercent = { 0 };


### PR DESCRIPTION
# Description

Changes the limit of the stored number

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change


## How Has This Been Tested

**Test Configuration**:

  - Server Version: actual
  - Client: 13.40
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
