### PR TITLE
Fix getstorage talkaction

### DIFF
--- a/data/scripts/talkactions/god/manage_storage.lua
+++ b/data/scripts/talkactions/god/manage_storage.lua
@@ -5,7 +5,7 @@ function Player.getStorageValueTalkaction(self, param)
 	if not HasValidTalkActionParams(self, param, "Usage: /getstorage <playername>, <storage key or name>") then
 		return true
 	end
-
+	
 	local split = param:split(",")
 	if split[2] == nil then
 		player:sendCancelMessage("Insufficient parameters.")
@@ -18,15 +18,14 @@ function Player.getStorageValueTalkaction(self, param)
 		return true
 	end
 
-	split[2] = split[2]:trimSpace()
-
+	storageStringToVar = loadstring("return " .. split[2])()
+	
 	-- Try to convert the second parameter to a number. If it's not a number, treat it as a storage name
 	local storageKey = tonumber(split[2])
 	if storageKey == nil then
 		-- Get the key for this storage name
-		local storageName = tostring(split[2])
-		local storageValue = target:getStorageValueByName(storageName)
-		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageName .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
+		local storageValue = target:getStorageValue(storageStringToVar)
+		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. split[2] .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 	else
 		local storageValue = target:getStorageValue(storageKey)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")


### PR DESCRIPTION
# Description

Fix the getstorage talkaction used by server admins, which helps imensely with quest debugging.

## Behaviour
### **Actual**

Whenever the talkaction /getstorage Player, storagename is called, the server receives a string (storage name) or a number (storage key) as parameters, the key works fine, but the name should not be a string, it should be converted to the actual global storage variable type.

### **Expected**

Given the admin prepares the /getstorage talkaction to be sent;
When the admin sends the storage parameter as a string e.g (/getstorage GOD, Storage.Quest.U8_0.TheIceIslands.Questline);
Then the /getstorage talkaction accepts the string parameter correctly.

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Tested the talkaction before my fix, all string typed parameters returned (e.g Storage.Quest.U8_0.BarbarianTest.Questline returned -1)
  - [ ] Tested the talkaction after my fix, all string typed parameters returned their actual value (e.g Storage.Quest.U8_0.BarbarianTest.Questline returned 8)

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.40
  - Operating System: Windows 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
