### PR TITLE
fix: eventcallback from std::forward to args

### DIFF
--- a/data/libs/functions/monstertype.lua
+++ b/data/libs/functions/monstertype.lua
@@ -28,7 +28,7 @@ function MonsterType:generateLootRoll(config, resultTable, player)
 		end
 
 		local chance = item.chance
-		if iType:getId() == SoulWarQuest.bagYouDesireItemId then
+		if SoulWarQuest and iType:getId() == SoulWarQuest.bagYouDesireItemId then
 			result[item.itemId].chance = self:calculateBagYouDesireChance(player, chance)
 			logger.debug("Final chance for bag you desire: {}, original chance: {}", result[item.itemId].chance, chance)
 		end

--- a/src/lua/callbacks/events_callbacks.hpp
+++ b/src/lua/callbacks/events_callbacks.hpp
@@ -90,8 +90,7 @@ public:
 	void executeCallback(EventCallback_t eventType, CallbackFunc callbackFunc, Args &&... args) {
 		for (const auto &[name, callback] : getCallbacksByType(eventType)) {
 			if (callback && callback->isLoadedCallback()) {
-				std::invoke(callbackFunc, *callback, std::forward<Args>(args)...);
-				// g_logger().trace("Executed callback: {}", name);
+				std::invoke(callbackFunc, *callback, args...);
 			}
 		}
 	}
@@ -107,7 +106,7 @@ public:
 	ReturnValue checkCallbackWithReturnValue(EventCallback_t eventType, CallbackFunc callbackFunc, Args &&... args) {
 		for (const auto &[name, callback] : getCallbacksByType(eventType)) {
 			if (callback && callback->isLoadedCallback()) {
-				ReturnValue callbackResult = std::invoke(callbackFunc, *callback, std::forward<Args>(args)...);
+				ReturnValue callbackResult = std::invoke(callbackFunc, *callback, args...);
 				if (callbackResult != RETURNVALUE_NOERROR) {
 					return callbackResult;
 				}
@@ -128,7 +127,7 @@ public:
 		bool allCallbacksSucceeded = true;
 		for (const auto &[name, callback] : getCallbacksByType(eventType)) {
 			if (callback && callback->isLoadedCallback()) {
-				bool callbackResult = std::invoke(callbackFunc, *callback, std::forward<Args>(args)...);
+				bool callbackResult = std::invoke(callbackFunc, *callback, args...);
 				allCallbacksSucceeded &= callbackResult;
 			}
 		}


### PR DESCRIPTION
Using std::forward inside a loop can cause rvalue arguments to be moved and invalidated after the first iteration. This happens because std::forward preserves the value category, allowing rvalues to be moved. To ensure arguments remain valid across all iterations when invoking callbacks, avoid using std::forward inside the loop and pass arguments directly as args....

Resolves #2959 