### PR TITLE
improve: fix thread pool shutdown

### DIFF
--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -33,7 +33,17 @@ void ThreadPool::start() {
 }
 
 void ThreadPool::shutdown() {
+	if (stopped) {
+		return;
+	}
+
 	logger.info("Shutting down thread pool...");
-	stopped = true;
+	{
+		std::unique_lock<std::mutex> lock(mutex);
+		stopped = true;
+		condition.notify_all();
+	}
+
 	wait();
+	logger.info("Thread pool shutdown complete.");
 }

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -6,6 +6,7 @@
  * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
  * Website: https://docs.opentibiabr.com/
  */
+
 #pragma once
 
 #include "lib/logging/logger.hpp"
@@ -17,7 +18,7 @@ public:
 
 	// Ensures that we don't accidentally copy it
 	ThreadPool(const ThreadPool &) = delete;
-	ThreadPool operator=(const ThreadPool &) = delete;
+	ThreadPool &operator=(const ThreadPool &) = delete;
 
 	void start();
 	void shutdown();
@@ -32,13 +33,16 @@ public:
 		}
 
 		return id;
-	};
+	}
 
 	bool isStopped() const {
 		return stopped;
 	}
 
 private:
+	std::mutex mutex;
+	std::condition_variable condition;
+
 	Logger &logger;
 	bool stopped = false;
 };


### PR DESCRIPTION
# Description

Fixed an issue where the `ThreadPool::shutdown()` method would hang indefinitely due to waiting on threads without proper condition signaling.

Depuration with gdb:
![image](https://github.com/user-attachments/assets/a090aad8-71f1-47fd-abf8-af44df1cc823)

Normal loading:
![image](https://github.com/user-attachments/assets/c584c93e-849e-4fe1-a714-8d5366725143)

## Behaviour
### **Actual**

The `ThreadPool` shutdown process hangs indefinitely with the message "Shutting down thread pool..." without completing.

### **Expected**

The `ThreadPool` should properly notify threads to complete their tasks and shut down gracefully, avoiding hanging indefinitely.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested

The fix was tested by reproducing the shutdown scenario where the hanging issue occurred. The shutdown process now correctly notifies threads to complete, and the shutdown process finishes as expected.

  - [x] Tested the shutdown of `ThreadPool` after an error in loading, confirming no indefinite hang.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
