### PR TITLE
fix: item usage under players and doors

### DIFF
--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1869,15 +1869,32 @@ bool Tile::isMovableBlocking() const {
 
 std::shared_ptr<Item> Tile::getUseItem(int32_t index) const {
 	const TileItemVector* items = getItemList();
+
 	if (!items || items->empty()) {
 		return ground;
 	}
 
-	if (const auto &thing = getThing(index)) {
-		return thing->getItem();
+	if (index >= 0 && index < static_cast<int32_t>(items->size())) {
+		if (const auto &thing = getThing(index)) {
+			auto thingItem = thing->getItem();
+			if (thingItem) {
+				return thingItem;
+			}
+		}
 	}
 
-	return nullptr;
+	auto topDownItem = getTopDownItem();
+	if (topDownItem) {
+		return topDownItem;
+	}
+
+	for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		if ((*it)->getDoor()) {
+			return (*it)->getItem();
+		}
+	}
+
+	return !items->empty() ? *items->begin() : nullptr;
 }
 
 std::shared_ptr<Item> Tile::getDoorItem() const {

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1869,32 +1869,15 @@ bool Tile::isMovableBlocking() const {
 
 std::shared_ptr<Item> Tile::getUseItem(int32_t index) const {
 	const TileItemVector* items = getItemList();
-
 	if (!items || items->empty()) {
 		return ground;
 	}
 
-	if (index >= 0 && index < static_cast<int32_t>(items->size())) {
-		if (const auto &thing = getThing(index)) {
-			auto thingItem = thing->getItem();
-			if (thingItem) {
-				return thingItem;
-			}
-		}
+	if (const auto &thing = getThing(index)) {
+		return thing->getItem();
 	}
 
-	auto topDownItem = getTopDownItem();
-	if (topDownItem) {
-		return topDownItem;
-	}
-
-	for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-		if ((*it)->getDoor()) {
-			return (*it)->getItem();
-		}
-	}
-
-	return !items->empty() ? *items->begin() : nullptr;
+	return nullptr;
 }
 
 std::shared_ptr<Item> Tile::getDoorItem() const {


### PR DESCRIPTION
You can now interact with items located under doors and your character.

![image](https://github.com/user-attachments/assets/712b866c-78d5-4e8a-9ee9-a4b842b0ebc1)
![image](https://github.com/user-attachments/assets/0c54d32d-6169-4780-8ee6-36b15b154bb9)
