### PR TITLE
fix: spirit of fire combat damage

### DIFF
--- a/data-otservbr-global/monster/quests/svargrond_arena/scrapper/spirit_of_fire.lua
+++ b/data-otservbr-global/monster/quests/svargrond_arena/scrapper/spirit_of_fire.lua
@@ -69,7 +69,7 @@ monster.loot = {}
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
 	{ name = "firefield", interval = 1000, chance = 15, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, target = true },
-	{ name = "combat", interval = 1000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -650, maxDamage = -315, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
+	{ name = "combat", interval = 1000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -300, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
 }
 
 monster.defenses = {


### PR DESCRIPTION
Small fix at the damage monster Spirit of Fire reported #2618. 
I also tested the "lack unique id" at the bucket but the first mission works perfect without it. TLDR, not a bug.