### PR TITLE
fix: null dereferencing on onAttackedCreatureDrainHealth function

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -1154,6 +1154,10 @@ void Creature::onAttacked() {
 }
 
 void Creature::onAttackedCreatureDrainHealth(const std::shared_ptr<Creature> &target, int32_t points) {
+	if (!target || points <= 0) {
+		return;
+	}
+
 	target->addDamagePoints(static_self_cast<Creature>(), points);
 }
 


### PR DESCRIPTION
- null check for the target pointer and ensuring that points > 0 before proceeding.

This prevents potential crashes due to null dereferencing and avoids processing invalid damage values.

It is possible to cause a crash due to misconfiguration in some servers 😅, this fix prevents such a failure.