### PR TITLE
improve: add check to boosted boss name empty

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -8857,7 +8857,11 @@ void ProtocolGame::parseSendBosstiarySlots() {
 	uint32_t boostedBossId = g_ioBosstiary().getBoostedBossId();
 
 	// Sanity checks
-	std::string boostedBossName = g_ioBosstiary().getBoostedBossName();
+	const std::string &boostedBossName = g_ioBosstiary().getBoostedBossName();
+	if (boostedBossName.empty()) {
+		g_logger().error("[{}] The boosted boss name is empty", __FUNCTION__);
+		return;
+	}
 	const auto mTypeBoosted = g_monsters().getMonsterType(boostedBossName);
 	auto boostedBossRace = mTypeBoosted ? mTypeBoosted->info.bosstiaryRace : BosstiaryRarity_t::BOSS_INVALID;
 	auto isValidBoostedBoss = boostedBossId == 0 || (boostedBossRace >= BosstiaryRarity_t::RARITY_BANE && boostedBossRace <= BosstiaryRarity_t::RARITY_NEMESIS);


### PR DESCRIPTION
Checks if the boosted boss name is empty