### PR TITLE
style: tryAddEvent to safeCall

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -2002,9 +2002,9 @@ void Creature::sendAsyncTasks() {
 	                          TaskGroup::WalkParallel);
 }
 
-void Creature::safeCall(std::function<void(void)> &&action) {
+void Creature::safeCall(std::function<void(void)> &&action) const {
 	if (g_dispatcher().context().isAsync()) {
-		g_dispatcher().addEvent([weak_self = std::weak_ptr<Creature>(getCreature()), action = std::move(action)] {
+		g_dispatcher().addEvent([weak_self = std::weak_ptr<const SharedObject>(shared_from_this()), action = std::move(action)] {
 			if (weak_self.lock()) {
 				action();
 			}

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -270,18 +270,17 @@ void Creature::addEventWalk(bool firstStep) {
 		return;
 	}
 
-	g_dispatcher().context().tryAddEvent([ticks, self = getCreature()]() {
+	safeCall([this, ticks]() {
 		// Take first step right away, but still queue the next
 		if (ticks == 1) {
-			g_game().checkCreatureWalk(self->getID());
+			g_game().checkCreatureWalk(getID());
 		}
 
-		self->eventWalk = g_dispatcher().scheduleEvent(
+		eventWalk = g_dispatcher().scheduleEvent(
 			static_cast<uint32_t>(ticks),
-			[creatureId = self->getID()] { g_game().checkCreatureWalk(creatureId); }, "Game::checkCreatureWalk"
+			[creatureId = getID()] { g_game().checkCreatureWalk(creatureId); }, "Game::checkCreatureWalk"
 		);
-	},
-	                                     "addEventWalk");
+	});
 }
 
 void Creature::stopEventWalk() {
@@ -1082,7 +1081,7 @@ void Creature::getPathSearchParams(const std::shared_ptr<Creature> &, FindPathPa
 
 void Creature::goToFollowCreature_async(std::function<void()> &&onComplete) {
 	if (!hasAsyncTaskFlag(Pathfinder) && onComplete) {
-		g_dispatcher().context().addEvent(std::move(onComplete), "goToFollowCreature_async");
+		g_dispatcher().addEvent(std::move(onComplete), "goToFollowCreature_async");
 	}
 
 	setAsyncTaskFlag(Pathfinder, true);
@@ -2001,4 +2000,17 @@ void Creature::sendAsyncTasks() {
 		}
 	},
 	                          TaskGroup::WalkParallel);
+}
+
+void Creature::safeCall(std::function<void(void)> &&action) {
+	if (g_dispatcher().context().isAsync()) {
+		g_dispatcher().addEvent([weak_self = std::weak_ptr<Creature>(getCreature()), action = std::move(action)] {
+			if (weak_self.lock()) {
+				action();
+			}
+		},
+		                        g_dispatcher().context().getName());
+	} else {
+		action();
+	}
 }

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -849,7 +849,7 @@ protected:
 	virtual void onExecuteAsyncTasks() {};
 
 	// This method maintains safety in asynchronous calls, avoiding competition between threads.
-	void safeCall(std::function<void(void)> &&action);
+	void safeCall(std::function<void(void)> &&action) const;
 
 private:
 	bool canFollowMaster() const;

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -849,7 +849,7 @@ protected:
 	virtual void onExecuteAsyncTasks() {};
 
 	// This method maintains safety in asynchronous calls, avoiding competition between threads.
-  void safeCall(std::function<void(void)> &&action);
+	void safeCall(std::function<void(void)> &&action);
 
 private:
 	bool canFollowMaster() const;

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -848,6 +848,9 @@ protected:
 
 	virtual void onExecuteAsyncTasks() {};
 
+	// This method maintains safety in asynchronous calls, avoiding competition between threads.
+  void safeCall(std::function<void(void)> &&action);
+
 private:
 	bool canFollowMaster() const;
 	bool isLostSummon();

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3783,14 +3783,9 @@ void Player::addInFightTicks(bool pzlock /*= false*/) {
 
 	updateImbuementTrackerStats();
 
-	// this method can be called asynchronously.
-	g_dispatcher().context().tryAddEvent([self = std::weak_ptr<Player>(getPlayer())] {
-		if (const auto &player = self.lock()) {
-			const auto &condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_configManager().getNumber(PZ_LOCKED), 0);
-			player->addCondition(condition);
-		}
-	},
-	                                     "Player::addInFightTicks");
+	safeCall([this] {
+		addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_configManager().getNumber(PZ_LOCKED), 0));
+	});
 }
 
 void Player::setDailyReward(uint8_t reward) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6440,10 +6440,9 @@ void Game::addCreatureCheck(const std::shared_ptr<Creature> &creature) {
 
 	creature->inCheckCreaturesVector.store(true);
 
-	g_dispatcher().context().tryAddEvent([creature] {
+	creature->safeCall([this, creature] {
 		checkCreatureLists[uniform_random(0, EVENT_CREATURECOUNT - 1)].emplace_back(creature);
-	},
-	                                     "addCreatureCheck");
+	});
 }
 
 void Game::removeCreatureCheck(const std::shared_ptr<Creature> &creature) {

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -251,22 +251,6 @@ void Dispatcher::stopEvent(uint64_t eventId) {
 	}
 }
 
-void DispatcherContext::addEvent(std::function<void(void)> &&f, std::string_view context) const {
-	g_dispatcher().addEvent(std::move(f), context);
-}
-
-void DispatcherContext::tryAddEvent(std::function<void(void)> &&f, std::string_view context) const {
-	if (!f) {
-		return;
-	}
-
-	if (isAsync()) {
-		g_dispatcher().addEvent(std::move(f), context);
-	} else {
-		f();
-	}
-}
-
 bool DispatcherContext::isOn() {
 	return OTSYS_TIME() != 0;
 }

--- a/src/game/scheduling/dispatcher.hpp
+++ b/src/game/scheduling/dispatcher.hpp
@@ -55,12 +55,6 @@ struct DispatcherContext {
 		return type;
 	}
 
-	// postpone the event
-	void addEvent(std::function<void(void)> &&f, std::string_view context) const;
-
-	// if the context is async, the event will be postponed, if not, it will be executed immediately.
-	void tryAddEvent(std::function<void(void)> &&f, std::string_view context) const;
-
 private:
 	void reset() {
 		group = TaskGroup::ThreadPool;

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -23,6 +23,7 @@
 #include "lua/creature/movement.hpp"
 #include "map/spectators.hpp"
 #include "utils/tools.hpp"
+#include "game/scheduling/dispatcher.hpp"
 
 auto real_nullptr_tile = std::make_shared<StaticTile>(0xFFFF, 0xFFFF, 0xFF);
 const std::shared_ptr<Tile> &Tile::nullptr_tile = real_nullptr_tile;

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1942,3 +1942,16 @@ void Tile::clearZones() {
 		zones.erase(zone);
 	}
 }
+
+void Tile::safeCall(std::function<void(void)> &&action) {
+	if (g_dispatcher().context().isAsync()) {
+		g_dispatcher().addEvent([weak_self = std::weak_ptr<Tile>(getTile()), action = std::move(action)] {
+			if (weak_self.lock()) {
+				action();
+			}
+		},
+		                        g_dispatcher().context().getName());
+	} else {
+		action();
+	}
+}

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1944,9 +1944,9 @@ void Tile::clearZones() {
 	}
 }
 
-void Tile::safeCall(std::function<void(void)> &&action) {
+void Tile::safeCall(std::function<void(void)> &&action) const {
 	if (g_dispatcher().context().isAsync()) {
-		g_dispatcher().addEvent([weak_self = std::weak_ptr<Tile>(getTile()), action = std::move(action)] {
+		g_dispatcher().addEvent([weak_self = std::weak_ptr<const SharedObject>(shared_from_this()), action = std::move(action)] {
 			if (weak_self.lock()) {
 				action();
 			}

--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -260,7 +260,7 @@ public:
 	}
 
 	// This method maintains safety in asynchronous calls, avoiding competition between threads.
-	void safeCall(std::function<void(void)> &&action);
+	void safeCall(std::function<void(void)> &&action) const;
 
 private:
 	void onAddTileItem(const std::shared_ptr<Item> &item);

--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -259,6 +259,9 @@ public:
 		}
 	}
 
+	// This method maintains safety in asynchronous calls, avoiding competition between threads.
+	void safeCall(std::function<void(void)> &&action);
+
 private:
 	void onAddTileItem(const std::shared_ptr<Item> &item);
 	void onUpdateTileItem(const std::shared_ptr<Item> &oldItem, const ItemType &oldType, const std::shared_ptr<Item> &newItem, const ItemType &newType);

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -146,15 +146,12 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 
 	tile->setFlag(static_cast<TileFlags_t>(cachedTile->flags));
 
-	// add zone synchronously
-	g_dispatcher().context().tryAddEvent(
-		[tile, pos] {
-			for (const auto &zone : Zone::getZones(pos)) {
-				tile->addZone(zone);
-			}
-		},
-		"Zone::getZones"
-	);
+
+	tile->safeCall([tile, pos] {
+		for (const auto &zone : Zone::getZones(pos)){
+			tile->addZone(zone);
+		}
+	});
 
 	floor->setTile(x, y, tile);
 

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -146,9 +146,8 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 
 	tile->setFlag(static_cast<TileFlags_t>(cachedTile->flags));
 
-
 	tile->safeCall([tile, pos] {
-		for (const auto &zone : Zone::getZones(pos)){
+		for (const auto &zone : Zone::getZones(pos)) {
 			tile->addZone(zone);
 		}
 	});


### PR DESCRIPTION
safeCall basically keeps calls safe when they are being executed asynchronously, that is, if the calls inside safeCall are being executed in a thread other than the dispatcher, they will simply be sent to that thread, thus avoiding concurrency.

What I just wrote is already being done with tryAddEvent, but it is not a very intuitive name, and it is visually polluted. In the safeCall method, besides being short, you can simply send 'this' as a parameter to the lambda, without having to fear that its execution will be done when the reference no longer exists, because inside safeCall, there is a reference check, if it has already been destroyed, it will simply not be executed.