### PR TITLE
fix: forge history

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5745,14 +5745,21 @@ void ProtocolGame::sendForgeHistory(uint8_t page) {
 	page = page + 1;
 	auto historyVector = player->getForgeHistory();
 	auto historyVectorLen = historyVector.size();
-	uint16_t lastPage = (1 < std::floor((historyVectorLen - 1) / 9) + 1) ? static_cast<uint16_t>(std::floor((historyVectorLen - 1) / 9) + 1) : 1;
-	uint16_t currentPage = (lastPage < page) ? lastPage : page;
+
+	uint16_t currentPage, lastPage = 1;
+	uint16_t pageFirstEntry, pageLastEntry = 0;
 
 	std::vector<ForgeHistory> historyPerPage;
-	uint16_t pageFirstEntry = (0 < historyVectorLen - (currentPage - 1) * 9) ? historyVectorLen - (currentPage - 1) * 9 : 0;
-	uint16_t pageLastEntry = (0 < historyVectorLen - currentPage * 9) ? historyVectorLen - currentPage * 9 : 0;
-	for (uint16_t entry = pageFirstEntry; entry > pageLastEntry; --entry) {
-		historyPerPage.emplace_back(historyVector[entry - 1]);
+	if (historyVectorLen > 0) {
+		lastPage = std::clamp<uint16_t>(std::floor((historyVectorLen - 1) / 9) + 1, 0, std::numeric_limits<uint16_t>::max());
+		currentPage = (lastPage < page) ? lastPage : page;
+
+		pageFirstEntry = std::clamp<uint16_t>(historyVectorLen - (currentPage - 1) * 9, 0, std::numeric_limits<uint16_t>::max());
+		pageLastEntry = historyVectorLen > currentPage * 9 ? std::clamp<uint16_t>(historyVectorLen - currentPage * 9, 0, std::numeric_limits<uint16_t>::max()) : 0;
+
+		for (uint16_t entry = pageFirstEntry; entry > pageLastEntry; --entry) {
+			historyPerPage.emplace_back(historyVector[entry - 1]);
+		}
 	}
 
 	auto historyPageToSend = historyPerPage.size();

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5746,8 +5746,10 @@ void ProtocolGame::sendForgeHistory(uint8_t page) {
 	auto historyVector = player->getForgeHistory();
 	auto historyVectorLen = historyVector.size();
 
-	uint16_t currentPage, lastPage = 1;
-	uint16_t pageFirstEntry, pageLastEntry = 0;
+	uint16_t currentPage = 1;
+	uint16_t lastPage = 1;
+	uint16_t pageFirstEntry = 0;
+	uint16_t pageLastEntry = 0;
 
 	std::vector<ForgeHistory> historyPerPage;
 	if (historyVectorLen > 0) {


### PR DESCRIPTION
# Description

This fixes the history forge that is crashing the server trying to access an index of a empty vector.

## Behaviour
### **Actual**

Open the forge window and the server crash

### **Expected**

Open the forge window and check the history, it should display the history if there is history and none if forge was never used

### Fixes #3121 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Open forge window in a fresh character
  - [x] Do some operations
  - [x] Check if the history was filled

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
