### PR TITLE
fix: adjust character limit for player names

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1484,79 +1484,79 @@ GameStore.canUseHirelingName = function(name)
 end
 
 GameStore.canChangeToName = function(name)
-    local result = {
-        ability = false,
-    }
+	local result = {
+		ability = false,
+	}
 
-    if name:len() < 3 or name:len() > 29 then
-        result.reason = "The length of your new name must be between 3 and 29 characters."
-        return result
-    end
+	if name:len() < 3 or name:len() > 29 then
+		result.reason = "The length of your new name must be between 3 and 29 characters."
+		return result
+	end
 
-    local match = name:gmatch("%s+")
-    local count = 0
-    for _ in match do
-        count = count + 1
-    end
+	local match = name:gmatch("%s+")
+	local count = 0
+	for _ in match do
+		count = count + 1
+	end
 
-    local matchtwo = name:match("^%s+")
-    if matchtwo then
-        result.reason = "Your new name can't have whitespace at the beginning."
-        return result
-    end
+	local matchtwo = name:match("^%s+")
+	if matchtwo then
+		result.reason = "Your new name can't have whitespace at the beginning."
+		return result
+	end
 
-    if count > 2 then
-        result.reason = "Your new name can't have more than 2 spaces."
-        return result
-    end
+	if count > 2 then
+		result.reason = "Your new name can't have more than 2 spaces."
+		return result
+	end
 
-    if name:match("%s%s") then
-        result.reason = "Your new name can't have consecutive spaces."
-        return result
-    end
-    
+	if name:match("%s%s") then
+		result.reason = "Your new name can't have consecutive spaces."
+		return result
+	end
+
 	-- just copied from znote aac.
-    local words = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor" }
-    local split = name:split(" ")
-    for _, word in ipairs(words) do
-        for _, nameWord in ipairs(split) do
-            if nameWord:lower() == word then
-                result.reason = "You can't use the word '" .. word .. "' in your new name."
-                return result
-            end
-        end
-    end
+	local words = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor" }
+	local split = name:split(" ")
+	for _, word in ipairs(words) do
+		for _, nameWord in ipairs(split) do
+			if nameWord:lower() == word then
+				result.reason = "You can't use the word '" .. word .. "' in your new name."
+				return result
+			end
+		end
+	end
 
-    local tmpName = name:gsub("%s+", "")
-    for _, word in ipairs(words) do
-        if tmpName:lower():find(word) then
-            result.reason = "You can't use the word '" .. word .. "' even with spaces in your new name."
-            return result
-        end
-    end
+	local tmpName = name:gsub("%s+", "")
+	for _, word in ipairs(words) do
+		if tmpName:lower():find(word) then
+			result.reason = "You can't use the word '" .. word .. "' even with spaces in your new name."
+			return result
+		end
+	end
 
-    if MonsterType(name) then
-        result.reason = "Your new name '" .. name .. "' can't be a monster's name."
-        return result
-    elseif Npc(name) then
-        result.reason = "Your new name '" .. name .. "' can't be an NPC's name."
-        return result
-    end
+	if MonsterType(name) then
+		result.reason = "Your new name '" .. name .. "' can't be a monster's name."
+		return result
+	elseif Npc(name) then
+		result.reason = "Your new name '" .. name .. "' can't be an NPC's name."
+		return result
+	end
 
-    local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
-    for i = 1, letters:len() do
-        local c = letters:sub(i, i)
-        for j = 1, name:len() do
-            local m = name:sub(j, j)
-            if m == c then
-                result.reason = "You can't use this character '" .. c .. "' in your new name."
-                return result
-            end
-        end
-    end
+	local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
+	for i = 1, letters:len() do
+		local c = letters:sub(i, i)
+		for j = 1, name:len() do
+			local m = name:sub(j, j)
+			if m == c then
+				result.reason = "You can't use this character '" .. c .. "' in your new name."
+				return result
+			end
+		end
+	end
 
-    result.ability = true
-    return result
+	result.ability = true
+	return result
 end
 
 --

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1484,72 +1484,79 @@ GameStore.canUseHirelingName = function(name)
 end
 
 GameStore.canChangeToName = function(name)
-	local result = {
-		ability = false,
-	}
-	if name:len() < 3 or name:len() > 18 then
-		result.reason = "The length of your new name must be between 3 and 18 characters."
-		return result
-	end
+    local result = {
+        ability = false,
+    }
 
