### PR TITLE
fix: empty fluid containers load

### DIFF
--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -278,7 +278,7 @@ Item::Item(const uint16_t itemId, uint16_t itemCount /*= 0*/) :
 	const ItemType &it = items[id];
 	const auto itemCharges = it.charges;
 	if (it.isFluidContainer() || it.isSplash()) {
-		const auto fluidType = std::clamp<uint16_t>(itemCount, 1, FLUID_INK);
+		const auto fluidType = std::clamp<uint16_t>(itemCount, 0, magic_enum::enum_count<Fluids_t>());
 		setAttribute(ItemAttribute_t::FLUIDTYPE, fluidType);
 	} else if (it.stackable) {
 		if (itemCount != 0) {


### PR DESCRIPTION
# Description

Fixes the empty containers load that were being loaded as water filled.

## Behaviour
### **Actual**

Loads fluid containers with water filled instead of empty.

### **Expected**

Loads fluid containers empty correctly.

### Fixes #2210 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Check an fluid container that should be loaded as empty in the map, it should be empty.

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
