### PR TITLE
fix: item usage under players and doors

### DIFF
--- a/data/scripts/actions/objects/cask_and_kegs.lua
+++ b/data/scripts/actions/objects/cask_and_kegs.lua
@@ -26,7 +26,7 @@ local targetIdList = {
 local flasks = Action()
 
 function flasks.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target or not target:getItem() then
+	if not target or not target:isItem() then
 		return false
 	end
 

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1876,11 +1876,25 @@ std::shared_ptr<Item> Tile::getUseItem(int32_t index) const {
 		return ground;
 	}
 
-	if (const auto &thing = getThing(index)) {
-		return thing->getItem();
+	if (index >= 0 && index < static_cast<int32_t>(items->size())) {
+		if (const auto &thing = getThing(index)) {
+			if (auto thingItem = thing->getItem()) {
+				return thingItem;
+			}
+		}
 	}
 
-	return nullptr;
+	if (auto topDownItem = getTopDownItem()) {
+		return topDownItem;
+	}
+
+	for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
+		if ((*it)->getDoor()) {
+			return (*it)->getItem();
+		}
+	}
+
+	return !items->empty() ? *items->begin() : nullptr;
 }
 
 std::shared_ptr<Item> Tile::getDoorItem() const {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cf51e6d5-1a13-487c-8970-4f5c99e0a8e2)


You can now interact with items located under doors and your character.

Fix for PVP servers.