-	local match = name:gmatch("%s+")
-	local count = 0
-	for v in match do
-		count = count + 1
-	end
+    if name:len() < 3 or name:len() > 29 then
+        result.reason = "The length of your new name must be between 3 and 29 characters."
+        return result
+    end
 
-	local matchtwo = name:match("^%s+")
-	if matchtwo then
-		result.reason = "Your new name can't have whitespace at begin."
-		return result
-	end
+    local match = name:gmatch("%s+")
+    local count = 0
+    for _ in match do
+        count = count + 1
+    end
 
-	if count > 1 then
-		result.reason = "Your new name have more than 1 whitespace."
-		return result
-	end
+    local matchtwo = name:match("^%s+")
+    if matchtwo then
+        result.reason = "Your new name can't have whitespace at the beginning."
+        return result
+    end
 
+    if count > 2 then
+        result.reason = "Your new name can't have more than 2 spaces."
+        return result
+    end
+
+    if name:match("%s%s") then
+        result.reason = "Your new name can't have consecutive spaces."
+        return result
+    end
+    
 	-- just copied from znote aac.
-	local words = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor" }
-	local split = name:split(" ")
-	for k, word in ipairs(words) do
-		for k, nameWord in ipairs(split) do
-			if nameWord:lower() == word then
-				result.reason = "You can't use word \"" .. word .. '" in your new name.'
-				return result
-			end
-		end
-	end
+    local words = { "owner", "gamemaster", "hoster", "admin", "staff", "tibia", "account", "god", "anal", "ass", "fuck", "sex", "hitler", "pussy", "dick", "rape", "adm", "cm", "gm", "tutor", "counsellor" }
+    local split = name:split(" ")
+    for _, word in ipairs(words) do
+        for _, nameWord in ipairs(split) do
+            if nameWord:lower() == word then
+                result.reason = "You can't use the word '" .. word .. "' in your new name."
+                return result
+            end
+        end
+    end
 
-	local tmpName = name:gsub("%s+", "")
-	for i = 1, #words do
-		if tmpName:lower():find(words[i]) then
-			result.reason = "You can't use word \"" .. words[i] .. '" with whitespace in your new name.'
-			return result
-		end
-	end
+    local tmpName = name:gsub("%s+", "")
+    for _, word in ipairs(words) do
+        if tmpName:lower():find(word) then
+            result.reason = "You can't use the word '" .. word .. "' even with spaces in your new name."
+            return result
+        end
+    end
 
-	if MonsterType(name) then
-		result.reason = 'Your new name "' .. name .. "\" can't be a monster's name."
-		return result
-	elseif Npc(name) then
-		result.reason = 'Your new name "' .. name .. "\" can't be a npc's name."
-		return result
-	end
+    if MonsterType(name) then
+        result.reason = "Your new name '" .. name .. "' can't be a monster's name."
+        return result
+    elseif Npc(name) then
+        result.reason = "Your new name '" .. name .. "' can't be an NPC's name."
+        return result
+    end
 
-	local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
-	for i = 1, letters:len() do
-		local c = letters:sub(i, i)
-		for i = 1, name:len() do
-			local m = name:sub(i, i)
-			if m == c then
-				result.reason = "You can't use this letter \"" .. c .. '" in your new name.'
-				return result
-			end
-		end
-	end
-	result.ability = true
-	return result
+    local letters = "{}|_*+-=<>0123456789@#%^&()/*'\\.,:;~!\"$"
+    for i = 1, letters:len() do
+        local c = letters:sub(i, i)
+        for j = 1, name:len() do
+            local m = name:sub(j, j)
+            if m == c then
+                result.reason = "You can't use this character '" .. c .. "' in your new name."
+                return result
+            end
+        end
+    end
+
+    result.ability = true
+    return result
 end
 
 --

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1092,7 +1092,7 @@ std::string Game::getPlayerNameByGUID(const uint32_t &guid) {
 
 ReturnValue Game::getPlayerByNameWildcard(const std::string &s, std::shared_ptr<Player> &player) {
 	size_t strlen = s.length();
-	if (strlen == 0 || strlen > 20) {
+	if (strlen == 0 || strlen > 29) {
 		return RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE;
 	}
 


### PR DESCRIPTION
# Description

During some tests I identified that, when the player had a very long name, some features did not work correctly, such as Exura Sio, Exiva, AddSkill.

Names with more than 20 characters currently return an error when instantiating Player(), this fix aims to adjust the character limit to the limit corresponding to the global one.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
