### PR TITLE
fix: party onLeave by forcing exit

### DIFF
--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -75,7 +75,7 @@ void Party::disband() {
 	membersData.clear();
 }
 
-bool Party::leaveParty(std::shared_ptr<Player> player) {
+bool Party::leaveParty(std::shared_ptr<Player> player, bool forceRemove /* = false */) {
 	if (!player) {
 		return false;
 	}
@@ -89,8 +89,9 @@ bool Party::leaveParty(std::shared_ptr<Player> player) {
 		return false;
 	}
 
-	if (!g_events().eventPartyOnLeave(getParty(), player)) {
-		return false;
+	bool canRemove = g_events().eventPartyOnLeave(getParty(), player);
+	if (!forceRemove && !canRemove) {
+	    return false;
 	}
 
 	if (!g_callbacks().checkCallback(EventCallback_t::partyOnLeave, &EventCallback::partyOnLeave, getParty(), player)) {

--- a/src/creatures/players/grouping/party.hpp
+++ b/src/creatures/players/grouping/party.hpp
@@ -61,7 +61,7 @@ public:
 	bool joinParty(const std::shared_ptr<Player> &player);
 	void revokeInvitation(const std::shared_ptr<Player> &player);
 	bool passPartyLeadership(std::shared_ptr<Player> player);
-	bool leaveParty(std::shared_ptr<Player> player);
+	bool leaveParty(std::shared_ptr<Player> player, bool forceRemove = false);
 
 	bool removeInvite(const std::shared_ptr<Player> &player, bool removeFromPlayer = true);
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1847,7 +1847,7 @@ void Player::onRemoveCreature(std::shared_ptr<Creature> creature, bool isLogout)
 			onDeEquipInventory();
 
 			if (m_party) {
-				m_party->leaveParty(player);
+				m_party->leaveParty(player, true);
 			}
 			if (guild) {
 				guild->removeMember(player);


### PR DESCRIPTION
If Party:onLeave() is used and returns false when a player is dying or logged out, the player is not properly removed from the party.

Issue #3013 