### PR TITLE
fix: bug when player dies with skillLost false

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2903,6 +2903,7 @@ void Player::death(std::shared_ptr<Creature> lastHitCreature) {
 				++it;
 			}
 		}
+		despawn();
 	} else {
 		setSkillLoss(true);
 
@@ -2928,7 +2929,6 @@ void Player::death(std::shared_ptr<Creature> lastHitCreature) {
 		sendStats();
 	}
 
-	despawn();
 }
 
 bool Player::spawn() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2928,7 +2928,6 @@ void Player::death(std::shared_ptr<Creature> lastHitCreature) {
 		onIdleStatus();
 		sendStats();
 	}
-
 }
 
 bool Player::spawn() {


### PR DESCRIPTION
# Description
just change despawn function to the right place

## Behaviour
### **Actual**

if player dies with skillLost false, pvp zone for example, he dont die, is teleported before despawn, forcing him to relogin, on relogin can cause bugs

### **Expected**

player dont despawn and can continue playing

### Fixes #issuenumber

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested


**Test Configuration**:

  - Server Version: current
  - Client: 13.40
  - Operating System: 

## Checklist

  - [x] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
