### PR TITLE
perf: skip spectator iteration if container has holding player

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -449,6 +449,14 @@ void Container::onAddContainerItem(const std::shared_ptr<Item> &item) {
 }
 
 void Container::onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item> &oldItem, const std::shared_ptr<Item> &newItem) {
+	const auto &holdingPlayer = getHoldingPlayer();
+	const auto &thisContainer = getContainer();
+	if (holdingPlayer) {
+		holdingPlayer->sendUpdateContainerItem(thisContainer, index, newItem);
+		holdingPlayer->onUpdateContainerItem(thisContainer, oldItem, newItem);
+		return;
+	}
+
 	const auto spectators = Spectators().find<Player>(getPosition(), false, 2, 2, 2, 2);
 
 	// send to client
@@ -463,6 +471,14 @@ void Container::onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item
 }
 
 void Container::onRemoveContainerItem(uint32_t index, const std::shared_ptr<Item> &item) {
+	const auto &holdingPlayer = getHoldingPlayer();
+	const auto &thisContainer = getContainer();
+	if (holdingPlayer) {
+		holdingPlayer->sendRemoveContainerItem(thisContainer, index);
+		holdingPlayer->onRemoveContainerItem(thisContainer, item);
+		return;
+	}
+
 	const auto spectators = Spectators().find<Player>(getPosition(), false, 2, 2, 2, 2);
 
 	// send change to client

--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -461,12 +461,12 @@ void Container::onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item
 
 	// send to client
 	for (const auto &spectator : spectators) {
-		spectator->getPlayer()->sendUpdateContainerItem(getContainer(), index, newItem);
+		spectator->getPlayer()->sendUpdateContainerItem(thisContainer, index, newItem);
 	}
 
 	// event methods
 	for (const auto &spectator : spectators) {
-		spectator->getPlayer()->onUpdateContainerItem(getContainer(), oldItem, newItem);
+		spectator->getPlayer()->onUpdateContainerItem(thisContainer, oldItem, newItem);
 	}
 }
 
@@ -483,12 +483,12 @@ void Container::onRemoveContainerItem(uint32_t index, const std::shared_ptr<Item
 
 	// send change to client
 	for (const auto &spectator : spectators) {
-		spectator->getPlayer()->sendRemoveContainerItem(getContainer(), index);
+		spectator->getPlayer()->sendRemoveContainerItem(thisContainer, index);
 	}
 
 	// event methods
 	for (const auto &spectator : spectators) {
-		spectator->getPlayer()->onRemoveContainerItem(getContainer(), item);
+		spectator->getPlayer()->onRemoveContainerItem(thisContainer, item);
 	}
 }
 


### PR DESCRIPTION
# Description

Optimized `onUpdateContainerItem` and `onRemoveContainerItem` to avoid iterating over spectators when the container has a holding player. If a holding player is present, updates are sent directly to them, preventing unnecessary performance overhead. This change reduces unnecessary iterations and improves efficiency when handling item updates inside player containers.

## Behaviour
### **Actual**

Every container item update/removal iterates over all nearby spectators, even when the item belongs to a holding player.

### **Expected**

When a holding player exists, only they receive the update, skipping the expensive spectator iteration.

## Type of change
  - [x] Performance improvement (optimization without changing behavior)

## How Has This Been Tested

Validated through gameplay testing and logging to ensure item updates are properly handled without iterating spectators when a holding player exists.

  - [x] Verified container updates work correctly when a holding player is present with visual studio profiling.
  - [x] Ensured spectator updates still occur when needed

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings