### PR TITLE
Revert "fix: item usage under players and doors"

### DIFF
--- a/data/scripts/actions/objects/cask_and_kegs.lua
+++ b/data/scripts/actions/objects/cask_and_kegs.lua
@@ -26,7 +26,7 @@ local targetIdList = {
 local flasks = Action()
 
 function flasks.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not target or not target:isItem() then
+	if not target or not target:getItem() then
 		return false
 	end
 

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1876,25 +1876,11 @@ std::shared_ptr<Item> Tile::getUseItem(int32_t index) const {
 		return ground;
 	}
 
-	if (index >= 0 && index < static_cast<int32_t>(items->size())) {
-		if (const auto &thing = getThing(index)) {
-			if (auto thingItem = thing->getItem()) {
-				return thingItem;
-			}
-		}
+	if (const auto &thing = getThing(index)) {
+		return thing->getItem();
 	}
 
-	if (auto topDownItem = getTopDownItem()) {
-		return topDownItem;
-	}
-
-	for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-		if ((*it)->getDoor()) {
-			return (*it)->getItem();
-		}
-	}
-
-	return !items->empty() ? *items->begin() : nullptr;
+	return nullptr;
 }
 
 std::shared_ptr<Item> Tile::getDoorItem() const {


### PR DESCRIPTION
Reverts opentibiabr/canary#3239

This caused inconsistencies in the "onUse" of other things, several people reported bugs in onUse to me so I preferred to revert, so the author can analyze it better and we can test the new pr with the reports made. For example, when there is a "border" below a dummy, it gets the id of the border and not the dummy (when using exercise rod)