### PR TITLE
fix: bug when dying with skilllost false

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2903,6 +2903,7 @@ void Player::death(std::shared_ptr<Creature> lastHitCreature) {
 				++it;
 			}
 		}
+		despawn();
 	} else {
 		setSkillLoss(true);
 
@@ -2928,7 +2929,6 @@ void Player::death(std::shared_ptr<Creature> lastHitCreature) {
 		sendStats();
 	}
 
-	despawn();
 }
 
 bool Player::spawn() {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

when the player die and has lostskill in false mode, he is teleported and despawned, when he relogs he duplicates his body

### **Expected**

when dying with lostskill false, it does not despawn

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Tested before changes, in tile with pvp zone flag
  - [ ] Tested after changes, in tile with pvp zone flag

**Test Configuration**:

  - Server Version: current
  - Client: 13.40
  - Operating System: windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
