### PR TITLE
fix: prevent teleportation

### DIFF
--- a/src/game/movement/teleport.cpp
+++ b/src/game/movement/teleport.cpp
@@ -80,29 +80,27 @@ void Teleport::addThing(int32_t, const std::shared_ptr<Thing> &thing) {
 	// Prevent infinity loop
 	if (checkInfinityLoop(destTile)) {
 		const Position &pos = getPosition();
-		g_logger().warn("[Teleport:addThing] - "
-		                "Infinity loop teleport at position: {}",
-		                pos.toString());
+		g_logger().warn("[Teleport:addThing] - Infinity loop teleport at position: {}", pos.toString());
 		return;
 	}
 
 	const MagicEffectClasses effect = Item::items[id].magicEffect;
 
-	if (const std::shared_ptr<Creature> &creature = thing->getCreature()) {
+	if (const auto &creature = thing->getCreature()) {
 		Position origPos = creature->getPosition();
 		g_game().internalCreatureTurn(creature, origPos.x > destPos.x ? DIRECTION_WEST : DIRECTION_EAST);
-		g_dispatcher().addWalkEvent([=] {
-			g_game().map.moveCreature(creature, destTile);
-			if (effect != CONST_ME_NONE) {
-				g_game().addMagicEffect(origPos, effect);
-				g_game().addMagicEffect(destTile->getPosition(), effect);
-			}
-		});
+		g_game().map.moveCreature(creature, destTile);
+
+		if (effect != CONST_ME_NONE) {
+			g_game().addMagicEffect(origPos, effect);
+			g_game().addMagicEffect(destTile->getPosition(), effect);
+		}
 	} else if (const auto &item = thing->getItem()) {
 		if (effect != CONST_ME_NONE) {
 			g_game().addMagicEffect(destTile->getPosition(), effect);
 			g_game().addMagicEffect(item->getPosition(), effect);
 		}
+
 		g_game().internalMoveItem(getTile(), destTile, INDEX_WHEREEVER, item, item->getItemCount(), nullptr);
 	}
 }


### PR DESCRIPTION
# Description
This PR fixes an issue where the player was teleported even when a Lua script was blocking the action. Additionally, the code has been refactored to optimize the handling of magic effects, eliminating redundancies and improving readability. The logic for checking and applying the magic effect has been consolidated, making the code more efficient.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
