### PR TITLE
fix: crash on daily reward

### DIFF
--- a/src/creatures/combat/condition.cpp
+++ b/src/creatures/combat/condition.cpp
@@ -1270,7 +1270,10 @@ bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature> &cr
 	const auto &player = creature->getPlayer();
 	int32_t dailyStreak = 0;
 	if (player) {
-		dailyStreak = static_cast<int32_t>(player->kv()->scoped("daily-reward")->get("streak")->getNumber());
+		auto optStreak = player->kv()->scoped("daily-reward")->get("streak");
+		if (optStreak) {
+			dailyStreak = static_cast<int32_t>(optStreak->getNumber());
+		}
 	}
 	if (creature->getZoneType() != ZONE_PROTECTION || dailyStreak >= DAILY_REWARD_HP_REGENERATION) {
 		if (internalHealthTicks >= getHealthTicks(creature)) {


### PR DESCRIPTION
Daily reward function accessing a nullptr std::optional