### PR TITLE
fix: packet interpretation parseSetOutfit for otcv8/old protocol

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1689,7 +1689,7 @@ void ProtocolGame::parseSetOutfit(NetworkMessage &msg) {
 				g_logger().debug("Bool isMounted: {}", isMounted);
 			}
 
-			uint8_t isMountRandomized = msg.getByte();
+			uint8_t isMountRandomized = !oldProtocol ? msg.getByte() : 0;
 			g_game().playerChangeOutfit(player->getID(), newOutfit, isMountRandomized);
 		} else if (outfitType == 1) {
 			// This value probably has something to do with try outfit variable inside outfit window dialog
@@ -3247,12 +3247,6 @@ void ProtocolGame::sendCreatureOutfit(const std::shared_ptr<Creature> &creature,
 	msg.add<uint32_t>(creature->getID());
 	AddOutfit(msg, newOutfit);
 
-	if (!oldProtocol && newOutfit.lookMount != 0) {
-		msg.addByte(newOutfit.lookMountHead);
-		msg.addByte(newOutfit.lookMountBody);
-		msg.addByte(newOutfit.lookMountLegs);
-		msg.addByte(newOutfit.lookMountFeet);
-	}
 	writeToOutputBuffer(msg);
 }
 
@@ -7184,10 +7178,12 @@ void ProtocolGame::sendOutfitWindow() {
 		return;
 	}
 
-	msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountHead);
-	msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountBody);
-	msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountLegs);
-	msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountFeet);
+	if (currentOutfit.lookMount == 0) {
+		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountHead);
+		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountBody);
+		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountLegs);
+		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountFeet);
+	}
 	msg.add<uint16_t>(currentOutfit.lookFamiliarsType);
 
 	auto startOutfits = msg.getBufferPosition();
@@ -7750,12 +7746,6 @@ void ProtocolGame::AddCreature(NetworkMessage &msg, const std::shared_ptr<Creatu
 	if (!creature->isInGhostMode() && !creature->isInvisible()) {
 		const Outfit_t &outfit = creature->getCurrentOutfit();
 		AddOutfit(msg, outfit);
-		if (!oldProtocol && outfit.lookMount != 0) {
-			msg.addByte(outfit.lookMountHead);
-			msg.addByte(outfit.lookMountBody);
-			msg.addByte(outfit.lookMountLegs);
-			msg.addByte(outfit.lookMountFeet);
-		}
 	} else {
 		static Outfit_t outfit;
 		AddOutfit(msg, outfit);
@@ -7945,6 +7935,12 @@ void ProtocolGame::AddOutfit(NetworkMessage &msg, const Outfit_t &outfit, bool a
 
 	if (addMount) {
 		msg.add<uint16_t>(outfit.lookMount);
+		if (!oldProtocol && outfit.lookMount != 0) {
+			msg.addByte(outfit.lookMountHead);
+			msg.addByte(outfit.lookMountBody);
+			msg.addByte(outfit.lookMountLegs);
+			msg.addByte(outfit.lookMountFeet);
+		}
 	}
 }
 


### PR DESCRIPTION
# Description
this problem is since August when  version was upgraded to 13.40 but no v8 user reported it, until issues: 3155

## 1) canary expects a packet “isMountRandomized” u16 but is only sent by cipsoft 13.34 and OTCR 13.34

v8 old Protocol no send "isMountRandomized" , last packet is newOutfit.lookMount = msg.get<uint16_t>();  canary read in (L1711)


this is from v8: 
![image](https://github.com/user-attachments/assets/257f6eb7-955f-4b11-b059-56c10f358c64)
https://github.com/opentibiabr/otcv8/blob/main/src/client/protocolgamesend.cpp#L833

(Redemption 11.00 no send isMountRandomized only in 13.34)

## 2) load this (sendCreatureOutfit and AddCreature) into AddOutfit
(same packets)
![image](https://github.com/user-attachments/assets/aa137bb6-8ec0-4654-aa3b-ca6c95a8ed4c)

## Behaviour
### **Actual**
```lua
[2024-29-11 14:25:47.050] [error] [NetworkMessage::getByte] Not enough data to read a byte. Current position: 26, Length: 18. Called line 1692:50 in void __cdecl ProtocolGame::parseSetOutfit(class NetworkMessage &)
```
### **Expected**

Do this and that happens

### Fixes 
https://github.com/opentibiabr/canary/issues/3155

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

![image](https://github.com/user-attachments/assets/0278d593-01e4-400f-afec-8c6ca63d265e)

**Test Configuration**:

  - Server Version: 11.00 / 13.40
  - Client: otcr / v8 / cip´soft
  - Operating System: win 11

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
