### PR TITLE
fix: koshei the deathless quest itemId and itemPos

### DIFF
--- a/data-otservbr-global/startup/tables/chest.lua
+++ b/data-otservbr-global/startup/tables/chest.lua
@@ -2144,8 +2144,8 @@ ChestUnique = {
 	},
 	-- Koshei The Deathless Quest
 	[6236] = {
-		itemId = 2908,
-		itemPos = { x = 33193, y = 32459, z = 7 },
+		itemId = 408,
+		itemPos = { x = 33194, y = 32458, z = 7 },
 		reward = { { 7530, 1 } },
 		weight = 1.00,
 		storage = Storage.Quest.U8_1.KosheiTheDeathless.KosheiAmuletPart1,


### PR DESCRIPTION
# Description

Fix koshei the deathless quest itemId and itemPos

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: Latest (main)
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
