### PR TITLE
fix: weight error when adding potions to container

### DIFF
--- a/data/scripts/actions/items/potions.lua
+++ b/data/scripts/actions/items/potions.lua
@@ -88,14 +88,8 @@ function flaskPotion.onUse(player, item, fromPosition, target, toPosition, isHot
 
 		local deactivatedFlasks = player:kv():get("talkaction.potions.flask") or false
 		if not deactivatedFlasks then
-			local container = Container(item:getParent().uid)
-			if container then
-				local storeInbox = player:getSlotItem(CONST_SLOT_STORE_INBOX)
-				if fromPosition.x == CONTAINER_POSITION and container ~= storeInbox and container:getEmptySlots() ~= 0 then
-					container:addItem(potion.flask, 1)
-				else
-					player:addItem(potion.flask, 1)
-				end
+			if fromPosition.x == CONTAINER_POSITION then
+				player:addItem(potion.flask, 1)
 			else
 				Game.createItem(potion.flask, 1, fromPosition)
 			end


### PR DESCRIPTION
# Description
The problem occurs when the player uses a flask from inside a container in their inventory and it does not have enough capacity to receive the flask.
In all cases, when the player for some reason cannot receive the flask for some specific reason, the flask must be created on the ground in its position, this is the expected behavior of `player:addItem()` unlike `container:addItem()` which caused the reported error.
In my tests on the global server, the store inbox flasks are created in the same way, directly in the player's backpack, just like the current behavior.

# Related Error
```Interface: Scripts Interface
Script ID: D:\Repositorios Git\baiak-yurots\data/scripts\actions\items\potions.lua:callback
Function: ContainerFunctions::luaContainerAddItem
Error Description: Cannot add item to container, error code: 'This object is too heavy for you to carry.'
Stack Trace:
Cannot add item to container, error code: 'This object is too heavy for you to carry.'
stack traceback:
        [C]: in function 'addItem'
        ... Git\baiak-yurots\data/scripts\actions\items\potions.lua:95: in function <... Git\baiak-yurots\data/scripts\actions\items\potions.lua:58>
```

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
