### PR TITLE
fix: player wheel string conversion

### DIFF
--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -778,7 +778,7 @@ std::vector<PlayerWheelGem> PlayerWheel::getRevealedGems() const {
 	}
 
 	std::sort(sortedUnlockedGemGUIDs.begin(), sortedUnlockedGemGUIDs.end(), [](const std::string &a, const std::string &b) {
-		if (std::all_of(a.begin(), a.end(), ::isdigit) && std::all_of(b.begin(), b.end(), ::isdigit)) {
+		if (std::ranges::all_of(a, ::isdigit) && std::ranges::all_of(b, ::isdigit)) {
 			return std::stoull(a) < std::stoull(b);
 		} else {
 			return a < b;

--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -771,12 +771,18 @@ std::vector<PlayerWheelGem> PlayerWheel::getRevealedGems() const {
 	if (unlockedGemUUIDs.empty()) {
 		return unlockedGems;
 	}
+
 	std::vector<std::string> sortedUnlockedGemGUIDs;
 	for (const auto &uuid : unlockedGemUUIDs) {
 		sortedUnlockedGemGUIDs.push_back(uuid);
 	}
+
 	std::sort(sortedUnlockedGemGUIDs.begin(), sortedUnlockedGemGUIDs.end(), [](const std::string &a, const std::string &b) {
-		return std::stoull(a) < std::stoull(b);
+		if (std::all_of(a.begin(), a.end(), ::isdigit) && std::all_of(b.begin(), b.end(), ::isdigit)) {
+			return std::stoull(a) < std::stoull(b);
+		} else {
+			return a < b;
+		}
 	});
 
 	for (const auto &uuid : sortedUnlockedGemGUIDs) {


### PR DESCRIPTION
Now checks to ensure that strings are numeric before converting them to numbers with std::stoull. If the strings are not numeric, it falls back to a lexicographical comparison, preventing crashes caused by invalid conversions.

Resolves #2966 