### PR TITLE
Morguthis wall action

### DIFF
--- a/data-otservbr-global/scripts/quests/the_ancient_tombs/action_morguthis_wall.lua
+++ b/data-otservbr-global/scripts/quests/the_ancient_tombs/action_morguthis_wall.lua
@@ -1,0 +1,39 @@
+local Morguthiswall = Action()
+
+function Morguthiswall.onUse(player, item, fromPosition, target, toPosition)
+    local wallPosition = Position(33211, 32698, 13)
+    local wallId = 1306
+
+    local tile = Tile(wallPosition)
+    if not tile then
+        return false
+    end
+
+    local wall = tile:getItemById(wallId)
+    if wall then
+        wall:remove()
+    else
+        local creatures = tile:getCreatures()
+        if creatures then
+            for _, creature in ipairs(creatures) do
+                local newPosition = Position(wallPosition.x, wallPosition.y + 1, wallPosition.z)
+                creature:teleportTo(newPosition)
+            end
+        end
+
+        local items = tile:getItems()
+        if items then
+            for _, tileItem in ipairs(items) do
+                local newPosition = Position(wallPosition.x, wallPosition.y + 1, wallPosition.z)
+                tileItem:moveTo(newPosition)
+            end
+        end
+
+        Game.createItem(wallId, 1, wallPosition)
+    end
+
+    return true
+end
+
+Morguthiswall:aid(10808)
+Morguthiswall:register()


### PR DESCRIPTION
Need to add on remere map editor or similar this action:
![image](https://github.com/user-attachments/assets/cd77c005-8141-4dac-952e-6cf8e8ef2f27)

Now you can open and close the wall.
Any creatures (players or monsters) standing in the wall's position are teleported one tile south. 
Any items in the wall's position are moved one tile south.

In the original game, a teleport effect is not created; however, in the Canary server, it is. 
I believe there is some configuration behind this, as the script does not create a CONST_ME_TELEPORT.