### PR TITLE
feat: add missing constants for client OS

### DIFF
--- a/src/lua/functions/core/game/lua_enums.cpp
+++ b/src/lua/functions/core/game/lua_enums.cpp
@@ -772,14 +772,22 @@ void LuaEnums::initCreatureTypeEnums(lua_State* L) {
 }
 
 void LuaEnums::initClientOsEnums(lua_State* L) {
+	registerEnum(L, CLIENTOS_NONE);
 	registerEnum(L, CLIENTOS_LINUX);
 	registerEnum(L, CLIENTOS_WINDOWS);
 	registerEnum(L, CLIENTOS_FLASH);
+	registerEnum(L, CLIENTOS_NEW_LINUX);
 	registerEnum(L, CLIENTOS_NEW_WINDOWS);
 	registerEnum(L, CLIENTOS_NEW_MAC);
 	registerEnum(L, CLIENTOS_OTCLIENT_LINUX);
 	registerEnum(L, CLIENTOS_OTCLIENT_WINDOWS);
 	registerEnum(L, CLIENTOS_OTCLIENT_MAC);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_LINUX);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_WINDOWS);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_MAC);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_ANDROID);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_IOS);
+	registerEnum(L, CLIENTOS_OTCLIENTV8_WEB);
 }
 
 void LuaEnums::initFightModeEnums(lua_State* L) {


### PR DESCRIPTION
# Description
Add missing constants for client OS handling

Example:
```lua
local allowedOS = {
	[CLIENTOS_NONE] = false,
	[CLIENTOS_LINUX] = true,
	[CLIENTOS_WINDOWS] = true,
	[CLIENTOS_FLASH] = false,
	[CLIENTOS_NEW_LINUX] = true,
	[CLIENTOS_NEW_WINDOWS] = true,
	[CLIENTOS_NEW_MAC] = true,
	[CLIENTOS_OTCLIENT_LINUX] = false,
	[CLIENTOS_OTCLIENT_WINDOWS] = false,
	[CLIENTOS_OTCLIENT_MAC] = false,
	[CLIENTOS_OTCLIENTV8_LINUX] = false,
	[CLIENTOS_OTCLIENTV8_WINDOWS] = false,
	[CLIENTOS_OTCLIENTV8_MAC] = false,
	[CLIENTOS_OTCLIENTV8_ANDROID] = false,
	[CLIENTOS_OTCLIENTV8_IOS] = false,
	[CLIENTOS_OTCLIENTV8_WEB] = false,
}

local blockUnofficialClients = CreatureEvent("BlockUnofficialClients")

function blockUnofficialClients.onLogin(player)
	local clientInfo = player:getClient()
	if not clientInfo or not allowedOS[clientInfo.os] then
		local osName = clientInfo and clientInfo.os or "Unknown OS"
		local clientVersion = clientInfo and clientInfo.version or "Unknown version"

		logger.info("[blockUnofficialClients.onLogin] Player attempted login with OS: {}, Version: {}", osName, clientVersion)
		return false
	end

	return true
end

blockUnofficialClients:register()
```

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
