### PR TITLE
fix: disable ssl/tls verification for newer version of mysql

### DIFF
--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -42,8 +42,9 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
-	uint8_t ssl_disabled = 0;
-	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_disabled);
+    // remove ssl verification
+	bool ssl_enabled = false;
+	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
 
 	// connects to database
 	if (!mysql_real_connect(handle, host->c_str(), user->c_str(), password->c_str(), database->c_str(), port, sock->c_str(), 0)) {

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -42,7 +42,7 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
-    // remove ssl verification
+	// remove ssl verification
 	bool ssl_enabled = false;
 	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -42,7 +42,7 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
 
-	// remove ssl verification
+	// Remove ssl verification
 	bool ssl_enabled = false;
 	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -41,9 +41,9 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	// automatic reconnect
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
-    
-    uint8_t ssl_disabled = 0;
-    mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_disabled);
+
+	uint8_t ssl_disabled = 0;
+	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_disabled);
 
 	// connects to database
 	if (!mysql_real_connect(handle, host->c_str(), user->c_str(), password->c_str(), database->c_str(), port, sock->c_str(), 0)) {

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -41,6 +41,9 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	// automatic reconnect
 	bool reconnect = true;
 	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
+    
+    uint8_t ssl_disabled = 0;
+    mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_disabled);
 
 	// connects to database
 	if (!mysql_real_connect(handle, host->c_str(), user->c_str(), password->c_str(), database->c_str(), port, sock->c_str(), 0)) {


### PR DESCRIPTION
# Description

The directive included in the connection options ignores the SSL check.

## Behaviour
### **Actual**

![image](https://github.com/user-attachments/assets/967211d5-9523-4a18-96de-ff5b62bf498f)
Image by OpenTibiaMX

### **Expected**

![image2](https://github.com/user-attachments/assets/9fbcfa1c-7414-4397-80e0-a69cf00ee4b3)


### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
