### PR TITLE
feat: add mystery box item action

### DIFF
--- a/data/scripts/actions/items/mystery_box.lua
+++ b/data/scripts/actions/items/mystery_box.lua
@@ -1,14 +1,13 @@
 local mysterybox = Action()
 
 function mysterybox.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-    local items = {25361, 25360}
-    local randomItem = items[math.random(#items)]
-    player:addItem(randomItem, 1)
-    player:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
-    item:remove(1)
-    return true
+	local items = { 25361, 25360 }
+	local randomItem = items[math.random(#items)]
+	player:addItem(randomItem, 1)
+	player:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
+	item:remove(1)
+	return true
 end
-
 
 mysterybox:id(26186)
 mysterybox:register()

--- a/data/scripts/actions/items/mystery_box.lua
+++ b/data/scripts/actions/items/mystery_box.lua
@@ -1,6 +1,6 @@
-local mysterybox = Action()
+local mysteryBox = Action()
 
-function mysterybox.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+function mysteryBox.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local items = { 25361, 25360 }
 	local randomItem = items[math.random(#items)]
 	player:addItem(randomItem, 1)
@@ -9,5 +9,5 @@ function mysterybox.onUse(player, item, fromPosition, target, toPosition, isHotk
 	return true
 end
 
-mysterybox:id(26186)
-mysterybox:register()
+mysteryBox:id(26186)
+mysteryBox:register()

--- a/data/scripts/actions/items/mystery_box.lua
+++ b/data/scripts/actions/items/mystery_box.lua
@@ -1,0 +1,14 @@
+local mysterybox = Action()
+
+function mysterybox.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    local items = {25361, 25360}
+    local randomItem = items[math.random(#items)]
+    player:addItem(randomItem, 1)
+    player:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
+    item:remove(1)
+    return true
+end
+
+
+mysterybox:id(26186)
+mysterybox:register()


### PR DESCRIPTION
# Description

When using mystery box after getting from the NPC (which is only possible after defeating final boss of cults of tibia), not is happening

## Behaviour
### **Actual**

When using mystery box after getting from the NPC (which is only possible after defeating final boss of cults of tibia), not is happening

### **Expected**

Give one of the blessings of the mountain.

https://www.tibiawiki.com.br/wiki/Mystery_Box

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Use the item and see if gonna give you the correct blessing charms.

**Test Configuration**:

  - Server Version: 13.40
  - Client: 13.40
  - Operating System: NA

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
