### PR TITLE
fix: wheel spells bonuses

### DIFF
--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -23,9 +23,6 @@
 #include "lua/scripts/scripts.hpp"
 #include "lib/di/container.hpp"
 
-std::array<int32_t, static_cast<uint8_t>(WheelSpellBoost_t::TOTAL_COUNT)> wheelOfDestinyRegularBoost = { 0 };
-std::array<int32_t, static_cast<uint8_t>(WheelSpellBoost_t::TOTAL_COUNT)> wheelOfDestinyUpgradedBoost = { 0 };
-
 Spells::Spells() = default;
 Spells::~Spells() = default;
 

--- a/src/creatures/combat/spells.hpp
+++ b/src/creatures/combat/spells.hpp
@@ -10,9 +10,7 @@
 #pragma once
 
 #include "lua/creature/actions.hpp"
-
-enum class WheelSpellBoost_t : uint8_t;
-enum class WheelSpellGrade_t : uint8_t;
+#include "creatures/players/wheel/wheel_definitions.hpp"
 
 class InstantSpell;
 class RuneSpell;
@@ -256,6 +254,8 @@ protected:
 	bool pzLocked = false;
 
 	bool whellOfDestinyUpgraded = false;
+	std::array<int32_t, static_cast<uint8_t>(WheelSpellBoost_t::TOTAL_COUNT)> wheelOfDestinyRegularBoost = { 0 };
+	std::array<int32_t, static_cast<uint8_t>(WheelSpellBoost_t::TOTAL_COUNT)> wheelOfDestinyUpgradedBoost = { 0 };
 
 private:
 	uint32_t mana = 0;

--- a/src/io/io_wheel.cpp
+++ b/src/io/io_wheel.cpp
@@ -58,7 +58,7 @@ namespace InternalPlayerWheel {
 			return;
 		}
 
-		auto spell = g_spells().getInstantSpellByName(name);
+		const auto &spell = g_spells().getInstantSpellByName(name);
 		if (spell) {
 			g_logger().trace("[{}] registering instant spell with name {}", __FUNCTION__, spell->getName());
 			// Increase data
@@ -127,7 +127,7 @@ bool IOWheel::initializeGlobalData(bool reload /* = false*/) {
 	// Register spells for druid
 	for (const auto &data : getWheelBonusData().spells.druid) {
 		for (size_t i = 1; i < 3; ++i) {
-			const auto grade = data.grade[i];
+			const auto &grade = data.grade[i];
 			InternalPlayerWheel::registerWheelSpellTable(grade, data.name, static_cast<WheelSpellGrade_t>(i));
 		}
 	}


### PR DESCRIPTION
# Description

This fixes the issue that some spells was sharing bonuses between all other spells

## Behaviour
### **Actual**

All spells sharing the same bonuses

### **Expected**

All spells are not sharing the same bonuses

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Log in on a Paladin and add the max points to the first Divine Caldera spell
  - [x] Say the spell and it shouldn't be the cooldown reduced

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
