### PR TITLE
perf: optimized account players badge loading

### DIFF
--- a/src/creatures/players/cyclopedia/player_badge.cpp
+++ b/src/creatures/players/cyclopedia/player_badge.cpp
@@ -13,6 +13,8 @@
 #include "game/game.hpp"
 #include "kv/kv.hpp"
 
+#include "enums/account_errors.hpp"
+
 PlayerBadge::PlayerBadge(Player &player) :
 	m_player(player) { }
 
@@ -113,8 +115,38 @@ bool PlayerBadge::loyalty(uint8_t amount) {
 	return m_player.getLoyaltyPoints() >= amount;
 }
 
+std::vector<std::shared_ptr<Player>> PlayerBadge::getPlayersInfoByAccount(std::shared_ptr<Account> acc) const {
+	auto [accountPlayers, error] = acc->getAccountPlayers();
+	if (error != enumToValue(AccountErrors_t::Ok) || accountPlayers.empty()) {
+		return {};
+	}
+
+	std::string namesList;
+	for (const auto &[name, _] : accountPlayers) {
+		if (!namesList.empty()) {
+			namesList += ", ";
+		}
+		namesList += fmt::format("'{}'", name);
+	}
+
+	auto query = fmt::format("SELECT name, level, vocation FROM players WHERE name IN ({})", namesList);
+	std::vector<std::shared_ptr<Player>> players;
+	DBResult_ptr result = g_database().storeQuery(query);
+	if (result) {
+		do {
+			auto player = std::make_shared<Player>(nullptr);
+			player->setName(result->getString("name"));
+			player->setLevel(result->getNumber<uint32_t>("level"));
+			player->setVocation(result->getNumber<uint16_t>("vocation"));
+			players.push_back(player);
+		} while (result->next());
+	}
+
+	return players;
+}
+
 bool PlayerBadge::accountAllLevel(uint8_t amount) {
-	auto players = g_game().getPlayersByAccount(m_player.getAccount(), true);
+	auto players = getPlayersInfoByAccount(m_player.getAccount());
 	uint16_t total = std::accumulate(players.begin(), players.end(), 0, [](uint16_t sum, const std::shared_ptr<Player> &player) {
 		return sum + player->getLevel();
 	});
@@ -126,7 +158,7 @@ bool PlayerBadge::accountAllVocations(uint8_t amount) {
 	auto paladin = false;
 	auto druid = false;
 	auto sorcerer = false;
-	for (const auto &player : g_game().getPlayersByAccount(m_player.getAccount(), true)) {
+	for (const auto &player : getPlayersInfoByAccount(m_player.getAccount())) {
 		if (player->getLevel() >= amount) {
 			auto vocationEnum = player->getPlayerVocationEnum();
 			if (vocationEnum == Vocation_t::VOCATION_KNIGHT_CIP) {

--- a/src/creatures/players/cyclopedia/player_badge.hpp
+++ b/src/creatures/players/cyclopedia/player_badge.hpp
@@ -13,6 +13,7 @@
 
 class Player;
 class KV;
+class Account;
 
 struct Badge {
 	uint8_t m_id = 0;
@@ -52,6 +53,7 @@ public:
 	// Badge Calculate Functions
 	bool accountAge(uint8_t amount);
 	bool loyalty(uint8_t amount);
+	std::vector<std::shared_ptr<Player>> getPlayersInfoByAccount(std::shared_ptr<Account> acc) const;
 	bool accountAllLevel(uint8_t amount);
 	bool accountAllVocations(uint8_t amount);
 	[[nodiscard]] bool tournamentParticipation(uint8_t skill);

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -606,6 +606,9 @@ public:
 	uint32_t getLevel() const {
 		return level;
 	}
+	void setLevel(uint32_t newLevel) {
+		level = newLevel;
+	}
 	uint8_t getLevelPercent() const {
 		return levelPercent;
 	}


### PR DESCRIPTION
# Description

This change optimizes the player information retrieval process by selecting only the pertinent details of each character instead of loading all player objects for an account. This prevents unnecessary memory allocation and reduces server load, especially in scenarios where accounts have multiple characters.

## Behaviour

### **Actual**

When a player logs in, all characters of the account are loaded into memory, even if only one character is needed. This can significantly increase memory usage and reduce performance, especially when players have many characters in their accounts.

### **Expected**

Only the relevant information (e.g., name, level, vocation) of each character is selected from the database, avoiding the need to load full player objects unnecessarily.

## Type of change

  - [x] Performance improvement (optimizing how data is loaded)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings