### PR TITLE
fix: guild leader channel

### DIFF
--- a/data/chatchannels/scripts/guild_leaders.lua
+++ b/data/chatchannels/scripts/guild_leaders.lua
@@ -5,7 +5,7 @@ end
 function onSpeak(player, type, message)
 	local staff = player:getGroup():getAccess()
 	local guild = player:getGuild()
-	local info = "staff"
+	local info = "Staff"
 	type = TALKTYPE_CHANNEL_Y
 	if staff then
 		if guild then
@@ -15,6 +15,6 @@ function onSpeak(player, type, message)
 	else
 		info = guild:getName()
 	end
-	sendChannelMessage(10, type, player:getName() .. " [" .. info .. "]: " .. message)
+	sendChannelMessage(11, type, player:getName() .. " [" .. info .. "]: " .. message)
 	return false
 end


### PR DESCRIPTION
# Description

I was playing with the Chat Channels and I could notice the message from **Guild Leaders** was delivered into another chat channel. 

I swapped to 11 which is the Channel according to the [Chat Channels](https://github.com/opentibiabr/canary/blob/af2f9df06d6ad41e9e2ecca1cac9defab2028d13/data/chatchannels/chatchannels.xml#L10)

# How to test it?
1. Create a Guild
2. Open Chat Channels (Ctrl + O in game)
3. Send a message into Guild Leaders
4. You could see the message was delivered correctly



