### PR TITLE
feat: checks if someone is training on the dummy

### DIFF
--- a/data/scripts/talkactions/god/buy_house.lua
+++ b/data/scripts/talkactions/god/buy_house.lua
@@ -1,0 +1,65 @@
+local buyHouse = TalkAction("!buyhouse")
+
+function buyHouse.onSay(player, words, param)
+	local housePrice = configManager.getNumber(configKeys.HOUSE_PRICE_PER_SQM)
+	if housePrice == -1 then
+		return true
+	end
+
+	if not player:isPremium() then
+		player:sendCancelMessage("You need a premium account.")
+		return true
+	end
+
+	local houseBuyLevel = configManager.getNumber(configKeys.HOUSE_BUY_LEVEL)
+	if player:getLevel() < houseBuyLevel then
+		player:sendCancelMessage("You need to be level " .. houseBuyLevel .. " to buy a house.")
+		return true
+	end
+
+	local position = player:getPosition()
+	position:getNextPosition(player:getDirection())
+
+	local tile = Tile(position)
+	local house = tile and tile:getHouse()
+	local playerPos = player:getPosition()
+	local houseEntry = house and house:getExitPosition()
+
+	if not house or playerPos ~= houseEntry then
+		player:sendCancelMessage("You have to be looking at the door of the house you would like to buy.")
+		return true
+	end
+
+	if house:getOwnerGuid() > 0 then
+		player:sendCancelMessage("This house already has an owner.")
+		return true
+	end
+
+	if player:getHouse() then
+		player:sendCancelMessage("You are already the owner of a house.")
+		return true
+	end
+
+	if house:hasItemOnTile() then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You cannot buy this house, as there are items inside it. Please, contact an administrator.")
+		return true
+	end
+
+	local price = house:getPrice()
+	if not player:removeMoneyBank(price) then
+		player:sendCancelMessage("You do not have enough money.")
+		return true
+	end
+	metrics.addCounter("balance_decrease", remainsPrice, {
+		player = player:getName(),
+		context = "house_purchase",
+	})
+
+	house:setHouseOwner(player:getGuid())
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have successfully bought this house, be sure to have the money for the rent in the bank.")
+	return true
+end
+
+buyHouse:separator(" ")
+buyHouse:groupType("god")
+buyHouse:register()

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -134,6 +134,7 @@ namespace InternalGame {
 			}
 
 			auto isGuest = house->getHouseAccessLevel(player) == HOUSE_GUEST;
+			auto isOwner = house->getHouseAccessLevel(player) == HOUSE_OWNER;
 			auto itemParentContainer = item->getParent() ? item->getParent()->getContainer() : nullptr;
 			auto isItemParentContainerBrowseField = itemParentContainer && itemParentContainer->getID() == ITEM_BROWSEFIELD;
 			if (isGuest && isItemParentContainerBrowseField) {
@@ -146,7 +147,7 @@ namespace InternalGame {
 				return false;
 			}
 
-			if (isGuest && item->isDummy()) {
+			if (!isOwner && item->isDummy() && (isGuest || item->hasActor())) {
 				return false;
 			}
 		}

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -706,6 +706,14 @@ public:
 	bool canBeMoved() const;
 	void checkDecayMapItemOnMove();
 
+	void setActor(bool value) {
+		m_hasActor = value;
+	}
+
+	bool hasActor() const {
+		return m_hasActor;
+	}
+
 protected:
 	std::weak_ptr<Cylinder> m_parent;
 
@@ -715,6 +723,7 @@ protected:
 	bool loadedFromMap = false;
 	bool isLootTrackeable = false;
 	bool decayDisabled = false;
+	bool m_hasActor = false;
 
 private:
 	void setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);

--- a/src/lua/creature/talkaction.cpp
+++ b/src/lua/creature/talkaction.cpp
@@ -14,6 +14,7 @@
 #include "creatures/players/player.hpp"
 #include "lua/scripts/scripts.hpp"
 #include "lib/di/container.hpp"
+#include "enums/account_group_type.hpp"
 
 TalkActions::TalkActions() = default;
 TalkActions::~TalkActions() = default;
