### PR TITLE
fix: remove bit_functions from vcxproj

### DIFF
--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -137,7 +137,6 @@
     <ClInclude Include="..\src\lua\functions\core\game\zone_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\core\game\lua_enums.hpp" />
     <ClInclude Include="..\src\lua\functions\core\game\modal_window_functions.hpp" />
-    <ClInclude Include="..\src\lua\functions\core\libs\bit_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\core\libs\core_libs_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\core\libs\kv_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\core\libs\db_functions.hpp" />
@@ -336,7 +335,6 @@
     <ClCompile Include="..\src\lua\functions\core\game\zone_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\core\game\lua_enums.cpp" />
     <ClCompile Include="..\src\lua\functions\core\game\modal_window_functions.cpp" />
-    <ClCompile Include="..\src\lua\functions\core\libs\bit_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\core\libs\kv_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\core\libs\db_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\core\libs\result_functions.cpp" />


### PR DESCRIPTION
# Description

At some point, the bit_functions.cpp and bit_functions.h files were removed from the project, but they continued to be referenced in the Visual Studio .vcxproj file, causing an error when trying to compile using it.

## Behaviour
### **Actual**

![image](https://github.com/user-attachments/assets/196b0ba5-b32e-49bb-b63a-a0d70fb5c303)

Compilation Error!!

![image](https://github.com/user-attachments/assets/8c3470c5-8989-4618-9ce2-7ae2b7002cb7)

### **Expected**

Compilation Success!!

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Compile the project using visual studio 2022 with vcpkg.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
