### PR TITLE
fix: spells and runes interactions

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1844,7 +1844,8 @@ void AreaCombat::getList(const Position &centerPos, const Position &targetPos, s
 		return;
 	}
 
-	uint32_t centerY, centerX;
+	uint32_t centerY;
+	uint32_t centerX;
 	area->getCenter(centerY, centerX);
 
 	const uint32_t rows = area->getRows();

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -114,7 +114,7 @@ void Combat::getCombatArea(const Position &centerPos, const Position &targetPos,
 	}
 
 	if (area) {
-		area->getList(centerPos, targetPos, list);
+		area->getList(centerPos, targetPos, list, getDirectionTo(targetPos, centerPos));
 	} else {
 		list.emplace_back(g_game().map.getOrCreateTile(targetPos));
 	}
@@ -246,18 +246,14 @@ ReturnValue Combat::canTargetCreature(std::shared_ptr<Player> player, std::share
 
 ReturnValue Combat::canDoCombat(std::shared_ptr<Creature> caster, std::shared_ptr<Tile> tile, bool aggressive) {
 	if (tile->hasProperty(CONST_PROP_BLOCKPROJECTILE)) {
-		return RETURNVALUE_NOTENOUGHROOM;
+		return RETURNVALUE_CANNOTTHROW;
 	}
 	if (aggressive && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		return RETURNVALUE_ACTIONNOTPERMITTEDINPROTECTIONZONE;
 	}
 
-	if (tile->hasFlag(TILESTATE_FLOORCHANGE)) {
-		return RETURNVALUE_NOTENOUGHROOM;
-	}
-
 	if (tile->getTeleportItem()) {
-		return RETURNVALUE_NOTENOUGHROOM;
+		return RETURNVALUE_CANNOTTHROW;
 	}
 
 	if (caster) {
@@ -1840,14 +1836,15 @@ AreaCombat::AreaCombat(const AreaCombat &rhs) {
 	}
 }
 
-void AreaCombat::getList(const Position &centerPos, const Position &targetPos, std::vector<std::shared_ptr<Tile>> &list) const {
+void AreaCombat::getList(const Position &centerPos, const Position &targetPos, std::vector<std::shared_ptr<Tile>> &list, const Direction dir) const {
+	auto casterPos = getNextPosition(dir, targetPos);
+
 	const std::unique_ptr<MatrixArea> &area = getArea(centerPos, targetPos);
 	if (!area) {
 		return;
 	}
 
-	uint32_t centerY;
-	uint32_t centerX;
+	uint32_t centerY, centerX;
 	area->getCenter(centerY, centerX);
 
 	const uint32_t rows = area->getRows();
@@ -1857,10 +1854,8 @@ void AreaCombat::getList(const Position &centerPos, const Position &targetPos, s
 	Position tmpPos(targetPos.x - centerX, targetPos.y - centerY, targetPos.z);
 	for (uint32_t y = 0; y < rows; ++y, ++tmpPos.y, tmpPos.x -= cols) {
 		for (uint32_t x = 0; x < cols; ++x, ++tmpPos.x) {
-			if (area->getValue(y, x) != 0) {
-				if (g_game().isSightClear(targetPos, tmpPos, true)) {
-					list.emplace_back(g_game().map.getOrCreateTile(tmpPos));
-				}
+			if (area->getValue(y, x) != 0 && g_game().isSightClear(casterPos, tmpPos, true)) {
+				list.emplace_back(g_game().map.getOrCreateTile(tmpPos));
 			}
 		}
 	}

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -218,7 +218,7 @@ public:
 	// non-assignable
 	AreaCombat &operator=(const AreaCombat &) = delete;
 
-	void getList(const Position &centerPos, const Position &targetPos, std::vector<std::shared_ptr<Tile>> &list) const;
+	void getList(const Position &centerPos, const Position &targetPos, std::vector<std::shared_ptr<Tile>> &list, const Direction dir) const;
 
 	void setupArea(const std::list<uint32_t> &list, uint32_t rows);
 	void setupArea(int32_t length, int32_t spread);

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -500,14 +500,6 @@ bool Spell::playerInstantSpellCheck(std::shared_ptr<Player> player, const Positi
 	}
 
 	const auto tile = g_game().map.getOrCreateTile(toPos);
-
-	ReturnValue ret = Combat::canDoCombat(player, tile, aggressive);
-	if (ret != RETURNVALUE_NOERROR) {
-		player->sendCancelMessage(ret);
-		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		return false;
-	}
-
 	if (blockingCreature && tile->getBottomVisibleCreature(player) != nullptr) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);


### PR DESCRIPTION
- It is now possible to throw runes over stairs and holes (Global Condition), and use spells on walls. 
- An efficiency improvement was also made to avoid unnecessary reallocations.

![image](https://github.com/user-attachments/assets/b3978419-674b-488a-984b-ac5549ea4d77)
![image](https://github.com/user-attachments/assets/d9ff4c66-e773-4ddd-a460-f171d2beb2ca)
![image](https://github.com/user-attachments/assets/405828fa-d79d-4475-812b-9e9526d620f8)


Maybe can close issue #2446 
