### PR TITLE
fix: ebb and flow boat summons teleport

### DIFF
--- a/data-otservbr-global/lib/quests/soul_war.lua
+++ b/data-otservbr-global/lib/quests/soul_war.lua
@@ -1455,7 +1455,7 @@ function Player:getSoulWarZoneMonster()
 	return zoneMonsterName
 end
 
-function Player:isInBoatSpot()
+function Creature:isInBoatSpot()
 	-- Get ebb and flow zone and check if player is in zone
 	local zone = SoulWarQuest.ebbAndFlow.getZone()
 	local tile = Tile(self:getPosition())
@@ -1464,11 +1464,11 @@ function Player:isInBoatSpot()
 		groundId = tile:getGround():getId()
 	end
 	if zone and zone:isInZone(self:getPosition()) and tile and groundId == SoulWarQuest.ebbAndFlow.boatId then
-		logger.trace("Player {} is in boat spot", self:getName())
+		logger.trace("Creature {} is in boat spot", self:getName())
 		return true
 	end
 
-	logger.trace("Player {} is not in boat spot", self:getName())
+	logger.trace("Creature {} is not in boat spot", self:getName())
 	return false
 end
 

--- a/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -18,17 +18,25 @@ local function updateWaterPoolsSize()
 end
 
 local function loadMapEmpty()
-	if SoulWarQuest.ebbAndFlow.getZone():countPlayers() > 0 then
-		local players = SoulWarQuest.ebbAndFlow.getZone():getPlayers()
-		for _, player in ipairs(players) do
-			if player:getPosition().z == 8 then
-				if player:isInBoatSpot() then
-					local teleportPosition = player:getPosition()
-					teleportPosition.z = 9
-					player:teleportTo(teleportPosition)
-					logger.trace("Teleporting player to down.")
+local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
+	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
+	if playersInZone > 0 or monstersInZone > 0 then
+		local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
+		for _, creature in ipairs(creatures) do
+			local creatureMaster = creature:getMaster()
+			local player = creature:getPlayer()
+			if creature:isPlayer() or (creature:isMonster() and creatureMaster and creatureMaster:getPlayer()) then
+				if creature:getPosition().z == 8 then
+					if creature:isInBoatSpot() then
+						local teleportPosition = creature:getPosition()
+						teleportPosition.z = 9
+						creature:teleportTo(teleportPosition)
+						logger.trace("Teleporting player to down.")
+					end
+					if player then
+						player:sendCreatureAppear()
+					end
 				end
-				player:sendCreatureAppear()
 			end
 		end
 	end
@@ -72,22 +80,30 @@ local function findNearestRoomPosition(playerPosition)
 end
 
 local function loadMapInundate()
-	if SoulWarQuest.ebbAndFlow.getZone():countPlayers() > 0 then
-		local players = SoulWarQuest.ebbAndFlow.getZone():getPlayers()
-		for _, player in ipairs(players) do
-			local playerPosition = player:getPosition()
-			if playerPosition.z == 9 then
-				if player:isInBoatSpot() then
-					local nearestCenterPosition = findNearestRoomPosition(playerPosition)
-					player:teleportTo(nearestCenterPosition)
-					logger.trace("Teleporting player to the near center position room and updating tile.")
-				else
-					player:teleportTo(SoulWarQuest.ebbAndFlow.waitPosition)
-					logger.trace("Teleporting player to wait position and updating tile.")
+	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
+	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
+	if playersInZone > 0 or monstersInZone > 0 then
+		local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
+		for _, creature in ipairs(creatures) do
+			local creatureMaster = creature:getMaster()
+			local player = creature:getPlayer()
+			if creature:isPlayer() or (creature:isMonster() and creatureMaster and creatureMaster:getPlayer()) then
+				local creaturePosition = creature:getPosition()
+				if creaturePosition.z == 9 then
+					if creature:isInBoatSpot() then
+						local nearestCenterPosition = findNearestRoomPosition(creaturePosition)
+						creature:teleportTo(nearestCenterPosition)
+						logger.trace("Teleporting player to the near center position room and updating tile.")
+					else
+						creature:teleportTo(SoulWarQuest.ebbAndFlow.waitPosition)
+						logger.trace("Teleporting player to wait position and updating tile.")
+					end
+					creaturePosition:sendMagicEffect(CONST_ME_TELEPORT)
 				end
-				playerPosition:sendMagicEffect(CONST_ME_TELEPORT)
+				if player then
+					player:sendCreatureAppear()
+				end
 			end
-			player:sendCreatureAppear()
 		end
 	end
 

--- a/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -18,7 +18,7 @@ local function updateWaterPoolsSize()
 end
 
 local function loadMapEmpty()
-local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
+	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
 	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
 	if playersInZone > 0 or monstersInZone > 0 then
 		local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()


### PR DESCRIPTION
# Description

This fixes the ebb and flow boat teleport that was not teleporting player summons

## Behaviour
### **Actual**

Ebb and flow boat does not teleport player summons

### **Expected**

Ebb and flow boat does teleport player summons

### Fixes #2943 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Go to ebb and flow with a summon
  - [x] Wait to inundate and empty the water map inside the boat with the summon, you and the summon should be teleported to new positions

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
