### PR TITLE
fix: player summon lasthit addUnjustifiedKills

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -577,6 +577,7 @@ void Creature::onDeath() {
 		}
 	}
 
+	const auto &mostDamagePlayer = mostDamageCreature ? mostDamageCreature->getPlayer() : nullptr;
 	const auto &mostMasterPlayer = mostDamageCreatureMaster ? mostDamageCreatureMaster->getPlayer() : nullptr;
 	bool killedByPlayer = mostDamagePlayer || mostMasterPlayer;
 	if (thisPlayer) {

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -481,13 +481,17 @@ void Creature::onDeath() {
 	bool lastHitUnjustified = false;
 	bool mostDamageUnjustified = false;
 	const auto &lastHitCreature = g_game().getCreatureByID(lastHitCreatureId);
+	const auto &thisPlayer = getPlayer();
+	const auto &thisCreature = getCreature();
+	const auto &thisMaster = getMaster();
+	const auto &thisMonster = getMonster();
 	std::shared_ptr<Creature> lastHitCreatureMaster;
-	if (lastHitCreature && getPlayer()) {
+	if (lastHitCreature && thisPlayer) {
 		/**
 		 * @deprecated -- This is here to trigger the deprecated onKill events in lua
 		 */
-		lastHitCreature->deprecatedOnKilledCreature(getCreature(), true);
-		lastHitUnjustified = lastHitCreature->onKilledPlayer(getPlayer(), true);
+		lastHitCreature->deprecatedOnKilledCreature(thisCreature, true);
+		lastHitUnjustified = lastHitCreature->onKilledPlayer(thisPlayer, true);
 		lastHitCreatureMaster = lastHitCreature->getMaster();
 	} else {
 		lastHitCreatureMaster = nullptr;
@@ -500,6 +504,7 @@ void Creature::onDeath() {
 	int32_t mostDamage = 0;
 	std::map<std::shared_ptr<Creature>, uint64_t> experienceMap;
 	std::unordered_set<std::shared_ptr<Player>> killers;
+
 	for (const auto &[creatureId, damageInfo] : damageMap) {
 		if (creatureId == 0) {
 			continue;
@@ -516,12 +521,10 @@ void Creature::onDeath() {
 				mostDamageCreature = attacker;
 			}
 
-			if (attacker != getCreature()) {
+			if (attacker != thisCreature) {
 				const uint64_t gainExp = getGainedExperience(attacker);
 				const auto &attackerMaster = attacker->getMaster() ? attacker->getMaster() : attacker;
-				if (auto attackerPlayer = attackerMaster->getPlayer()) {
-					attackerPlayer->removeAttacked(getPlayer());
-
+				if (const auto &attackerPlayer = attackerMaster->getPlayer()) {
 					const auto &party = attackerPlayer->getParty();
 					killers.insert(attackerPlayer);
 					if (party && party->getLeader() && party->isSharedExperienceActive() && party->isSharedExperienceEnabled()) {
@@ -546,36 +549,43 @@ void Creature::onDeath() {
 	}
 
 	for (const auto &[creature, experience] : experienceMap) {
-		creature->onGainExperience(experience, getCreature());
+		creature->onGainExperience(experience, thisCreature);
 	}
 
-	mostDamageCreature = mostDamageCreature && mostDamageCreature->getMaster() ? mostDamageCreature->getMaster() : mostDamageCreature;
+	const auto &mostDamageCreatureMaster = mostDamageCreature ? mostDamageCreature->getMaster() : nullptr;
+	mostDamageCreature = mostDamageCreatureMaster ? mostDamageCreatureMaster : mostDamageCreature;
+
 	for (const auto &killer : killers) {
-		if (const auto &monster = getMonster()) {
-			killer->onKilledMonster(monster);
-		} else if (const auto &player = getPlayer(); player && mostDamageCreature != killer) {
-			killer->onKilledPlayer(player, false);
+		if (thisMonster) {
+			killer->onKilledMonster(thisMonster);
+		} else if (thisPlayer) {
+			bool isResponsible = mostDamageCreature == killer || (mostDamageCreatureMaster && mostDamageCreatureMaster == killer);
+			if (isResponsible) {
+				killer->onKilledPlayer(thisPlayer, false);
+			}
+
+			killer->removeAttacked(thisPlayer);
 		}
 	}
 
 	/**
 	 * @deprecated -- This is here to trigger the deprecated onKill events in lua
 	 */
-	const auto &mostDamageCreatureMaster = mostDamageCreature ? mostDamageCreature->getMaster() : nullptr;
-	if (mostDamageCreature && (mostDamageCreature != lastHitCreature || getMonster()) && mostDamageCreature != lastHitCreatureMaster) {
+	if (mostDamageCreature && (mostDamageCreature != lastHitCreature || thisMonster) && mostDamageCreature != lastHitCreatureMaster) {
 		if (lastHitCreature != mostDamageCreatureMaster && (lastHitCreatureMaster == nullptr || mostDamageCreatureMaster != lastHitCreatureMaster)) {
-			mostDamageUnjustified = mostDamageCreature->deprecatedOnKilledCreature(getCreature(), false);
+			mostDamageUnjustified = mostDamageCreature->deprecatedOnKilledCreature(thisCreature, false);
 		}
 	}
 
-	bool killedByPlayer = (mostDamageCreature && mostDamageCreature->getPlayer()) || (mostDamageCreatureMaster && mostDamageCreatureMaster->getPlayer());
-	if (getPlayer()) {
+	const auto &mostMasterPlayer = mostDamageCreatureMaster ? mostDamageCreatureMaster->getPlayer() : nullptr;
+	bool killedByPlayer = mostDamagePlayer || mostMasterPlayer;
+	if (thisPlayer) {
 		g_metrics().addCounter(
 			"player_death",
 			1,
 			{
 				{ "name", getNameDescription() },
-				{ "level", std::to_string(getPlayer()->getLevel()) },
+				{ "level", std::to_string(thisPlayer->getLevel()) },
 				{ "most_damage_creature", mostDamageCreature ? mostDamageCreature->getName() : "(none)" },
 				{ "last_hit_creature", lastHitCreature ? lastHitCreature->getName() : "(none)" },
 				{ "most_damage_dealt", std::to_string(mostDamage) },
@@ -596,7 +606,7 @@ void Creature::onDeath() {
 			{
 				{ "name", getName() },
 				{ "killer", killerName },
-				{ "is_summon", std::to_string(getMaster() ? true : false) },
+				{ "is_summon", std::to_string(thisMaster ? true : false) },
 				{ "by_player", std::to_string(killedByPlayer) },
 			}
 		);
@@ -605,11 +615,11 @@ void Creature::onDeath() {
 	bool droppedCorpse = dropCorpse(lastHitCreature, mostDamageCreature, lastHitUnjustified, mostDamageUnjustified);
 	death(lastHitCreature);
 
-	if (droppedCorpse && !getPlayer()) {
-		g_game().removeCreature(static_self_cast<Creature>(), false);
+	if (droppedCorpse && !thisPlayer) {
+		g_game().removeCreature(thisCreature, false);
 	}
 
-	if (getMaster()) {
+	if (thisMaster) {
 		removeMaster();
 	}
 }


### PR DESCRIPTION
# Description

This PR addresses an issue where unjustified kills were not being properly activated when the last hit on a player was caused by a summon. The issue occurred because the master of the summon was not being correctly treated as responsible for the kill in certain scenarios. This fix ensures that the master of the summon is correctly identified and unjustified kills are processed appropriately.

## Behaviour

### **Actual**

When a summon delivers the last hit to a player:
- The master's unjustified kills are **not activated**.
- The system fails to recognize the master's involvement.

### **Expected**

When a summon delivers the last hit to a player:
- The master should be treated as responsible for the kill.
- Unjustified kills should be processed correctly for the master.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested

The following tests were performed to ensure the correctness of the fix:

- **Test A**: A summon delivers the last hit to a player in a PvP scenario. Verified that the master's unjustified kills were correctly activated.
- **Test B**: A player directly delivers the last hit to a player. Verified that the behaviour remained consistent.
- **Test C**: A summon and its master both participate in damaging the target, with the summon delivering the last hit. Verified that the master was treated as responsible.

**Test Configuration**:

- Server Version: Canary
- Client: Tibia Client
- Operating System: Linux / Windows

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
