### PR TITLE
fix: lava lurker heals on fire damage

### DIFF
--- a/data-otservbr-global/monster/elementals/lava_lurker.lua
+++ b/data-otservbr-global/monster/elementals/lava_lurker.lua
@@ -95,7 +95,7 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
-	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
@@ -109,6 +109,10 @@ monster.immunities = {
 	{ type = "outfit", condition = false },
 	{ type = "invisible", condition = true },
 	{ type = "bleed", condition = false },
+}
+
+monster.heals = {
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
 }
 
 mType:register(monster)


### PR DESCRIPTION
# Description

Lava Lurker did not heal when taking fire damage.

## Behaviour
### **Actual**

No heals at fire damage

### **Expected**


https://github.com/user-attachments/assets/6772da5b-f0b8-4746-bdbb-11bd64e8ab4a



### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: canary from main
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works