### PR TITLE
fix: combat type out of index in ashes item

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -4435,6 +4435,9 @@
 	<item id="2140" name="ashes">
 		<attribute key="primarytype" value="fields"/>
 		<attribute key="type" value="magicfield"/>
+		<attribute key="field" value="fire">
+			<attribute key="damage" value="0"/>
+		</attribute>
 		<attribute key="replaceable" value="0"/>
 		<attribute key="duration" value="5"/>
 		<attribute key="decayTo" value="2137"/>


### PR DESCRIPTION
# Description

Fixes #2874

## Behaviour
### **Actual**

Fix combat type out of index error being spammable if monster is above this specific item.

**Also, this should be take in consideration. If a item with primaryType field don't have the attribute key "field" with a proper value and damage as sub-attribute, this can cause a errors.**

### **Expected**

Not throw errors and spamming on terminal.

### Fixes #2874

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Make a monster walk above this item.

**Test Configuration**:

  - Server Version: Canary Latest
  - Client: 13.40
  - Operating System: N/A

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
