### PR TITLE
fix: crash on try gem grade upgrade greater than 3

### DIFF
--- a/src/creatures/players/wheel/player_wheel.cpp
+++ b/src/creatures/players/wheel/player_wheel.cpp
@@ -1448,8 +1448,13 @@ void PlayerWheel::improveGemGrade(WheelFragmentType_t fragmentType, uint8_t pos)
 			return;
 	}
 
+	if (value == 0 && quantity == 0) {
+		g_logger().error("[{}] Player {} trying to upgrade gem to grade greater than 3", std::source_location::current().function_name(), m_player.getName());
+		return;
+	}
+
 	if (!m_player.hasItemCountById(fragmentId, quantity, true)) {
-		g_logger().error("[{}] Player {} does not have the required {} fragments with id {}", __FUNCTION__, m_player.getName(), quantity, fragmentId);
+		g_logger().error("[{}] Player {} does not have the required {} fragments with id {}", std::source_location::current().function_name(), m_player.getName(), quantity, fragmentId);
 		return;
 	}
 
@@ -1477,7 +1482,7 @@ std::tuple<int, int> PlayerWheel::getLesserGradeCost(uint8_t grade) const {
 		case 3:
 			return std::make_tuple(30000000, 30);
 		default:
-			throw std::invalid_argument("Invalid level for Lesser Fragment.");
+			return {};
 	}
 }
 
@@ -1490,7 +1495,7 @@ std::tuple<int, int> PlayerWheel::getGreaterGradeCost(uint8_t grade) const {
 		case 3:
 			return std::make_tuple(75000000, 30);
 		default:
-			throw std::invalid_argument("Invalid level for Greater Fragment.");
+			return {};
 	}
 }
 


### PR DESCRIPTION
# Description

Fixes the crash when trying to upgrade gem to a grade greater than 3

## Behaviour
### **Actual**

Crashes the server when trying to upgrade gem to a grade greater than 3.

### **Expected**

Only logs the error when trying to upgrade gem to a grade greater than 3.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Try upgrading gem to a grade greater than 3

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
