### PR TITLE
fix: encounter set reward

### DIFF
--- a/data/libs/systems/encounters.lua
+++ b/data/libs/systems/encounters.lua
@@ -214,7 +214,7 @@ function Encounter:spawnMonsters(config)
 			if not monster then
 				return false
 			end
-			monster:setReward(true)
+			monster:setRewardBoss()
 			if spawn then
 				spawn(monster)
 			end

--- a/data/libs/systems/encounters.lua
+++ b/data/libs/systems/encounters.lua
@@ -214,6 +214,7 @@ function Encounter:spawnMonsters(config)
 			if not monster then
 				return false
 			end
+			monster:setReward(true)
 			if spawn then
 				spawn(monster)
 			end


### PR DESCRIPTION
Resolves encounter drop loot for bosses.

Fix #3377