### PR TITLE
fix: familiars upon death

### DIFF
--- a/data-otservbr-global/monster/familiars/druid_familiar.lua
+++ b/data-otservbr-global/monster/familiars/druid_familiar.lua
@@ -1,4 +1,4 @@
-local mType = Game.createMonsterType("Druid Familiar")
+local mType = Game.createMonsterType("Druid familiar")
 local monster = {}
 
 monster.description = "a druid familiar"

--- a/data-otservbr-global/monster/familiars/knight_familiar.lua
+++ b/data-otservbr-global/monster/familiars/knight_familiar.lua
@@ -1,4 +1,4 @@
-local mType = Game.createMonsterType("Knight Familiar")
+local mType = Game.createMonsterType("Knight familiar")
 local monster = {}
 
 monster.description = "a knight familiar"

--- a/data-otservbr-global/monster/familiars/paladin_familiar.lua
+++ b/data-otservbr-global/monster/familiars/paladin_familiar.lua
@@ -1,4 +1,4 @@
-local mType = Game.createMonsterType("Paladin Familiar")
+local mType = Game.createMonsterType("Paladin familiar")
 local monster = {}
 
 monster.description = "a paladin familiar"


### PR DESCRIPTION
This will not affect any behavior besides what is mentioned in the description

# Description

This will fix the issue where if a familiar die and the player relogs he will summon his familiar with the remaining time, so the summon is infinite until time runs out. This will fix that and have a normal behavior

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Tested with promotion / no promotion
  - [ ] Tested with exit / suicide / pvp death / monsters death
  - [ ] Tested all combinations trying to break it again, and its working as expected.

**Test Configuration**:

  - Server Version: 
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
