### PR TITLE
fix: grand master oberon immunity and butterfly's raceid

### DIFF
--- a/data-otservbr-global/monster/quests/the_explorer_society/blue_butterfly.lua
+++ b/data-otservbr-global/monster/quests/the_explorer_society/blue_butterfly.lua
@@ -14,7 +14,7 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.raceId = 213
+monster.raceId = 227
 monster.Bestiary = {
 	class = "Vermin",
 	race = BESTY_RACE_VERMIN,

--- a/data-otservbr-global/monster/quests/the_explorer_society/yellow_butterfly.lua
+++ b/data-otservbr-global/monster/quests/the_explorer_society/yellow_butterfly.lua
@@ -14,7 +14,7 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.raceId = 227
+monster.raceId = 235
 monster.Bestiary = {
 	class = "Vermin",
 	race = BESTY_RACE_VERMIN,

--- a/data-otservbr-global/monster/quests/the_secret_library/bosses/grand_master_oberon.lua
+++ b/data-otservbr-global/monster/quests/the_secret_library/bosses/grand_master_oberon.lua
@@ -27,7 +27,6 @@ monster.manaCost = 0
 
 monster.events = {
 	"killingLibrary",
-	"oberonImmune",
 }
 
 monster.changeTarget = {

--- a/data-otservbr-global/monster/vermins/butterfly.lua
+++ b/data-otservbr-global/monster/vermins/butterfly.lua
@@ -13,7 +13,7 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.raceId = 213
+monster.raceId = 227
 monster.Bestiary = {
 	class = "Vermin",
 	race = BESTY_RACE_VERMIN,
@@ -31,7 +31,7 @@ monster.Bestiary = {
 monster.health = 2
 monster.maxHealth = 2
 monster.race = "venom"
-monster.corpse = 4378
+monster.corpse = 4993
 monster.speed = 160
 monster.manaCost = 0
 

--- a/data-otservbr-global/scripts/quests/the_secret_library_quest/creaturescripts_kill.lua
+++ b/data-otservbr-global/scripts/quests/the_secret_library_quest/creaturescripts_kill.lua
@@ -45,13 +45,3 @@ function creaturescripts_library_bosses.onDeath(creature, corpse, killer, mostDa
 end
 
 creaturescripts_library_bosses:register()
-
-local creaturescripts_library_bosses_oberon = CreatureEvent("oberonImmune")
-
-function creaturescripts_library_bosses_oberon.onHealthChange(creature, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
-	primaryDamage = 0
-	secondaryDamage = 0
-	return primaryDamage, primaryType, secondaryDamage, secondaryType
-end
-
-creaturescripts_library_bosses_oberon:register()


### PR DESCRIPTION
It was setting him immune on the start immunity is already handled in his monster file.

Butterfly's had the wrong raceId's and and the Bestiary Kills weren't assigned properly.
