### PR TITLE
fix: exclude gold pouch from sale item count

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4117,17 +4117,18 @@ std::map<uint32_t, uint32_t> &Player::getAllItemTypeCount(std::map<uint32_t, uin
 
 std::map<uint16_t, uint16_t> &Player::getAllSaleItemIdAndCount(std::map<uint16_t, uint16_t> &countMap) const {
 	for (const auto &item : getAllInventoryItems(false, true)) {
-		if (!item->hasMarketAttributes()) {
+		const auto itemId = item->getID();
+
+		if (itemId == ITEM_GOLD_POUCH) {
+			countMap[itemId] += item->getItemCount();
 			continue;
 		}
 
-		if (const auto &container = item->getContainer()) {
-			if (container->size() > 0) {
-				continue;
-			}
+		if (!item->hasMarketAttributes() || (const auto &container = item->getContainer()) && !container->empty()) {
+			continue;
 		}
 
-		countMap[item->getID()] += item->getItemCount();
+		countMap[itemId] += item->getItemCount();
 	}
 
 	return countMap;


### PR DESCRIPTION
# Description
This update modifies the `getAllSaleItemIdAndCount` function to exclude the Gold Pouch `(ITEM_GOLD_POUCH)` from being counted as a saleable item. The previous behavior included all items with market attributes, even Gold Pouches, which led to incorrect item counts in certain situations.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
