### PR TITLE
fix: corrected mana spent for exercise wand

### DIFF
--- a/data/scripts/actions/items/exercise_training_weapons.lua
+++ b/data/scripts/actions/items/exercise_training_weapons.lua
@@ -106,7 +106,7 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 	local rate = dummies[dummyId] / 100
 	local isMagic = exerciseWeaponsTable[weaponId].skill == SKILL_MAGLEVEL
 	if isMagic then
-		player:addManaSpent(500 * rate)
+		player:addManaSpent(600 * rate)
 	else
 		player:addSkillTries(exerciseWeaponsTable[weaponId].skill, 7 * rate)
 	end


### PR DESCRIPTION
# Description

> And as for Wands or Rods, one charge is equivalent of 600 burned mana
source:
[Exercise Weapon](https://tibia.fandom.com/wiki/Exercise_Weapons)


## Behaviour
### **Actual**

500 spent mana per charge

### **Expected**

600 mana per charge

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [X] Use exercise wand on dummy

**Test Configuration**:

  - Server Version: Canary 13.40
  - Client: OTC Mehah
  - Operating System: Windows 10

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] My changes generate no new warnings
