### PR TITLE
fix: stash bugs and adjustments

### DIFF
--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -732,9 +732,8 @@ bool MoveEvent::executeStep(const std::shared_ptr<Creature> &creature, const std
 			g_game().internalTeleport(player, player->getTemplePosition());
 			player->sendMagicEffect(player->getTemplePosition(), CONST_ME_TELEPORT);
 			player->sendCancelMessage(getReturnMessage(RETURNVALUE_CONTACTADMINISTRATOR));
+			return false;
 		}
-
-		return false;
 	}
 
 	if (!LuaScriptInterface::reserveScriptEnv()) {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -8613,7 +8613,7 @@ void ProtocolGame::parseStashWithdraw(NetworkMessage &msg) {
 		return;
 	}
 
-	if (!player->isSupplyStashMenuAvailable()) {
+	if (!player->isAccessPlayer() && !player->isSupplyStashMenuAvailable()) {
 		player->sendCancelMessage("You can't use supply stash right now.");
 		return;
 	}


### PR DESCRIPTION
Allow GM access to depot tiles and refine supply stash notifications

• Fixed "Your depot contains/stash contains" message to appear in the "serverlog".
• Enable God/GM accounts to step on depot tiles to trigger stash/depot search.
• Restrict the "You can't use supply stash right now." message to normal players only.
• Activate step-in tile functionality on player login, excluding only teleports.
