### PR TITLE
fix: ferumbras ascension quest actions and creaturescripts

### DIFF
--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_first.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_first.lua
@@ -5,7 +5,7 @@ function ferumbrasAscendantLeverFirst.onUse(player, item, fromPosition, target, 
 	end
 	if item.itemid == 9110 then
 		if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Elements.Done) >= 1 then
-			local spectators = player:getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
+			local spectators = Game.getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
 			for i = 1, #spectators do
 				if spectators[i]:isPlayer() then
 					local spec = spectators[i]

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_four.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_four.lua
@@ -5,7 +5,7 @@ function ferumbrasAscendantLevelFour.onUse(player, item, fromPosition, target, t
 	end
 	if item.itemid == 9110 then
 		if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Elements.Done) < 4 then
-			local spectators = player:getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
+			local spectators = Game.getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
 			for i = 1, #spectators do
 				if spectators[i]:isPlayer() then
 					local spec = spectators[i]

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_second.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_second.lua
@@ -5,7 +5,7 @@ function ferumbrasAscendantLeverSecond.onUse(player, item, fromPosition, target,
 	end
 	if item.itemid == 9110 then
 		if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Elements.Done) < 2 then
-			local spectators = player:getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
+			local spectators = Game.getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
 			for i = 1, #spectators do
 				if spectators[i]:isPlayer() then
 					local spec = spectators[i]

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_third.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_lever_third.lua
@@ -5,7 +5,7 @@ function ferumbrasAscendantLeverThird.onUse(player, item, fromPosition, target, 
 	end
 	if item.itemid == 9110 then
 		if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Elements.Done) < 3 then
-			local spectators = player:getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
+			local spectators = Game.getSpectators(item:getPosition(), false, false, 9, 9, 6, 6)
 			for i = 1, #spectators do
 				if spectators[i]:isPlayer() then
 					local spec = spectators[i]

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_the_shatterer_levers.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_the_shatterer_levers.lua
@@ -39,13 +39,11 @@ local chains = {
 }
 
 local ferumbrasAscendantTheShattererLevers = Action()
-
 function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShatterer) >= 1 then
 		player:sendCancelMessage("You cannot use this lever again.")
 		return true
 	end
-
 	if item.itemid == 8911 then
 		item:transform(8912)
 		if item:getPosition() == Position(33385, 32410, 14) then
@@ -57,10 +55,10 @@ function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, 
 					Game.createMonster("Fury", { x = player:getPosition().x + math.random(-3, 3), y = player:getPosition().y + math.random(-3, 3), z = player:getPosition().z })
 				end
 			end
-			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) + 1)
+			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, math.max(Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever), 0) + 1)
 			if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) >= 4 then
 				local boss = Tile(Position(33406, 32418, 14)):getTopCreature()
-				if boss:getName():lower() == "the shatterer" then
+				if boss and boss:getName():lower() == "the shatterer" then
 					boss:teleportTo(Position(33400, 32415, 14))
 					boss:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 					return true
@@ -75,10 +73,10 @@ function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, 
 					Game.createMonster("Destroyer", { x = player:getPosition().x + math.random(-3, 3), y = player:getPosition().y + math.random(-3, 3), z = player:getPosition().z })
 				end
 			end
-			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) + 1)
+			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, math.max(Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever), 0) + 1)
 			if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) >= 4 then
 				local boss = Tile(Position(33406, 32418, 14)):getTopCreature()
-				if boss:getName():lower() == "the shatterer" then
+				if boss and boss:getName():lower() == "the shatterer" then
 					boss:teleportTo(Position(33400, 32415, 14))
 					boss:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 					return true
@@ -92,10 +90,10 @@ function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, 
 					bla:remove()
 				end
 			end
-			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) + 1)
+			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, math.max(Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever), 0) + 1)
 			if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) >= 4 then
 				local boss = Tile(Position(33406, 32418, 14)):getTopCreature()
-				if boss:getName():lower() == "the shatterer" then
+				if boss and boss:getName():lower() == "the shatterer" then
 					boss:teleportTo(Position(33400, 32415, 14))
 					boss:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 					return true
@@ -109,10 +107,10 @@ function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, 
 					bla:remove()
 				end
 			end
-			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) + 1)
+			Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, math.max(Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever), 0) + 1)
 			if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever) >= 4 then
 				local boss = Tile(Position(33406, 32418, 14)):getTopCreature()
-				if boss:getName():lower() == "the shatterer" then
+				if boss and boss:getName():lower() == "the shatterer" then
 					boss:teleportTo(Position(33400, 32415, 14))
 					boss:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 					return true
@@ -124,7 +122,6 @@ function ferumbrasAscendantTheShattererLevers.onUse(player, item, fromPosition, 
 		player:sendCancelMessage("Sorry, not possible.")
 		return true
 	end
-
 	return true
 end
 

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_bosses_kill.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_bosses_kill.lua
@@ -24,7 +24,7 @@ local bosses = {
 		storage = Storage.Quest.U10_90.FerumbrasAscension.PlagirathTimer,
 	},
 	["razzagorn"] = {
-		teleportPos = Position(33357, 32434, 12),
+		teleportPos = Position(33413, 32467, 14),
 		godbreakerPos = Position(33357, 32440, 13),
 		cooldown = 44, -- hours
 		storage = Storage.Quest.U10_90.FerumbrasAscension.RazzagornTimer,

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_death_dragon.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_death_dragon.lua
@@ -9,7 +9,7 @@ function deathDragon.onDeath(creature, corpse, lasthitkiller, mostdamagekiller, 
 		return true
 	end
 
-	local spectators = player:getSpectators(creature:getPosition(), false, false, 10, 10, 10, 10)
+	local spectators = Game.getSpectators(creature:getPosition(), false, false, 10, 10, 10, 10)
 	for i = 1, #spectators do
 		local spectator = spectators[i]
 		if spectator:isMonster() and spectator:getName():lower() == "ragiaz" then

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_the_shatterer_kill.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_the_shatterer_kill.lua
@@ -100,8 +100,8 @@ function theShattererKill.onDeath(creature)
 		addEvent(revertTeleport, 2 * 60 * 1000, teleportPos, 22761, 1949, oldPos)
 		revert()
 	end
-	player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, 0)
-	player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererTimer, 0)
+	Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererLever, 0)
+	Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.TheShattererTimer, 0)
 	return true
 end
 

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_zamulosh_clone.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_zamulosh_clone.lua
@@ -8,7 +8,7 @@ end
 
 local zamuloshClone = CreatureEvent("ZamuloshClone")
 function zamuloshClone.onThink(creature)
-	local spectators = player:getSpectators(Position(33644, 32757, 11), false, false, 10, 10, 10, 10)
+	local spectators = Game.getSpectators(Position(33644, 32757, 11), false, false, 10, 10, 10, 10)
 	for i = 1, #spectators do
 		local master = spectators[i]
 		if master:getMaxHealth() == 300000 and not master:getMaster() then


### PR DESCRIPTION
# Description

Fix ferumbras ascension quest getSpectators method and the shatterer boss

### Fixes #3279 

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
