### PR TITLE
fix: added a nullity check in depotLockerMap

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -65,9 +65,11 @@ Player::~Player() {
 		}
 	}
 
-	for (const auto &it : depotLockerMap) {
-		it.second->removeInbox(inbox);
-		it.second->stopDecaying();
+	for (const auto& it : depotLockerMap) {
+		if (it.second) {
+			it.second->stopDecaying();
+			it.second->decrementReferenceCounter();
+		}
 	}
 
 	inbox->stopDecaying();

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -65,11 +65,10 @@ Player::~Player() {
 		}
 	}
 
-	for (const auto& it : depotLockerMap) {
+	for (const auto &it : depotLockerMap) {
 		if (it.second) {
-			it.second->removeInbox(inbox);		
+			it.second->removeInbox(inbox);
 			it.second->stopDecaying();
-			it.second->decrementReferenceCounter();
 		}
 	}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -67,6 +67,7 @@ Player::~Player() {
 
 	for (const auto& it : depotLockerMap) {
 		if (it.second) {
+			it.second->removeInbox(inbox);		
 			it.second->stopDecaying();
 			it.second->decrementReferenceCounter();
 		}


### PR DESCRIPTION
If, for some reason, `it.second` can be null, it will cause a runtime error.