### PR TITLE
fix: house mailboxes

### DIFF
--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -988,14 +988,12 @@ std::shared_ptr<Cylinder> Tile::queryDestination(int32_t &, const std::shared_pt
 		if (destThing) {
 			destItem = destThing->getItem();
 			const auto &thingItem = thing ? thing->getItem() : nullptr;
-			if (thingItem) {
-				if (thingItem->getMailbox() != destItem->getMailbox()) {
-					return destTile;
-				}
-				const auto &destCylinder = destThing->getCylinder();
-				if (destCylinder && !destCylinder->getContainer()) {
-					return destThing->getCylinder();
-				}
+			if (!thingItem || thingItem->getMailbox() != destItem->getMailbox()) {
+				return destTile;
+			}
+			const auto &destCylinder = destThing->getCylinder();
+			if (destCylinder && !destCylinder->getContainer()) {
+				return destThing->getCylinder();
 			}
 		}
 	}

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -987,7 +987,11 @@ std::shared_ptr<Cylinder> Tile::queryDestination(int32_t &, const std::shared_pt
 		const auto &destThing = destTile->getTopDownItem();
 		if (destThing) {
 			destItem = destThing->getItem();
-			if (thing && thing->getItem()) {
+			const auto &thingItem = thing ? thing->getItem() : nullptr;
+			if (thingItem) {
+				if (thingItem->getMailbox() != destItem->getMailbox()) {
+					return destTile;
+				}
 				const auto &destCylinder = destThing->getCylinder();
 				if (destCylinder && !destCylinder->getContainer()) {
 					return destThing->getCylinder();


### PR DESCRIPTION
# Description

Fixes the houses mailbox that were not sending parcels and consuming them.

## Behaviour
### **Actual**

Try send an empty parcel and a parcel with a label addressed to a existing player and they will not be sent.

### **Expected**

Try send an empty parcel and it should not be sent and be placed at the top of the mailbox.
Try send a parcel with a label addressed to a existing player and it should be sent.

### Fixes #2891 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Try send an empty parcel
  - [x] Try send a parcel with a label addressed to a existing player

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
