### PR TITLE
perf: memory efficiency and improvements in monster walkback pathfind

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1329,27 +1329,28 @@ void Monster::doRandomStep(Direction &nextDirection, bool &result) {
 }
 
 void Monster::doWalkBack(uint32_t &flags, Direction &nextDirection, bool &result) {
-	result = Creature::getNextStep(nextDirection, flags);
-	if (result) {
+	if (result = Creature::getNextStep(nextDirection, flags)) {
 		flags |= FLAG_PATHFINDING;
-	} else {
-		if (ignoreFieldDamage) {
-			ignoreFieldDamage = false;
-			updateMapCache();
-		}
+		return;
+	}
 
-		int32_t distance = std::max<int32_t>(Position::getDistanceX(position, masterPos), Position::getDistanceY(position, masterPos));
-		if (distance == 0) {
-			isWalkingBack = false;
-			return;
-		}
+	if (ignoreFieldDamage) {
+		ignoreFieldDamage = false;
+		updateMapCache();
+	}
 
-		std::vector<Direction> listDir;
-		if (!getPathTo(masterPos, listDir, 0, std::max<int32_t>(0, distance - 5), true, true, distance)) {
-			isWalkingBack = false;
-			return;
-		}
+	// Return if the distance is less than or equal to 10
+	int32_t distance = std::max(Position::getDistanceX(position, masterPos), Position::getDistanceY(position, masterPos));
+	if (distance <= 10 || !spawnMonster) {
+		isWalkingBack = false;
+		return;
+	}
+
+	std::vector<Direction> listDir;
+	if (getPathTo(masterPos, listDir, 0, distance - 10, true, true, distance)) {
 		startAutoWalk(listDir);
+	} else {
+		isWalkingBack = false;
 	}
 }
 


### PR DESCRIPTION
I sought to prevent null pointers in spawnMonster and listDir.
I made a correction for reusing the distance: the calculation of the distance between the current position and masterPos was done only once and reused in both the std::max comparison and getPathTo, reducing memory usage. Now, the calculation is performed only once, saving memory.
I added a condition that checks if the distance is less than or equal to 10 before deciding whether the monster should return. This will effectively reduce memory usage, as the monster was returning on any step outside the spawn location.