### PR TITLE
fix: prevent error when creature is nil in checkCreatureInsideDoor

### DIFF
--- a/data/libs/functions/creature.lua
+++ b/data/libs/functions/creature.lua
@@ -173,29 +173,36 @@ end
 
 function Creature.checkCreatureInsideDoor(player, toPosition)
 	local creature = Tile(toPosition):getTopCreature()
-	if creature then
-		toPosition.x = toPosition.x + 1
-		local query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
-		if query ~= RETURNVALUE_NOERROR then
-			toPosition.x = toPosition.x - 1
-			toPosition.y = toPosition.y + 1
-			query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
-		end
-		if query ~= RETURNVALUE_NOERROR then
-			toPosition.y = toPosition.y - 2
-			query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
-		end
-		if query ~= RETURNVALUE_NOERROR then
-			toPosition.x = toPosition.x - 1
-			toPosition.y = toPosition.y + 1
-			query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
-		end
-		if query ~= RETURNVALUE_NOERROR then
-			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-			return true
-		end
-		creature:teleportTo(toPosition, true)
+	if not creature then
+		return true
 	end
+
+	toPosition.x = toPosition.x + 1
+	local query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
+	if query ~= RETURNVALUE_NOERROR then
+		toPosition.x = toPosition.x - 1
+		toPosition.y = toPosition.y + 1
+		query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
+	end
+
+	if query ~= RETURNVALUE_NOERROR then
+		toPosition.y = toPosition.y - 2
+		query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
+	end
+
+	if query ~= RETURNVALUE_NOERROR then
+		toPosition.x = toPosition.x - 1
+		toPosition.y = toPosition.y + 1
+		query = Tile(toPosition):queryAdd(creature, bit.bor(FLAG_IGNOREBLOCKCREATURE, FLAG_PATHFINDING))
+	end
+
+	if query ~= RETURNVALUE_NOERROR then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		return true
+	end
+
+	creature:teleportTo(toPosition, true)
+	return true
 end
 
 function Creature:canAccessPz()


### PR DESCRIPTION
# Description
Prevented a Lua error when attempting to access a nil creature in the checkCreatureInsideDoor function. Added a check to ensure the creature exists before performing any actions.

Close #3363 

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
