### PR TITLE
fix: remove duplicate "update impact tracker" for elemental damage

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7428,10 +7428,6 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature> &attacker, const s
 
 		target->drainHealth(attacker, realDamage);
 		if (realDamage > 0 && targetMonster) {
-			if (attackerPlayer && attackerPlayer->getPlayer()) {
-				attackerPlayer->updateImpactTracker(damage.secondary.type, damage.secondary.value);
-			}
-
 			if (targetMonster->israndomStepping()) {
 				targetMonster->setIgnoreFieldDamage(true);
 			}


### PR DESCRIPTION
It's already send here: https://github.com/opentibiabr/canary/blob/729387bc8b8a6171de32d936a6442cb285c9da42/src/game/game.cpp#L7375