### PR TITLE
fix: xp rates display

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2739,12 +2739,20 @@ uint16_t Player::getGrindingXpBoost() const {
 	return grindingXpBoost;
 }
 
+uint16_t Player::getDisplayGrindingXpBoost() const {
+	return std::clamp<uint16_t>(grindingXpBoost * (baseXpGain / 100), 0, std::numeric_limits<uint16_t>::max());
+}
+
 void Player::setGrindingXpBoost(uint16_t value) {
 	grindingXpBoost = std::min<uint16_t>(std::numeric_limits<uint16_t>::max(), value);
 }
 
 uint16_t Player::getXpBoostPercent() const {
 	return xpBoostPercent;
+}
+
+uint16_t Player::getDisplayXpBoostPercent() const {
+	return std::clamp<uint16_t>(xpBoostPercent * (baseXpGain / 100), 0, std::numeric_limits<uint16_t>::max());
 }
 
 void Player::setXpBoostPercent(uint16_t percent) {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -972,8 +972,10 @@ public:
 	uint16_t getVoucherXpBoost() const;
 	void setVoucherXpBoost(uint16_t value);
 	uint16_t getGrindingXpBoost() const;
+	uint16_t getDisplayGrindingXpBoost() const;
 	void setGrindingXpBoost(uint16_t value);
 	uint16_t getXpBoostPercent() const;
+	uint16_t getDisplayXpBoostPercent() const;
 	void setXpBoostPercent(uint16_t percent);
 	uint16_t getStaminaXpBoost() const;
 	void setStaminaXpBoost(uint16_t value);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -3480,8 +3480,8 @@ void ProtocolGame::sendCyclopediaCharacterGeneralStats() {
 	msg.add<uint16_t>(player->getLevel());
 	msg.addByte(player->getLevelPercent());
 	msg.add<uint16_t>(player->getBaseXpGain()); // BaseXPGainRate
-	msg.add<uint16_t>(player->getGrindingXpBoost()); // LowLevelBonus
-	msg.add<uint16_t>(player->getXpBoostPercent()); // XPBoost
+	msg.add<uint16_t>(player->getDisplayGrindingXpBoost()); // LowLevelBonus
+	msg.add<uint16_t>(player->getDisplayXpBoostPercent()); // XPBoost
 	msg.add<uint16_t>(player->getStaminaXpBoost()); // StaminaMultiplier(100=x1.0)
 	msg.add<uint16_t>(player->getXpBoostTime()); // xpBoostRemainingTime
 	msg.addByte(player->getXpBoostTime() > 0 ? 0x00 : 0x01); // canBuyXpBoost
@@ -7840,8 +7840,8 @@ void ProtocolGame::AddPlayerStats(NetworkMessage &msg) {
 		msg.add<uint16_t>(player->getVoucherXpBoost()); // xp voucher
 	}
 
-	msg.add<uint16_t>(player->getGrindingXpBoost()); // low level bonus
-	msg.add<uint16_t>(player->getXpBoostPercent()); // xp boost
+	msg.add<uint16_t>(player->getDisplayGrindingXpBoost()); // low level bonus
+	msg.add<uint16_t>(player->getDisplayXpBoostPercent()); // xp boost
 	msg.add<uint16_t>(player->getStaminaXpBoost()); // stamina multiplier (100 = 1.0x)
 
 	if (!oldProtocol) {


### PR DESCRIPTION
# Description

This fixes the display xp rates with low level bonus and boost xp.

## Behaviour
### **Actual**

XP boost:

![image](https://github.com/user-attachments/assets/e83903ff-2327-4e2d-876a-f44645a3e327)

Low Level:

![image](https://github.com/user-attachments/assets/ac6fe81a-c1ec-46bd-a496-34930ce021ab)

Low Level + XP boost:

![image](https://github.com/user-attachments/assets/dd656575-42cb-4129-abe9-fd85dc645ffa)

### **Expected**

XP boost:

![image](https://github.com/user-attachments/assets/f6e44df6-1ab6-468c-8609-b315aec85707)

Low Level:

![image](https://github.com/user-attachments/assets/8e4d55d6-94bd-4d3b-a2ec-c5c1f4ffafda)

Low Level + XP boost:

![image](https://github.com/user-attachments/assets/fbfeb280-2b18-45ec-a6e4-abfe7bda10c2)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Log in on a low level character and check the xp bonus
  - [x] Buy a xp boost and check the xp bonus (on low level character, level <50 and on a higher level)

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
