### PR TITLE
fix: root desync

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -249,6 +249,18 @@ void Creature::onWalk(Direction &dir) {
 	}
 }
 
+void Creature::resetMovementState() {
+	listWalkDir.clear();
+	cancelNextWalk = false;
+	eventWalk = 0;
+	if (const auto &player = getPlayer()) {
+		player->sendCancelWalk();
+		if (const auto &playerTile = player->getTile()) {
+			player->sendUpdateTile(playerTile, player->getPosition());
+		}
+	}
+}
+
 bool Creature::getNextStep(Direction &dir, uint32_t &) {
 	if (listWalkDir.empty()) {
 		return false;
@@ -416,6 +428,11 @@ void Creature::checkSummonMove(const Position &newPos, bool teleportSummon) {
 
 void Creature::onCreatureMove(const std::shared_ptr<Creature> &creature, const std::shared_ptr<Tile> &newTile, const Position &newPos, const std::shared_ptr<Tile> &oldTile, const Position &oldPos, bool teleport) {
 	metrics::method_latency measure(__METRICS_METHOD_NAME__);
+	if (hasCondition(CONDITION_ROOTED)) {
+		resetMovementState();
+		return;
+	}
+
 	if (creature.get() == this) {
 		lastStep = OTSYS_TIME();
 		lastStepCost = 1;

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -315,6 +315,7 @@ public:
 	void startAutoWalk(const std::vector<Direction> &listDir, bool ignoreConditions = false);
 	void addEventWalk(bool firstStep = false);
 	void stopEventWalk();
+	void resetMovementState();
 
 	void updateCreatureWalk() {
 		goToFollowCreature_async();


### PR DESCRIPTION
# Description

Fixes #2843 

## Behaviour
### **Actual**

https://github.com/user-attachments/assets/69a96bbc-6b22-48b2-9fbb-e9b998267f14

### **Expected**

https://github.com/user-attachments/assets/91436537-61a0-448d-985c-08327471c432

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

1. Created a creature (Carocelio) that only casts root spell. 
2. Logged a regular player and ran next to the creature to analyze its behaviour when rooted.

**Test Configuration**:

  - Server Version: Latest
  - Client: 13.40
  - Operating System: Linux/Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
