### PR TITLE
fix: prevent player corpses from being removed during tile cleaning

### DIFF
--- a/data/scripts/movements/closing_door.lua
+++ b/data/scripts/movements/closing_door.lua
@@ -104,7 +104,7 @@ function closingDoor.onStepOut(creature, item, position, fromPosition)
 
 	while tileItem and i < tileCount do
 		tileItem = tile:getThing(i)
-		if tileItem and tileItem:getUniqueId() ~= item.uid and tileItem:getType():isMovable() then
+		if tileItem and tileItem:getUniqueId() ~= item.uid and tileItem:getType():isMovable() and not isCorpse(tileItem:getUniqueId()) then
 			tileItem:remove()
 		else
 			i = i + 1


### PR DESCRIPTION
# Description

This PR fixes an issue where player corpses were being removed during tile cleaning when a level door closes in the `onStepOut` movement. The fix ensures that corpses are preserved and not inadvertently deleted when players die, especially in cases where there is not enough room to move the player corpse to a valid position.

## Behaviour
### **Actual**

When a player dies in a level door area and there is not enough room to relocate their corpse, the corpse is removed during tile cleaning.

https://github.com/user-attachments/assets/12a4213a-88d4-46b2-9b6c-f5db6efdc59f


### **Expected**

When a player dies in a level door area and there is not enough room to relocate their corpse, the corpse should remain intact or relocated and not be deleted.


https://github.com/user-attachments/assets/a299de73-228a-495d-b5d0-be9abdeef96e



### Fixes #2226

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested



 - [x]  Simulated player death in a level door area with no available space for the corpse and ensured the corpse remained intact during the onStepOut movement.
- [x] Tile cleaning logic when there are additional items alongside the corpse, ensuring only non-corpse items are removed.
- [x] Dropped an item in a level door area without dying, verifying it was correctly relocated during the onStepOut movement.
- [ ]  Different types of corpses (e.g., player vs. creature corpses) to confirm behavior across all cases.
- [ ]  Player death when there is enough room for the corpse to be relocated, ensuring proper positioning.

**Test Configuration**:

- Server Version: 13.40
- Client: cipsoft client
- Operating Server (docker ubuntu), Client (Windows):

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
