### PR TITLE
fix: speed breakpoints

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -1431,7 +1431,7 @@ uint16_t Creature::getStepDuration(Direction dir) {
 	}
 
 	if (walk.needRecache()) {
-		walk.duration = static_cast<uint16_t>(std::ceil(walk.calculatedStepSpeed / SERVER_BEAT) * SERVER_BEAT);
+		walk.duration = static_cast<uint16_t>(std::round(walk.calculatedStepSpeed / SERVER_BEAT) * SERVER_BEAT);
 		walk.duration = std::max<uint16_t>(50, walk.duration);
 	}
 

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -1568,7 +1568,7 @@ void Creature::setParent(std::weak_ptr<Cylinder> cylinder) {
 	}
 
 	if (walk.groundSpeed != oldGroundSpeed) {
-		walk.recache();
+		updateCalculatedStepSpeed();
 	}
 }
 

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -1431,8 +1431,8 @@ uint16_t Creature::getStepDuration(Direction dir) {
 	}
 
 	if (walk.needRecache()) {
-		auto duration = std::floor(1000 * walk.groundSpeed / walk.calculatedStepSpeed);
-		walk.duration = static_cast<uint16_t>(std::ceil(duration / SERVER_BEAT) * SERVER_BEAT);
+		walk.duration = static_cast<uint16_t>(std::ceil(walk.calculatedStepSpeed / SERVER_BEAT) * SERVER_BEAT);
+		walk.duration = std::max<uint16_t>(50, walk.duration);
 	}
 
 	auto duration = walk.duration;

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -208,7 +208,7 @@ void Creature::onCreatureWalk() {
 			if (getNextStep(dir, flags)) {
 				ReturnValue ret = g_game().internalMoveCreature(static_self_cast<Creature>(), dir, flags);
 				if (ret != RETURNVALUE_NOERROR) {
-					if (std::shared_ptr<Player> player = getPlayer()) {
+					if (const auto &player = getPlayer()) {
 						player->sendCancelMessage(ret);
 						player->sendCancelWalk();
 					}

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -869,8 +869,9 @@ private:
 	void updateCalculatedStepSpeed() {
 		const auto stepSpeed = getStepSpeed();
 		walk.calculatedStepSpeed = 1;
+		const auto tileFriction = walk.groundSpeed;
 		if (stepSpeed > -Creature::speedB) {
-			const auto formula = std::floor((Creature::speedA * log(stepSpeed + Creature::speedB) + Creature::speedC) + .5);
+			const auto formula = (1000 * tileFriction) / (Creature::speedA * std::log(stepSpeed + Creature::speedB) - 0.5 + Creature::speedC) - 1.;
 			walk.calculatedStepSpeed = static_cast<uint16_t>(std::max(formula, 1.));
 		}
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1485,7 +1485,7 @@ void ProtocolGame::GetMapDescription(int32_t x, int32_t y, int32_t z, int32_t wi
 void ProtocolGame::GetFloorDescription(NetworkMessage &msg, int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, int32_t offset, int32_t &skip) {
 	for (int32_t nx = 0; nx < width; nx++) {
 		for (int32_t ny = 0; ny < height; ny++) {
-			std::shared_ptr<Tile> tile = g_game().map.getTile(static_cast<uint16_t>(x + nx + offset), static_cast<uint16_t>(y + ny + offset), static_cast<uint8_t>(z));
+			const std::shared_ptr<Tile> &tile = g_game().map.getTile(static_cast<uint16_t>(x + nx + offset), static_cast<uint16_t>(y + ny + offset), static_cast<uint8_t>(z));
 			if (tile) {
 				if (skip >= 0) {
 					msg.addByte(skip);


### PR DESCRIPTION
# Description

Speed breakpoints calculatations were wrong.

https://tibia.fandom.com/wiki/Speed_Breakpoints
https://tibia.fandom.com/wiki/Formulae#Speed_breakpoints

In the formula above, it gave us the speed based on Tile Friction, so:

![image](https://github.com/user-attachments/assets/35f0402b-cfa1-49c0-a076-def1009e8778)

### Fixes #3268 

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Walk around.

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
