### PR TITLE
fix: add missing storage breaking the ice quest

### DIFF
--- a/data-otservbr-global/lib/core/storages.lua
+++ b/data-otservbr-global/lib/core/storages.lua
@@ -923,6 +923,7 @@ Storage = {
 				NoblemanSecondAddon = 41308,
 				FormorgarMinesHoistSkeleton = 41309,
 				FormorgarMinesHoistChest = 41310,
+				PickAmount = 41311,
 			},
 		},
 		U8_1 = { -- update 8.1 - Reserved Storages 41351 - 41650

--- a/data-otservbr-global/scripts/creaturescripts/customs/freequests.lua
+++ b/data-otservbr-global/scripts/creaturescripts/customs/freequests.lua
@@ -173,6 +173,7 @@ local questTable = {
 	{ storageName = "TheIceIslands.Mission10", storage = Storage.Quest.U8_0.TheIceIslands.Mission10, storageValue = 2 },
 	{ storageName = "TheIceIslands.Mission11", storage = Storage.Quest.U8_0.TheIceIslands.Mission11, storageValue = 2 },
 	{ storageName = "TheIceIslands.Mission12", storage = Storage.Quest.U8_0.TheIceIslands.Mission12, storageValue = 6 },
+	{ storageName = "TheIceIslands.PickAmount", storage = Storage.Quest.U8_0.TheIceIslands.PickAmount, storageValue = 3 },
 	{ storageName = "TheIceIslands.yakchalDoor", storage = Storage.Quest.U8_0.TheIceIslands.yakchalDoor, storageValue = 1 },
 	{ storageName = "TheInquisitionQuest.Questline", storage = Storage.Quest.U8_2.TheInquisitionQuest.Questline, storageValue = 25 },
 	{ storageName = "TheInquisitionQuest.Mission01", storage = Storage.Quest.U8_2.TheInquisitionQuest.Mission01, storageValue = 7 },

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -652,10 +652,6 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		local missionProgress = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Mission02)
 		local pickAmount = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount)
 
-		if pickAmount < 0 or pickAmount == nil then
-			player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount, 0)
-		end
-
 		if missionProgress < 1 or pickAmount >= 3 or player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline) ~= 3 then
 			return false
 		end

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -651,6 +651,11 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		--The Ice Islands Quest, Nibelor 1: Breaking the Ice
 		local missionProgress = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Mission02)
 		local pickAmount = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount)
+		
+		if pickAmount < 0 or pickAmount == nil then
+			player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount, 0)
+		end
+		
 		if missionProgress < 1 or pickAmount >= 3 or player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline) ~= 3 then
 			return false
 		end

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -651,11 +651,11 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		--The Ice Islands Quest, Nibelor 1: Breaking the Ice
 		local missionProgress = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Mission02)
 		local pickAmount = player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount)
-		
+
 		if pickAmount < 0 or pickAmount == nil then
 			player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.PickAmount, 0)
 		end
-		
+
 		if missionProgress < 1 or pickAmount >= 3 or player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline) ~= 3 then
 			return false
 		end

--- a/data/scripts/talkactions/god/manage_storage.lua
+++ b/data/scripts/talkactions/god/manage_storage.lua
@@ -18,15 +18,14 @@ function Player.getStorageValueTalkaction(self, param)
 		return true
 	end
 
-	split[2] = split[2]:trimSpace()
+	storageStringToVar = loadstring("return " .. split[2])()
 
 	-- Try to convert the second parameter to a number. If it's not a number, treat it as a storage name
 	local storageKey = tonumber(split[2])
 	if storageKey == nil then
 		-- Get the key for this storage name
-		local storageName = tostring(split[2])
-		local storageValue = target:getStorageValueByName(storageName)
-		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageName .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
+		local storageValue = target:getStorageValue(storageStringToVar)
+		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. split[2] .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 	else
 		local storageValue = target:getStorageValue(storageKey)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")

--- a/data/scripts/talkactions/god/manage_storage.lua
+++ b/data/scripts/talkactions/god/manage_storage.lua
@@ -18,14 +18,15 @@ function Player.getStorageValueTalkaction(self, param)
 		return true
 	end
 
-	storageStringToVar = loadstring("return " .. split[2])()
+	split[2] = split[2]:trimSpace()
 
 	-- Try to convert the second parameter to a number. If it's not a number, treat it as a storage name
 	local storageKey = tonumber(split[2])
 	if storageKey == nil then
 		-- Get the key for this storage name
-		local storageValue = target:getStorageValue(storageStringToVar)
-		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. split[2] .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
+		local storageName = tostring(split[2])
+		local storageValue = target:getStorageValueByName(storageName)
+		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageName .. " from player " .. split[1] .. " is: " .. storageValue .. ".")
 	else
 		local storageValue = target:getStorageValue(storageKey)
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The storage with id: " .. storageKey .. " from player " .. split[1] .. " is: " .. storageValue .. ".")


### PR DESCRIPTION
# Description

Mission 1 of the breaking the quest questline (breaking the ice) is currently broken, because we forgot to add the 'PickAmount' storage as an actual storage on the storages.lua file, so any attempt to set values to this storage by the quest luas were returning nil key id. 

Fix was adding a storage key to the 'PickAmount' storage, adding this storage to freequests.lua for peace of mind, and setting the initial value of this storage to 0 on the quest start, quest can now be continued past the "Hjaern" NPC!

## Behaviour
### **Actual**

Given the player starts the quest from Hjaern
When the player breaks the 3 ices
Then the player cannot talk to Hjaern to complete the quest because the mission storage was updated but the PickAmount storage was not updated

### **Expected**

Given the player starts the quest from Hjaern
When the player tries to break the 3 ices
Then the player is able to talk to Hjaern and move forward with the quest

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [ ] Reset my storages to pre-quest, then did it again, after my fix, quest can be continued by talking to Hjaern

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.40
  - Operating System: W10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
