### PR TITLE
fix: sharpshooter not applying paralyze icon

### DIFF
--- a/data/scripts/spells/support/sharpshooter.lua
+++ b/data/scripts/spells/support/sharpshooter.lua
@@ -4,9 +4,9 @@ local combat = Combat()
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 
-local speed = Condition(CONDITION_HASTE)
+local speed = Condition(CONDITION_PARALYZE)
 speed:setParameter(CONDITION_PARAM_TICKS, spellDuration)
-speed:setFormula(0.7, 0, 0.7, 0)
+speed:setFormula(0.7, 56, 0.7, 56)
 combat:addCondition(speed)
 
 local exhaustHealGroup = Condition(CONDITION_SPELLGROUPCOOLDOWN)


### PR DESCRIPTION
# Description

This commit aims to fix a problem that occurs when a player cast sharpshooter. 
The main behavior should be remove haste icon  and apply paralyze, counting with the speed decreasement.

(utito tempo san)

## Behaviour
### **Actual**

![image](https://github.com/user-attachments/assets/feab5bb6-f560-4a22-a5cb-4f94d6dfd4a1)

### **Expected**

![image](https://github.com/user-attachments/assets/77d469ad-22c1-4df2-98d5-1175cee5af74)


## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Cast utito tempo san and see if the haste icon will dissapear. Paralyze icon should be displayed.
  - [x] The speed should be decrease at 70%

**Test Configuration**:

  - Server Version: latest
  - Client: latest
  - Operating System: latest

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
