### PR TITLE
improve: lower boss name on boss lever system

### DIFF
--- a/data/libs/functions/boss_lever.lua
+++ b/data/libs/functions/boss_lever.lua
@@ -56,7 +56,7 @@ setmetatable(BossLever, {
 			error("BossLever: boss is required")
 		end
 		return setmetatable({
-			name = boss.name,
+			name = boss.name:lower(),
 			encounter = config.encounter,
 			bossPosition = boss.position,
 			timeToFightAgain = config.timeToFightAgain or configManager.getNumber(configKeys.BOSS_DEFAULT_TIME_TO_FIGHT_AGAIN),

--- a/data/scripts/creaturescripts/monster/boss_lever_death.lua
+++ b/data/scripts/creaturescripts/monster/boss_lever_death.lua
@@ -13,7 +13,7 @@ function onBossDeath.onDeath(creature)
 		return true
 	end
 
-	local bossLever = BossLever[name]
+	local bossLever = BossLever[name:lower()]
 	if not bossLever then
 		return true
 	end


### PR DESCRIPTION
This ensures the integrity of the name during searches. If a name is added with a different capitalization than the monster's actual name, it can lead to conflicts, preventing the onDeath code from executing properly.