### PR TITLE
fix: unintended depot message and improve code

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -855,3 +855,26 @@ function Player.findItemInInbox(self, itemId, name)
 	end
 	return nil
 end
+
+function Player.checkAndSendDepotMessage(self)
+	for _, direction in ipairs(DIRECTIONS_TABLE) do
+		local playerPosition = self:getPosition()
+		playerPosition:getNextPosition(direction)
+
+		local tile = playerPosition:getTile()
+		if tile then
+			local depotItem = tile:getItemByType(ITEM_TYPE_DEPOT)
+			if depotItem then
+				local depotItems = 0
+				for id = 1, configManager.getNumber(configKeys.DEPOT_BOXES) do
+					depotItems = depotItems + self:getDepotChest(id, true):getItemHoldingCount()
+				end
+
+				self:sendTextMessage(MESSAGE_STATUS, string.format("Your depot contains %d item%s Your supply stash contains %d item%s", depotItems, depotItems ~= 1 and "s." or ".", self:getStashCount(), self:getStashCount() ~= 1 and "s." or "."))
+				self:setSpecialContainersAvailable(true, true, true)
+				return true
+			end
+		end
+	end
+	return true
+end

--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -870,7 +870,10 @@ function Player.checkAndSendDepotMessage(self)
 					depotItems = depotItems + self:getDepotChest(id, true):getItemHoldingCount()
 				end
 
-				self:sendTextMessage(MESSAGE_STATUS, string.format("Your depot contains %d item%s Your supply stash contains %d item%s", depotItems, depotItems ~= 1 and "s." or ".", self:getStashCount(), self:getStashCount() ~= 1 and "s." or "."))
+				local depotMessage = string.format("Your depot contains %d item%s", depotItems, depotItems ~= 1 and "s." or ".")
+				local stashMessage = string.format("Your supply stash contains %d item%s", self:getStashCount(), self:getStashCount() ~= 1 and "s." or ".")
+
+				self:sendTextMessage(MESSAGE_STATUS, string.format("%s %s", depotMessage, stashMessage))
 				self:setSpecialContainersAvailable(true, true, true)
 				return true
 			end

--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -855,29 +855,3 @@ function Player.findItemInInbox(self, itemId, name)
 	end
 	return nil
 end
-
-function Player.checkAndSendDepotMessage(self)
-	for _, direction in ipairs(DIRECTIONS_TABLE) do
-		local playerPosition = self:getPosition()
-		playerPosition:getNextPosition(direction)
-
-		local tile = playerPosition:getTile()
-		if tile then
-			local depotItem = tile:getItemByType(ITEM_TYPE_DEPOT)
-			if depotItem then
-				local depotItems = 0
-				for id = 1, configManager.getNumber(configKeys.DEPOT_BOXES) do
-					depotItems = depotItems + self:getDepotChest(id, true):getItemHoldingCount()
-				end
-
-				local depotMessage = string.format("Your depot contains %d item%s", depotItems, depotItems ~= 1 and "s." or ".")
-				local stashMessage = string.format("Your supply stash contains %d item%s", self:getStashCount(), self:getStashCount() ~= 1 and "s." or ".")
-
-				self:sendTextMessage(MESSAGE_STATUS, string.format("%s %s", depotMessage, stashMessage))
-				self:setSpecialContainersAvailable(true, true, true)
-				return true
-			end
-		end
-	end
-	return true
-end

--- a/data/scripts/movements/special_tiles.lua
+++ b/data/scripts/movements/special_tiles.lua
@@ -1,34 +1,12 @@
 local increasing = { [419] = 420, [431] = 430, [452] = 453, [563] = 564, [549] = 562, [10145] = 10146 }
 local decreasing = { [420] = 419, [430] = 431, [453] = 452, [564] = 563, [562] = 549, [10146] = 10145 }
 
-function Player:checkAndSendDepotMessage()
-	for _, direction in ipairs(DIRECTIONS_TABLE) do
-		local playerPosition = self:getPosition()
-		playerPosition:getNextPosition(direction)
-		local depotItem = playerPosition:getTile():getItemByType(ITEM_TYPE_DEPOT)
-		if depotItem ~= nil or self:getGroup():getAccess() then
-			local depotItems = 0
-			for id = 1, configManager.getNumber(configKeys.DEPOT_BOXES) do
-				depotItems = depotItems + self:getDepotChest(id, true):getItemHoldingCount()
-			end
-			self:sendTextMessage(MESSAGE_STATUS, string.format("Your depot contains %d item%s Your supply stash contains %d item%s", depotItems, depotItems > 1 and "s." or ".", self:getStashCount(), self:getStashCount() > 1 and "s." or "."))
-			self:setSpecialContainersAvailable(true, true, true)
-			return true
-		end
-	end
-	return false
-end
-
 local tile = MoveEvent()
 
 function tile.onStepIn(creature, item, position, fromPosition)
 	local player = creature:getPlayer()
 	if not player then
 		return true
-	end
-
-	if player:isInGhostMode() then
-		return player:checkAndSendDepotMessage()
 	end
 
 	if not increasing[item.itemid] then

--- a/data/scripts/movements/special_tiles.lua
+++ b/data/scripts/movements/special_tiles.lua
@@ -1,6 +1,31 @@
 local increasing = { [419] = 420, [431] = 430, [452] = 453, [563] = 564, [549] = 562, [10145] = 10146 }
 local decreasing = { [420] = 419, [430] = 431, [453] = 452, [564] = 563, [562] = 549, [10146] = 10145 }
 
+local function checkAndSendDepotMessage(player)
+	for _, direction in ipairs(DIRECTIONS_TABLE) do
+		local playerPosition = player:getPosition()
+		playerPosition:getNextPosition(direction)
+
+		local tile = playerPosition:getTile()
+		if tile then
+			local depotItem = tile:getItemByType(ITEM_TYPE_DEPOT)
+			if depotItem then
+				local depotItems = 0
+				for id = 1, configManager.getNumber(configKeys.DEPOT_BOXES) do
+					depotItems = depotItems + player:getDepotChest(id, true):getItemHoldingCount()
+				end
+
+				local depotMessage = string.format("Your depot contains %d item%s", depotItems, depotItems ~= 1 and "s." or ".")
+				local stashMessage = string.format("Your supply stash contains %d item%s", player:getStashCount(), player:getStashCount() ~= 1 and "s." or ".")
+
+				player:sendTextMessage(MESSAGE_STATUS, string.format("%s %s", depotMessage, stashMessage))
+				player:setSpecialContainersAvailable(true, true, true)
+			end
+		end
+	end
+	return true
+end
+
 local tile = MoveEvent()
 
 function tile.onStepIn(creature, item, position, fromPosition)
@@ -25,7 +50,7 @@ function tile.onStepIn(creature, item, position, fromPosition)
 	end
 
 	if Tile(position):hasFlag(TILESTATE_PROTECTIONZONE) then
-		return player:checkAndSendDepotMessage()
+		return checkAndSendDepotMessage(player)
 	end
 
 	if item.actionid ~= 0 and player:getStorageValue(item.actionid) <= 0 then


### PR DESCRIPTION
# Description
Fixes an issue where the depot message was sent even when no depot was nearby.  
Also improves readability and prevents potential errors when accessing nil tiles. 

https://github.com/user-attachments/assets/f3f43eb6-b3ca-4fdb-b9d6-87cb73c8d588

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
