### PR TITLE
fix: the ape city quest storage

### DIFF
--- a/data-otservbr-global/scripts/quests/the_ape_city/movements_mission4_parchment_decyphering.lua
+++ b/data-otservbr-global/scripts/quests/the_ape_city/movements_mission4_parchment_decyphering.lua
@@ -6,7 +6,7 @@ function mission4ParchmentDecyphering.onStepIn(creature, item, position, fromPos
 		return true
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_6.TheApeCity.Questline) == 6 and player:getStorageValue(Storage.Quest.U7_6.TheApeCity.ParchmentDecyphering) ~= 1 then
+	if player:getStorageValue(Storage.Quest.U7_6.TheApeCity.Questline) == 7 and player:getStorageValue(Storage.Quest.U7_6.TheApeCity.ParchmentDecyphering) ~= 1 then
 		player:setStorageValue(Storage.Quest.U7_6.TheApeCity.ParchmentDecyphering, 1)
 	end
 


### PR DESCRIPTION
# Description

With 6 the quest can't be completed with hairycles, with 7 you can continue with normality.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
