### PR TITLE
fix: safe call add creatures on tile get/creation

### DIFF
--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -142,8 +142,8 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 
 	tile->setFlag(static_cast<TileFlags_t>(cachedTile->flags));
 
-	tile->safeCall([tile, pos, oldCreatureList = std::move(oldCreatureList)]() {
-		for (const auto &creature : oldCreatureList) {
+	tile->safeCall([tile, pos, movedOldCreatureList = std::move(oldCreatureList)]() {
+		for (const auto &creature : movedOldCreatureList) {
 			tile->internalAddThing(creature);
 		}
 

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -132,10 +132,6 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 
 	auto pos = Position(x, y, z);
 
-	for (const auto &creature : oldCreatureList) {
-		tile->internalAddThing(creature);
-	}
-
 	if (cachedTile->ground != nullptr) {
 		tile->internalAddThing(createItem(cachedTile->ground, pos));
 	}
@@ -146,7 +142,11 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 
 	tile->setFlag(static_cast<TileFlags_t>(cachedTile->flags));
 
-	tile->safeCall([tile, pos] {
+	tile->safeCall([tile, pos, oldCreatureList = std::move(oldCreatureList)]() {
+		for (const auto &creature : oldCreatureList) {
+			tile->internalAddThing(creature);
+		}
+
 		for (const auto &zone : Zone::getZones(pos)) {
 			tile->addZone(zone);
 		}


### PR DESCRIPTION
Possible resolve this crash: [crash.txt](https://github.com/user-attachments/files/17688777/crash.txt)
