### PR TITLE
feat: add soul core items

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -76427,5 +76427,3305 @@ Granted by TibiaGoals.com"/>
 		<attribute key="loottype" value="tools"/>
 		<attribute key="weight" value="30"/>
 	</item>
+	<item id="47381" article="an" name="orc warlord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47383" article="an" name="orc rider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47384" article="an" name="orc soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47385" article="an" name="orc shaman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47386" article="an" name="orc warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47387" article="an" name="orc berserker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47388" article="an" name="necromancer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47390" article="an" name="hunter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47392" article="an" name="sheep soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47394" article="an" name="bear soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47395" article="an" name="bonelord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47396" article="an" name="ghoul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47397" article="an" name="slime soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47398" article="an" name="rat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47399" article="an" name="cyclops soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47400" article="an" name="minotaur mage soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47401" article="an" name="minotaur archer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47402" article="an" name="minotaur soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47403" article="an" name="rotworm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47405" article="an" name="snake soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47406" article="an" name="minotaur guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47407" article="an" name="spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47408" article="an" name="deer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47409" article="an" name="dog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47410" article="an" name="skeleton soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47411" article="an" name="dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47412" article="an" name="demon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47413" article="an" name="poison spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47414" article="an" name="demon skeleton soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47415" article="an" name="giant spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47416" article="an" name="dragon lord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47417" article="an" name="fire devil soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47418" article="an" name="lion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47419" article="an" name="polar bear soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47420" article="an" name="scorpion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47422" article="an" name="bug soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47424" article="an" name="ghost soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47425" article="an" name="fire elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47426" article="an" name="orc spearman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47427" article="an" name="green djinn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47429" article="an" name="frost troll soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47431" article="an" name="behemoth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47432" article="an" name="cave rat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47433" article="an" name="monk soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47434" article="an" name="priestess soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47435" article="an" name="orc leader soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47436" article="an" name="pig soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47437" article="an" name="goblin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47438" article="an" name="elf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47439" article="an" name="elf arcanist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47440" article="an" name="elf scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47441" article="an" name="mummy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47442" article="an" name="dwarf geomancer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47443" article="an" name="stone golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47445" article="an" name="dwarf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47446" article="an" name="dwarf guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47447" article="an" name="dwarf soldier soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47448" article="an" name="stalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47449" article="an" name="hero soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47450" article="an" name="rabbit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47451" article="an" name="swamp troll soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47452" article="an" name="amazon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47453" article="an" name="banshee soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47454" article="an" name="ancient scarab soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47455" article="an" name="blue djinn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47456" article="an" name="cobra soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47457" article="an" name="larva soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47458" article="an" name="scarab soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47459" article="an" name="hyaena soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47460" article="an" name="gargoyle soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47461" article="an" name="lich soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47462" article="an" name="crypt shambler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47463" article="an" name="bonebeast soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47465" article="an" name="efreet soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47466" article="an" name="marid soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47467" article="an" name="badger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47468" article="an" name="skunk soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47470" article="an" name="elder bonelord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47471" article="an" name="gazer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47473" article="an" name="chicken soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47474" article="an" name="crab soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47475" article="an" name="lizard templar soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47476" article="an" name="lizard sentinel soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47477" article="an" name="lizard snakecharmer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47478" article="an" name="kongra soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47479" article="an" name="merlkin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47480" article="an" name="sibang soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47481" article="an" name="crocodile soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47482" article="an" name="carniphila soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47483" article="an" name="hydra soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47484" article="an" name="bat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47485" article="an" name="panda soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47486" article="an" name="centipede soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47488" article="an" name="elephant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47489" article="an" name="flamingo soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47490" article="an" name="butterfly soul core (purple)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47491" article="an" name="dworc voodoomaster soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47492" article="an" name="dworc fleshhunter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47493" article="an" name="dworc venomsniper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47494" article="an" name="parrot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47496" article="an" name="tarantula soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47497" article="an" name="serpent spawn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47498" article="an" name="spit nettle soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47499" article="an" name="smuggler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47500" article="an" name="bandit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47501" article="an" name="assassin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47502" article="an" name="dark monk soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47503" article="an" name="butterfly soul core (blue)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47504" article="an" name="butterfly soul core (red)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47506" article="an" name="quara predator soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47507" article="an" name="quara predator scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47508" article="an" name="quara constrictor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47509" article="an" name="quara constrictor scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47510" article="an" name="quara mantassin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47511" article="an" name="quara mantassin scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47512" article="an" name="quara hydromancer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47513" article="an" name="quara hydromancer scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47514" article="an" name="quara pincher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47515" article="an" name="quara pincher scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47516" article="an" name="pirate marauder soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47517" article="an" name="pirate cutthroat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47518" article="an" name="pirate buccaneer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47519" article="an" name="pirate corsair soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47520" article="an" name="carrion worm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47521" article="an" name="enlightened of the cult soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47522" article="an" name="acolyte of the cult soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47523" article="an" name="adept of the cult soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47524" article="an" name="novice of the cult soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47525" article="an" name="pirate skeleton soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47526" article="an" name="pirate ghost soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47529" article="an" name="mammoth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47530" article="an" name="blood crab soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47532" article="an" name="seagull soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47533" article="an" name="son of verminor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47534" article="an" name="green frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47535" article="an" name="azure frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47536" article="an" name="coral frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47537" article="an" name="crimson frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47538" article="an" name="orchid frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47539" article="an" name="island troll soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47540" article="an" name="massive water elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47541" article="an" name="hand of cursed fate soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47543" article="an" name="lost soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47544" article="an" name="betrayed wraith soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47545" article="an" name="dark torturer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47546" article="an" name="spectre soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47547" article="an" name="destroyer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47548" article="an" name="diabolic imp soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47549" article="an" name="defiler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47551" article="an" name="fury soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47552" article="an" name="phantasm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47553" article="an" name="hellhound soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47554" article="an" name="hellfire fighter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47555" article="an" name="juggernaut soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47556" article="an" name="blightwalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47557" article="an" name="nightmare soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47558" article="an" name="nomad soul core (basic)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47559" article="an" name="massive fire elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47560" article="an" name="plaguesmith soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47561" article="an" name="frost dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47562" article="an" name="penguin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47563" article="an" name="chakoya tribewarden soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47564" article="an" name="braindeath soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47565" article="an" name="barbarian skullhunter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47566" article="an" name="barbarian bloodwalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47567" article="an" name="frost giant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47568" article="an" name="ice golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47569" article="an" name="silver rabbit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47570" article="an" name="chakoya toolshaper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47571" article="an" name="chakoya windcaller soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47572" article="an" name="crystal spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47573" article="an" name="ice witch soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47574" article="an" name="barbarian brutetamer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47575" article="an" name="barbarian headsplitter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47576" article="an" name="frost giantess soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47577" article="an" name="dire penguin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47578" article="an" name="dark magician soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47579" article="an" name="dark apprentice soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47580" article="an" name="poacher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47581" article="an" name="goblin leader soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47582" article="an" name="dwarf henchman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47583" article="an" name="dryad soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47584" article="an" name="squirrel soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47585" article="an" name="dragon hatchling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47586" article="an" name="dragon lord hatchling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47587" article="an" name="cat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47589" article="an" name="cyclops smith soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47590" article="an" name="cyclops drone soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47592" article="an" name="grynch clan goblin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47593" article="an" name="frost dragon hatchling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47594" article="an" name="deepsea blood crab soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47595" article="an" name="sea serpent soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47598" article="an" name="skeleton warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47600" article="an" name="massive earth elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47601" article="an" name="energy elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47602" article="an" name="earth elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47603" article="an" name="bog raider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47606" article="an" name="goblin assassin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47607" article="an" name="goblin scavenger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47608" article="an" name="grim reaper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47619" article="an" name="mutated rat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47622" article="an" name="mutated bat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47624" article="an" name="haunted treeling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47626" article="an" name="acid blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47627" article="an" name="death blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47628" article="an" name="mercury blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47629" article="an" name="mutated tiger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47631" article="an" name="nightmare scion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47632" article="an" name="hellspawn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47633" article="an" name="nightstalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47634" article="an" name="mutated human soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47635" article="an" name="gozzler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47636" article="an" name="damaged worker golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47637" article="an" name="crazed beggar soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47638" article="an" name="gang member soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47639" article="an" name="gladiator soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47640" article="an" name="mad scientist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47641" article="an" name="infernalist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47643" article="an" name="furious troll soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47645" article="an" name="evil sheep soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47646" article="an" name="medusa soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47653" article="an" name="acolyte of darkness soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47654" article="an" name="nightslayer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47655" article="an" name="bane of light soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47656" article="an" name="duskbringer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47657" article="an" name="shadow hound soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47658" article="an" name="doomsday cultist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47659" article="an" name="midnight spawn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47660" article="an" name="midnight warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47661" article="an" name="herald of gloom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47662" article="an" name="bride of night soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47667" article="an" name="orc marauder soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47668" article="an" name="eternal guardian soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47669" article="an" name="lizard zaogun soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47670" article="an" name="draken warmaster soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47671" article="an" name="draken spellweaver soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47672" article="an" name="lizard chosen soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47673" article="an" name="insect swarm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47674" article="an" name="lizard dragon priest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47675" article="an" name="lizard legionnaire soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47676" article="an" name="lizard high guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47677" article="an" name="killer caiman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47678" article="an" name="gnarlhound soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47681" article="an" name="lancer beetle soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47682" article="an" name="sandcrawler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47683" article="an" name="ghastly dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47684" article="an" name="lizard magistratus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47685" article="an" name="lizard noble soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47686" article="an" name="draken elite soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47687" article="an" name="draken abomination soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47688" article="an" name="brimstone bug soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47689" article="an" name="souleater soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47690" article="an" name="bane bringer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47691" article="an" name="cake golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47697" article="an" name="berrypest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47698" article="an" name="boar soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47699" article="an" name="stampor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47700" article="an" name="draptor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47702" article="an" name="crustacea gigantica soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47703" article="an" name="midnight panther soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47704" article="an" name="iron servant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47705" article="an" name="golden servant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47706" article="an" name="diamond servant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47707" article="an" name="clay guardian soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47709" article="an" name="shaburak demon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47710" article="an" name="askarak demon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47712" article="an" name="slug soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47713" article="an" name="dromedary soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47714" article="an" name="deepling scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47715" article="an" name="bog frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47717" article="an" name="crystal wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47718" article="an" name="elf overseer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47722" article="an" name="deepling warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47723" article="an" name="deepling guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47724" article="an" name="deepling spellsinger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47725" article="an" name="shark soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47726" article="an" name="fish soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47727" article="an" name="crawler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47729" article="an" name="swarmer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47730" article="an" name="spitter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47732" article="an" name="deepling worker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47733" article="an" name="insectoid worker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47734" article="an" name="crystalcrusher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47735" article="an" name="mushroom sniffer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47738" article="an" name="enraged crystal golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47739" article="an" name="drillworm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47740" article="an" name="humongous fungus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47741" article="an" name="magma crawler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47742" article="an" name="enslaved dwarf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47743" article="an" name="lost berserker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47744" article="an" name="hideous fungus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47747" article="an" name="emerald damselfly soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47748" article="an" name="salamander soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47749" article="an" name="marsh stalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47750" article="an" name="corym charlatan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47751" article="an" name="corym skirmisher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47752" article="an" name="corym vanguard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47753" article="an" name="swampling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47754" article="an" name="adventurer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47755" article="an" name="lost husher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47756" article="an" name="lost basher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47757" article="an" name="lost thrower soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47760" article="an" name="shadow pupil soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47761" article="an" name="blood priest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47763" article="an" name="elder wyrm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47764" article="an" name="nightfiend soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47765" article="an" name="blood hand soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47766" article="an" name="gravedigger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47767" article="an" name="tarnished spirit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47768" article="an" name="rorc soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47769" article="an" name="leaf golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47770" article="an" name="forest fury soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47771" article="an" name="roaring lion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47773" article="an" name="furious fire elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47774" article="an" name="shock head soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47775" article="an" name="sight of surrender soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47776" article="an" name="guzzlemaw soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47777" article="an" name="silencer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47778" article="an" name="choking fear soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47780" article="an" name="retching horror soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47781" article="an" name="demon outcast soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47783" article="an" name="feversleep soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47784" article="an" name="frazzlemaw soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47786" article="an" name="glooth golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47787" article="an" name="metal gargoyle soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47788" article="an" name="blood beast soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47789" article="an" name="rustheap golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47790" article="an" name="glooth anemone soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47791" article="an" name="moohtant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47792" article="an" name="minotaur amazon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47793" article="an" name="execowtioner soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47794" article="an" name="mooh'tah warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47795" article="an" name="minotaur hunter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47797" article="an" name="glooth blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47798" article="an" name="rot elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47799" article="an" name="devourer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47810" article="an" name="abyssal calamary soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47812" article="an" name="high voltage elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47813" article="an" name="glooth bandit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47814" article="an" name="glooth brigand soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47815" article="an" name="raging fire soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47816" article="an" name="dawnfire asura soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47817" article="an" name="midnight asura soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47818" article="an" name="tainted soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47819" article="an" name="omnivora soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47824" article="an" name="renegade knight soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47826" article="an" name="ogre brute soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47827" article="an" name="ogre savage soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47828" article="an" name="ogre shaman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47829" article="an" name="clomp soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47830" article="an" name="grimeleech soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47832" article="an" name="hellflayer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47838" article="an" name="reality reaver soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47839" article="an" name="sparkion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47840" article="an" name="breach brood soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47842" article="an" name="dread intruder soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47844" article="an" name="instable sparkion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47845" article="an" name="instable breach brood soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47846" article="an" name="stabilizing reality reaver soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47847" article="an" name="stabilizing dread intruder soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47848" article="an" name="cave parrot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47849" article="an" name="orclops doomhauler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47850" article="an" name="orclops ravager soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47851" article="an" name="broken shaper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47853" article="an" name="iron servant replica soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47854" article="an" name="shaper matriarch soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47855" article="an" name="misguided bully soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47856" article="an" name="misguided thief soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47857" article="an" name="putrid mummy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47858" article="an" name="faun soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47859" article="an" name="pooka soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47861" article="an" name="pixie soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47862" article="an" name="boogy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47864" article="an" name="enfeebled silencer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47865" article="an" name="nymph soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47866" article="an" name="barkless devotee soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47867" article="an" name="barkless fanatic soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47868" article="an" name="dark faun soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47869" article="an" name="orc cult inquisitor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47870" article="an" name="orc cult minion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47871" article="an" name="minotaur cult follower soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47872" article="an" name="minotaur cult prophet soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47873" article="an" name="minotaur cult zealot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47874" article="an" name="cult believer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47875" article="an" name="cult enforcer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47876" article="an" name="stonerefiner soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47877" article="an" name="lost exile soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47878" article="an" name="deepworm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47879" article="an" name="diremaw soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47880" article="an" name="cave devourer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47882" article="an" name="chasm spawn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47883" article="an" name="fox soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47886" article="an" name="lava lurker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47888" article="an" name="ravenous lava lurker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47890" article="an" name="frost flower asura soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47896" article="an" name="floating savant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47899" article="an" name="falcon knight soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47900" article="an" name="falcon paladin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47901" article="an" name="brain squid soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47902" article="an" name="biting book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47903" article="an" name="ink blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47904" article="an" name="burning book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47905" article="an" name="icecold book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47906" article="an" name="energetic book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47907" article="an" name="energuardian of tales soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47908" article="an" name="deathling scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47909" article="an" name="rage squid soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47910" article="an" name="squid warden soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47911" article="an" name="animated feather soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47913" article="an" name="skeleton elite warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47915" article="an" name="deathling spellsinger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47916" article="an" name="lumbering carnivor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47917" article="an" name="spiky carnivor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47918" article="an" name="menacing carnivor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47919" article="an" name="ripper spectre soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47920" article="an" name="gazer spectre soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47921" article="an" name="burster spectre soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47923" article="an" name="arachnophobica soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47924" article="an" name="crazed winter vanguard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47925" article="an" name="crazed winter rearguard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47926" article="an" name="crazed summer vanguard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47927" article="an" name="crazed summer rearguard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47928" article="an" name="soul-broken harbinger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47929" article="an" name="insane siren soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47930" article="an" name="cobra assassin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47931" article="an" name="cobra scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47933" article="an" name="burning gladiator soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47934" article="an" name="priestess of the wild sun soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47935" article="an" name="black sphinx acolyte soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47936" article="an" name="crypt warden soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47937" article="an" name="lamassu soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47938" article="an" name="feral sphinx soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47939" article="an" name="sphinx soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47940" article="an" name="manticore soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47942" article="an" name="adult goanna soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47943" article="an" name="ogre ruffian soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47944" article="an" name="ogre rowdy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47945" article="an" name="ogre sage soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47946" article="an" name="cobra vizier soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47947" article="an" name="flimsy lost soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47948" article="an" name="mean lost soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47949" article="an" name="freakish lost soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47950" article="an" name="cursed prospector soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47951" article="an" name="evil prospector soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47952" article="an" name="bony sea devil soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47953" article="an" name="many faces soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47954" article="an" name="cloak of terror soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47956" article="an" name="brachiodemon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47957" article="an" name="branchy crawler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47958" article="an" name="capricious phantom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47959" article="an" name="infernal phantom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47961" article="an" name="infernal demon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47962" article="an" name="rotten golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47964" article="an" name="courage leech soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47965" article="an" name="mould phantom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47966" article="an" name="druid's apparition soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47967" article="an" name="knight's apparition soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47968" article="an" name="paladin's apparition soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47969" article="an" name="sorcerer's apparition soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47973" article="an" name="distorted phantom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47981" article="an" name="agrestic chicken soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47984" article="an" name="crypt warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47985" article="an" name="exotic cave spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47986" article="an" name="pirat cutthroat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47987" article="an" name="pirat scoundrel soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47988" article="an" name="pirat bombardier soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47989" article="an" name="pirat mate soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47990" article="an" name="exotic bat soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47991" article="an" name="lavaworm soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47994" article="an" name="streaked devourer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47995" article="an" name="eyeless devourer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47996" article="an" name="blemished spawn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47997" article="an" name="afflicted strider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47998" article="an" name="lavafungus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="47999" article="an" name="cave chimera soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48001" article="an" name="girtablilu warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48002" article="an" name="bashmu soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48003" article="an" name="juvenile bashmu soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48004" article="an" name="hulking carnisylvan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48005" article="an" name="poisonous carnisylvan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48006" article="an" name="dark carnisylvan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48032" article="an" name="parder soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48033" article="an" name="jungle moa soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48035" article="an" name="foam stalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48036" article="an" name="naga archer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48037" article="an" name="naga warrior soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48038" article="an" name="makara soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48039" article="an" name="sulphider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48040" article="an" name="sulphur spouter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48041" article="an" name="gore horn soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48042" article="an" name="sabretooth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48043" article="an" name="emerald tortoise soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48045" article="an" name="nighthunter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48046" article="an" name="hulking prehemoth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48047" article="an" name="stalking stalk soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48048" article="an" name="mantosaurus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48049" article="an" name="headpecker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48050" article="an" name="noxious ripptor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48051" article="an" name="gorerilla soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48052" article="an" name="shrieking cry-stal soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48053" article="an" name="mercurial menace soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48054" article="an" name="crape man soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48055" article="an" name="liodile soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48056" article="an" name="boar man soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48057" article="an" name="harpy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48058" article="an" name="carnivostrich soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48059" article="an" name="rhindeer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48060" article="an" name="iks pututu soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48061" article="an" name="iks aucar soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48062" article="an" name="iks chuka soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48063" article="an" name="cursed ape soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48064" article="an" name="iks ahpututu soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48065" article="an" name="mycobiontic beetle soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48066" article="an" name="meandering mushroom soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48067" article="an" name="oozing carcass soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48068" article="an" name="darklight construct soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48069" article="an" name="converter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48070" article="an" name="darklight matter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48071" article="an" name="oozing corpus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48072" article="an" name="darklight emitter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48076" article="an" name="feral werecrocodile soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48079" article="an" name="bloated man-maggot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48080" article="an" name="rotten man-maggot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48083" article="an" name="sopping carcass soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48084" article="an" name="sopping corpus soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48085" article="an" name="darklight source soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48086" article="an" name="darklight striker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48087" article="an" name="cunning werepanther soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48089" article="an" name="albino dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48091" article="an" name="iks yapunac soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48092" article="an" name="bulltaur brute soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48093" article="an" name="bulltaur alchemist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48094" article="an" name="bulltaur forgepriest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48095" article="an" name="dragolisk soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48097" article="an" name="mega dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48098" article="an" name="mitmah scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48099" article="an" name="mitmah seer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48929" article="an" name="black sheep soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48930" article="an" name="squidgy slime soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48931" article="an" name="husky soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48932" article="an" name="massive energy elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48933" article="an" name="evil sheep lord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48934" article="an" name="hot dog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48936" article="an" name="doom deer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48937" article="an" name="killer rabbit soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48938" article="an" name="berserker chicken soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48939" article="an" name="demon parrot soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48940" article="an" name="infernal frog soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48943" article="an" name="ghoulish hyaena soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48944" article="an" name="sandstone scorpion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48945" article="an" name="grave guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48947" article="an" name="sacred spider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48948" article="an" name="death priest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48949" article="an" name="elder mummy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48950" article="an" name="honour guard soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48951" article="an" name="feverish citizen soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48953" article="an" name="starving wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48954" article="an" name="shaburak lord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48955" article="an" name="shaburak prince soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48956" article="an" name="askarak lord soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48957" article="an" name="askarak prince soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48958" article="an" name="insectoid scout soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48959" article="an" name="filth toad soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48960" article="an" name="firestarter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48961" article="an" name="horse soul core (taupe)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48962" article="an" name="horse soul core (brown)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48963" article="an" name="horse soul core (gray)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48965" article="an" name="nomad soul core (blue)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48966" article="an" name="nomad soul core (female)">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48967" article="an" name="ladybug soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48968" article="an" name="manta ray soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48969" article="an" name="calamary soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48970" article="an" name="jellyfish soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48971" article="an" name="northern pike soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48972" article="an" name="spidris soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48973" article="an" name="kollos soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48974" article="an" name="spidris elite soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48975" article="an" name="hive overseer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48976" article="an" name="deepling brawler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48977" article="an" name="deepling master librarian soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48978" article="an" name="deepling tyrant soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48979" article="an" name="deepling elite soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48980" article="an" name="grave robber soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48981" article="an" name="crypt defiler soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48982" article="an" name="damaged crystal golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48983" article="an" name="modified gnarlhound soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48984" article="an" name="stone devourer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48985" article="an" name="armadile soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48987" article="an" name="orewalker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48988" article="an" name="lava golem soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48989" article="an" name="cliff strider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48990" article="an" name="ironblight soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48991" article="an" name="dragonling soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48992" article="an" name="infected weeper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48993" article="an" name="pigeon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48994" article="an" name="little corym charlatan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48996" article="an" name="seacrest serpent soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48997" article="an" name="renegade quara constrictor soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48998" article="an" name="renegade quara hydromancer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="48999" article="an" name="renegade quara mantassin soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49000" article="an" name="renegade quara pincher soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49001" article="an" name="renegade quara predator soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49002" article="an" name="minotaur invader soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49003" article="an" name="noble lion soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49004" article="an" name="redeemed soul soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49005" article="an" name="gloom wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49006" article="an" name="ghost wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49007" article="an" name="elder forest fury soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49008" article="an" name="diamond servant replica soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49009" article="an" name="golden servant replica soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49010" article="an" name="haunted dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49011" article="an" name="ice dragon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49012" article="an" name="stone rhino soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49013" article="an" name="swan maiden soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49014" article="an" name="goldhanded cultist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49015" article="an" name="goldhanded cultist bride soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49016" article="an" name="orc cultist soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49017" article="an" name="orc cult priest soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49018" article="an" name="orc cult fanatic soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49019" article="an" name="cult scholar soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49020" article="an" name="mole soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49021" article="an" name="arctic faun soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49022" article="an" name="flying book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49023" article="an" name="cursed book soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49024" article="an" name="guardian of tales soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49025" article="an" name="knowledge elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49026" article="an" name="lacewing moth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49027" article="an" name="hibernal moth soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49028" article="an" name="percht soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49029" article="an" name="schiach soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49030" article="an" name="baleful bunny soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49031" article="an" name="animated snowman soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49032" article="an" name="gryphon soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49033" article="an" name="orger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49034" article="an" name="roast pork soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49035" article="an" name="cow soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49036" article="an" name="loricate orger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49037" article="an" name="bellicose orger soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49039" article="an" name="iks churrascan soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49040" article="an" name="rabid wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49041" article="an" name="ragged rabid wolf soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49073" article="an" name="nibblemaw soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49074" article="an" name="candy floss elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49075" article="an" name="goggle cake soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49076" article="an" name="candy horror soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49077" article="an" name="rootthing bug tracker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49078" article="an" name="rootthing amber shaper soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49079" article="an" name="rootthing nutshell soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49080" article="an" name="quara raider soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49081" article="an" name="quara plunderer soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49082" article="an" name="quara looter soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49085" article="an" name="sugar cube soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49086" article="an" name="gingerbread man soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49087" article="an" name="chocolate blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49088" article="an" name="honey elemental soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49089" article="an" name="angry sugar fairy soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49092" article="an" name="fruit drop soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49094" article="an" name="sugar cube worker soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49095" article="an" name="cream blob soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
+	<item id="49163" article="an" name="ominous soul core">
+		<attribute key="primarytype" value="soul cores"/>
+		<attribute key="description" value="Offers a soul to the Soulpit. Combine with an exalted core to turn it into a lesser soul core."/>
+		<attribute key="weight" value="100"/>
+	</item>
 </items>
 


### PR DESCRIPTION
# Description

Add 660 Soulcore items, in preparation to further Soulpit Development.

**Extracted via script using Python - Source: Tibia Fandom** - Already sorted in descending order of ID.

## Behaviour
### **Actual**

Canary don't have Soul Core Items.

### **Expected**

Canary should have Soul Core Items.


## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Check if Soul Core item's is spawnable.

**Test Configuration**:

  - Server Version: LATEST
  - Client: 13.40
  - Operating System: NA

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
