### PR TITLE
fix: suppress get byte log

### DIFF
--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -45,10 +45,12 @@ int32_t NetworkMessage::decodeHeader() {
 }
 
 // Simply read functions for incoming message
-uint8_t NetworkMessage::getByte(const std::source_location &location /*= std::source_location::current()*/) {
+uint8_t NetworkMessage::getByte(bool suppresLog /*= false*/, const std::source_location &location /*= std::source_location::current()*/) {
 	// Check if there is at least 1 byte to read
 	if (!canRead(1)) {
-		g_logger().error("[{}] Not enough data to read a byte. Current position: {}, Length: {}. Called line {}:{} in {}", __FUNCTION__, info.position, info.length, location.line(), location.column(), location.function_name());
+		if (!suppresLog) {
+			g_logger().error("[{}] Not enough data to read a byte. Current position: {}, Length: {}. Called line {}:{} in {}", __FUNCTION__, info.position, info.length, location.line(), location.column(), location.function_name());
+		}
 		return {};
 	}
 
@@ -113,7 +115,7 @@ Position NetworkMessage::getPosition() {
 	Position pos;
 	pos.x = get<uint16_t>();
 	pos.y = get<uint16_t>();
-	pos.z = getByte();
+	pos.z = getByte(true);
 	return pos;
 }
 

--- a/src/server/network/message/networkmessage.hpp
+++ b/src/server/network/message/networkmessage.hpp
@@ -34,7 +34,7 @@ public:
 	}
 
 	// simply read functions for incoming message
-	uint8_t getByte(const std::source_location &location = std::source_location::current());
+	uint8_t getByte(bool suppresLog = false, const std::source_location &location = std::source_location::current());
 
 	uint8_t getPreviousByte();
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1713,14 +1713,14 @@ void ProtocolGame::parseSetOutfit(NetworkMessage &msg) {
 }
 
 void ProtocolGame::parseToggleMount(NetworkMessage &msg) {
-	bool mount = msg.getByte() != 0;
+	bool mount = msg.getByte(true) != 0;
 	g_game().playerToggleMount(player->getID(), mount);
 }
 
 void ProtocolGame::parseApplyImbuement(NetworkMessage &msg) {
 	uint8_t slot = msg.getByte();
 	auto imbuementId = msg.get<uint32_t>();
-	bool protectionCharm = msg.getByte() != 0x00;
+	bool protectionCharm = msg.getByte(true) != 0x00;
 	g_game().playerApplyImbuement(player->getID(), imbuementId, slot, protectionCharm);
 }
 
@@ -1967,8 +1967,8 @@ void ProtocolGame::parsePlayerBuyOnShop(NetworkMessage &msg) {
 	auto id = msg.get<uint16_t>();
 	uint8_t count = msg.getByte();
 	uint16_t amount = oldProtocol ? static_cast<uint16_t>(msg.getByte()) : msg.get<uint16_t>();
-	bool ignoreCap = msg.getByte() != 0;
-	bool inBackpacks = msg.getByte() != 0;
+	bool ignoreCap = msg.getByte(true) != 0;
+	bool inBackpacks = msg.getByte(true) != 0;
 	g_game().playerBuyItem(player->getID(), id, count, amount, ignoreCap, inBackpacks);
 }
 
@@ -1976,7 +1976,7 @@ void ProtocolGame::parsePlayerSellOnShop(NetworkMessage &msg) {
 	auto id = msg.get<uint16_t>();
 	uint8_t count = std::max(msg.getByte(), (uint8_t)1);
 	uint16_t amount = oldProtocol ? static_cast<uint16_t>(msg.getByte()) : msg.get<uint16_t>();
-	bool ignoreEquipped = msg.getByte() != 0;
+	bool ignoreEquipped = msg.getByte(true) != 0;
 
 	g_game().playerSellItem(player->getID(), id, count, amount, ignoreEquipped);
 }
@@ -2010,7 +2010,7 @@ void ProtocolGame::parseEditVip(NetworkMessage &msg) {
 	auto guid = msg.get<uint32_t>();
 	const std::string description = msg.getString();
 	uint32_t icon = std::min<uint32_t>(10, msg.get<uint32_t>()); // 10 is max icon in 9.63
-	bool notify = msg.getByte() != 0;
+	bool notify = msg.getByte(true) != 0;
 	uint8_t groupsAmount = msg.getByte();
 	for (uint8_t i = 0; i < groupsAmount; ++i) {
 		uint8_t groupId = msg.getByte();
@@ -3141,7 +3141,7 @@ void ProtocolGame::parseMarketCreateOffer(NetworkMessage &msg) {
 
 	auto amount = msg.get<uint16_t>();
 	uint64_t price = oldProtocol ? static_cast<uint64_t>(msg.get<uint32_t>()) : msg.get<uint64_t>();
-	bool anonymous = (msg.getByte() != 0);
+	bool anonymous = (msg.getByte(true) != 0);
 	if (amount > 0 && price > 0) {
 		g_game().playerCreateMarketOffer(player->getID(), type, itemId, amount, price, itemTier, anonymous);
 	}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2176,7 +2176,7 @@ void ProtocolGame::parseTaskHuntingAction(NetworkMessage &msg) {
 
 	uint8_t slot = msg.getByte();
 	uint8_t action = msg.getByte();
-	bool upgrade = msg.getByte() != 0;
+	bool upgrade = msg.getByte(true) != 0;
 	auto raceId = msg.get<uint16_t>();
 
 	if (!g_configManager().getBoolean(TASK_HUNTING_ENABLED)) {


### PR DESCRIPTION
Resolves #3153
Resolves #3131

This simple "suppress" the "getByte" log, some locations send "0" by default, so we don't need to send log in these locations.