### PR TITLE
fix: resolve nil index issue in destroy script callback

### DIFF
--- a/data-canary/scripts/actions/other/destroy.lua
+++ b/data-canary/scripts/actions/other/destroy.lua
@@ -250,7 +250,7 @@ local setting = {
 local destroy = Action()
 
 function destroy.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	return ActionsLib.destroyItem(player, target, toPosition)
+	return destroyItem(player, target, toPosition)
 end
 
 for index, value in ipairs(setting) do


### PR DESCRIPTION
# Description
Fixed an error in the item destruction script where calling `ActionsLib.destroyItem` resulted in a `nil` reference. The function call was adjusted to use `destroyItem` directly, ensuring the script works correctly and avoids global index errors.

# Fixes
```
Interface: Scripts Interface
Script ID: D:\Repositorios Git\baiak-yurots\data-canary/scripts\actions\other\destroy.lua:callback
Error Description: ...iak-yurots\data-canary/scripts\actions\other\destroy.lua:253: attempt to index global 'ActionsLib' (a nil value)
stack traceback:
        [C]: in function '__index'
        ...iak-yurots\data-canary/scripts\actions\other\destroy.lua:253: in function <...iak-yurots\data-canary/scripts\actions\other\destroy.lua:252>
```

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
