### PR TITLE
fix: prevent crash in condition light division

### DIFF
--- a/src/creatures/combat/condition.cpp
+++ b/src/creatures/combat/condition.cpp
@@ -2540,7 +2540,7 @@ void ConditionLight::addCondition(std::shared_ptr<Creature> creature, const std:
 		const auto &conditionLight = condition->static_self_cast<ConditionLight>();
 		lightInfo.level = conditionLight->lightInfo.level;
 		lightInfo.color = conditionLight->lightInfo.color;
-		lightChangeInterval = ticks / lightInfo.level;
+		lightChangeInterval = ticks / std::max<uint8_t>(1, lightInfo.level);
 		internalLightTicks = 0;
 		creature->setCreatureLight(lightInfo);
 		g_game().changeLight(creature);
@@ -2558,9 +2558,13 @@ bool ConditionLight::setParam(ConditionParam_t param, int32_t value) {
 	}
 
 	switch (param) {
-		case CONDITION_PARAM_LIGHT_LEVEL:
-			lightInfo.level = value;
+		case CONDITION_PARAM_LIGHT_LEVEL: {
+			if (value < 1) {
+				g_logger().warn("[ConditionLight::setParam] Trying to set invalid light value: '{}', defaulting to 1.", value);
+			}
+			lightInfo.level = std::max<uint8_t>(1, static_cast<uint8_t>(value));
 			return true;
+		}
 
 		case CONDITION_PARAM_LIGHT_COLOR:
 			lightInfo.color = value;

--- a/src/creatures/combat/condition.hpp
+++ b/src/creatures/combat/condition.hpp
@@ -391,7 +391,7 @@ public:
 	bool unserializeProp(ConditionAttr_t attr, PropStream &propStream) override;
 
 private:
-	LightInfo lightInfo;
+	LightInfo lightInfo { 1, 215 };
 	uint32_t internalLightTicks = 0;
 	uint32_t lightChangeInterval = 0;
 };


### PR DESCRIPTION
Fix #3047 

Now min light level is always 1.
Prevent division by zero.