### PR TITLE
fix: Monster::removeTarget crash

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -586,7 +586,11 @@ bool Monster::removeTarget(const std::shared_ptr<Creature> &creature) {
 		totalPlayersOnScreen--;
 	}
 
-	targetList.erase(it);
+	if (auto shared = it->lock()) {
+		targetList.erase(it);
+	} else {
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
Fixes this crash: [crash remove target.log](https://github.com/user-attachments/files/18379498/crash.remove.target.log)

Removing an expired "weak_ptr"