### PR TITLE
fix: combat type 255 when monster walk on field (none)

### DIFF
--- a/src/map/utils/astarnodes.cpp
+++ b/src/map/utils/astarnodes.cpp
@@ -286,7 +286,7 @@ int_fast32_t AStarNodes::getTileWalkCost(const std::shared_ptr<Creature> &creatu
 		}
 		if (const auto &field = tile->getFieldItem()) {
 			const CombatType_t combatType = field->getCombatType();
-			if (!creature->isImmune(combatType) && !creature->hasCondition(Combat::DamageToConditionType(combatType)) && (creature->getMonster() && !creature->getMonster()->canWalkOnFieldType(combatType))) {
+			if (combatType != COMBAT_NONE && !creature->isImmune(combatType) && !creature->hasCondition(Combat::DamageToConditionType(combatType)) && (creature->getMonster() && !creature->getMonster()->canWalkOnFieldType(combatType))) {
 				cost += MAP_NORMALWALKCOST * 18;
 			}
 		}


### PR DESCRIPTION
# Description

Fixes the combat type 255 error when monsters walk on a field with stepin moveevent and without a damage type specified.

## Behaviour
### **Actual**

When a monster walk on a field the error will be displayed.

### **Expected**

When a monster walk on a field no error will be displayed.

### Fixes #3220 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Create a field without a combat type specified (damage), e.g. smoke (id 2136)
  - [x] Create a monster and make it walk on the field

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
