### PR TITLE
fix: for lava tiles in entrance of The Pits of Inferno Quest

### DIFF
--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -704,7 +704,10 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		-- The Pits of Inferno Quest
 		if toPosition == Position(32808, 32334, 11) then
 			for i = 1, #lava do
-				Game.createItem(5815, 1, lava[i])
+				local lavaTile = Tile(lava[i]):getItemById(21477)
+				if lavaTile then
+					lavaTile:transform(5815)
+				end
 			end
 			target:transform(3141)
 			toPosition:sendMagicEffect(CONST_ME_SMOKE)


### PR DESCRIPTION
# Description
This pull request implements an alternative solution to handle lava tiles in The Pits of Inferno Quest. The logic in register_actions.lua has been modified to transform existing lava items (ID: 21477) into the floor item (ID: 5815) using Tile:getItemById and Item:transform, instead of relying on Game.createItem.
This PR addresses an issue where lava tiles in The Pits of Inferno Quest were not behaving as expected [3144](https://github.com/opentibiabr/canary/issues/3144). 

## Behaviour
### **Actual**
When using the pick on the stone, the floor is created but it does not let you pass, you just bounce and it tells you "there is not enough room"

### **Expected**
By using the pickaxe on the stone, the floor is created and you can pass through and continue the mission.

### Fixes #3144

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Go to The Pits of Inferno lever.
- Use oil on the lever.
- Use the lever.
- Use a pick on the corner stone.
- Pass through the lava to continue your mission.
- Verify that the lava tiles (ID: 21477) are properly transformed into floor items (ID: 5815) during this process.

**Test Configuration**:

  - Server Version: 13.40
  - Client: mehah otclient
  - Operating Server (docker ubuntu), Client (Windows):

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
