### PR TITLE
fix: forge cores consumption

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7477,7 +7477,9 @@ void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemI
 			sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
 			break;
 		}
-		auto tierPriecs = itemClassification->tiers.at(donorItem->getTier());
+
+		const uint8_t toTier = convergence ? donorItem->getTier() : donorItem->getTier() - 1;
+		auto tierPriecs = itemClassification->tiers.at(toTier);
 		cost = convergence ? tierPriecs.convergenceTransferPrice : tierPriecs.regularPrice;
 		coresAmount = tierPriecs.corePrice;
 		break;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5596,13 +5596,22 @@ void ProtocolGame::parseForgeEnter(NetworkMessage &msg) {
 
 	// 0xBF -> 0 = fusion, 1 = transfer, 2 = dust to sliver, 3 = sliver to core, 4 = increase dust limit
 	auto actionType = static_cast<ForgeAction_t>(msg.getByte());
-	bool convergence = msg.getByte();
-	uint16_t firstItem = msg.get<uint16_t>();
-	uint8_t tier = msg.getByte();
-	uint16_t secondItem = msg.get<uint16_t>();
-	bool usedCore = msg.getByte();
-	bool reduceTierLoss = msg.getByte();
+
+	bool convergence = false;
+	uint16_t firstItem = 0;
+	uint8_t tier = 0;
+	uint16_t secondItem = 0;
+
+	if (actionType == ForgeAction_t::FUSION || actionType == ForgeAction_t::TRANSFER) {
+		convergence = msg.getByte();
+		firstItem = msg.get<uint16_t>();
+		tier = msg.getByte();
+		secondItem = msg.get<uint16_t>();
+	}
+
 	if (actionType == ForgeAction_t::FUSION) {
+		bool usedCore = convergence ? false : msg.getByte();
+		bool reduceTierLoss = convergence ? false : msg.getByte();
 		g_game().playerForgeFuseItems(player->getID(), actionType, firstItem, tier, secondItem, usedCore, reduceTierLoss, convergence);
 	} else if (actionType == ForgeAction_t::TRANSFER) {
 		g_game().playerForgeTransferItemTier(player->getID(), actionType, firstItem, tier, secondItem, convergence);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5595,7 +5595,7 @@ void ProtocolGame::parseForgeEnter(NetworkMessage &msg) {
 	}
 
 	// 0xBF -> 0 = fusion, 1 = transfer, 2 = dust to sliver, 3 = sliver to core, 4 = increase dust limit
-	auto actionType = static_cast<ForgeAction_t>(msg.getByte());
+	const auto actionType = static_cast<ForgeAction_t>(msg.getByte());
 
 	bool convergence = false;
 	uint16_t firstItem = 0;
@@ -5610,8 +5610,8 @@ void ProtocolGame::parseForgeEnter(NetworkMessage &msg) {
 	}
 
 	if (actionType == ForgeAction_t::FUSION) {
-		bool usedCore = convergence ? false : msg.getByte();
-		bool reduceTierLoss = convergence ? false : msg.getByte();
+		const bool usedCore = convergence ? false : msg.getByte();
+		const bool reduceTierLoss = convergence ? false : msg.getByte();
 		g_game().playerForgeFuseItems(player->getID(), actionType, firstItem, tier, secondItem, usedCore, reduceTierLoss, convergence);
 	} else if (actionType == ForgeAction_t::TRANSFER) {
 		g_game().playerForgeTransferItemTier(player->getID(), actionType, firstItem, tier, secondItem, convergence);


### PR DESCRIPTION
# Description

Fixes the exalted core consumption between normal and convergence transfers.

## Behaviour
### **Actual**

Try transfer a classification 4 tier 3 item to another item to tier 2 using exactly the amount of cores needed and it will fail.

### **Expected**

Try transfer a classification 4 tier 3 item to another item to tier 2 using exactly the amount of cores needed and it should work.

### Fixes #2994 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Get an item classification 4 tier 3
  - [x] Try transfering normally the tier 3 to another item of same slot and classification 4 using exactly the amount of cores needed
  - [x] Do the same above using convergence transfer

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
