### PR TITLE
fix: chagorz and vemiath specpos

### DIFF
--- a/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_chagorz.lua
+++ b/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_chagorz.lua
@@ -12,8 +12,8 @@ local config = {
 		{ pos = Position(33074, 32367, 15), teleport = Position(33044, 32373, 15), effect = CONST_ME_TELEPORT },
 	},
 	specPos = {
-		from = Position(33035, 32327, 15),
-		to = Position(33053, 32345, 15),
+		from = Position(33034, 32357, 15),
+		to = Position(33052, 32376, 15),
 	},
 	exit = Position(33043, 32344, 15),
 }

--- a/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
+++ b/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
@@ -12,8 +12,8 @@ local config = {
 		{ pos = Position(33074, 32333, 15), teleport = Position(33043, 32341, 15), effect = CONST_ME_TELEPORT },
 	},
 	specPos = {
-		from = Position(33034, 32357, 15),
-		to = Position(33052, 32376, 15),
+		from = Position(33035, 32327, 15),
+		to = Position(33053, 32345, 15),
 	},
 	exit = Position(33043, 32344, 15),
 }


### PR DESCRIPTION
# Description

Chagorz and vemiath spectPos were not working properly, allowing players to press the lever enter the room and duplicate the boss. with this change thas was corrected.

Thanks to @fugu320 for giving me this solution in #3432 

Problem:
![image](https://github.com/user-attachments/assets/c02651ec-d342-469d-8e3c-da0b0fc1e0e4)

Fix:
![image](https://github.com/user-attachments/assets/e0511de7-4e49-43e9-b99a-1b4cb4ad3203)



Please delete options that are not relevant.

  - [* ] Bug fix (non-breaking change which fixes an issue)
  - [* ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Test Configuration**:

  - Server Version: Canary 13.40
  - Client: Client 13.40
  - Operating System: Windows 11
 
## Checklist

  - [* ] My code follows the style guidelines of this project
  - [* ] I have performed a self-review of my own code
  - [* ] My changes generate no new warnings
  - [* ] I have added tests that prove my fix is effective or that my feature works
