### PR TITLE
fix: position after try to cross bridge

### DIFF
--- a/data-otservbr-global/scripts/movements/rookgaard/rook_village.lua
+++ b/data-otservbr-global/scripts/movements/rookgaard/rook_village.lua
@@ -6,7 +6,7 @@ function rookVillage.onStepIn(creature, item, position, fromPosition)
 		return true
 	end
 
-	player:teleportTo(Position(player:getPosition().x, player:getPosition().y - 1, player:getPosition().z))
+	player:teleportTo(Position(player:getPosition().x, player:getPosition().y - 3, player:getPosition().z + 1))
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You don't have any business there anymore.")
 
 	return true


### PR DESCRIPTION
# Description

The problem was that the ladder action was executed first, followed immediately by the teleportTo action, causing the Player to move above the ladder with the possibility of crossing the bridge.

## Behaviour
### **Actual**

![before](https://github.com/user-attachments/assets/6775f470-2688-475a-aaca-0725426426f8)


### **Expected**

![after](https://github.com/user-attachments/assets/e7f1b7b7-f898-43fb-9e6a-791fd4213568)


### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: canary from main
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