@@ -40,9 +41,30 @@ bool TalkActions::checkWord(const std::shared_ptr<Player> &player, SpeakClasses 
 		return false;
 	}
 
-	const auto groupId = player->getGroup()->id;
-	if (groupId < talkActionPtr->getGroupType()) {
-		return false;
+	// Helper lambda that maps an account type to the maximum allowed group type
+	auto allowedGroupLevelForAccount = [](AccountType account) -> uint8_t {
+		switch (account) {
+			case ACCOUNT_TYPE_NORMAL:
+				return GROUP_TYPE_NORMAL;
+			case ACCOUNT_TYPE_TUTOR:
+				return GROUP_TYPE_TUTOR;
+			case ACCOUNT_TYPE_SENIORTUTOR:
+				return GROUP_TYPE_SENIORTUTOR;
+			case ACCOUNT_TYPE_GAMEMASTER:
+				// Allow both GAMEMASTER and COMMUNITYMANAGER talk actions.
+				return GROUP_TYPE_COMMUNITYMANAGER; // COMMUNITYMANAGER = 5
+			case ACCOUNT_TYPE_GOD:
+				return GROUP_TYPE_GOD;
+			default:
+				return GROUP_TYPE_NONE;
+		}
+	};
+
+	if (player->getAccountType() != ACCOUNT_TYPE_GOD) {
+		// Compare the talk action's required group level to the allowed maximum for the account.
+		if (talkActionPtr->getGroupType() > allowedGroupLevelForAccount(static_cast<AccountType>(player->getAccountType()))) {
+			return false;
+		}
 	}
 
 	std::string param;

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -66,6 +66,7 @@ void ItemFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Item", "isOwner", ItemFunctions::luaItemIsOwner);
 	Lua::registerMethod(L, "Item", "getOwnerName", ItemFunctions::luaItemGetOwnerName);
 	Lua::registerMethod(L, "Item", "hasOwner", ItemFunctions::luaItemHasOwner);
+	Lua::registerMethod(L, "Item", "actor", ItemFunctions::luaItemActor);
 
 	Lua::registerMethod(L, "Item", "moveTo", ItemFunctions::luaItemMoveTo);
 	Lua::registerMethod(L, "Item", "transform", ItemFunctions::luaItemTransform);
@@ -1119,5 +1120,23 @@ int ItemFunctions::luaItemHasOwner(lua_State* L) {
 	}
 
 	Lua::pushBoolean(L, item->hasOwner());
+	return 1;
+}
+
+int ItemFunctions::luaItemActor(lua_State* L) {
+	// item:actor()
+	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	if (!item) {
+		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
+		return 1;
+	}
+
+	if (lua_gettop(L) == 1) {
+		Lua::pushBoolean(L, item->hasActor());
+	} else {
+		item->setActor(Lua::getBoolean(L, 2));
+		Lua::pushBoolean(L, true);
+	}
+
 	return 1;
 }

--- a/src/lua/functions/items/item_functions.hpp
+++ b/src/lua/functions/items/item_functions.hpp
@@ -89,4 +89,5 @@ private:
 	static int luaItemIsOwner(lua_State* L);
 	static int luaItemGetOwnerName(lua_State* L);
 	static int luaItemHasOwner(lua_State* L);
+	static int luaItemActor(lua_State* L);
 };


### PR DESCRIPTION
• Dummy Movement Restriction:
Before: The dummy could be moved or rotated without strict ownership verification.
Now: Only the house owner is allowed to move or rotate the dummy. Additionally, the system checks if someone is training on the dummy before allowing the action. This prevents unauthorized modifications and ensures that the dummy is only used as intended.

• Enhanced Account-Level Checks:
New Feature: A "buy house" talk action has been added specifically for god-level accounts.
Improvement: The system now verifies the player's account type when processing talk actions. This means that if a talk action requires a certain account privilege (for example, only GM-level or lower actions), the system will enforce that check. In short, even if a character appears eligible based on their group, the underlying account type must also have the necessary permissions.