### PR TITLE
fix: preserve decimal precision for skill percentage calculation

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -885,7 +885,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count) {
 
 	skills[skill].tries += count;
 
-	uint32_t newPercent;
+	double_t newPercent;
 	if (nextReqTries > currReqTries) {
 		newPercent = Player::getPercentLevel(skills[skill].tries, nextReqTries);
 	} else {


### PR DESCRIPTION
# Description

This PR fixes an issue where skill progress percentages were being rounded to the nearest integer, resulting in a loss of precision. The `newPercent` variable in `addSkillAdvance` was changed from `uint32_t` to `double_t` to retain decimal values. This ensures accurate feedback for players regarding their skill progress.

## Behaviour
### **Actual**

When skill progress increases, the displayed percentage is rounded to the nearest integer (e.g., 93.24% was shown as 93%).

### **Expected**

When skill progress increases, the displayed percentage should include decimal values (e.g., 93.24% is shown as 93.24%).


https://github.com/user-attachments/assets/6d977614-f65b-40a8-837b-4650eb79681d



### Fixes #2430

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

This change was tested by simulating skill progress updates in the game. Logs were used to verify that the percentage now retains decimal values. The issue was resolved when the correct percentage (e.g., 93.24%) was displayed instead of a rounded integer.

  - [x] Login and check skill progress is right
  - [x] Skill progress update when increase skill tries attacking some monster with a weapon skill

**Test Configuration**:

- Server Version: 13.40
- Client: cipsoft client
- Operating Server (docker ubuntu), Client (Windows):

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
