### PR TITLE
fix: initialize totalCost correctly and refactor blessing purchase logic

### DIFF
--- a/data/libs/systems/blessing.lua
+++ b/data/libs/systems/blessing.lua
@@ -258,8 +258,9 @@ Blessings.BuyAllBlesses = function(player)
 	local hasToF = Blessings.Config.HasToF and player:hasBlessing(1) or true
 	local missingBless = player:getBlessings(nil, donthavefilter)
 	local missingBlessAmt = #missingBless + (hasToF and 0 or 1)
-	local totalCost
-	for i, bless in ipairs(missingBless) do
+	local totalCost = 0
+
+	for _, bless in ipairs(missingBless) do
 		totalCost = totalCost + Blessings.getBlessingCost(player:getLevel(), true, bless.id >= 7)
 	end
 
@@ -274,19 +275,19 @@ Blessings.BuyAllBlesses = function(player)
 	end
 
 	if player:removeMoneyBank(totalCost) then
-		metrics.addCounter("balance_decrease", remainsPrice, {
+		metrics.addCounter("balance_decrease", totalCost, {
 			player = player:getName(),
 			context = "blessings",
 		})
 
-		for i, v in ipairs(missingBless) do
-			player:addBlessing(v.id, 1)
+		for _, bless in ipairs(missingBless) do
+			player:addBlessing(bless.id, 1)
 		end
 
-		player:sendCancelMessage("You received the remaining " .. missingBlessAmt .. " blesses for a total of " .. totalCost .. " gold.")
+		player:sendCancelMessage(string.format("You received the remaining %d blesses for a total of %d gold.", missingBlessAmt, totalCost))
 		player:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 	else
-		player:sendCancelMessage("You don't have enough money. You need " .. totalCost .. " to buy all blesses.", cid)
+		player:sendCancelMessage(string.format("You don't have enough money. You need %d to buy all blesses.", totalCost))
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	end
 


### PR DESCRIPTION
# Description
This PR fixes the initialization of the `totalCost` variable and refactors the blessing purchase logic. Improvements include replacing string concatenation with `string.format` for more efficient formatting, as well as adjustments for better code clarity and readability. The code is now more organized, and the calculation error has been fixed.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
