### PR TITLE
enhance: change from to std::ranges::find_if in Chat::getPrivateChannel

### DIFF
--- a/src/creatures/interactions/chat.cpp
+++ b/src/creatures/interactions/chat.cpp
@@ -604,11 +604,14 @@ std::shared_ptr<ChatChannel> Chat::getChannelById(uint16_t channelId) {
 	return it->second;
 }
 
-std::shared_ptr<PrivateChatChannel> Chat::getPrivateChannel(const std::shared_ptr<Player> &player) {
-	for (auto &it : privateChannels) {
-		if (it.second->getOwner() == player->getGUID()) {
-			return it.second;
-		}
+std::shared_ptr<PrivateChatChannel> Chat::getPrivateChannel(const std::shared_ptr<Player> &player) const {
+	auto it = std::ranges::find_if(privateChannels, [&player](const auto &channelPair) {
+		const auto &[channelId, channel] = channelPair;
+		return channel->getOwner() == player->getGUID();
+	});
+
+	if (it != privateChannels.end()) {
+		return it->second;
 	}
 	return nullptr;
 }

--- a/src/creatures/interactions/chat.hpp
+++ b/src/creatures/interactions/chat.hpp
@@ -137,7 +137,7 @@ public:
 	std::shared_ptr<ChatChannel> getChannel(const std::shared_ptr<Player> &player, uint16_t channelId);
 	std::shared_ptr<ChatChannel> getChannelById(uint16_t channelId);
 	std::shared_ptr<ChatChannel> getGuildChannelById(uint32_t guildId);
-	std::shared_ptr<PrivateChatChannel> getPrivateChannel(const std::shared_ptr<Player> &player);
+	std::shared_ptr<PrivateChatChannel> getPrivateChannel(const std::shared_ptr<Player> &player) const;
 
 	LuaScriptInterface* getScriptInterface() {
 		return &scriptInterface;


### PR DESCRIPTION
# Description

This pull request refactors the iteration and conditional logic used to find a specific `PrivateChatChannel` in `privateChannels` to use `std::ranges::find_if`. The updated version of the code improves readability by reducing boilerplate, leveraging structured bindings and modern C++ features.

## Behaviour
### **Actual**

Iterating over `privateChannels` using a for loop and checking if the owner's GUID matches the player's GUID manually.

### **Expected**

Using `std::ranges::find_if` to streamline the search for the private channel, simplifying the code by using a lambda and structured bindings.

## Type of change

- [x] Code refactor (non-breaking change that improves the code quality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable)
