### PR TITLE
fix: prevent crashes by validating userdata in Lua bindings

### DIFF
--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -793,7 +793,7 @@ int GameFunctions::luaGameGetNormalizedGuildName(lua_State* L) {
 
 int GameFunctions::luaGameAddInfluencedMonster(lua_State* L) {
 	// Game.addInfluencedMonster(monster)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -477,7 +477,7 @@ int GlobalFunctions::luaDoAreaCombatCondition(lua_State* L) {
 		return 1;
 	}
 
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 4);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 4, "Condition");
 	if (!condition) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CONDITION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -515,7 +515,7 @@ int GlobalFunctions::luaDoTargetCombatCondition(lua_State* L) {
 		return 1;
 	}
 
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 3);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 3, "Condition");
 	if (!condition) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CONDITION_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/core/game/modal_window_functions.cpp
+++ b/src/lua/functions/core/game/modal_window_functions.cpp
@@ -56,7 +56,7 @@ int ModalWindowFunctions::luaModalWindowCreate(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetId(lua_State* L) {
 	// modalWindow:getId()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		lua_pushnumber(L, window->id);
 	} else {
@@ -67,7 +67,7 @@ int ModalWindowFunctions::luaModalWindowGetId(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetTitle(lua_State* L) {
 	// modalWindow:getTitle()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		Lua::pushString(L, window->title);
 	} else {
@@ -78,7 +78,7 @@ int ModalWindowFunctions::luaModalWindowGetTitle(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetMessage(lua_State* L) {
 	// modalWindow:getMessage()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		Lua::pushString(L, window->message);
 	} else {
@@ -90,7 +90,7 @@ int ModalWindowFunctions::luaModalWindowGetMessage(lua_State* L) {
 int ModalWindowFunctions::luaModalWindowSetTitle(lua_State* L) {
 	// modalWindow:setTitle(text)
 	const std::string &text = Lua::getString(L, 2);
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->title = text;
 		Lua::pushBoolean(L, true);
@@ -103,7 +103,7 @@ int ModalWindowFunctions::luaModalWindowSetTitle(lua_State* L) {
 int ModalWindowFunctions::luaModalWindowSetMessage(lua_State* L) {
 	// modalWindow:setMessage(text)
 	const std::string &text = Lua::getString(L, 2);
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->message = text;
 		Lua::pushBoolean(L, true);
@@ -115,7 +115,7 @@ int ModalWindowFunctions::luaModalWindowSetMessage(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetButtonCount(lua_State* L) {
 	// modalWindow:getButtonCount()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		lua_pushnumber(L, window->buttons.size());
 	} else {
@@ -126,7 +126,7 @@ int ModalWindowFunctions::luaModalWindowGetButtonCount(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetChoiceCount(lua_State* L) {
 	// modalWindow:getChoiceCount()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		lua_pushnumber(L, window->choices.size());
 	} else {
@@ -139,7 +139,7 @@ int ModalWindowFunctions::luaModalWindowAddButton(lua_State* L) {
 	// modalWindow:addButton(id, text)
 	const std::string &text = Lua::getString(L, 3);
 	uint8_t id = Lua::getNumber<uint8_t>(L, 2);
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->buttons.emplace_back(text, id);
 		Lua::pushBoolean(L, true);
@@ -153,7 +153,7 @@ int ModalWindowFunctions::luaModalWindowAddChoice(lua_State* L) {
 	// modalWindow:addChoice(id, text)
 	const std::string &text = Lua::getString(L, 3);
 	uint8_t id = Lua::getNumber<uint8_t>(L, 2);
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->choices.emplace_back(text, id);
 		Lua::pushBoolean(L, true);
@@ -165,7 +165,7 @@ int ModalWindowFunctions::luaModalWindowAddChoice(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetDefaultEnterButton(lua_State* L) {
 	// modalWindow:getDefaultEnterButton()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		lua_pushnumber(L, window->defaultEnterButton);
 	} else {
@@ -176,7 +176,7 @@ int ModalWindowFunctions::luaModalWindowGetDefaultEnterButton(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowSetDefaultEnterButton(lua_State* L) {
 	// modalWindow:setDefaultEnterButton(buttonId)
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->defaultEnterButton = Lua::getNumber<uint8_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -188,7 +188,7 @@ int ModalWindowFunctions::luaModalWindowSetDefaultEnterButton(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowGetDefaultEscapeButton(lua_State* L) {
 	// modalWindow:getDefaultEscapeButton()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		lua_pushnumber(L, window->defaultEscapeButton);
 	} else {
@@ -199,7 +199,7 @@ int ModalWindowFunctions::luaModalWindowGetDefaultEscapeButton(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowSetDefaultEscapeButton(lua_State* L) {
 	// modalWindow:setDefaultEscapeButton(buttonId)
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->defaultEscapeButton = Lua::getNumber<uint8_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -211,7 +211,7 @@ int ModalWindowFunctions::luaModalWindowSetDefaultEscapeButton(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowHasPriority(lua_State* L) {
 	// modalWindow:hasPriority()
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		Lua::pushBoolean(L, window->priority);
 	} else {
@@ -222,7 +222,7 @@ int ModalWindowFunctions::luaModalWindowHasPriority(lua_State* L) {
 
 int ModalWindowFunctions::luaModalWindowSetPriority(lua_State* L) {
 	// modalWindow:setPriority(priority)
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		window->priority = Lua::getBoolean(L, 2);
 		Lua::pushBoolean(L, true);
@@ -240,7 +240,7 @@ int ModalWindowFunctions::luaModalWindowSendToPlayer(lua_State* L) {
 		return 1;
 	}
 
-	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1);
+	const auto &window = Lua::getUserdataShared<ModalWindow>(L, 1, "ModalWindow");
 	if (window) {
 		if (!player->hasModalWindowOpen(window->id)) {
 			player->sendModalWindow(*window);

--- a/src/lua/functions/core/game/zone_functions.cpp
+++ b/src/lua/functions/core/game/zone_functions.cpp
@@ -56,8 +56,8 @@ int ZoneFunctions::luaZoneCreate(lua_State* L) {
 }
 
 int ZoneFunctions::luaZoneCompare(lua_State* L) {
-	const auto &zone1 = Lua::getUserdataShared<Zone>(L, 1);
-	const auto &zone2 = Lua::getUserdataShared<Zone>(L, 2);
+	const auto &zone1 = Lua::getUserdataShared<Zone>(L, 1, "Zone");
+	const auto &zone2 = Lua::getUserdataShared<Zone>(L, 2, "Zone");
 	if (!zone1) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -75,7 +75,7 @@ int ZoneFunctions::luaZoneCompare(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetName(lua_State* L) {
 	// Zone:getName()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -87,7 +87,7 @@ int ZoneFunctions::luaZoneGetName(lua_State* L) {
 
 int ZoneFunctions::luaZoneAddArea(lua_State* L) {
 	// Zone:addArea(fromPos, toPos)
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -103,7 +103,7 @@ int ZoneFunctions::luaZoneAddArea(lua_State* L) {
 
 int ZoneFunctions::luaZoneSubtractArea(lua_State* L) {
 	// Zone:subtractArea(fromPos, toPos)
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -119,7 +119,7 @@ int ZoneFunctions::luaZoneSubtractArea(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetRemoveDestination(lua_State* L) {
 	// Zone:getRemoveDestination()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		return 1;
@@ -130,7 +130,7 @@ int ZoneFunctions::luaZoneGetRemoveDestination(lua_State* L) {
 
 int ZoneFunctions::luaZoneSetRemoveDestination(lua_State* L) {
 	// Zone:setRemoveDestination(pos)
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		return 1;
@@ -142,7 +142,7 @@ int ZoneFunctions::luaZoneSetRemoveDestination(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetPositions(lua_State* L) {
 	// Zone:getPositions()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -162,7 +162,7 @@ int ZoneFunctions::luaZoneGetPositions(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetCreatures(lua_State* L) {
 	// Zone:getCreatures()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -183,7 +183,7 @@ int ZoneFunctions::luaZoneGetCreatures(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetPlayers(lua_State* L) {
 	// Zone:getPlayers()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -204,7 +204,7 @@ int ZoneFunctions::luaZoneGetPlayers(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetMonsters(lua_State* L) {
 	// Zone:getMonsters()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -225,7 +225,7 @@ int ZoneFunctions::luaZoneGetMonsters(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetNpcs(lua_State* L) {
 	// Zone:getNpcs()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -246,7 +246,7 @@ int ZoneFunctions::luaZoneGetNpcs(lua_State* L) {
 
 int ZoneFunctions::luaZoneGetItems(lua_State* L) {
 	// Zone:getItems()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -267,7 +267,7 @@ int ZoneFunctions::luaZoneGetItems(lua_State* L) {
 
 int ZoneFunctions::luaZoneRemovePlayers(lua_State* L) {
 	// Zone:removePlayers()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -280,7 +280,7 @@ int ZoneFunctions::luaZoneRemovePlayers(lua_State* L) {
 
 int ZoneFunctions::luaZoneRemoveMonsters(lua_State* L) {
 	// Zone:removeMonsters()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -292,7 +292,7 @@ int ZoneFunctions::luaZoneRemoveMonsters(lua_State* L) {
 
 int ZoneFunctions::luaZoneRemoveNpcs(lua_State* L) {
 	// Zone:removeNpcs()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -304,7 +304,7 @@ int ZoneFunctions::luaZoneRemoveNpcs(lua_State* L) {
 
 int ZoneFunctions::luaZoneSetMonsterVariant(lua_State* L) {
 	// Zone:setMonsterVariant(variant)
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -369,7 +369,7 @@ int ZoneFunctions::luaZoneGetAll(lua_State* L) {
 
 int ZoneFunctions::luaZoneRefresh(lua_State* L) {
 	// Zone:refresh()
-	const auto &zone = Lua::getUserdataShared<Zone>(L, 1);
+	const auto &zone = Lua::getUserdataShared<Zone>(L, 1, "Zone");
 	if (!zone) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ZONE_NOT_FOUND));
 		return 1;

--- a/src/lua/functions/core/libs/kv_functions.cpp
+++ b/src/lua/functions/core/libs/kv_functions.cpp
@@ -36,7 +36,7 @@ int KVFunctions::luaKVScoped(lua_State* L) {
 	const auto key = Lua::getString(L, -1);
 
 	if (Lua::isUserdata(L, 1)) {
-		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
+		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		const auto &newScope = scopedKV->scoped(key);
 		Lua::pushUserdata<KV>(L, newScope);
 		Lua::setMetatable(L, -1, "KV");
@@ -61,7 +61,7 @@ int KVFunctions::luaKVSet(lua_State* L) {
 	}
 
 	if (Lua::isUserdata(L, 1)) {
-		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
+		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		scopedKV->set(key, valueWrapper.value());
 		Lua::pushBoolean(L, true);
 		return 1;
@@ -82,7 +82,7 @@ int KVFunctions::luaKVGet(lua_State* L) {
 		key = Lua::getString(L, -2);
 	}
 	if (Lua::isUserdata(L, 1)) {
-		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
+		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		valueWrapper = scopedKV->get(key, forceLoad);
 	} else {
 		valueWrapper = g_kv().get(key, forceLoad);
@@ -100,7 +100,7 @@ int KVFunctions::luaKVRemove(lua_State* L) {
 	// KV.remove(key) | scopedKV:remove(key)
 	const auto key = Lua::getString(L, -1);
 	if (Lua::isUserdata(L, 1)) {
-		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
+		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		scopedKV->remove(key);
 	} else {
 		g_kv().remove(key);
@@ -119,7 +119,7 @@ int KVFunctions::luaKVKeys(lua_State* L) {
 	}
 
 	if (Lua::isUserdata(L, 1)) {
-		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1);
+		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		keys = scopedKV->keys();
 	} else {
 		keys = g_kv().keys(prefix);

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -53,7 +53,7 @@ int NetworkMessageFunctions::luaNetworkMessageCreate(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetByte(lua_State* L) {
 	// networkMessage:getByte()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		lua_pushnumber(L, message->getByte());
 	} else {
@@ -64,7 +64,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetByte(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetU16(lua_State* L) {
 	// networkMessage:getU16()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		lua_pushnumber(L, message->get<uint16_t>());
 	} else {
@@ -75,7 +75,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetU16(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetU32(lua_State* L) {
 	// networkMessage:getU32()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		lua_pushnumber(L, message->get<uint32_t>());
 	} else {
@@ -86,7 +86,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetU32(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetU64(lua_State* L) {
 	// networkMessage:getU64()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		lua_pushnumber(L, message->get<uint64_t>());
 	} else {
@@ -97,7 +97,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetU64(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetString(lua_State* L) {
 	// networkMessage:Lua::getString()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		Lua::pushString(L, message->getString());
 	} else {
@@ -108,7 +108,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetString(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageGetPosition(lua_State* L) {
 	// networkMessage:Lua::getPosition()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		Lua::pushPosition(L, message->getPosition());
 	} else {
@@ -120,7 +120,7 @@ int NetworkMessageFunctions::luaNetworkMessageGetPosition(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddByte(lua_State* L) {
 	// networkMessage:addByte(number)
 	const uint8_t number = Lua::getNumber<uint8_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->addByte(number);
 		Lua::pushBoolean(L, true);
@@ -133,7 +133,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddByte(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddU16(lua_State* L) {
 	// networkMessage:addU16(number)
 	const uint16_t number = Lua::getNumber<uint16_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<uint16_t>(number);
 		Lua::pushBoolean(L, true);
@@ -146,7 +146,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddU16(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddU32(lua_State* L) {
 	// networkMessage:addU32(number)
 	const uint32_t number = Lua::getNumber<uint32_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<uint32_t>(number);
 		Lua::pushBoolean(L, true);
@@ -159,7 +159,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddU32(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddU64(lua_State* L) {
 	// networkMessage:addU64(number)
 	const uint64_t number = Lua::getNumber<uint64_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<uint64_t>(number);
 		Lua::pushBoolean(L, true);
@@ -172,7 +172,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddU64(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAdd8(lua_State* L) {
 	// networkMessage:add8(number)
 	const auto number = Lua::getNumber<int8_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<int8_t>(number);
 		Lua::pushBoolean(L, true);
@@ -185,7 +185,7 @@ int NetworkMessageFunctions::luaNetworkMessageAdd8(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAdd16(lua_State* L) {
 	// networkMessage:add16(number)
 	const auto number = Lua::getNumber<int16_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<int16_t>(number);
 		Lua::pushBoolean(L, true);
@@ -198,7 +198,7 @@ int NetworkMessageFunctions::luaNetworkMessageAdd16(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAdd32(lua_State* L) {
 	// networkMessage:add32(number)
 	const auto number = Lua::getNumber<int32_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<int32_t>(number);
 		Lua::pushBoolean(L, true);
@@ -211,7 +211,7 @@ int NetworkMessageFunctions::luaNetworkMessageAdd32(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAdd64(lua_State* L) {
 	// networkMessage:add64(number)
 	const auto number = Lua::getNumber<int64_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->add<int64_t>(number);
 		Lua::pushBoolean(L, true);
@@ -225,7 +225,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddString(lua_State* L) {
 	// networkMessage:addString(string, function)
 	const std::string &string = Lua::getString(L, 2);
 	const std::string &function = Lua::getString(L, 3);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->addString(string, std::source_location::current(), function);
 		Lua::pushBoolean(L, true);
@@ -238,7 +238,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddString(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddPosition(lua_State* L) {
 	// networkMessage:addPosition(position)
 	const Position &position = Lua::getPosition(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->addPosition(position);
 		Lua::pushBoolean(L, true);
@@ -251,7 +251,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddPosition(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageAddDouble(lua_State* L) {
 	// networkMessage:addDouble(number)
 	const double number = Lua::getNumber<double>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->addDouble(number);
 		Lua::pushBoolean(L, true);
@@ -263,21 +263,21 @@ int NetworkMessageFunctions::luaNetworkMessageAddDouble(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageAddItem(lua_State* L) {
 	// networkMessage:addItem(item, player)
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 3);
+	const auto &player = Lua::getUserdataShared<Player>(L, 3, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message && player->client) {
 		player->client->AddItem(*message, item);
 		Lua::pushBoolean(L, true);
@@ -289,7 +289,7 @@ int NetworkMessageFunctions::luaNetworkMessageAddItem(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageReset(lua_State* L) {
 	// networkMessage:reset()
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->reset();
 		Lua::pushBoolean(L, true);
@@ -302,7 +302,7 @@ int NetworkMessageFunctions::luaNetworkMessageReset(lua_State* L) {
 int NetworkMessageFunctions::luaNetworkMessageSkipBytes(lua_State* L) {
 	// networkMessage:skipBytes(number)
 	const int16_t number = Lua::getNumber<int16_t>(L, 2);
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (message) {
 		message->skipBytes(number);
 		Lua::pushBoolean(L, true);
@@ -314,7 +314,7 @@ int NetworkMessageFunctions::luaNetworkMessageSkipBytes(lua_State* L) {
 
 int NetworkMessageFunctions::luaNetworkMessageSendToPlayer(lua_State* L) {
 	// networkMessage:sendToPlayer(player)
-	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1);
+	const auto &message = Lua::getUserdataShared<NetworkMessage>(L, 1, "NetworkMessage");
 	if (!message) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -47,7 +47,7 @@ int CombatFunctions::luaCombatCreate(lua_State* L) {
 
 int CombatFunctions::luaCombatSetParameter(lua_State* L) {
 	// combat:setParameter(key, value)
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (!combat) {
 		lua_pushnil(L);
 		return 1;
@@ -67,7 +67,7 @@ int CombatFunctions::luaCombatSetParameter(lua_State* L) {
 
 int CombatFunctions::luaCombatSetFormula(lua_State* L) {
 	// combat:setFormula(type, mina, minb, maxa, maxb)
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (!combat) {
 		lua_pushnil(L);
 		return 1;
@@ -98,7 +98,7 @@ int CombatFunctions::luaCombatSetArea(lua_State* L) {
 		return 1;
 	}
 
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (combat) {
 		auto areaClone = area->clone();
 		combat->setArea(areaClone);
@@ -111,7 +111,7 @@ int CombatFunctions::luaCombatSetArea(lua_State* L) {
 
 int CombatFunctions::luaCombatSetCondition(lua_State* L) {
 	// combat:addCondition(condition)
-	const std::shared_ptr<Condition> &condition = Lua::getUserdataShared<Condition>(L, 2);
+	const std::shared_ptr<Condition> &condition = Lua::getUserdataShared<Condition>(L, 2, "Condition");
 	auto* combat = Lua::getUserdata<Combat>(L, 1);
 	if (combat && condition) {
 		combat->addCondition(condition->clone());
@@ -124,7 +124,7 @@ int CombatFunctions::luaCombatSetCondition(lua_State* L) {
 
 int CombatFunctions::luaCombatSetCallback(lua_State* L) {
 	// combat:setCallback(key, function)
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (!combat) {
 		lua_pushnil(L);
 		return 1;
@@ -149,7 +149,7 @@ int CombatFunctions::luaCombatSetCallback(lua_State* L) {
 
 int CombatFunctions::luaCombatSetOrigin(lua_State* L) {
 	// combat:setOrigin(origin)
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (combat) {
 		combat->setOrigin(Lua::getNumber<CombatOrigin>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -161,7 +161,7 @@ int CombatFunctions::luaCombatSetOrigin(lua_State* L) {
 
 int CombatFunctions::luaCombatExecute(lua_State* L) {
 	// combat:execute(creature, variant)
-	const auto &combat = Lua::getUserdataShared<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (!combat) {
 		Lua::pushBoolean(L, false);
 		return 1;

--- a/src/lua/functions/creatures/combat/condition_functions.cpp
+++ b/src/lua/functions/creatures/combat/condition_functions.cpp
@@ -71,7 +71,7 @@ int ConditionFunctions::luaConditionDelete(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetId(lua_State* L) {
 	// condition:getId()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		lua_pushnumber(L, condition->getId());
 	} else {
@@ -82,7 +82,7 @@ int ConditionFunctions::luaConditionGetId(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetSubId(lua_State* L) {
 	// condition:getSubId()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		lua_pushnumber(L, condition->getSubId());
 	} else {
@@ -93,7 +93,7 @@ int ConditionFunctions::luaConditionGetSubId(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetType(lua_State* L) {
 	// condition:getType()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		lua_pushnumber(L, condition->getType());
 	} else {
@@ -104,7 +104,7 @@ int ConditionFunctions::luaConditionGetType(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetIcons(lua_State* L) {
 	// condition:getIcons()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		const auto icons = condition->getIcons();
 		lua_newtable(L); // Creates a new table on the Lua stack
@@ -121,7 +121,7 @@ int ConditionFunctions::luaConditionGetIcons(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetEndTime(lua_State* L) {
 	// condition:getEndTime()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		lua_pushnumber(L, condition->getEndTime());
 	} else {
@@ -132,7 +132,7 @@ int ConditionFunctions::luaConditionGetEndTime(lua_State* L) {
 
 int ConditionFunctions::luaConditionClone(lua_State* L) {
 	// condition:clone()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		Lua::pushUserdata<Condition>(L, condition->clone());
 		Lua::setMetatable(L, -1, "Condition");
@@ -144,7 +144,7 @@ int ConditionFunctions::luaConditionClone(lua_State* L) {
 
 int ConditionFunctions::luaConditionGetTicks(lua_State* L) {
 	// condition:getTicks()
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		lua_pushnumber(L, condition->getTicks());
 	} else {
@@ -156,7 +156,7 @@ int ConditionFunctions::luaConditionGetTicks(lua_State* L) {
 int ConditionFunctions::luaConditionSetTicks(lua_State* L) {
 	// condition:setTicks(ticks)
 	const int32_t ticks = Lua::getNumber<int32_t>(L, 2);
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
 		condition->setTicks(ticks);
 		Lua::pushBoolean(L, true);
@@ -168,7 +168,7 @@ int ConditionFunctions::luaConditionSetTicks(lua_State* L) {
 
 int ConditionFunctions::luaConditionSetParameter(lua_State* L) {
 	// condition:setParameter(key, value)
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 1);
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (!condition) {
 		lua_pushnil(L);
 		return 1;
@@ -192,7 +192,7 @@ int ConditionFunctions::luaConditionSetFormula(lua_State* L) {
 	const double maxa = Lua::getNumber<double>(L, 4);
 	const double minb = Lua::getNumber<double>(L, 3);
 	const double mina = Lua::getNumber<double>(L, 2);
-	const std::shared_ptr<ConditionSpeed> &condition = Lua::getUserdataShared<Condition>(L, 1)->dynamic_self_cast<ConditionSpeed>();
+	const std::shared_ptr<ConditionSpeed> &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition")->dynamic_self_cast<ConditionSpeed>();
 	if (condition) {
 		condition->setFormulaVars(mina, minb, maxa, maxb);
 		Lua::pushBoolean(L, true);
@@ -225,7 +225,7 @@ int ConditionFunctions::luaConditionSetOutfit(lua_State* L) {
 		outfit.lookTypeEx = Lua::getNumber<uint16_t>(L, 2);
 	}
 
-	const std::shared_ptr<ConditionOutfit> &condition = Lua::getUserdataShared<Condition>(L, 1)->dynamic_self_cast<ConditionOutfit>();
+	const std::shared_ptr<ConditionOutfit> &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition")->dynamic_self_cast<ConditionOutfit>();
 	if (condition) {
 		condition->setOutfit(outfit);
 		Lua::pushBoolean(L, true);
@@ -240,7 +240,7 @@ int ConditionFunctions::luaConditionAddDamage(lua_State* L) {
 	const int32_t value = Lua::getNumber<int32_t>(L, 4);
 	const int32_t time = Lua::getNumber<int32_t>(L, 3);
 	const int32_t rounds = Lua::getNumber<int32_t>(L, 2);
-	const std::shared_ptr<ConditionDamage> &condition = Lua::getUserdataShared<Condition>(L, 1)->dynamic_self_cast<ConditionDamage>();
+	const std::shared_ptr<ConditionDamage> &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition")->dynamic_self_cast<ConditionDamage>();
 	if (condition) {
 		Lua::pushBoolean(L, condition->addDamage(rounds, time, value));
 	} else {

--- a/src/lua/functions/creatures/combat/spell_functions.cpp
+++ b/src/lua/functions/creatures/combat/spell_functions.cpp
@@ -135,7 +135,7 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 
 int SpellFunctions::luaSpellOnCastSpell(lua_State* L) {
 	// spell:onCastSpell(callback)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (spell->spellType == SPELL_INSTANT) {
 			const auto &instant = std::static_pointer_cast<InstantSpell>(spell);
@@ -160,7 +160,7 @@ int SpellFunctions::luaSpellOnCastSpell(lua_State* L) {
 
 int SpellFunctions::luaSpellRegister(lua_State* L) {
 	// spell:register()
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (!spell) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_SPELL_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -168,7 +168,7 @@ int SpellFunctions::luaSpellRegister(lua_State* L) {
 	}
 
 	if (spell->spellType == SPELL_INSTANT) {
-		const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+		const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 		const auto &instant = std::static_pointer_cast<InstantSpell>(spellBase);
 		if (!instant->isLoadedScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -176,7 +176,7 @@ int SpellFunctions::luaSpellRegister(lua_State* L) {
 		}
 		Lua::pushBoolean(L, g_spells().registerInstantLuaEvent(instant));
 	} else if (spell->spellType == SPELL_RUNE) {
-		const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+		const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 		const auto &rune = std::static_pointer_cast<RuneSpell>(spellBase);
 		if (rune->getMagicLevel() != 0 || rune->getLevel() != 0) {
 			// Change information in the ItemType to get accurate description
@@ -201,7 +201,7 @@ int SpellFunctions::luaSpellRegister(lua_State* L) {
 int SpellFunctions::luaSpellName(lua_State* L) {
 
 	// spell:name(name)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, spell->getName());
@@ -217,7 +217,7 @@ int SpellFunctions::luaSpellName(lua_State* L) {
 
 int SpellFunctions::luaSpellId(lua_State* L) {
 	// spell:id(id)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (spell->spellType != SPELL_INSTANT && spell->spellType != SPELL_RUNE) {
 			Lua::reportErrorFunc("The method: 'spell:id(id)' is only for use of instant spells and rune spells");
@@ -238,7 +238,7 @@ int SpellFunctions::luaSpellId(lua_State* L) {
 
 int SpellFunctions::luaSpellGroup(lua_State* L) {
 	// spell:group(primaryGroup[, secondaryGroup])
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getGroup());
@@ -313,7 +313,7 @@ int SpellFunctions::luaSpellGroup(lua_State* L) {
 
 int SpellFunctions::luaSpellCastSound(lua_State* L) {
 	// get: spell:castSound() set: spell:castSound(effect)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, static_cast<uint16_t>(spell->soundCastEffect));
@@ -329,7 +329,7 @@ int SpellFunctions::luaSpellCastSound(lua_State* L) {
 
 int SpellFunctions::luaSpellImpactSound(lua_State* L) {
 	// get: spell:impactSound() set: spell:impactSound(effect)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, static_cast<uint16_t>(spell->soundImpactEffect));
@@ -345,7 +345,7 @@ int SpellFunctions::luaSpellImpactSound(lua_State* L) {
 
 int SpellFunctions::luaSpellCooldown(lua_State* L) {
 	// spell:cooldown(cooldown)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getCooldown());
@@ -361,7 +361,7 @@ int SpellFunctions::luaSpellCooldown(lua_State* L) {
 
 int SpellFunctions::luaSpellGroupCooldown(lua_State* L) {
 	// spell:groupCooldown(primaryGroupCd[, secondaryGroupCd])
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getGroupCooldown());
@@ -383,7 +383,7 @@ int SpellFunctions::luaSpellGroupCooldown(lua_State* L) {
 
 int SpellFunctions::luaSpellLevel(lua_State* L) {
 	// spell:level(lvl)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getLevel());
@@ -399,7 +399,7 @@ int SpellFunctions::luaSpellLevel(lua_State* L) {
 
 int SpellFunctions::luaSpellMagicLevel(lua_State* L) {
 	// spell:magicLevel(lvl)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getMagicLevel());
@@ -415,7 +415,7 @@ int SpellFunctions::luaSpellMagicLevel(lua_State* L) {
 
 int SpellFunctions::luaSpellMana(lua_State* L) {
 	// spell:mana(mana)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getMana());
@@ -431,7 +431,7 @@ int SpellFunctions::luaSpellMana(lua_State* L) {
 
 int SpellFunctions::luaSpellManaPercent(lua_State* L) {
 	// spell:manaPercent(percent)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getManaPercent());
@@ -447,7 +447,7 @@ int SpellFunctions::luaSpellManaPercent(lua_State* L) {
 
 int SpellFunctions::luaSpellSoul(lua_State* L) {
 	// spell:soul(soul)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getSoulCost());
@@ -463,7 +463,7 @@ int SpellFunctions::luaSpellSoul(lua_State* L) {
 
 int SpellFunctions::luaSpellRange(lua_State* L) {
 	// spell:range(range)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, spell->getRange());
@@ -479,7 +479,7 @@ int SpellFunctions::luaSpellRange(lua_State* L) {
 
 int SpellFunctions::luaSpellPremium(lua_State* L) {
 	// spell:isPremium(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->isPremium());
@@ -495,7 +495,7 @@ int SpellFunctions::luaSpellPremium(lua_State* L) {
 
 int SpellFunctions::luaSpellEnabled(lua_State* L) {
 	// spell:isEnabled(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->isEnabled());
@@ -511,7 +511,7 @@ int SpellFunctions::luaSpellEnabled(lua_State* L) {
 
 int SpellFunctions::luaSpellNeedTarget(lua_State* L) {
 	// spell:needTarget(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getNeedTarget());
@@ -527,7 +527,7 @@ int SpellFunctions::luaSpellNeedTarget(lua_State* L) {
 
 int SpellFunctions::luaSpellNeedWeapon(lua_State* L) {
 	// spell:needWeapon(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getNeedWeapon());
@@ -543,7 +543,7 @@ int SpellFunctions::luaSpellNeedWeapon(lua_State* L) {
 
 int SpellFunctions::luaSpellNeedLearn(lua_State* L) {
 	// spell:needLearn(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getNeedLearn());
@@ -559,7 +559,7 @@ int SpellFunctions::luaSpellNeedLearn(lua_State* L) {
 
 int SpellFunctions::luaSpellSelfTarget(lua_State* L) {
 	// spell:isSelfTarget(bool)
-	if (const auto &spell = Lua::getUserdataShared<Spell>(L, 1)) {
+	if (const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell")) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getSelfTarget());
 		} else {
@@ -574,7 +574,7 @@ int SpellFunctions::luaSpellSelfTarget(lua_State* L) {
 
 int SpellFunctions::luaSpellBlocking(lua_State* L) {
 	// spell:isBlocking(blockingSolid, blockingCreature)
-	if (const auto &spell = Lua::getUserdataShared<Spell>(L, 1)) {
+	if (const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell")) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getBlockingSolid());
 			Lua::pushBoolean(L, spell->getBlockingCreature());
@@ -592,7 +592,7 @@ int SpellFunctions::luaSpellBlocking(lua_State* L) {
 
 int SpellFunctions::luaSpellAggressive(lua_State* L) {
 	// spell:isAggressive(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getAggressive());
@@ -608,7 +608,7 @@ int SpellFunctions::luaSpellAggressive(lua_State* L) {
 
 int SpellFunctions::luaSpellAllowOnSelf(lua_State* L) {
 	// spell:allowOnSelf(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getAllowOnSelf());
@@ -624,7 +624,7 @@ int SpellFunctions::luaSpellAllowOnSelf(lua_State* L) {
 
 int SpellFunctions::luaSpellPzLocked(lua_State* L) {
 	// spell:isPzLocked(bool)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, spell->getLockedPZ());
@@ -640,7 +640,7 @@ int SpellFunctions::luaSpellPzLocked(lua_State* L) {
 
 int SpellFunctions::luaSpellVocation(lua_State* L) {
 	// spell:vocation(vocation)
-	const auto &spell = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			lua_createtable(L, 0, 0);
@@ -682,7 +682,7 @@ int SpellFunctions::luaSpellVocation(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellWords(lua_State* L) {
 	// spell:words(words[, separator = ""])
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -713,7 +713,7 @@ int SpellFunctions::luaSpellWords(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellNeedDirection(lua_State* L) {
 	// spell:needDirection(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -737,7 +737,7 @@ int SpellFunctions::luaSpellNeedDirection(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellHasParams(lua_State* L) {
 	// spell:hasParams(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -761,7 +761,7 @@ int SpellFunctions::luaSpellHasParams(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellHasPlayerNameParam(lua_State* L) {
 	// spell:hasPlayerNameParam(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -785,7 +785,7 @@ int SpellFunctions::luaSpellHasPlayerNameParam(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellNeedCasterTargetOrDirection(lua_State* L) {
 	// spell:needCasterTargetOrDirection(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -809,7 +809,7 @@ int SpellFunctions::luaSpellNeedCasterTargetOrDirection(lua_State* L) {
 // only for InstantSpells
 int SpellFunctions::luaSpellIsBlockingWalls(lua_State* L) {
 	// spell:blockWalls(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<InstantSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_INSTANT, it means that this actually is no InstantSpell, so we return nil
@@ -833,7 +833,7 @@ int SpellFunctions::luaSpellIsBlockingWalls(lua_State* L) {
 // only for RuneSpells
 int SpellFunctions::luaSpellRuneId(lua_State* L) {
 	// spell:runeId(id)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<RuneSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_RUNE, it means that this actually is no RuneSpell, so we return nil
@@ -857,7 +857,7 @@ int SpellFunctions::luaSpellRuneId(lua_State* L) {
 // only for RuneSpells
 int SpellFunctions::luaSpellCharges(lua_State* L) {
 	// spell:charges(charges)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<RuneSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_RUNE, it means that this actually is no RuneSpell, so we return nil
@@ -881,7 +881,7 @@ int SpellFunctions::luaSpellCharges(lua_State* L) {
 // only for RuneSpells
 int SpellFunctions::luaSpellAllowFarUse(lua_State* L) {
 	// spell:allowFarUse(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<RuneSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_RUNE, it means that this actually is no RuneSpell, so we return nil
@@ -905,7 +905,7 @@ int SpellFunctions::luaSpellAllowFarUse(lua_State* L) {
 // only for RuneSpells
 int SpellFunctions::luaSpellBlockWalls(lua_State* L) {
 	// spell:blockWalls(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<RuneSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_RUNE, it means that this actually is no RuneSpell, so we return nil
@@ -929,7 +929,7 @@ int SpellFunctions::luaSpellBlockWalls(lua_State* L) {
 // only for RuneSpells
 int SpellFunctions::luaSpellCheckFloor(lua_State* L) {
 	// spell:checkFloor(bool)
-	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1);
+	const auto &spellBase = Lua::getUserdataShared<Spell>(L, 1, "Spell");
 	const auto &spell = std::static_pointer_cast<RuneSpell>(spellBase);
 	if (spell) {
 		// if spell != SPELL_RUNE, it means that this actually is no RuneSpell, so we return nil

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -109,7 +109,7 @@ int CreatureFunctions::luaCreatureCreate(lua_State* L) {
 			lua_pushnil(L);
 			return 1;
 		}
-		creature = Lua::getUserdataShared<Creature>(L, 2);
+		creature = Lua::getUserdataShared<Creature>(L, 2, "Creature");
 	} else {
 		creature = nullptr;
 	}
@@ -125,7 +125,7 @@ int CreatureFunctions::luaCreatureCreate(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetEvents(lua_State* L) {
 	// creature:getEvents(type)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -145,7 +145,7 @@ int CreatureFunctions::luaCreatureGetEvents(lua_State* L) {
 
 int CreatureFunctions::luaCreatureRegisterEvent(lua_State* L) {
 	// creature:registerEvent(name)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		const std::string &name = Lua::getString(L, 2);
 		Lua::pushBoolean(L, creature->registerCreatureEvent(name));
@@ -158,7 +158,7 @@ int CreatureFunctions::luaCreatureRegisterEvent(lua_State* L) {
 int CreatureFunctions::luaCreatureUnregisterEvent(lua_State* L) {
 	// creature:unregisterEvent(name)
 	const std::string &name = Lua::getString(L, 2);
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->unregisterCreatureEvent(name));
 	} else {
@@ -169,7 +169,7 @@ int CreatureFunctions::luaCreatureUnregisterEvent(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsRemoved(lua_State* L) {
 	// creature:isRemoved()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->isRemoved());
 	} else {
@@ -180,13 +180,13 @@ int CreatureFunctions::luaCreatureIsRemoved(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsCreature(lua_State* L) {
 	// creature:isCreature()
-	Lua::pushBoolean(L, Lua::getUserdataShared<Creature>(L, 1) != nullptr);
+	Lua::pushBoolean(L, Lua::getUserdataShared<Creature>(L, 1, "Creature") != nullptr);
 	return 1;
 }
 
 int CreatureFunctions::luaCreatureIsInGhostMode(lua_State* L) {
 	// creature:isInGhostMode()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->isInGhostMode());
 	} else {
@@ -197,7 +197,7 @@ int CreatureFunctions::luaCreatureIsInGhostMode(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsHealthHidden(lua_State* L) {
 	// creature:isHealthHidden()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->isHealthHidden());
 	} else {
@@ -208,7 +208,7 @@ int CreatureFunctions::luaCreatureIsHealthHidden(lua_State* L) {
 
 int CreatureFunctions::luaCreatureCanSee(lua_State* L) {
 	// creature:canSee(position)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		const Position &position = Lua::getPosition(L, 2);
 		Lua::pushBoolean(L, creature->canSee(position));
@@ -220,7 +220,7 @@ int CreatureFunctions::luaCreatureCanSee(lua_State* L) {
 
 int CreatureFunctions::luaCreatureCanSeeCreature(lua_State* L) {
 	// creature:canSeeCreature(creature)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		const auto &otherCreature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, creature->canSeeCreature(otherCreature));
@@ -232,7 +232,7 @@ int CreatureFunctions::luaCreatureCanSeeCreature(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetParent(lua_State* L) {
 	// creature:getParent()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -250,7 +250,7 @@ int CreatureFunctions::luaCreatureGetParent(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetId(lua_State* L) {
 	// creature:getId()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getID());
 	} else {
@@ -261,7 +261,7 @@ int CreatureFunctions::luaCreatureGetId(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetName(lua_State* L) {
 	// creature:getName()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushString(L, creature->getName());
 	} else {
@@ -272,7 +272,7 @@ int CreatureFunctions::luaCreatureGetName(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetTypeName(lua_State* L) {
 	// creature:getTypeName()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushString(L, creature->getTypeName());
 	} else {
@@ -283,7 +283,7 @@ int CreatureFunctions::luaCreatureGetTypeName(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetTarget(lua_State* L) {
 	// creature:getTarget()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -301,7 +301,7 @@ int CreatureFunctions::luaCreatureGetTarget(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetTarget(lua_State* L) {
 	// creature:setTarget(target)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		const auto &target = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, creature->setAttackedCreature(target));
@@ -313,7 +313,7 @@ int CreatureFunctions::luaCreatureSetTarget(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetFollowCreature(lua_State* L) {
 	// creature:getFollowCreature()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -331,7 +331,7 @@ int CreatureFunctions::luaCreatureGetFollowCreature(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetFollowCreature(lua_State* L) {
 	// creature:setFollowCreature(followedCreature)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		const auto &followCreature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, creature->setFollowCreature(followCreature));
@@ -343,7 +343,7 @@ int CreatureFunctions::luaCreatureSetFollowCreature(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetMaster(lua_State* L) {
 	// creature:getMaster()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -362,7 +362,7 @@ int CreatureFunctions::luaCreatureGetMaster(lua_State* L) {
 
 int CreatureFunctions::luaCreatureReload(lua_State* L) {
 	// creature:reload()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -375,7 +375,7 @@ int CreatureFunctions::luaCreatureReload(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetMaster(lua_State* L) {
 	// creature:setMaster(master)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -389,7 +389,7 @@ int CreatureFunctions::luaCreatureSetMaster(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetLight(lua_State* L) {
 	// creature:getLight()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -403,7 +403,7 @@ int CreatureFunctions::luaCreatureGetLight(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetLight(lua_State* L) {
 	// creature:setLight(color, level)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -420,7 +420,7 @@ int CreatureFunctions::luaCreatureSetLight(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetSpeed(lua_State* L) {
 	// creature:getSpeed()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getSpeed());
 	} else {
@@ -446,7 +446,7 @@ int CreatureFunctions::luaCreatureSetSpeed(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetBaseSpeed(lua_State* L) {
 	// creature:getBaseSpeed()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getBaseSpeed());
 	} else {
@@ -472,7 +472,7 @@ int CreatureFunctions::luaCreatureChangeSpeed(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetDropLoot(lua_State* L) {
 	// creature:setDropLoot(doDrop)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setDropLoot(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -484,7 +484,7 @@ int CreatureFunctions::luaCreatureSetDropLoot(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetSkillLoss(lua_State* L) {
 	// creature:setSkillLoss(skillLoss)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setSkillLoss(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -496,7 +496,7 @@ int CreatureFunctions::luaCreatureSetSkillLoss(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetPosition(lua_State* L) {
 	// creature:Lua::getPosition()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushPosition(L, creature->getPosition());
 	} else {
@@ -507,7 +507,7 @@ int CreatureFunctions::luaCreatureGetPosition(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetTile(lua_State* L) {
 	// creature:getTile()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -525,7 +525,7 @@ int CreatureFunctions::luaCreatureGetTile(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetDirection(lua_State* L) {
 	// creature:getDirection()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getDirection());
 	} else {
@@ -536,7 +536,7 @@ int CreatureFunctions::luaCreatureGetDirection(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetDirection(lua_State* L) {
 	// creature:setDirection(direction)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, g_game().internalCreatureTurn(creature, Lua::getNumber<Direction>(L, 2)));
 	} else {
@@ -547,7 +547,7 @@ int CreatureFunctions::luaCreatureSetDirection(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetHealth(lua_State* L) {
 	// creature:getHealth()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getHealth());
 	} else {
@@ -558,7 +558,7 @@ int CreatureFunctions::luaCreatureGetHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetHealth(lua_State* L) {
 	// creature:setHealth(health)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -577,7 +577,7 @@ int CreatureFunctions::luaCreatureSetHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureAddHealth(lua_State* L) {
 	// creature:addHealth(healthChange, combatType)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -598,7 +598,7 @@ int CreatureFunctions::luaCreatureAddHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetMaxHealth(lua_State* L) {
 	// creature:getMaxHealth()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getMaxHealth());
 	} else {
@@ -609,7 +609,7 @@ int CreatureFunctions::luaCreatureGetMaxHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetMaxHealth(lua_State* L) {
 	// creature:setMaxHealth(maxHealth)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -629,7 +629,7 @@ int CreatureFunctions::luaCreatureSetMaxHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetHiddenHealth(lua_State* L) {
 	// creature:setHiddenHealth(hide)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setHiddenHealth(Lua::getBoolean(L, 2));
 		g_game().addCreatureHealth(creature);
@@ -642,7 +642,7 @@ int CreatureFunctions::luaCreatureSetHiddenHealth(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsMoveLocked(lua_State* L) {
 	// creature:isMoveLocked()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->isMoveLocked());
 	} else {
@@ -653,7 +653,7 @@ int CreatureFunctions::luaCreatureIsMoveLocked(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetMoveLocked(lua_State* L) {
 	// creature:setMoveLocked(moveLocked)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setMoveLocked(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -665,7 +665,7 @@ int CreatureFunctions::luaCreatureSetMoveLocked(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsDirectionLocked(lua_State* L) {
 	// creature:isDirectionLocked()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->isDirectionLocked());
 	} else {
@@ -676,7 +676,7 @@ int CreatureFunctions::luaCreatureIsDirectionLocked(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetDirectionLocked(lua_State* L) {
 	// creature:setDirectionLocked(directionLocked)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setDirectionLocked(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -688,7 +688,7 @@ int CreatureFunctions::luaCreatureSetDirectionLocked(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetSkull(lua_State* L) {
 	// creature:getSkull()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getSkull());
 	} else {
@@ -699,7 +699,7 @@ int CreatureFunctions::luaCreatureGetSkull(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetSkull(lua_State* L) {
 	// creature:setSkull(skull)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		creature->setSkull(Lua::getNumber<Skulls_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -711,7 +711,7 @@ int CreatureFunctions::luaCreatureSetSkull(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetOutfit(lua_State* L) {
 	// creature:Lua::getOutfit()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushOutfit(L, creature->getCurrentOutfit());
 	} else {
@@ -722,7 +722,7 @@ int CreatureFunctions::luaCreatureGetOutfit(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetOutfit(lua_State* L) {
 	// creature:setOutfit(outfit)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Outfit_t outfit = Lua::getOutfit(L, 2);
 		if (g_configManager().getBoolean(WARN_UNSAFE_SCRIPTS) && outfit.lookType != 0 && !g_game().isLookTypeRegistered(outfit.lookType)) {
@@ -741,7 +741,7 @@ int CreatureFunctions::luaCreatureSetOutfit(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetCondition(lua_State* L) {
 	// creature:getCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0]])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -763,8 +763,8 @@ int CreatureFunctions::luaCreatureGetCondition(lua_State* L) {
 
 int CreatureFunctions::luaCreatureAddCondition(lua_State* L) {
 	// creature:addCondition(condition)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
-	const auto &condition = Lua::getUserdataShared<Condition>(L, 2);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
+	const auto &condition = Lua::getUserdataShared<Condition>(L, 2, "Condition");
 	if (creature && condition) {
 		Lua::pushBoolean(L, creature->addCondition(condition->clone()));
 	} else {
@@ -775,7 +775,7 @@ int CreatureFunctions::luaCreatureAddCondition(lua_State* L) {
 
 int CreatureFunctions::luaCreatureRemoveCondition(lua_State* L) {
 	// creature:removeCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0[, force = false]]])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -801,7 +801,7 @@ int CreatureFunctions::luaCreatureRemoveCondition(lua_State* L) {
 
 int CreatureFunctions::luaCreatureHasCondition(lua_State* L) {
 	// creature:hasCondition(conditionType[, subId = 0])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -815,7 +815,7 @@ int CreatureFunctions::luaCreatureHasCondition(lua_State* L) {
 
 int CreatureFunctions::luaCreatureIsImmune(lua_State* L) {
 	// creature:isImmune(condition or conditionType)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -823,7 +823,7 @@ int CreatureFunctions::luaCreatureIsImmune(lua_State* L) {
 
 	if (Lua::isNumber(L, 2)) {
 		Lua::pushBoolean(L, creature->isImmune(Lua::getNumber<ConditionType_t>(L, 2)));
-	} else if (const auto condition = Lua::getUserdataShared<Condition>(L, 2)) {
+	} else if (const auto condition = Lua::getUserdataShared<Condition>(L, 2, "Condition")) {
 		Lua::pushBoolean(L, creature->isImmune(condition->getType()));
 	} else {
 		lua_pushnil(L);
@@ -866,7 +866,7 @@ int CreatureFunctions::luaCreatureTeleportTo(lua_State* L) {
 	const bool pushMovement = Lua::getBoolean(L, 3, false);
 
 	const Position &position = Lua::getPosition(L, 2);
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature == nullptr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -921,7 +921,7 @@ int CreatureFunctions::luaCreatureSay(lua_State* L) {
 
 	const auto type = Lua::getNumber<SpeakClasses>(L, 3, TALKTYPE_MONSTER_SAY);
 	const std::string &text = Lua::getString(L, 2);
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -942,7 +942,7 @@ int CreatureFunctions::luaCreatureSay(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetDamageMap(lua_State* L) {
 	// creature:getDamageMap()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -960,7 +960,7 @@ int CreatureFunctions::luaCreatureGetDamageMap(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetSummons(lua_State* L) {
 	// creature:getSummons()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -981,7 +981,7 @@ int CreatureFunctions::luaCreatureGetSummons(lua_State* L) {
 
 int CreatureFunctions::luaCreatureHasBeenSummoned(lua_State* L) {
 	// creature:hasBeenSummoned()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushBoolean(L, creature->hasBeenSummoned());
 	} else {
@@ -994,7 +994,7 @@ int CreatureFunctions::luaCreatureHasBeenSummoned(lua_State* L) {
 int CreatureFunctions::luaCreatureGetDescription(lua_State* L) {
 	// creature:getDescription(distance)
 	const int32_t distance = Lua::getNumber<int32_t>(L, 2);
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		Lua::pushString(L, creature->getDescription(distance));
 	} else {
@@ -1005,7 +1005,7 @@ int CreatureFunctions::luaCreatureGetDescription(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetPathTo(lua_State* L) {
 	// creature:getPathTo(pos[, minTargetDist = 0[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -1038,7 +1038,7 @@ int CreatureFunctions::luaCreatureGetPathTo(lua_State* L) {
 int CreatureFunctions::luaCreatureMove(lua_State* L) {
 	// creature:move(direction)
 	// creature:move(tile[, flags = 0])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -1052,7 +1052,7 @@ int CreatureFunctions::luaCreatureMove(lua_State* L) {
 		}
 		lua_pushnumber(L, g_game().internalMoveCreature(creature, direction, FLAG_NOLIMIT));
 	} else {
-		const auto &tile = Lua::getUserdataShared<Tile>(L, 2);
+		const auto &tile = Lua::getUserdataShared<Tile>(L, 2, "Tile");
 		if (!tile) {
 			lua_pushnil(L);
 			return 1;
@@ -1064,7 +1064,7 @@ int CreatureFunctions::luaCreatureMove(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetZoneType(lua_State* L) {
 	// creature:getZoneType()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature) {
 		lua_pushnumber(L, creature->getZoneType());
 	} else {
@@ -1075,7 +1075,7 @@ int CreatureFunctions::luaCreatureGetZoneType(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetZones(lua_State* L) {
 	// creature:getZones()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (creature == nullptr) {
 		lua_pushnil(L);
 		return 1;
@@ -1095,7 +1095,7 @@ int CreatureFunctions::luaCreatureGetZones(lua_State* L) {
 
 int CreatureFunctions::luaCreatureSetIcon(lua_State* L) {
 	// creature:setIcon(key, category, icon[, number])
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1120,7 +1120,7 @@ int CreatureFunctions::luaCreatureSetIcon(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetIcons(lua_State* L) {
 	// creature:getIcons()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1141,7 +1141,7 @@ int CreatureFunctions::luaCreatureGetIcons(lua_State* L) {
 
 int CreatureFunctions::luaCreatureGetIcon(lua_State* L) {
 	// creature:getIcon(key)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1162,7 +1162,7 @@ int CreatureFunctions::luaCreatureGetIcon(lua_State* L) {
 
 int CreatureFunctions::luaCreatureRemoveIcon(lua_State* L) {
 	// creature:removeIcon(key)
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1176,7 +1176,7 @@ int CreatureFunctions::luaCreatureRemoveIcon(lua_State* L) {
 
 int CreatureFunctions::luaCreatureClearIcons(lua_State* L) {
 	// creature:clearIcons()
-	const auto &creature = Lua::getUserdataShared<Creature>(L, 1);
+	const auto &creature = Lua::getUserdataShared<Creature>(L, 1, "Creature");
 	if (!creature) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/creatures/monster/charm_functions.cpp
+++ b/src/lua/functions/creatures/monster/charm_functions.cpp
@@ -51,7 +51,7 @@ int CharmFunctions::luaCharmCreate(lua_State* L) {
 
 int CharmFunctions::luaCharmName(lua_State* L) {
 	// get: charm:name() set: charm:name(string)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		Lua::pushString(L, charm->name);
 	} else {
@@ -63,7 +63,7 @@ int CharmFunctions::luaCharmName(lua_State* L) {
 
 int CharmFunctions::luaCharmDescription(lua_State* L) {
 	// get: charm:description() set: charm:description(string)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		Lua::pushString(L, charm->description);
 	} else {
@@ -75,7 +75,7 @@ int CharmFunctions::luaCharmDescription(lua_State* L) {
 
 int CharmFunctions::luaCharmType(lua_State* L) {
 	// get: charm:type() set: charm:type(charm_t)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->type);
 	} else {
@@ -87,7 +87,7 @@ int CharmFunctions::luaCharmType(lua_State* L) {
 
 int CharmFunctions::luaCharmPoints(lua_State* L) {
 	// get: charm:points() set: charm:points(value)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->points);
 	} else {
@@ -99,7 +99,7 @@ int CharmFunctions::luaCharmPoints(lua_State* L) {
 
 int CharmFunctions::luaCharmDamageType(lua_State* L) {
 	// get: charm:damageType() set: charm:damageType(type)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->dmgtype);
 	} else {
@@ -111,7 +111,7 @@ int CharmFunctions::luaCharmDamageType(lua_State* L) {
 
 int CharmFunctions::luaCharmPercentage(lua_State* L) {
 	// get: charm:percentage() set: charm:percentage(value)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->percent);
 	} else {
@@ -123,7 +123,7 @@ int CharmFunctions::luaCharmPercentage(lua_State* L) {
 
 int CharmFunctions::luaCharmChance(lua_State* L) {
 	// get: charm:chance() set: charm:chance(value)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->chance);
 	} else {
@@ -135,7 +135,7 @@ int CharmFunctions::luaCharmChance(lua_State* L) {
 
 int CharmFunctions::luaCharmMessageCancel(lua_State* L) {
 	// get: charm:messageCancel() set: charm:messageCancel(string)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		Lua::pushString(L, charm->cancelMsg);
 	} else {
@@ -147,7 +147,7 @@ int CharmFunctions::luaCharmMessageCancel(lua_State* L) {
 
 int CharmFunctions::luaCharmMessageServerLog(lua_State* L) {
 	// get: charm:messageServerLog() set: charm:messageServerLog(string)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		Lua::pushString(L, charm->logMsg);
 	} else {
@@ -159,7 +159,7 @@ int CharmFunctions::luaCharmMessageServerLog(lua_State* L) {
 
 int CharmFunctions::luaCharmEffect(lua_State* L) {
 	// get: charm:effect() set: charm:effect(value)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, charm->effect);
 	} else {
@@ -171,7 +171,7 @@ int CharmFunctions::luaCharmEffect(lua_State* L) {
 
 int CharmFunctions::luaCharmCastSound(lua_State* L) {
 	// get: charm:castSound() set: charm:castSound(sound)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, static_cast<lua_Number>(charm->soundCastEffect));
 	} else {
@@ -183,7 +183,7 @@ int CharmFunctions::luaCharmCastSound(lua_State* L) {
 
 int CharmFunctions::luaCharmImpactSound(lua_State* L) {
 	// get: charm:impactSound() set: charm:impactSound(sound)
-	const auto &charm = Lua::getUserdataShared<Charm>(L, 1);
+	const auto &charm = Lua::getUserdataShared<Charm>(L, 1, "Charm");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, static_cast<lua_Number>(charm->soundImpactEffect));
 	} else {

--- a/src/lua/functions/creatures/monster/loot_functions.cpp
+++ b/src/lua/functions/creatures/monster/loot_functions.cpp
@@ -47,7 +47,7 @@ int LootFunctions::luaCreateLoot(lua_State* L) {
 
 int LootFunctions::luaLootSetId(lua_State* L) {
 	// loot:setId(id)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		if (Lua::isNumber(L, 2)) {
 			loot->lootBlock.id = Lua::getNumber<uint16_t>(L, 2);
@@ -65,7 +65,7 @@ int LootFunctions::luaLootSetId(lua_State* L) {
 
 int LootFunctions::luaLootSetIdFromName(lua_State* L) {
 	// loot:setIdFromName(name)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot && Lua::isString(L, 2)) {
 		auto name = Lua::getString(L, 2);
 		const auto ids = Item::items.nameToItems.equal_range(asLowerCaseString(name));
@@ -98,7 +98,7 @@ int LootFunctions::luaLootSetIdFromName(lua_State* L) {
 
 int LootFunctions::luaLootSetSubType(lua_State* L) {
 	// loot:setSubType(type)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.subType = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -110,7 +110,7 @@ int LootFunctions::luaLootSetSubType(lua_State* L) {
 
 int LootFunctions::luaLootSetChance(lua_State* L) {
 	// loot:setChance(chance)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.chance = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -122,7 +122,7 @@ int LootFunctions::luaLootSetChance(lua_State* L) {
 
 int LootFunctions::luaLootSetMinCount(lua_State* L) {
 	// loot:setMinCount(min)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.countmin = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -134,7 +134,7 @@ int LootFunctions::luaLootSetMinCount(lua_State* L) {
 
 int LootFunctions::luaLootSetMaxCount(lua_State* L) {
 	// loot:setMaxCount(max)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.countmax = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -146,7 +146,7 @@ int LootFunctions::luaLootSetMaxCount(lua_State* L) {
 
 int LootFunctions::luaLootSetActionId(lua_State* L) {
 	// loot:setActionId(actionid)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.actionId = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -158,7 +158,7 @@ int LootFunctions::luaLootSetActionId(lua_State* L) {
 
 int LootFunctions::luaLootSetText(lua_State* L) {
 	// loot:setText(text)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.text = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -170,7 +170,7 @@ int LootFunctions::luaLootSetText(lua_State* L) {
 
 int LootFunctions::luaLootSetNameItem(lua_State* L) {
 	// loot:setNameItem(name)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.name = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -182,7 +182,7 @@ int LootFunctions::luaLootSetNameItem(lua_State* L) {
 
 int LootFunctions::luaLootSetArticle(lua_State* L) {
 	// loot:setArticle(article)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.article = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -194,7 +194,7 @@ int LootFunctions::luaLootSetArticle(lua_State* L) {
 
 int LootFunctions::luaLootSetAttack(lua_State* L) {
 	// loot:setAttack(attack)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.attack = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -206,7 +206,7 @@ int LootFunctions::luaLootSetAttack(lua_State* L) {
 
 int LootFunctions::luaLootSetDefense(lua_State* L) {
 	// loot:setDefense(defense)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.defense = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -218,7 +218,7 @@ int LootFunctions::luaLootSetDefense(lua_State* L) {
 
 int LootFunctions::luaLootSetExtraDefense(lua_State* L) {
 	// loot:setExtraDefense(defense)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.extraDefense = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -230,7 +230,7 @@ int LootFunctions::luaLootSetExtraDefense(lua_State* L) {
 
 int LootFunctions::luaLootSetArmor(lua_State* L) {
 	// loot:setArmor(armor)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.armor = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -242,7 +242,7 @@ int LootFunctions::luaLootSetArmor(lua_State* L) {
 
 int LootFunctions::luaLootSetShootRange(lua_State* L) {
 	// loot:setShootRange(range)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.shootRange = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -254,7 +254,7 @@ int LootFunctions::luaLootSetShootRange(lua_State* L) {
 
 int LootFunctions::luaLootSetHitChance(lua_State* L) {
 	// loot:setHitChance(chance)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		loot->lootBlock.hitChance = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -266,7 +266,7 @@ int LootFunctions::luaLootSetHitChance(lua_State* L) {
 
 int LootFunctions::luaLootSetUnique(lua_State* L) {
 	// loot:setUnique(bool)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, loot->lootBlock.unique);
@@ -282,7 +282,7 @@ int LootFunctions::luaLootSetUnique(lua_State* L) {
 
 int LootFunctions::luaLootAddChildLoot(lua_State* L) {
 	// loot:addChildLoot(loot)
-	const auto &loot = Lua::getUserdataShared<Loot>(L, 1);
+	const auto &loot = Lua::getUserdataShared<Loot>(L, 1, "Loot");
 	if (loot) {
 		const auto childLoot = Lua::getUserdata<Loot>(L, 2);
 		if (childLoot) {

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -97,7 +97,7 @@ int MonsterFunctions::luaMonsterCreate(lua_State* L) {
 			lua_pushnil(L);
 			return 1;
 		}
-		monster = Lua::getUserdataShared<Monster>(L, 2);
+		monster = Lua::getUserdataShared<Monster>(L, 2, "Monster");
 	} else {
 		monster = nullptr;
 	}
@@ -113,13 +113,13 @@ int MonsterFunctions::luaMonsterCreate(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsMonster(lua_State* L) {
 	// monster:isMonster()
-	Lua::pushBoolean(L, Lua::getUserdataShared<Monster>(L, 1) != nullptr);
+	Lua::pushBoolean(L, Lua::getUserdataShared<Monster>(L, 1, "Monster") != nullptr);
 	return 1;
 }
 
 int MonsterFunctions::luaMonsterGetType(lua_State* L) {
 	// monster:getType()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		Lua::pushUserdata<MonsterType>(L, monster->mType);
 		Lua::setMetatable(L, -1, "MonsterType");
@@ -132,7 +132,7 @@ int MonsterFunctions::luaMonsterGetType(lua_State* L) {
 int MonsterFunctions::luaMonsterSetType(lua_State* L) {
 	// monster:setType(name or raceid, restoreHealth = false)
 	bool restoreHealth = Lua::getBoolean(L, 3, false);
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		std::shared_ptr<MonsterType> mType;
 		if (Lua::isNumber(L, 2)) {
@@ -187,7 +187,7 @@ int MonsterFunctions::luaMonsterSetType(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetSpawnPosition(lua_State* L) {
 	// monster:getSpawnPosition()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		Lua::pushPosition(L, monster->getMasterPos());
 	} else {
@@ -198,7 +198,7 @@ int MonsterFunctions::luaMonsterGetSpawnPosition(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsInSpawnRange(lua_State* L) {
 	// monster:isInSpawnRange([position])
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		Lua::pushBoolean(L, monster->isInSpawnRange(lua_gettop(L) >= 2 ? Lua::getPosition(L, 2) : monster->getPosition()));
 	} else {
@@ -209,7 +209,7 @@ int MonsterFunctions::luaMonsterIsInSpawnRange(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsIdle(lua_State* L) {
 	// monster:isIdle()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		Lua::pushBoolean(L, monster->getIdleStatus());
 	} else {
@@ -220,7 +220,7 @@ int MonsterFunctions::luaMonsterIsIdle(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSetIdle(lua_State* L) {
 	// monster:setIdle(idle)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -233,7 +233,7 @@ int MonsterFunctions::luaMonsterSetIdle(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsTarget(lua_State* L) {
 	// monster:isTarget(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, monster->isTarget(creature));
@@ -245,7 +245,7 @@ int MonsterFunctions::luaMonsterIsTarget(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsOpponent(lua_State* L) {
 	// monster:isOpponent(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, monster->isOpponent(creature));
@@ -257,7 +257,7 @@ int MonsterFunctions::luaMonsterIsOpponent(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsFriend(lua_State* L) {
 	// monster:isFriend(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, monster->isFriend(creature));
@@ -269,7 +269,7 @@ int MonsterFunctions::luaMonsterIsFriend(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddFriend(lua_State* L) {
 	// monster:addFriend(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		monster->addFriend(creature);
@@ -282,7 +282,7 @@ int MonsterFunctions::luaMonsterAddFriend(lua_State* L) {
 
 int MonsterFunctions::luaMonsterRemoveFriend(lua_State* L) {
 	// monster:removeFriend(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		monster->removeFriend(creature);
@@ -295,7 +295,7 @@ int MonsterFunctions::luaMonsterRemoveFriend(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetFriendList(lua_State* L) {
 	// monster:getFriendList()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -315,7 +315,7 @@ int MonsterFunctions::luaMonsterGetFriendList(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetFriendCount(lua_State* L) {
 	// monster:getFriendCount()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		lua_pushnumber(L, monster->getFriendList().size());
 	} else {
@@ -326,7 +326,7 @@ int MonsterFunctions::luaMonsterGetFriendCount(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddTarget(lua_State* L) {
 	// monster:addTarget(creature[, pushFront = false])
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -341,7 +341,7 @@ int MonsterFunctions::luaMonsterAddTarget(lua_State* L) {
 
 int MonsterFunctions::luaMonsterRemoveTarget(lua_State* L) {
 	// monster:removeTarget(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -354,7 +354,7 @@ int MonsterFunctions::luaMonsterRemoveTarget(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetTargetList(lua_State* L) {
 	// monster:getTargetList()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -374,7 +374,7 @@ int MonsterFunctions::luaMonsterGetTargetList(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetTargetCount(lua_State* L) {
 	// monster:getTargetCount()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		lua_pushnumber(L, monster->getTargetList().size());
 	} else {
@@ -385,7 +385,7 @@ int MonsterFunctions::luaMonsterGetTargetCount(lua_State* L) {
 
 int MonsterFunctions::luaMonsterChangeTargetDistance(lua_State* L) {
 	// monster:changeTargetDistance(distance[, duration = 12000])
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto distance = Lua::getNumber<int32_t>(L, 2, 1);
 		const auto duration = Lua::getNumber<uint32_t>(L, 3, 12000);
@@ -398,7 +398,7 @@ int MonsterFunctions::luaMonsterChangeTargetDistance(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsChallenged(lua_State* L) {
 	// monster:isChallenged()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		Lua::pushBoolean(L, monster->isChallenged());
 	} else {
@@ -409,7 +409,7 @@ int MonsterFunctions::luaMonsterIsChallenged(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSelectTarget(lua_State* L) {
 	// monster:selectTarget(creature)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &creature = Lua::getCreature(L, 2);
 		Lua::pushBoolean(L, monster->selectTarget(creature));
@@ -421,7 +421,7 @@ int MonsterFunctions::luaMonsterSelectTarget(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSearchTarget(lua_State* L) {
 	// monster:searchTarget([searchType = TARGETSEARCH_DEFAULT])
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
 		const auto &searchType = Lua::getNumber<TargetSearchType_t>(L, 2, TARGETSEARCH_DEFAULT);
 		Lua::pushBoolean(L, monster->searchTarget(searchType));
@@ -433,7 +433,7 @@ int MonsterFunctions::luaMonsterSearchTarget(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSetSpawnPosition(lua_State* L) {
 	// monster:setSpawnPosition(interval)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -455,7 +455,7 @@ int MonsterFunctions::luaMonsterSetSpawnPosition(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetRespawnType(lua_State* L) {
 	// monster:getRespawnType()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 
 	if (!monster) {
 		lua_pushnil(L);
@@ -471,7 +471,7 @@ int MonsterFunctions::luaMonsterGetRespawnType(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetTimeToChangeFiendish(lua_State* L) {
 	// monster:getTimeToChangeFiendish()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -485,7 +485,7 @@ int MonsterFunctions::luaMonsterGetTimeToChangeFiendish(lua_State* L) {
 int MonsterFunctions::luaMonsterSetTimeToChangeFiendish(lua_State* L) {
 	// monster:setTimeToChangeFiendish(endTime)
 	const time_t endTime = Lua::getNumber<uint32_t>(L, 2, 1);
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -498,7 +498,7 @@ int MonsterFunctions::luaMonsterSetTimeToChangeFiendish(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetMonsterForgeClassification(lua_State* L) {
 	// monster:getMonsterForgeClassification()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -513,7 +513,7 @@ int MonsterFunctions::luaMonsterGetMonsterForgeClassification(lua_State* L) {
 int MonsterFunctions::luaMonsterSetMonsterForgeClassification(lua_State* L) {
 	// monster:setMonsterForgeClassification(classication)
 	const ForgeClassifications_t classification = Lua::getNumber<ForgeClassifications_t>(L, 2);
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -526,7 +526,7 @@ int MonsterFunctions::luaMonsterSetMonsterForgeClassification(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetForgeStack(lua_State* L) {
 	// monster:getForgeStack()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -540,7 +540,7 @@ int MonsterFunctions::luaMonsterGetForgeStack(lua_State* L) {
 int MonsterFunctions::luaMonsterSetForgeStack(lua_State* L) {
 	// monster:setForgeStack(stack)
 	const auto stack = Lua::getNumber<uint16_t>(L, 2, 0);
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -559,7 +559,7 @@ int MonsterFunctions::luaMonsterSetForgeStack(lua_State* L) {
 
 int MonsterFunctions::luaMonsterConfigureForgeSystem(lua_State* L) {
 	// monster:configureForgeSystem()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -572,7 +572,7 @@ int MonsterFunctions::luaMonsterConfigureForgeSystem(lua_State* L) {
 
 int MonsterFunctions::luaMonsterClearFiendishStatus(lua_State* L) {
 	// monster:clearFiendishStatus()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -585,7 +585,7 @@ int MonsterFunctions::luaMonsterClearFiendishStatus(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsForgeable(lua_State* L) {
 	// monster:isForgeable()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -598,7 +598,7 @@ int MonsterFunctions::luaMonsterIsForgeable(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetName(lua_State* L) {
 	// monster:getName()
-	const auto monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -611,7 +611,7 @@ int MonsterFunctions::luaMonsterGetName(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSetName(lua_State* L) {
 	// monster:setName(name[, nameDescription])
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -629,7 +629,7 @@ int MonsterFunctions::luaMonsterSetName(lua_State* L) {
 
 int MonsterFunctions::luaMonsterHazard(lua_State* L) {
 	// get: monster:hazard() ; set: monster:hazard(hazard)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool hazard = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -646,7 +646,7 @@ int MonsterFunctions::luaMonsterHazard(lua_State* L) {
 
 int MonsterFunctions::luaMonsterHazardCrit(lua_State* L) {
 	// get: monster:hazardCrit() ; set: monster:hazardCrit(hazardCrit)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool hazardCrit = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -663,7 +663,7 @@ int MonsterFunctions::luaMonsterHazardCrit(lua_State* L) {
 
 int MonsterFunctions::luaMonsterHazardDodge(lua_State* L) {
 	// get: monster:hazardDodge() ; set: monster:hazardDodge(hazardDodge)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool hazardDodge = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -680,7 +680,7 @@ int MonsterFunctions::luaMonsterHazardDodge(lua_State* L) {
 
 int MonsterFunctions::luaMonsterHazardDamageBoost(lua_State* L) {
 	// get: monster:hazardDamageBoost() ; set: monster:hazardDamageBoost(hazardDamageBoost)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool hazardDamageBoost = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -697,7 +697,7 @@ int MonsterFunctions::luaMonsterHazardDamageBoost(lua_State* L) {
 
 int MonsterFunctions::luaMonsterHazardDefenseBoost(lua_State* L) {
 	// get: monster:hazardDefenseBoost() ; set: monster:hazardDefenseBoost(hazardDefenseBoost)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool hazardDefenseBoost = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -714,7 +714,7 @@ int MonsterFunctions::luaMonsterHazardDefenseBoost(lua_State* L) {
 
 int MonsterFunctions::luaMonsterSoulPit(lua_State* L) {
 	// get: monster:soulPit() ; set: monster:soulPit(hazard)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const bool soulPit = Lua::getBoolean(L, 2, false);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -731,7 +731,7 @@ int MonsterFunctions::luaMonsterSoulPit(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddReflectElement(lua_State* L) {
 	// monster:addReflectElement(type, percent)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -746,7 +746,7 @@ int MonsterFunctions::luaMonsterAddReflectElement(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddDefense(lua_State* L) {
 	// monster:addDefense(defense)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -760,7 +760,7 @@ int MonsterFunctions::luaMonsterAddDefense(lua_State* L) {
 
 int MonsterFunctions::luaMonsterGetDefense(lua_State* L) {
 	// monster:getDefense(defense)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -773,7 +773,7 @@ int MonsterFunctions::luaMonsterGetDefense(lua_State* L) {
 
 int MonsterFunctions::luaMonsterIsDead(lua_State* L) {
 	// monster:isDead()
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -787,7 +787,7 @@ int MonsterFunctions::luaMonsterIsDead(lua_State* L) {
 int MonsterFunctions::luaMonsterImmune(lua_State* L) {
 	// to get: isImmune = monster:immune()
 	// to set and get: newImmuneBool = monster:immune(newImmuneBool)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -804,7 +804,7 @@ int MonsterFunctions::luaMonsterImmune(lua_State* L) {
 
 int MonsterFunctions::luaMonsterCriticalChance(lua_State* L) {
 	// get: monster:criticalChance(); set: monster:criticalChance(critical)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const auto critical = Lua::getNumber<uint16_t>(L, 2, 0);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -821,7 +821,7 @@ int MonsterFunctions::luaMonsterCriticalChance(lua_State* L) {
 
 int MonsterFunctions::luaMonsterCriticalDamage(lua_State* L) {
 	// get: monster:criticalDamage(); set: monster:criticalDamage(damage)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	const auto damage = Lua::getNumber<uint16_t>(L, 2, 0);
 	if (monster) {
 		if (lua_gettop(L) == 1) {
@@ -838,9 +838,9 @@ int MonsterFunctions::luaMonsterCriticalDamage(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddAttackSpell(lua_State* L) {
 	// monster:addAttackSpell(monsterspell)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
-		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2);
+		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2, "MonsterSpell");
 		if (spell) {
 			spellBlock_t sb;
 			const auto &monsterName = monster->getName();
@@ -860,9 +860,9 @@ int MonsterFunctions::luaMonsterAddAttackSpell(lua_State* L) {
 
 int MonsterFunctions::luaMonsterAddDefenseSpell(lua_State* L) {
 	// monster:addDefenseSpell(monsterspell)
-	const auto &monster = Lua::getUserdataShared<Monster>(L, 1);
+	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
-		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2);
+		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2, "MonsterSpell");
 		if (spell) {
 			spellBlock_t sb;
 			const auto &monsterName = monster->getName();

--- a/src/lua/functions/creatures/monster/monster_spell_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_spell_functions.cpp
@@ -49,7 +49,7 @@ int MonsterSpellFunctions::luaCreateMonsterSpell(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetType(lua_State* L) {
 	// monsterSpell:setType(type)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->name = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -61,7 +61,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetType(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetScriptName(lua_State* L) {
 	// monsterSpell:setScriptName(name)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->scriptName = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -73,7 +73,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetScriptName(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetChance(lua_State* L) {
 	// monsterSpell:setChance(chance)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->chance = Lua::getNumber<uint8_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -85,7 +85,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetChance(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetInterval(lua_State* L) {
 	// monsterSpell:setInterval(interval)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->interval = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -97,7 +97,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetInterval(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetRange(lua_State* L) {
 	// monsterSpell:setRange(range)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->range = Lua::getNumber<uint8_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -109,7 +109,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetRange(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatValue(lua_State* L) {
 	// monsterSpell:setCombatValue(min, max)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->minCombatValue = Lua::getNumber<int32_t>(L, 2);
 		spell->maxCombatValue = Lua::getNumber<int32_t>(L, 3);
@@ -122,7 +122,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatValue(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatType(lua_State* L) {
 	// monsterSpell:setCombatType(combatType_t)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->combatType = Lua::getNumber<CombatType_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -134,7 +134,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatType(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetAttackValue(lua_State* L) {
 	// monsterSpell:setAttackValue(attack, skill)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->attack = Lua::getNumber<int32_t>(L, 2);
 		spell->skill = Lua::getNumber<int32_t>(L, 3);
@@ -147,7 +147,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetAttackValue(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetNeedTarget(lua_State* L) {
 	// monsterSpell:setNeedTarget(bool)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->needTarget = Lua::getBoolean(L, 2);
 		Lua::pushBoolean(L, true);
@@ -159,7 +159,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetNeedTarget(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatLength(lua_State* L) {
 	// monsterSpell:setCombatLength(length)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->length = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -171,7 +171,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatLength(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatSpread(lua_State* L) {
 	// monsterSpell:setCombatSpread(spread)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->spread = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -183,7 +183,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatSpread(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatRadius(lua_State* L) {
 	// monsterSpell:setCombatRadius(radius)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->radius = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -195,7 +195,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatRadius(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetConditionType(lua_State* L) {
 	// monsterSpell:setConditionType(type)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		auto conditionType = Lua::getNumber<uint8_t>(L, 2);
 		if (conditionType == 254) {
@@ -215,7 +215,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetConditionType(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetConditionDamage(lua_State* L) {
 	// monsterSpell:setConditionDamage(min, max, start)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->conditionMinDamage = Lua::getNumber<int32_t>(L, 2);
 		spell->conditionMaxDamage = Lua::getNumber<int32_t>(L, 3);
@@ -229,7 +229,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetConditionDamage(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetConditionSpeedChange(lua_State* L) {
 	// monsterSpell:setConditionSpeedChange(speed)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->speedChange = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -241,7 +241,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetConditionSpeedChange(lua_State* L) 
 
 int MonsterSpellFunctions::luaMonsterSpellSetConditionDuration(lua_State* L) {
 	// monsterSpell:setConditionDuration(duration)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->duration = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -253,7 +253,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetConditionDuration(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetConditionTickInterval(lua_State* L) {
 	// monsterSpell:setConditionTickInterval(interval)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->tickInterval = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -265,7 +265,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetConditionTickInterval(lua_State* L)
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatShootEffect(lua_State* L) {
 	// monsterSpell:setCombatShootEffect(effect)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->shoot = Lua::getNumber<ShootType_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -277,7 +277,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatShootEffect(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetCombatEffect(lua_State* L) {
 	// monsterSpell:setCombatEffect(effect)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->effect = Lua::getNumber<MagicEffectClasses>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -289,7 +289,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetCombatEffect(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetOutfitMonster(lua_State* L) {
 	// monsterSpell:setOutfitMonster(effect)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->outfitMonster = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
@@ -301,7 +301,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetOutfitMonster(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellSetOutfitItem(lua_State* L) {
 	// monsterSpell:setOutfitItem(effect)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (spell) {
 		spell->outfitItem = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -313,7 +313,7 @@ int MonsterSpellFunctions::luaMonsterSpellSetOutfitItem(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellCastSound(lua_State* L) {
 	// get: monsterSpell:castSound() set: monsterSpell:castSound(sound)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, static_cast<lua_Number>(spell->soundCastEffect));
 	} else {
@@ -325,7 +325,7 @@ int MonsterSpellFunctions::luaMonsterSpellCastSound(lua_State* L) {
 
 int MonsterSpellFunctions::luaMonsterSpellImpactSound(lua_State* L) {
 	// get: monsterSpell:impactSound() set: monsterSpell:impactSound(sound)
-	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1);
+	const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 1, "MonsterSpell");
 	if (lua_gettop(L) == 1) {
 		lua_pushnumber(L, static_cast<lua_Number>(spell->soundImpactEffect));
 	} else {

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -199,7 +199,7 @@ int MonsterTypeFunctions::luaMonsterTypeCreate(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsAttackable(lua_State* L) {
 	// get: monsterType:isAttackable() set: monsterType:isAttackable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isAttackable);
@@ -215,7 +215,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsAttackable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsConvinceable(lua_State* L) {
 	// get: monsterType:isConvinceable() set: monsterType:isConvinceable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isConvinceable);
@@ -231,7 +231,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsConvinceable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsSummonable(lua_State* L) {
 	// get: monsterType:isSummonable() set: monsterType:isSummonable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isSummonable);
@@ -247,7 +247,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsSummonable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsPreyExclusive(lua_State* L) {
 	// get: monsterType:isPreyExclusive() set: monsterType:isPreyExclusive(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isPreyExclusive);
@@ -263,7 +263,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsPreyExclusive(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsPreyable(lua_State* L) {
 	// get: monsterType:isPreyable() set: monsterType:isPreyable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isPreyable);
@@ -279,7 +279,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsPreyable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsIllusionable(lua_State* L) {
 	// get: monsterType:isIllusionable() set: monsterType:isIllusionable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isIllusionable);
@@ -295,7 +295,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsIllusionable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsHostile(lua_State* L) {
 	// get: monsterType:isHostile() set: monsterType:isHostile(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isHostile);
@@ -311,7 +311,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsHostile(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeFamiliar(lua_State* L) {
 	// get: monsterType:familiar() set: monsterType:familiar(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isFamiliar);
@@ -327,7 +327,7 @@ int MonsterTypeFunctions::luaMonsterTypeFamiliar(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsRewardBoss(lua_State* L) {
 	// get: monsterType:isRewardBoss() set: monsterType:isRewardBoss(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isRewardBoss);
@@ -343,7 +343,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsRewardBoss(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsPushable(lua_State* L) {
 	// get: monsterType:isPushable() set: monsterType:isPushable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.pushable);
@@ -359,7 +359,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsPushable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsHealthHidden(lua_State* L) {
 	// get: monsterType:isHealthHidden() set: monsterType:isHealthHidden(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.hiddenHealth);
@@ -375,7 +375,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsHealthHidden(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsBlockable(lua_State* L) {
 	// get: monsterType:isBlockable() set: monsterType:isBlockable(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.isBlockable);
@@ -391,7 +391,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsBlockable(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeIsForgeCreature(lua_State* L) {
 	// get: monsterType:isForgeCreature() set: monsterType:isForgeCreature(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -409,7 +409,7 @@ int MonsterTypeFunctions::luaMonsterTypeIsForgeCreature(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanSpawn(lua_State* L) {
 	// monsterType:canSpawn(pos)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	const Position &position = Lua::getPosition(L, 2);
 	if (monsterType) {
 		Lua::pushBoolean(L, monsterType->canSpawn(position));
@@ -421,7 +421,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanSpawn(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanPushItems(lua_State* L) {
 	// get: monsterType:canPushItems() set: monsterType:canPushItems(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.canPushItems);
@@ -437,7 +437,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanPushItems(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanPushCreatures(lua_State* L) {
 	// get: monsterType:canPushCreatures() set: monsterType:canPushCreatures(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.canPushCreatures);
@@ -453,7 +453,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanPushCreatures(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCritChance(lua_State* L) {
 	// get: monsterType:critChance() set: monsterType:critChance(int)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 2) {
 			monsterType->info.critChance = Lua::getNumber<uint16_t>(L, 2);
@@ -467,7 +467,7 @@ int MonsterTypeFunctions::luaMonsterTypeCritChance(lua_State* L) {
 
 int32_t MonsterTypeFunctions::luaMonsterTypeName(lua_State* L) {
 	// get: monsterType:name() set: monsterType:name(name)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, monsterType->name);
@@ -483,7 +483,7 @@ int32_t MonsterTypeFunctions::luaMonsterTypeName(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeNameDescription(lua_State* L) {
 	// get: monsterType:nameDescription() set: monsterType:nameDescription(desc)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, monsterType->nameDescription);
@@ -499,7 +499,7 @@ int MonsterTypeFunctions::luaMonsterTypeNameDescription(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypegetCorpseId(lua_State* L) {
 	// monsterType:getCorpseId()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		lua_pushnumber(L, monsterType->info.lookcorpse);
 	} else {
@@ -510,7 +510,7 @@ int MonsterTypeFunctions::luaMonsterTypegetCorpseId(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeHealth(lua_State* L) {
 	// get: monsterType:health() set: monsterType:health(health)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.health);
@@ -526,7 +526,7 @@ int MonsterTypeFunctions::luaMonsterTypeHealth(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeMaxHealth(lua_State* L) {
 	// get: monsterType:maxHealth() set: monsterType:maxHealth(health)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.healthMax);
@@ -542,7 +542,7 @@ int MonsterTypeFunctions::luaMonsterTypeMaxHealth(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRunHealth(lua_State* L) {
 	// get: monsterType:runHealth() set: monsterType:runHealth(health)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.runAwayHealth);
@@ -558,7 +558,7 @@ int MonsterTypeFunctions::luaMonsterTypeRunHealth(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeExperience(lua_State* L) {
 	// get: monsterType:experience() set: monsterType:experience(exp)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.experience);
@@ -574,7 +574,7 @@ int MonsterTypeFunctions::luaMonsterTypeExperience(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeFaction(lua_State* L) {
 	// get: monsterType:faction() set: monsterType:faction(faction)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.faction);
@@ -590,7 +590,7 @@ int MonsterTypeFunctions::luaMonsterTypeFaction(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeEnemyFactions(lua_State* L) {
 	// get: monsterType:enemyFactions() set: monsterType:enemyFactions(enemyFaction)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_createtable(L, monsterType->info.enemyFactions.size(), 0);
@@ -613,7 +613,7 @@ int MonsterTypeFunctions::luaMonsterTypeEnemyFactions(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeTargetPreferPlayer(lua_State* L) {
 	// get: monsterType:targetPreferPlayer() set: monsterType:targetPreferPlayer(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushboolean(L, monsterType->info.targetPreferPlayer);
@@ -629,7 +629,7 @@ int MonsterTypeFunctions::luaMonsterTypeTargetPreferPlayer(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeTargetPreferMaster(lua_State* L) {
 	// get: monsterType:targetPreferMaster() set: monsterType:targetPreferMaster(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.faction);
@@ -645,7 +645,7 @@ int MonsterTypeFunctions::luaMonsterTypeTargetPreferMaster(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRaceid(lua_State* L) {
 	// get: monsterType:raceId() set: monsterType:raceId(id)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.raceid);
@@ -662,7 +662,7 @@ int MonsterTypeFunctions::luaMonsterTypeRaceid(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeSoulCore(lua_State* L) {
 	// get: monsterType:luaMonsterTypeSoulCore() set: monsterType:luaMonsterTypeSoulCore(id)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.soulCore);
@@ -678,7 +678,7 @@ int MonsterTypeFunctions::luaMonsterTypeSoulCore(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiarytoKill(lua_State* L) {
 	// get: monsterType:BestiarytoKill() set: monsterType:BestiarytoKill(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryToUnlock);
@@ -694,7 +694,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiarytoKill(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryFirstUnlock(lua_State* L) {
 	// get: monsterType:BestiaryFirstUnlock() set: monsterType:BestiaryFirstUnlock(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryFirstUnlock);
@@ -710,7 +710,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryFirstUnlock(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiarySecondUnlock(lua_State* L) {
 	// get: monsterType:BestiarySecondUnlock() set: monsterType:BestiarySecondUnlock(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiarySecondUnlock);
@@ -726,7 +726,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiarySecondUnlock(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryCharmsPoints(lua_State* L) {
 	// get: monsterType:BestiaryCharmsPoints() set: monsterType:BestiaryCharmsPoints(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryCharmsPoints);
@@ -742,7 +742,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryCharmsPoints(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryStars(lua_State* L) {
 	// get: monsterType:BestiaryStars() set: monsterType:BestiaryStars(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryStars);
@@ -758,7 +758,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryStars(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryOccurrence(lua_State* L) {
 	// get: monsterType:BestiaryOccurrence() set: monsterType:BestiaryOccurrence(value)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryOccurrence);
@@ -774,7 +774,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryOccurrence(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryLocations(lua_State* L) {
 	// get: monsterType:BestiaryLocations() set: monsterType:BestiaryLocations(string)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, monsterType->info.bestiaryLocations);
@@ -790,7 +790,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryLocations(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryclass(lua_State* L) {
 	// get: monsterType:Bestiaryclass() set: monsterType:Bestiaryclass(string)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, monsterType->info.bestiaryClass);
@@ -806,7 +806,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryclass(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBestiaryrace(lua_State* L) {
 	// get: monsterType:Bestiaryrace() set: monsterType:Bestiaryrace(raceid)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.bestiaryRace);
@@ -823,7 +823,7 @@ int MonsterTypeFunctions::luaMonsterTypeBestiaryrace(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 	// get: monsterType:combatImmunities() set: monsterType:combatImmunities(immunity)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -879,7 +879,7 @@ int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 	// get: monsterType:conditionImmunities() set: monsterType:conditionImmunities(immunity)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -937,7 +937,7 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetAttackList(lua_State* L) {
 	// monsterType:getAttackList()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -967,9 +967,9 @@ int MonsterTypeFunctions::luaMonsterTypeGetAttackList(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddAttack(lua_State* L) {
 	// monsterType:addAttack(monsterspell)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
-		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2);
+		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2, "MonsterSpell");
 		if (spell) {
 			spellBlock_t sb;
 			if (g_monsters().deserializeSpell(spell, sb, monsterType->name)) {
@@ -988,7 +988,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddAttack(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetDefenseList(lua_State* L) {
 	// monsterType:getDefenseList()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1018,7 +1018,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetDefenseList(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetTypeName(lua_State* L) {
 	// monsterType:getTypeName()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		return 1;
 	}
@@ -1029,9 +1029,9 @@ int MonsterTypeFunctions::luaMonsterTypeGetTypeName(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddDefense(lua_State* L) {
 	// monsterType:addDefense(monsterspell)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
-		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2);
+		const auto &spell = Lua::getUserdataShared<MonsterSpell>(L, 2, "MonsterSpell");
 		if (spell) {
 			spellBlock_t sb;
 			if (g_monsters().deserializeSpell(spell, sb, monsterType->name)) {
@@ -1050,7 +1050,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddDefense(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddElement(lua_State* L) {
 	// monsterType:addElement(type, percent)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		const CombatType_t element = Lua::getNumber<CombatType_t>(L, 2);
 		monsterType->info.elementMap[element] = Lua::getNumber<int32_t>(L, 3);
@@ -1063,7 +1063,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddElement(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddReflect(lua_State* L) {
 	// monsterType:addReflect(type, percent)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		const CombatType_t element = Lua::getNumber<CombatType_t>(L, 2);
 		monsterType->info.reflectMap[element] = Lua::getNumber<int32_t>(L, 3);
@@ -1076,7 +1076,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddReflect(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddHealing(lua_State* L) {
 	// monsterType:addHealing(type, percent)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		const CombatType_t element = Lua::getNumber<CombatType_t>(L, 2);
 		monsterType->info.healingMap[element] = Lua::getNumber<int32_t>(L, 3);
@@ -1089,7 +1089,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddHealing(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetElementList(lua_State* L) {
 	// monsterType:getElementList()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1105,7 +1105,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetElementList(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddVoice(lua_State* L) {
 	// monsterType:addVoice(sentence, interval, chance, yell)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		voiceBlock_t voice;
 		voice.text = Lua::getString(L, 2);
@@ -1122,7 +1122,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddVoice(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetVoices(lua_State* L) {
 	// monsterType:getVoices()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1141,7 +1141,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetVoices(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetLoot(lua_State* L) {
 	// monsterType:getLoot()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1153,9 +1153,9 @@ int MonsterTypeFunctions::luaMonsterTypeGetLoot(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddLoot(lua_State* L) {
 	// monsterType:addLoot(loot)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
-		const auto &loot = Lua::getUserdataShared<Loot>(L, 2);
+		const auto &loot = Lua::getUserdataShared<Loot>(L, 2, "Loot");
 		if (loot) {
 			monsterType->loadLoot(monsterType, loot->lootBlock);
 			Lua::pushBoolean(L, true);
@@ -1170,7 +1170,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddLoot(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetCreatureEvents(lua_State* L) {
 	// monsterType:getCreatureEvents()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1187,7 +1187,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetCreatureEvents(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRegisterEvent(lua_State* L) {
 	// monsterType:registerEvent(name)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1215,7 +1215,7 @@ int MonsterTypeFunctions::luaMonsterTypeEventOnCallback(lua_State* L) {
 	// monsterType:onSay(callback)
 	// monsterType:onPlayerAttack(callback)
 	// monsterType:onSpawn(callback)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (monsterType->loadCallback(&g_scripts().getScriptInterface())) {
 			Lua::pushBoolean(L, true);
@@ -1230,7 +1230,7 @@ int MonsterTypeFunctions::luaMonsterTypeEventOnCallback(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeEventType(lua_State* L) {
 	// monstertype:eventType(event)
-	const auto &mType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &mType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (mType) {
 		mType->info.eventType = Lua::getNumber<MonstersEvent_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -1242,7 +1242,7 @@ int MonsterTypeFunctions::luaMonsterTypeEventType(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetSummonList(lua_State* L) {
 	// monsterType:getSummonList()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1262,7 +1262,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetSummonList(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddSummon(lua_State* L) {
 	// monsterType:addSummon(name, interval, chance[, count = 1])
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		summonBlock_t summon;
 		summon.name = Lua::getString(L, 2);
@@ -1279,7 +1279,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddSummon(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeMaxSummons(lua_State* L) {
 	// get: monsterType:maxSummons() set: monsterType:maxSummons(ammount)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.maxSummons);
@@ -1295,7 +1295,7 @@ int MonsterTypeFunctions::luaMonsterTypeMaxSummons(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeArmor(lua_State* L) {
 	// get: monsterType:armor() set: monsterType:armor(armor)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.armor);
@@ -1311,7 +1311,7 @@ int MonsterTypeFunctions::luaMonsterTypeArmor(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeMitigation(lua_State* L) {
 	// get: monsterType:mitigation() set: monsterType:mitigation(mitigation)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -1329,7 +1329,7 @@ int MonsterTypeFunctions::luaMonsterTypeMitigation(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeDefense(lua_State* L) {
 	// get: monsterType:defense() set: monsterType:defense(defense)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.defense);
@@ -1345,7 +1345,7 @@ int MonsterTypeFunctions::luaMonsterTypeDefense(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeOutfit(lua_State* L) {
 	// get: monsterType:outfit() set: monsterType:outfit(outfit)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushOutfit(L, monsterType->info.outfit);
@@ -1367,7 +1367,7 @@ int MonsterTypeFunctions::luaMonsterTypeOutfit(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRace(lua_State* L) {
 	// get: monsterType:race() set: monsterType:race(race)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	std::string race = Lua::getString(L, 2);
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
@@ -1402,7 +1402,7 @@ int MonsterTypeFunctions::luaMonsterTypeRace(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCorpseId(lua_State* L) {
 	// get: monsterType:corpseId() set: monsterType:corpseId(id)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.lookcorpse);
@@ -1418,7 +1418,7 @@ int MonsterTypeFunctions::luaMonsterTypeCorpseId(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeManaCost(lua_State* L) {
 	// get: monsterType:manaCost() set: monsterType:manaCost(mana)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.manaCost);
@@ -1434,7 +1434,7 @@ int MonsterTypeFunctions::luaMonsterTypeManaCost(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeBaseSpeed(lua_State* L) {
 	// monsterType:baseSpeed()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->getBaseSpeed());
@@ -1449,7 +1449,7 @@ int MonsterTypeFunctions::luaMonsterTypeBaseSpeed(lua_State* L) {
 }
 int MonsterTypeFunctions::luaMonsterTypeLight(lua_State* L) {
 	// get: monsterType:light() set: monsterType:light(color, level)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1469,7 +1469,7 @@ int MonsterTypeFunctions::luaMonsterTypeLight(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeStaticAttackChance(lua_State* L) {
 	// get: monsterType:staticAttackChance() set: monsterType:staticAttackChance(chance)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.staticAttackChance);
@@ -1485,7 +1485,7 @@ int MonsterTypeFunctions::luaMonsterTypeStaticAttackChance(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeTargetDistance(lua_State* L) {
 	// get: monsterType:targetDistance() set: monsterType:targetDistance(distance)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.targetDistance);
@@ -1501,7 +1501,7 @@ int MonsterTypeFunctions::luaMonsterTypeTargetDistance(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeYellChance(lua_State* L) {
 	// get: monsterType:yellChance() set: monsterType:yellChance(chance)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			if (lua_gettop(L) == 1) {
@@ -1522,7 +1522,7 @@ int MonsterTypeFunctions::luaMonsterTypeYellChance(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeYellSpeedTicks(lua_State* L) {
 	// get: monsterType:yellSpeedTicks() set: monsterType:yellSpeedTicks(rate)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.yellSpeedTicks);
@@ -1538,7 +1538,7 @@ int MonsterTypeFunctions::luaMonsterTypeYellSpeedTicks(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeChangeTargetChance(lua_State* L) {
 	// monsterType:getChangeTargetChance()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.changeTargetChance);
@@ -1554,7 +1554,7 @@ int MonsterTypeFunctions::luaMonsterTypeChangeTargetChance(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeChangeTargetSpeed(lua_State* L) {
 	// get: monsterType:changeTargetSpeed() set: monsterType:changeTargetSpeed(speed)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.changeTargetSpeed);
@@ -1570,7 +1570,7 @@ int MonsterTypeFunctions::luaMonsterTypeChangeTargetSpeed(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanWalkOnEnergy(lua_State* L) {
 	// get: monsterType:canWalkOnEnergy() set: monsterType:canWalkOnEnergy(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.canWalkOnEnergy);
@@ -1586,7 +1586,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanWalkOnEnergy(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanWalkOnFire(lua_State* L) {
 	// get: monsterType:canWalkOnFire() set: monsterType:canWalkOnFire(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.canWalkOnFire);
@@ -1602,7 +1602,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanWalkOnFire(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeCanWalkOnPoison(lua_State* L) {
 	// get: monsterType:canWalkOnPoison() set: monsterType:canWalkOnPoison(bool)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, monsterType->info.canWalkOnPoison);
@@ -1618,7 +1618,7 @@ int MonsterTypeFunctions::luaMonsterTypeCanWalkOnPoison(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetNearest(lua_State* L) {
 	// monsterType:strategiesTargetNearest()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.strategiesTargetNearest);
@@ -1634,7 +1634,7 @@ int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetNearest(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetHealth(lua_State* L) {
 	// monsterType:strategiesTargetHealth()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.strategiesTargetHealth);
@@ -1650,7 +1650,7 @@ int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetHealth(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetDamage(lua_State* L) {
 	// monsterType:strategiesTargetDamage()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.strategiesTargetDamage);
@@ -1666,7 +1666,7 @@ int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetDamage(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetRandom(lua_State* L) {
 	// monsterType:strategiesTargetRandom()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.strategiesTargetRandom);
@@ -1686,7 +1686,7 @@ int MonsterTypeFunctions::luaMonsterTypeStrategiesTargetRandom(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRespawnTypePeriod(lua_State* L) {
 	// monsterType:respawnTypePeriod()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.respawnType.period);
@@ -1702,7 +1702,7 @@ int MonsterTypeFunctions::luaMonsterTypeRespawnTypePeriod(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeRespawnTypeIsUnderground(lua_State* L) {
 	// monsterType:respawnTypeIsUnderground()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (monsterType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, monsterType->info.respawnType.underground);
@@ -1719,7 +1719,7 @@ int MonsterTypeFunctions::luaMonsterTypeRespawnTypeIsUnderground(lua_State* L) {
 int MonsterTypeFunctions::luaMonsterTypeBossRace(lua_State* L) {
 	// set: monsterType:bosstiaryRace(raceId, class)
 	// get: monsterType:bosstiaryRace() = this return only class name
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -1746,7 +1746,7 @@ int MonsterTypeFunctions::luaMonsterTypeBossRace(lua_State* L) {
 int MonsterTypeFunctions::luaMonsterTypeBossRaceId(lua_State* L) {
 	// set: monsterType:bossRaceId(raceId)
 	// get: monsterType:bossRaceId()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_TYPE_NOT_FOUND));
@@ -1771,7 +1771,7 @@ int MonsterTypeFunctions::luaMonsterTypeBossRaceId(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeSoundChance(lua_State* L) {
 	// get: monsterType:soundChance() set: monsterType:soundChance(chance)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1789,7 +1789,7 @@ int MonsterTypeFunctions::luaMonsterTypeSoundChance(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeSoundSpeedTicks(lua_State* L) {
 	// get: monsterType:soundSpeedTicks() set: monsterType:soundSpeedTicks(ticks)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1807,7 +1807,7 @@ int MonsterTypeFunctions::luaMonsterTypeSoundSpeedTicks(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeAddSound(lua_State* L) {
 	// monsterType:addSound(soundId)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1821,7 +1821,7 @@ int MonsterTypeFunctions::luaMonsterTypeAddSound(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeGetSounds(lua_State* L) {
 	// monsterType:getSounds()
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		lua_pushnil(L);
 		return 1;
@@ -1840,7 +1840,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetSounds(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypedeathSound(lua_State* L) {
 	// get: monsterType:deathSound() set: monsterType:deathSound(sound)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1859,7 +1859,7 @@ int MonsterTypeFunctions::luaMonsterTypedeathSound(lua_State* L) {
 
 int MonsterTypeFunctions::luaMonsterTypeVariant(lua_State* L) {
 	// get: monsterType:variant() set: monsterType:variant(variantName)
-	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1);
+	const auto &monsterType = Lua::getUserdataShared<MonsterType>(L, 1, "MonsterType");
 	if (!monsterType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/creatures/npc/npc_functions.cpp
+++ b/src/lua/functions/creatures/npc/npc_functions.cpp
@@ -66,12 +66,12 @@ int NpcFunctions::luaNpcCreate(lua_State* L) {
 				lua_pushnil(L);
 				return 1;
 			}
-			npc = Lua::getUserdataShared<Npc>(L, 2);
+			npc = Lua::getUserdataShared<Npc>(L, 2, "Npc");
 		} else {
 			npc = nullptr;
 		}
 	} else {
-		npc = Lua::getUserdataShared<Npc>(L, 1);
+		npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	}
 
 	if (npc) {
@@ -85,13 +85,13 @@ int NpcFunctions::luaNpcCreate(lua_State* L) {
 
 int NpcFunctions::luaNpcIsNpc(lua_State* L) {
 	// npc:isNpc()
-	Lua::pushBoolean(L, Lua::getUserdataShared<const Npc>(L, 1) != nullptr);
+	Lua::pushBoolean(L, Lua::getUserdataShared<Npc>(L, 1, "Npc") != nullptr);
 	return 1;
 }
 
 int NpcFunctions::luaNpcSetMasterPos(lua_State* L) {
 	// npc:setMasterPos(pos)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -106,7 +106,7 @@ int NpcFunctions::luaNpcSetMasterPos(lua_State* L) {
 
 int NpcFunctions::luaNpcGetCurrency(lua_State* L) {
 	// npc:getCurrency()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -118,7 +118,7 @@ int NpcFunctions::luaNpcGetCurrency(lua_State* L) {
 
 int NpcFunctions::luaNpcSetCurrency(lua_State* L) {
 	// npc:getCurrency()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -131,7 +131,7 @@ int NpcFunctions::luaNpcSetCurrency(lua_State* L) {
 
 int NpcFunctions::luaNpcGetSpeechBubble(lua_State* L) {
 	// npc:getSpeechBubble()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -143,7 +143,7 @@ int NpcFunctions::luaNpcGetSpeechBubble(lua_State* L) {
 
 int NpcFunctions::luaNpcSetSpeechBubble(lua_State* L) {
 	// npc:setSpeechBubble(speechBubble)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -155,7 +155,7 @@ int NpcFunctions::luaNpcSetSpeechBubble(lua_State* L) {
 
 int NpcFunctions::luaNpcGetName(lua_State* L) {
 	// npc:getName()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -168,7 +168,7 @@ int NpcFunctions::luaNpcGetName(lua_State* L) {
 
 int NpcFunctions::luaNpcSetName(lua_State* L) {
 	// npc:setName(name)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const std::string &name = Lua::getString(L, 2);
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
@@ -181,7 +181,7 @@ int NpcFunctions::luaNpcSetName(lua_State* L) {
 
 int NpcFunctions::luaNpcPlace(lua_State* L) {
 	// npc:place(position[, extended = false[, force = true]])
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -223,7 +223,7 @@ int NpcFunctions::luaNpcSay(lua_State* L) {
 
 	const auto &type = Lua::getNumber<SpeakClasses>(L, 3, TALKTYPE_PRIVATE_NP);
 	const std::string &text = Lua::getString(L, 2);
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -248,7 +248,7 @@ int NpcFunctions::luaNpcSay(lua_State* L) {
  */
 int NpcFunctions::luaNpcTurnToCreature(lua_State* L) {
 	// npc:turnToCreature(creature, true)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const auto &creature = Lua::getCreature(L, 2);
 
 	if (!npc) {
@@ -274,7 +274,7 @@ int NpcFunctions::luaNpcTurnToCreature(lua_State* L) {
 
 int NpcFunctions::luaNpcSetPlayerInteraction(lua_State* L) {
 	// npc:setPlayerInteraction(creature, topic = 0)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const auto &creature = Lua::getCreature(L, 2);
 	const auto topicId = Lua::getNumber<uint16_t>(L, 3, 0);
 
@@ -297,7 +297,7 @@ int NpcFunctions::luaNpcSetPlayerInteraction(lua_State* L) {
 
 int NpcFunctions::luaNpcRemovePlayerInteraction(lua_State* L) {
 	// npc:removePlayerInteraction()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const auto &creature = Lua::getCreature(L, 2);
 
 	if (!npc) {
@@ -319,7 +319,7 @@ int NpcFunctions::luaNpcRemovePlayerInteraction(lua_State* L) {
 
 int NpcFunctions::luaNpcIsInteractingWithPlayer(lua_State* L) {
 	// npc:isInteractingWithPlayer(creature)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const auto &creature = Lua::getCreature(L, 2);
 
 	if (!npc) {
@@ -340,7 +340,7 @@ int NpcFunctions::luaNpcIsInteractingWithPlayer(lua_State* L) {
 
 int NpcFunctions::luaNpcIsPlayerInteractingOnTopic(lua_State* L) {
 	// npc:isPlayerInteractingOnTopic(creature, topicId = 0)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const auto &creature = Lua::getCreature(L, 2);
 	const auto topicId = Lua::getNumber<uint32_t>(L, 3, 0);
 
@@ -362,7 +362,7 @@ int NpcFunctions::luaNpcIsPlayerInteractingOnTopic(lua_State* L) {
 
 int NpcFunctions::luaNpcIsInTalkRange(lua_State* L) {
 	// npc:isInTalkRange(position[, range = 4])
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	const Position &position = Lua::getPosition(L, 2);
 	const auto range = Lua::getNumber<uint32_t>(L, 3, 4);
 
@@ -378,7 +378,7 @@ int NpcFunctions::luaNpcIsInTalkRange(lua_State* L) {
 
 int NpcFunctions::luaNpcOpenShopWindow(lua_State* L) {
 	// npc:openShopWindow(player)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -399,14 +399,14 @@ int NpcFunctions::luaNpcOpenShopWindow(lua_State* L) {
 
 int NpcFunctions::luaNpcOpenShopWindowTable(lua_State* L) {
 	// npc:openShopWindowTable(player, items)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 2);
+	const auto &player = Lua::getUserdataShared<Player>(L, 2, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -457,7 +457,7 @@ int NpcFunctions::luaNpcCloseShopWindow(lua_State* L) {
 		return 1;
 	}
 
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -474,7 +474,7 @@ int NpcFunctions::luaNpcCloseShopWindow(lua_State* L) {
 
 int NpcFunctions::luaNpcIsMerchant(lua_State* L) {
 	// npc:isMerchant()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -494,7 +494,7 @@ int NpcFunctions::luaNpcIsMerchant(lua_State* L) {
 
 int NpcFunctions::luaNpcGetShopItem(lua_State* L) {
 	// npc:getShopItem(itemId)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -519,7 +519,7 @@ int NpcFunctions::luaNpcGetShopItem(lua_State* L) {
 
 int NpcFunctions::luaNpcMove(lua_State* L) {
 	// npc:move(direction)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (npc) {
 		g_game().internalMoveCreature(npc, Lua::getNumber<Direction>(L, 2));
 	}
@@ -528,7 +528,7 @@ int NpcFunctions::luaNpcMove(lua_State* L) {
 
 int NpcFunctions::luaNpcTurn(lua_State* L) {
 	// npc:turn(direction)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (npc) {
 		g_game().internalCreatureTurn(npc, Lua::getNumber<Direction>(L, 2));
 	}
@@ -537,7 +537,7 @@ int NpcFunctions::luaNpcTurn(lua_State* L) {
 
 int NpcFunctions::luaNpcFollow(lua_State* L) {
 	// npc:follow(player)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::pushBoolean(L, false);
 		return 1;
@@ -555,7 +555,7 @@ int NpcFunctions::luaNpcFollow(lua_State* L) {
 
 int NpcFunctions::luaNpcGetId(lua_State* L) {
 	// npc:getId()
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		lua_pushnil(L);
@@ -568,7 +568,7 @@ int NpcFunctions::luaNpcGetId(lua_State* L) {
 
 int NpcFunctions::luaNpcSellItem(lua_State* L) {
 	// npc:sellItem(player, itemid, amount, <optional: default: 1> subtype, <optional: default: 0> actionid, <optional: default: false> ignoreCap, <optional: default: false> inBackpacks)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -686,7 +686,7 @@ int NpcFunctions::luaNpcSellItem(lua_State* L) {
 
 int NpcFunctions::luaNpcGetDistanceTo(lua_State* L) {
 	// npc:getDistanceTo(uid)
-	const auto &npc = Lua::getUserdataShared<Npc>(L, 1);
+	const auto &npc = Lua::getUserdataShared<Npc>(L, 1, "Npc");
 	if (!npc) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/creatures/npc/npc_type_functions.cpp
+++ b/src/lua/functions/creatures/npc/npc_type_functions.cpp
@@ -104,7 +104,7 @@ int NpcTypeFunctions::luaNpcTypeCreate(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeIsPushable(lua_State* L) {
 	// get: npcType:isPushable() set: npcType:isPushable(bool)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, npcType->info.pushable);
@@ -120,7 +120,7 @@ int NpcTypeFunctions::luaNpcTypeIsPushable(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeFloorChange(lua_State* L) {
 	// get: npcType:floorChange() set: npcType:floorChange(bool)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, npcType->info.floorChange);
@@ -136,7 +136,7 @@ int NpcTypeFunctions::luaNpcTypeFloorChange(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeCanSpawn(lua_State* L) {
 	// monsterType:canSpawn(pos)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	const Position &position = Lua::getPosition(L, 2);
 	if (npcType) {
 		Lua::pushBoolean(L, npcType->canSpawn(position));
@@ -148,7 +148,7 @@ int NpcTypeFunctions::luaNpcTypeCanSpawn(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeCanPushItems(lua_State* L) {
 	// get: npcType:canPushItems() set: npcType:canPushItems(bool)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, npcType->info.canPushItems);
@@ -164,7 +164,7 @@ int NpcTypeFunctions::luaNpcTypeCanPushItems(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeCanPushCreatures(lua_State* L) {
 	// get: npcType:canPushCreatures() set: npcType:canPushCreatures(bool)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, npcType->info.canPushCreatures);
@@ -180,7 +180,7 @@ int NpcTypeFunctions::luaNpcTypeCanPushCreatures(lua_State* L) {
 
 int32_t NpcTypeFunctions::luaNpcTypeName(lua_State* L) {
 	// get: npcType:name() set: npcType:name(name)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, npcType->name);
@@ -196,7 +196,7 @@ int32_t NpcTypeFunctions::luaNpcTypeName(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeNameDescription(lua_State* L) {
 	// get: npcType:nameDescription() set: npcType:nameDescription(desc)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushString(L, npcType->nameDescription);
@@ -212,7 +212,7 @@ int NpcTypeFunctions::luaNpcTypeNameDescription(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeHealth(lua_State* L) {
 	// get: npcType:health() set: npcType:health(health)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.health);
@@ -228,7 +228,7 @@ int NpcTypeFunctions::luaNpcTypeHealth(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeMaxHealth(lua_State* L) {
 	// get: npcType:maxHealth() set: npcType:maxHealth(health)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.healthMax);
@@ -244,13 +244,13 @@ int NpcTypeFunctions::luaNpcTypeMaxHealth(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeAddShopItem(lua_State* L) {
 	// npcType:addShopItem(shop)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &shop = Lua::getUserdataShared<Shop>(L, 2);
+	const auto &shop = Lua::getUserdataShared<Shop>(L, 2, "Shop");
 	if (shop) {
 		npcType->loadShop(npcType, shop->shopBlock);
 		Lua::pushBoolean(L, true);
@@ -262,7 +262,7 @@ int NpcTypeFunctions::luaNpcTypeAddShopItem(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeAddVoice(lua_State* L) {
 	// npcType:addVoice(sentence, interval, chance, yell)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		voiceBlock_t voice;
 		voice.text = Lua::getString(L, 2);
@@ -279,7 +279,7 @@ int NpcTypeFunctions::luaNpcTypeAddVoice(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeGetVoices(lua_State* L) {
 	// npcType:getVoices()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		lua_pushnil(L);
 		return 1;
@@ -298,7 +298,7 @@ int NpcTypeFunctions::luaNpcTypeGetVoices(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeGetCreatureEvents(lua_State* L) {
 	// npcType:getCreatureEvents()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		lua_pushnil(L);
 		return 1;
@@ -315,7 +315,7 @@ int NpcTypeFunctions::luaNpcTypeGetCreatureEvents(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeRegisterEvent(lua_State* L) {
 	// npcType:registerEvent(name)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		npcType->info.scripts.insert(Lua::getString(L, 2));
 		Lua::pushBoolean(L, true);
@@ -334,7 +334,7 @@ int NpcTypeFunctions::luaNpcTypeEventOnCallback(lua_State* L) {
 	// npcType:onBuyItem(callback)
 	// npcType:onSellItem(callback)
 	// npcType:onCheckItem(callback)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (npcType->loadCallback(&g_scripts().getScriptInterface())) {
 			Lua::pushBoolean(L, true);
@@ -349,7 +349,7 @@ int NpcTypeFunctions::luaNpcTypeEventOnCallback(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeEventType(lua_State* L) {
 	// npcType:eventType(event)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		npcType->info.eventType = Lua::getNumber<NpcsEvent_t>(L, 2);
 		Lua::pushBoolean(L, true);
@@ -361,7 +361,7 @@ int NpcTypeFunctions::luaNpcTypeEventType(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeOutfit(lua_State* L) {
 	// get: npcType:outfit() set: npcType:outfit(outfit)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushOutfit(L, npcType->info.outfit);
@@ -383,7 +383,7 @@ int NpcTypeFunctions::luaNpcTypeOutfit(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeBaseSpeed(lua_State* L) {
 	// npcType:getBaseSpeed()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.baseSpeed);
@@ -399,7 +399,7 @@ int NpcTypeFunctions::luaNpcTypeBaseSpeed(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeWalkInterval(lua_State* L) {
 	// get: npcType:walkInterval() set: npcType:walkInterval(interval)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.walkInterval);
@@ -415,7 +415,7 @@ int NpcTypeFunctions::luaNpcTypeWalkInterval(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeWalkRadius(lua_State* L) {
 	// get: npcType:walkRadius() set: npcType:walkRadius(id)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.walkRadius);
@@ -431,7 +431,7 @@ int NpcTypeFunctions::luaNpcTypeWalkRadius(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeLight(lua_State* L) {
 	// get: npcType:light() set: npcType:light(color, level)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		lua_pushnil(L);
 		return 1;
@@ -451,7 +451,7 @@ int NpcTypeFunctions::luaNpcTypeLight(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeYellChance(lua_State* L) {
 	// get: npcType:yellChance() set: npcType:yellChance(chance)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			if (lua_gettop(L) == 1) {
@@ -472,7 +472,7 @@ int NpcTypeFunctions::luaNpcTypeYellChance(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeYellSpeedTicks(lua_State* L) {
 	// get: npcType:yellSpeedTicks() set: npcType:yellSpeedTicks(rate)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.yellSpeedTicks);
@@ -492,7 +492,7 @@ int NpcTypeFunctions::luaNpcTypeYellSpeedTicks(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeRespawnTypePeriod(lua_State* L) {
 	// npcType:respawnTypePeriod()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.respawnType.period);
@@ -508,7 +508,7 @@ int NpcTypeFunctions::luaNpcTypeRespawnTypePeriod(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeRespawnTypeIsUnderground(lua_State* L) {
 	// npcType:respawnTypeIsUnderground()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (npcType) {
 		if (lua_gettop(L) == 1) {
 			lua_pushnumber(L, npcType->info.respawnType.underground);
@@ -525,7 +525,7 @@ int NpcTypeFunctions::luaNpcTypeRespawnTypeIsUnderground(lua_State* L) {
 int NpcTypeFunctions::luaNpcTypeSpeechBubble(lua_State* L) {
 	// get = npcType:speechBubble()
 	// set = npcType:speechBubble(newSpeechBubble)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_TYPE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -544,7 +544,7 @@ int NpcTypeFunctions::luaNpcTypeSpeechBubble(lua_State* L) {
 int NpcTypeFunctions::luaNpcTypeCurrency(lua_State* L) {
 	// get = npcType:currency()
 	// set = npcType:currency(newCurrency)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_TYPE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -562,7 +562,7 @@ int NpcTypeFunctions::luaNpcTypeCurrency(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeSoundChance(lua_State* L) {
 	// get: npcType:soundChance() set: npcType:soundChance(chance)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_TYPE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -580,7 +580,7 @@ int NpcTypeFunctions::luaNpcTypeSoundChance(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeSoundSpeedTicks(lua_State* L) {
 	// get: npcType:soundSpeedTicks() set: npcType:soundSpeedTicks(ticks)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_TYPE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -598,7 +598,7 @@ int NpcTypeFunctions::luaNpcTypeSoundSpeedTicks(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeAddSound(lua_State* L) {
 	// npcType:addSound(soundId)
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_NPC_TYPE_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -612,7 +612,7 @@ int NpcTypeFunctions::luaNpcTypeAddSound(lua_State* L) {
 
 int NpcTypeFunctions::luaNpcTypeGetSounds(lua_State* L) {
 	// npcType:getSounds()
-	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1);
+	const auto &npcType = Lua::getUserdataShared<NpcType>(L, 1, "NpcType");
 	if (!npcType) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/creatures/npc/shop_functions.cpp
+++ b/src/lua/functions/creatures/npc/shop_functions.cpp
@@ -38,7 +38,7 @@ int ShopFunctions::luaCreateShop(lua_State* L) {
 int ShopFunctions::luaShopSetId(lua_State* L) {
 	// shop:setId(id)
 
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		if (Lua::isNumber(L, 2)) {
 			shop->shopBlock.itemId = Lua::getNumber<uint16_t>(L, 2);
 			Lua::pushBoolean(L, true);
@@ -55,7 +55,7 @@ int ShopFunctions::luaShopSetId(lua_State* L) {
 
 int ShopFunctions::luaShopSetIdFromName(lua_State* L) {
 	// shop:setIdFromName(name)
-	const auto &shop = Lua::getUserdataShared<Shop>(L, 1);
+	const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop");
 	if (shop && Lua::isString(L, 2)) {
 		auto name = Lua::getString(L, 2);
 		const auto ids = Item::items.nameToItems.equal_range(asLowerCaseString(name));
@@ -88,7 +88,7 @@ int ShopFunctions::luaShopSetIdFromName(lua_State* L) {
 
 int ShopFunctions::luaShopSetNameItem(lua_State* L) {
 	// shop:setNameItem(name)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemName = Lua::getString(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -99,7 +99,7 @@ int ShopFunctions::luaShopSetNameItem(lua_State* L) {
 
 int ShopFunctions::luaShopSetCount(lua_State* L) {
 	// shop:setCount(count)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemSubType = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -110,7 +110,7 @@ int ShopFunctions::luaShopSetCount(lua_State* L) {
 
 int ShopFunctions::luaShopSetBuyPrice(lua_State* L) {
 	// shop:setBuyPrice(price)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemBuyPrice = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -121,7 +121,7 @@ int ShopFunctions::luaShopSetBuyPrice(lua_State* L) {
 
 int ShopFunctions::luaShopSetSellPrice(lua_State* L) {
 	// shop:setSellPrice(chance)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemSellPrice = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -132,7 +132,7 @@ int ShopFunctions::luaShopSetSellPrice(lua_State* L) {
 
 int ShopFunctions::luaShopSetStorageKey(lua_State* L) {
 	// shop:setStorageKey(storage)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemStorageKey = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -143,7 +143,7 @@ int ShopFunctions::luaShopSetStorageKey(lua_State* L) {
 
 int ShopFunctions::luaShopSetStorageValue(lua_State* L) {
 	// shop:setStorageValue(value)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
 		shop->shopBlock.itemStorageValue = Lua::getNumber<uint32_t>(L, 2);
 		Lua::pushBoolean(L, true);
 	} else {
@@ -154,8 +154,8 @@ int ShopFunctions::luaShopSetStorageValue(lua_State* L) {
 
 int ShopFunctions::luaShopAddChildShop(lua_State* L) {
 	// shop:addChildShop(shop)
-	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1)) {
-		shop->shopBlock.childShop.push_back(Lua::getUserdataShared<Shop>(L, 2)->shopBlock);
+	if (const auto &shop = Lua::getUserdataShared<Shop>(L, 1, "Shop")) {
+		shop->shopBlock.childShop.push_back(Lua::getUserdataShared<Shop>(L, 2, "Shop")->shopBlock);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/group_functions.cpp
+++ b/src/lua/functions/creatures/player/group_functions.cpp
@@ -42,7 +42,7 @@ int GroupFunctions::luaGroupCreate(lua_State* L) {
 
 int GroupFunctions::luaGroupGetId(lua_State* L) {
 	// group:getId()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		lua_pushnumber(L, group->id);
 	} else {
@@ -53,7 +53,7 @@ int GroupFunctions::luaGroupGetId(lua_State* L) {
 
 int GroupFunctions::luaGroupGetName(lua_State* L) {
 	// group:getName()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		Lua::pushString(L, group->name);
 	} else {
@@ -64,7 +64,7 @@ int GroupFunctions::luaGroupGetName(lua_State* L) {
 
 int GroupFunctions::luaGroupGetFlags(lua_State* L) {
 	// group:getFlags()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		std::bitset<magic_enum::enum_integer(PlayerFlags_t::FlagLast)> flags;
 		for (uint8_t i = 0; i < magic_enum::enum_integer(PlayerFlags_t::FlagLast); ++i) {
@@ -81,7 +81,7 @@ int GroupFunctions::luaGroupGetFlags(lua_State* L) {
 
 int GroupFunctions::luaGroupGetAccess(lua_State* L) {
 	// group:getAccess()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		Lua::pushBoolean(L, group->access);
 	} else {
@@ -92,7 +92,7 @@ int GroupFunctions::luaGroupGetAccess(lua_State* L) {
 
 int GroupFunctions::luaGroupGetMaxDepotItems(lua_State* L) {
 	// group:getMaxDepotItems()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		lua_pushnumber(L, group->maxDepotItems);
 	} else {
@@ -103,7 +103,7 @@ int GroupFunctions::luaGroupGetMaxDepotItems(lua_State* L) {
 
 int GroupFunctions::luaGroupGetMaxVipEntries(lua_State* L) {
 	// group:getMaxVipEntries()
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		lua_pushnumber(L, group->maxVipEntries);
 	} else {
@@ -114,7 +114,7 @@ int GroupFunctions::luaGroupGetMaxVipEntries(lua_State* L) {
 
 int GroupFunctions::luaGroupHasFlag(lua_State* L) {
 	// group:hasFlag(flag)
-	const auto &group = Lua::getUserdataShared<Group>(L, 1);
+	const auto &group = Lua::getUserdataShared<Group>(L, 1, "Group");
 	if (group) {
 		const auto flag = static_cast<PlayerFlags_t>(Lua::getNumber<int>(L, 2));
 		Lua::pushBoolean(L, group->flags[Groups::getFlagNumber(flag)]);

--- a/src/lua/functions/creatures/player/guild_functions.cpp
+++ b/src/lua/functions/creatures/player/guild_functions.cpp
@@ -45,7 +45,7 @@ int GuildFunctions::luaGuildCreate(lua_State* L) {
 }
 
 int GuildFunctions::luaGuildGetId(lua_State* L) {
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (guild) {
 		lua_pushnumber(L, guild->getId());
 	} else {
@@ -56,7 +56,7 @@ int GuildFunctions::luaGuildGetId(lua_State* L) {
 
 int GuildFunctions::luaGuildGetName(lua_State* L) {
 	// guild:getName()
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -67,7 +67,7 @@ int GuildFunctions::luaGuildGetName(lua_State* L) {
 
 int GuildFunctions::luaGuildGetMembersOnline(lua_State* L) {
 	// guild:getMembersOnline()
-	const auto &guild = Lua::getUserdataShared<const Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -87,7 +87,7 @@ int GuildFunctions::luaGuildGetMembersOnline(lua_State* L) {
 
 int GuildFunctions::luaGuildGetBankBalance(lua_State* L) {
 	// guild:getBankBalance()
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -98,7 +98,7 @@ int GuildFunctions::luaGuildGetBankBalance(lua_State* L) {
 
 int GuildFunctions::luaGuildSetBankBalance(lua_State* L) {
 	// guild:setBankBalance(bankBalance)
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -111,7 +111,7 @@ int GuildFunctions::luaGuildSetBankBalance(lua_State* L) {
 
 int GuildFunctions::luaGuildAddRank(lua_State* L) {
 	// guild:addRank(id, name, level)
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -126,7 +126,7 @@ int GuildFunctions::luaGuildAddRank(lua_State* L) {
 
 int GuildFunctions::luaGuildGetRankById(lua_State* L) {
 	// guild:getRankById(id)
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -147,7 +147,7 @@ int GuildFunctions::luaGuildGetRankById(lua_State* L) {
 
 int GuildFunctions::luaGuildGetRankByLevel(lua_State* L) {
 	// guild:getRankByLevel(level)
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -168,7 +168,7 @@ int GuildFunctions::luaGuildGetRankByLevel(lua_State* L) {
 
 int GuildFunctions::luaGuildGetMotd(lua_State* L) {
 	// guild:getMotd()
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -179,7 +179,7 @@ int GuildFunctions::luaGuildGetMotd(lua_State* L) {
 
 int GuildFunctions::luaGuildSetMotd(lua_State* L) {
 	// guild:setMotd(motd)
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 1);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 1, "Guild");
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/creatures/player/mount_functions.cpp
+++ b/src/lua/functions/creatures/player/mount_functions.cpp
@@ -47,7 +47,7 @@ int MountFunctions::luaCreateMount(lua_State* L) {
 
 int MountFunctions::luaMountGetName(lua_State* L) {
 	// mount:getName()
-	const auto &mount = Lua::getUserdataShared<Mount>(L, 1);
+	const auto &mount = Lua::getUserdataShared<Mount>(L, 1, "Mount");
 	if (mount) {
 		Lua::pushString(L, mount->name);
 	} else {
@@ -59,7 +59,7 @@ int MountFunctions::luaMountGetName(lua_State* L) {
 
 int MountFunctions::luaMountGetId(lua_State* L) {
 	// mount:getId()
-	const auto &mount = Lua::getUserdataShared<Mount>(L, 1);
+	const auto &mount = Lua::getUserdataShared<Mount>(L, 1, "Mount");
 	if (mount) {
 		lua_pushnumber(L, mount->id);
 	} else {
@@ -71,7 +71,7 @@ int MountFunctions::luaMountGetId(lua_State* L) {
 
 int MountFunctions::luaMountGetClientId(lua_State* L) {
 	// mount:getClientId()
-	const auto &mount = Lua::getUserdataShared<Mount>(L, 1);
+	const auto &mount = Lua::getUserdataShared<Mount>(L, 1, "Mount");
 	if (mount) {
 		lua_pushnumber(L, mount->clientId);
 	} else {
@@ -83,7 +83,7 @@ int MountFunctions::luaMountGetClientId(lua_State* L) {
 
 int MountFunctions::luaMountGetSpeed(lua_State* L) {
 	// mount:getSpeed()
-	const auto &mount = Lua::getUserdataShared<Mount>(L, 1);
+	const auto &mount = Lua::getUserdataShared<Mount>(L, 1, "Mount");
 	if (mount) {
 		lua_pushnumber(L, mount->speed);
 	} else {

--- a/src/lua/functions/creatures/player/party_functions.cpp
+++ b/src/lua/functions/creatures/player/party_functions.cpp
@@ -37,7 +37,7 @@ void PartyFunctions::init(lua_State* L) {
 
 int32_t PartyFunctions::luaPartyCreate(lua_State* L) {
 	// Party(userdata)
-	const auto &player = Lua::getUserdataShared<Player>(L, 2);
+	const auto &player = Lua::getUserdataShared<Player>(L, 2, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -72,7 +72,7 @@ int PartyFunctions::luaPartyDisband(lua_State* L) {
 
 int PartyFunctions::luaPartyGetLeader(lua_State* L) {
 	// party:getLeader()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (!party) {
 		lua_pushnil(L);
 		return 1;
@@ -96,7 +96,7 @@ int PartyFunctions::luaPartySetLeader(lua_State* L) {
 		return 1;
 	}
 
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		Lua::pushBoolean(L, party->passPartyLeadership(player));
 	} else {
@@ -107,7 +107,7 @@ int PartyFunctions::luaPartySetLeader(lua_State* L) {
 
 int PartyFunctions::luaPartyGetMembers(lua_State* L) {
 	// party:getMembers()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (!party) {
 		lua_pushnil(L);
 		return 1;
@@ -125,7 +125,7 @@ int PartyFunctions::luaPartyGetMembers(lua_State* L) {
 
 int PartyFunctions::luaPartyGetMemberCount(lua_State* L) {
 	// party:getMemberCount()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		lua_pushnumber(L, party->getMemberCount());
 	} else {
@@ -136,7 +136,7 @@ int PartyFunctions::luaPartyGetMemberCount(lua_State* L) {
 
 int PartyFunctions::luaPartyGetInvitees(lua_State* L) {
 	// party:getInvitees()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		lua_createtable(L, party->getInvitationCount(), 0);
 
@@ -154,7 +154,7 @@ int PartyFunctions::luaPartyGetInvitees(lua_State* L) {
 
 int PartyFunctions::luaPartyGetInviteeCount(lua_State* L) {
 	// party:getInviteeCount()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		lua_pushnumber(L, party->getInvitationCount());
 	} else {
@@ -165,7 +165,7 @@ int PartyFunctions::luaPartyGetInviteeCount(lua_State* L) {
 
 int PartyFunctions::luaPartyGetUniqueVocationsCount(lua_State* L) {
 	// party:getUniqueVocationsCount()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		lua_pushnumber(L, party->getUniqueVocationsCount());
 	} else {
@@ -182,7 +182,7 @@ int PartyFunctions::luaPartyAddInvite(lua_State* L) {
 		return 1;
 	}
 
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party && player) {
 		Lua::pushBoolean(L, party->invitePlayer(player));
 	} else {
@@ -199,7 +199,7 @@ int PartyFunctions::luaPartyRemoveInvite(lua_State* L) {
 		return 1;
 	}
 
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party && player) {
 		Lua::pushBoolean(L, party->removeInvite(player));
 	} else {
@@ -216,7 +216,7 @@ int PartyFunctions::luaPartyAddMember(lua_State* L) {
 		return 1;
 	}
 
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party && player) {
 		Lua::pushBoolean(L, party->joinParty(player));
 	} else {
@@ -233,7 +233,7 @@ int PartyFunctions::luaPartyRemoveMember(lua_State* L) {
 		return 1;
 	}
 
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party && player) {
 		Lua::pushBoolean(L, party->leaveParty(player));
 	} else {
@@ -244,7 +244,7 @@ int PartyFunctions::luaPartyRemoveMember(lua_State* L) {
 
 int PartyFunctions::luaPartyIsSharedExperienceActive(lua_State* L) {
 	// party:isSharedExperienceActive()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		Lua::pushBoolean(L, party->isSharedExperienceActive());
 	} else {
@@ -255,7 +255,7 @@ int PartyFunctions::luaPartyIsSharedExperienceActive(lua_State* L) {
 
 int PartyFunctions::luaPartyIsSharedExperienceEnabled(lua_State* L) {
 	// party:isSharedExperienceEnabled()
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		Lua::pushBoolean(L, party->isSharedExperienceEnabled());
 	} else {
@@ -267,7 +267,7 @@ int PartyFunctions::luaPartyIsSharedExperienceEnabled(lua_State* L) {
 int PartyFunctions::luaPartyShareExperience(lua_State* L) {
 	// party:shareExperience(experience)
 	const uint64_t experience = Lua::getNumber<uint64_t>(L, 2);
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		party->shareExperience(experience);
 		Lua::pushBoolean(L, true);
@@ -280,7 +280,7 @@ int PartyFunctions::luaPartyShareExperience(lua_State* L) {
 int PartyFunctions::luaPartySetSharedExperience(lua_State* L) {
 	// party:setSharedExperience(active)
 	const bool active = Lua::getBoolean(L, 2);
-	const auto &party = Lua::getUserdataShared<Party>(L, 1);
+	const auto &party = Lua::getUserdataShared<Party>(L, 1, "Party");
 	if (party) {
 		Lua::pushBoolean(L, party->setSharedExperience(party->getLeader(), active));
 	} else {

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -418,7 +418,7 @@ void PlayerFunctions::init(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendInventory(lua_State* L) {
 	// player:sendInventory()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -432,13 +432,13 @@ int PlayerFunctions::luaPlayerSendInventory(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendLootStats(lua_State* L) {
 	// player:sendLootStats(item, count)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -458,13 +458,13 @@ int PlayerFunctions::luaPlayerSendLootStats(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUpdateSupplyTracker(lua_State* L) {
 	// player:updateSupplyTracker(item)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -478,19 +478,19 @@ int PlayerFunctions::luaPlayerUpdateSupplyTracker(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUpdateKillTracker(lua_State* L) {
 	// player:updateKillTracker(creature, corpse)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &monster = Lua::getUserdataShared<Creature>(L, 2);
+	const auto &monster = Lua::getUserdataShared<Creature>(L, 2, "Creature");
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &corpse = Lua::getUserdataShared<Container>(L, 3);
+	const auto &corpse = Lua::getUserdataShared<Container>(L, 3, "Container");
 	if (!corpse) {
 		lua_pushnil(L);
 		return 1;
@@ -525,7 +525,7 @@ int PlayerFunctions::luaPlayerCreate(lua_State* L) {
 			lua_pushnil(L);
 			return 1;
 		}
-		player = Lua::getUserdataShared<Player>(L, 2);
+		player = Lua::getUserdataShared<Player>(L, 2, "Player");
 	} else {
 		player = nullptr;
 	}
@@ -541,7 +541,7 @@ int PlayerFunctions::luaPlayerCreate(lua_State* L) {
 
 int PlayerFunctions::luaPlayerResetCharmsMonsters(lua_State* L) {
 	// player:resetCharmsBestiary()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setCharmPoints(0);
 		player->setCharmExpansion(false);
@@ -559,7 +559,7 @@ int PlayerFunctions::luaPlayerResetCharmsMonsters(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUnlockAllCharmRunes(lua_State* L) {
 	// player:unlockAllCharmRunes()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		for (int8_t i = CHARM_WOUND; i <= CHARM_LAST; i++) {
 			const auto charm = g_iobestiary().getBestiaryCharm(static_cast<charmRune_t>(i));
@@ -577,7 +577,7 @@ int PlayerFunctions::luaPlayerUnlockAllCharmRunes(lua_State* L) {
 
 int PlayerFunctions::luaPlayeraddCharmPoints(lua_State* L) {
 	// player:addCharmPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		int16_t charms = Lua::getNumber<int16_t>(L, 2);
 		if (charms >= 0) {
@@ -595,13 +595,13 @@ int PlayerFunctions::luaPlayeraddCharmPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsPlayer(lua_State* L) {
 	// player:isPlayer()
-	Lua::pushBoolean(L, Lua::getUserdataShared<Player>(L, 1) != nullptr);
+	Lua::pushBoolean(L, Lua::getUserdataShared<Player>(L, 1, "Player") != nullptr);
 	return 1;
 }
 
 int PlayerFunctions::luaPlayerGetGuid(lua_State* L) {
 	// player:getGuid()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getGUID());
 	} else {
@@ -612,7 +612,7 @@ int PlayerFunctions::luaPlayerGetGuid(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetIp(lua_State* L) {
 	// player:getIp()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getIP());
 	} else {
@@ -623,7 +623,7 @@ int PlayerFunctions::luaPlayerGetIp(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetAccountId(lua_State* L) {
 	// player:getAccountId()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || player->getAccountId() == 0) {
 		lua_pushnil(L);
 		return 1;
@@ -636,7 +636,7 @@ int PlayerFunctions::luaPlayerGetAccountId(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLastLoginSaved(lua_State* L) {
 	// player:getLastLoginSaved()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getLastLoginSaved());
 	} else {
@@ -647,7 +647,7 @@ int PlayerFunctions::luaPlayerGetLastLoginSaved(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLastLogout(lua_State* L) {
 	// player:getLastLogout()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getLastLogout());
 	} else {
@@ -658,7 +658,7 @@ int PlayerFunctions::luaPlayerGetLastLogout(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetAccountType(lua_State* L) {
 	// player:getAccountType()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getAccountType());
 	} else {
@@ -669,7 +669,7 @@ int PlayerFunctions::luaPlayerGetAccountType(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetAccountType(lua_State* L) {
 	// player:setAccountType(accountType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		lua_pushnil(L);
 		return 1;
@@ -691,7 +691,7 @@ int PlayerFunctions::luaPlayerSetAccountType(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddBestiaryKill(lua_State* L) {
 	// player:addBestiaryKill(name[, amount = 1])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const auto &mtype = g_monsters().getMonsterType(Lua::getString(L, 2));
 		if (mtype) {
@@ -708,7 +708,7 @@ int PlayerFunctions::luaPlayerAddBestiaryKill(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsMonsterBestiaryUnlocked(lua_State* L) {
 	// player:isMonsterBestiaryUnlocked(raceId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player == nullptr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -735,7 +735,7 @@ int PlayerFunctions::luaPlayerIsMonsterBestiaryUnlocked(lua_State* L) {
 
 int PlayerFunctions::luaPlayergetCharmMonsterType(lua_State* L) {
 	// player:getCharmMonsterType(charmRune_t)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const charmRune_t charmid = Lua::getNumber<charmRune_t>(L, 2);
 		const uint16_t raceid = player->parseRacebyCharm(charmid, false, 0);
@@ -758,7 +758,7 @@ int PlayerFunctions::luaPlayergetCharmMonsterType(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemovePreyStamina(lua_State* L) {
 	// player:removePreyStamina(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		g_ioprey().checkPlayerPreys(player, Lua::getNumber<uint8_t>(L, 2, 1));
 		Lua::pushBoolean(L, true);
@@ -770,7 +770,7 @@ int PlayerFunctions::luaPlayerRemovePreyStamina(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddPreyCards(lua_State* L) {
 	// player:addPreyCards(amount)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		player->addPreyCards(Lua::getNumber<uint64_t>(L, 2, 0));
 		Lua::pushBoolean(L, true);
 	} else {
@@ -781,7 +781,7 @@ int PlayerFunctions::luaPlayerAddPreyCards(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetPreyCards(lua_State* L) {
 	// player:getPreyCards()
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		lua_pushnumber(L, static_cast<lua_Number>(player->getPreyCards()));
 	} else {
 		lua_pushnil(L);
@@ -791,7 +791,7 @@ int PlayerFunctions::luaPlayerGetPreyCards(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetPreyExperiencePercentage(lua_State* L) {
 	// player:getPreyExperiencePercentage(raceId)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		if (const std::unique_ptr<PreySlot> &slot = player->getPreyWithMonster(Lua::getNumber<uint16_t>(L, 2, 0));
 		    slot && slot->isOccupied() && slot->bonus == PreyBonus_Experience && slot->bonusTimeLeft > 0) {
 			lua_pushnumber(L, static_cast<lua_Number>(100 + slot->bonusPercentage));
@@ -806,7 +806,7 @@ int PlayerFunctions::luaPlayerGetPreyExperiencePercentage(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveTaskHuntingPoints(lua_State* L) {
 	// player:removeTaskHuntingPoints(amount)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		Lua::pushBoolean(L, player->useTaskHuntingPoints(Lua::getNumber<uint64_t>(L, 2, 0)));
 	} else {
 		lua_pushnil(L);
@@ -816,7 +816,7 @@ int PlayerFunctions::luaPlayerRemoveTaskHuntingPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetTaskHuntingPoints(lua_State* L) {
 	// player:getTaskHuntingPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player == nullptr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -829,7 +829,7 @@ int PlayerFunctions::luaPlayerGetTaskHuntingPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddTaskHuntingPoints(lua_State* L) {
 	// player:addTaskHuntingPoints(amount)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		const auto points = Lua::getNumber<uint64_t>(L, 2);
 		player->addTaskHuntingPoints(Lua::getNumber<uint64_t>(L, 2));
 		lua_pushnumber(L, static_cast<lua_Number>(points));
@@ -841,7 +841,7 @@ int PlayerFunctions::luaPlayerAddTaskHuntingPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetPreyLootPercentage(lua_State* L) {
 	// player:getPreyLootPercentage(raceid)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		if (const std::unique_ptr<PreySlot> &slot = player->getPreyWithMonster(Lua::getNumber<uint16_t>(L, 2, 0));
 		    slot && slot->isOccupied() && slot->bonus == PreyBonus_Loot) {
 			lua_pushnumber(L, slot->bonusPercentage);
@@ -856,7 +856,7 @@ int PlayerFunctions::luaPlayerGetPreyLootPercentage(lua_State* L) {
 
 int PlayerFunctions::luaPlayerisMonsterPrey(lua_State* L) {
 	// player:isMonsterPrey(raceid)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1)) {
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player")) {
 		if (const std::unique_ptr<PreySlot> &slot = player->getPreyWithMonster(Lua::getNumber<uint16_t>(L, 2, 0));
 		    slot && slot->isOccupied()) {
 			Lua::pushBoolean(L, true);
@@ -871,7 +871,7 @@ int PlayerFunctions::luaPlayerisMonsterPrey(lua_State* L) {
 
 int PlayerFunctions::luaPlayerPreyThirdSlot(lua_State* L) {
 	// get: player:preyThirdSlot() set: player:preyThirdSlot(bool)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	    const auto &slot = player->getPreySlotById(PreySlot_Three)) {
 		if (!slot) {
 			lua_pushnil(L);
@@ -898,7 +898,7 @@ int PlayerFunctions::luaPlayerPreyThirdSlot(lua_State* L) {
 
 int PlayerFunctions::luaPlayerTaskThirdSlot(lua_State* L) {
 	// get: player:taskHuntingThirdSlot() set: player:taskHuntingThirdSlot(bool)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	    const auto &slot = player->getTaskHuntingSlotById(PreySlot_Three)) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, slot->state != PreyTaskDataState_Locked);
@@ -923,7 +923,7 @@ int PlayerFunctions::luaPlayerTaskThirdSlot(lua_State* L) {
 
 int PlayerFunctions::luaPlayercharmExpansion(lua_State* L) {
 	// get: player:charmExpansion() set: player:charmExpansion(bool)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		if (lua_gettop(L) == 1) {
 			Lua::pushBoolean(L, player->hasCharmExpansion());
@@ -939,7 +939,7 @@ int PlayerFunctions::luaPlayercharmExpansion(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetCapacity(lua_State* L) {
 	// player:getCapacity()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getCapacity());
 	} else {
@@ -950,7 +950,7 @@ int PlayerFunctions::luaPlayerGetCapacity(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetCapacity(lua_State* L) {
 	// player:setCapacity(capacity)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->capacity = Lua::getNumber<uint32_t>(L, 2);
 		player->sendStats();
@@ -963,7 +963,7 @@ int PlayerFunctions::luaPlayerSetCapacity(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetTraining(lua_State* L) {
 	// player:setTraining(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const bool value = Lua::getBoolean(L, 2, false);
 		player->setTraining(value);
@@ -976,7 +976,7 @@ int PlayerFunctions::luaPlayerSetTraining(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetIsTraining(lua_State* L) {
 	// player:isTraining()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
@@ -989,7 +989,7 @@ int PlayerFunctions::luaPlayerGetIsTraining(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetFreeCapacity(lua_State* L) {
 	// player:getFreeCapacity()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getFreeCapacity());
 	} else {
@@ -1000,7 +1000,7 @@ int PlayerFunctions::luaPlayerGetFreeCapacity(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetKills(lua_State* L) {
 	// player:getKills()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1024,7 +1024,7 @@ int PlayerFunctions::luaPlayerGetKills(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetKills(lua_State* L) {
 	// player:setKills(kills)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1052,7 +1052,7 @@ int PlayerFunctions::luaPlayerSetKills(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetReward(lua_State* L) {
 	// player:getReward(rewardId[, autoCreate = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1071,7 +1071,7 @@ int PlayerFunctions::luaPlayerGetReward(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveReward(lua_State* L) {
 	// player:removeReward(rewardId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1085,7 +1085,7 @@ int PlayerFunctions::luaPlayerRemoveReward(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetRewardList(lua_State* L) {
 	// player:getRewardList()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1105,7 +1105,7 @@ int PlayerFunctions::luaPlayerGetRewardList(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetDailyReward(lua_State* L) {
 	// player:setDailyReward(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setDailyReward(Lua::getNumber<uint8_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -1117,7 +1117,7 @@ int PlayerFunctions::luaPlayerSetDailyReward(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetDepotLocker(lua_State* L) {
 	// player:getDepotLocker(depotId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1137,7 +1137,7 @@ int PlayerFunctions::luaPlayerGetDepotLocker(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStashCounter(lua_State* L) {
 	// player:getStashCount()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t sizeStash = getStashSize(player->getStashItems());
 		lua_pushnumber(L, sizeStash);
@@ -1149,7 +1149,7 @@ int PlayerFunctions::luaPlayerGetStashCounter(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetDepotChest(lua_State* L) {
 	// player:getDepotChest(depotId[, autoCreate = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1170,7 +1170,7 @@ int PlayerFunctions::luaPlayerGetDepotChest(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetInbox(lua_State* L) {
 	// player:getInbox()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1188,7 +1188,7 @@ int PlayerFunctions::luaPlayerGetInbox(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetSkullTime(lua_State* L) {
 	// player:getSkullTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getSkullTicks());
 	} else {
@@ -1199,7 +1199,7 @@ int PlayerFunctions::luaPlayerGetSkullTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetSkullTime(lua_State* L) {
 	// player:setSkullTime(skullTime)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setSkullTicks(Lua::getNumber<int64_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -1211,7 +1211,7 @@ int PlayerFunctions::luaPlayerSetSkullTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetDeathPenalty(lua_State* L) {
 	// player:getDeathPenalty()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, static_cast<uint32_t>(player->getLostPercent() * 100));
 	} else {
@@ -1222,7 +1222,7 @@ int PlayerFunctions::luaPlayerGetDeathPenalty(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetExperience(lua_State* L) {
 	// player:getExperience()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getExperience());
 	} else {
@@ -1233,7 +1233,7 @@ int PlayerFunctions::luaPlayerGetExperience(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddExperience(lua_State* L) {
 	// player:addExperience(experience[, sendText = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const int64_t experience = Lua::getNumber<int64_t>(L, 2);
 		const bool sendText = Lua::getBoolean(L, 3, false);
@@ -1247,7 +1247,7 @@ int PlayerFunctions::luaPlayerAddExperience(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveExperience(lua_State* L) {
 	// player:removeExperience(experience[, sendText = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const int64_t experience = Lua::getNumber<int64_t>(L, 2);
 		const bool sendText = Lua::getBoolean(L, 3, false);
@@ -1261,7 +1261,7 @@ int PlayerFunctions::luaPlayerRemoveExperience(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLevel(lua_State* L) {
 	// player:getLevel()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getLevel());
 	} else {
@@ -1272,7 +1272,7 @@ int PlayerFunctions::luaPlayerGetLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMagicShieldCapacityFlat(lua_State* L) {
 	// player:getMagicShieldCapacityFlat(useCharges)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMagicShieldCapacityFlat(Lua::getBoolean(L, 2, false)));
 	} else {
@@ -1283,7 +1283,7 @@ int PlayerFunctions::luaPlayerGetMagicShieldCapacityFlat(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMagicShieldCapacityPercent(lua_State* L) {
 	// player:getMagicShieldCapacityPercent(useCharges)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMagicShieldCapacityPercent(Lua::getBoolean(L, 2, false)));
 	} else {
@@ -1294,7 +1294,7 @@ int PlayerFunctions::luaPlayerGetMagicShieldCapacityPercent(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendSpellCooldown(lua_State* L) {
 	// player:sendSpellCooldown(spellId, time)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1310,7 +1310,7 @@ int PlayerFunctions::luaPlayerSendSpellCooldown(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendSpellGroupCooldown(lua_State* L) {
 	// player:sendSpellGroupCooldown(groupId, time)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1326,7 +1326,7 @@ int PlayerFunctions::luaPlayerSendSpellGroupCooldown(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMagicLevel(lua_State* L) {
 	// player:getMagicLevel()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMagicLevel());
 	} else {
@@ -1337,7 +1337,7 @@ int PlayerFunctions::luaPlayerGetMagicLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBaseMagicLevel(lua_State* L) {
 	// player:getBaseMagicLevel()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getBaseMagicLevel());
 	} else {
@@ -1348,7 +1348,7 @@ int PlayerFunctions::luaPlayerGetBaseMagicLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMana(lua_State* L) {
 	// player:getMana()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMana());
 	} else {
@@ -1359,7 +1359,7 @@ int PlayerFunctions::luaPlayerGetMana(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddMana(lua_State* L) {
 	// player:addMana(manaChange[, animationOnLoss = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1381,7 +1381,7 @@ int PlayerFunctions::luaPlayerAddMana(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMaxMana(lua_State* L) {
 	// player:getMaxMana()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMaxMana());
 	} else {
@@ -1408,7 +1408,7 @@ int PlayerFunctions::luaPlayerSetMaxMana(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetManaSpent(lua_State* L) {
 	// player:getManaSpent()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getSpentMana());
 	} else {
@@ -1419,7 +1419,7 @@ int PlayerFunctions::luaPlayerGetManaSpent(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddManaSpent(lua_State* L) {
 	// player:addManaSpent(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->addManaSpent(Lua::getNumber<uint64_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -1431,7 +1431,7 @@ int PlayerFunctions::luaPlayerAddManaSpent(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBaseMaxHealth(lua_State* L) {
 	// player:getBaseMaxHealth()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->healthMax);
 	} else {
@@ -1442,7 +1442,7 @@ int PlayerFunctions::luaPlayerGetBaseMaxHealth(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBaseMaxMana(lua_State* L) {
 	// player:getBaseMaxMana()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->manaMax);
 	} else {
@@ -1454,7 +1454,7 @@ int PlayerFunctions::luaPlayerGetBaseMaxMana(lua_State* L) {
 int PlayerFunctions::luaPlayerGetSkillLevel(lua_State* L) {
 	// player:getSkillLevel(skillType)
 	const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushnumber(L, player->skills[skillType].level);
 	} else {
@@ -1466,7 +1466,7 @@ int PlayerFunctions::luaPlayerGetSkillLevel(lua_State* L) {
 int PlayerFunctions::luaPlayerGetEffectiveSkillLevel(lua_State* L) {
 	// player:getEffectiveSkillLevel(skillType)
 	const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushnumber(L, player->getSkillLevel(skillType));
 	} else {
@@ -1478,7 +1478,7 @@ int PlayerFunctions::luaPlayerGetEffectiveSkillLevel(lua_State* L) {
 int PlayerFunctions::luaPlayerGetSkillPercent(lua_State* L) {
 	// player:getSkillPercent(skillType)
 	const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushnumber(L, player->skills[skillType].percent);
 	} else {
@@ -1490,7 +1490,7 @@ int PlayerFunctions::luaPlayerGetSkillPercent(lua_State* L) {
 int PlayerFunctions::luaPlayerGetSkillTries(lua_State* L) {
 	// player:getSkillTries(skillType)
 	const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushnumber(L, player->skills[skillType].tries);
 	} else {
@@ -1501,7 +1501,7 @@ int PlayerFunctions::luaPlayerGetSkillTries(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddSkillTries(lua_State* L) {
 	// player:addSkillTries(skillType, tries)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
 		const uint64_t tries = Lua::getNumber<uint64_t>(L, 3);
@@ -1515,7 +1515,7 @@ int PlayerFunctions::luaPlayerAddSkillTries(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetLevel(lua_State* L) {
 	// player:setLevel(level)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t level = Lua::getNumber<uint16_t>(L, 2);
 		player->level = level;
@@ -1531,7 +1531,7 @@ int PlayerFunctions::luaPlayerSetLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetMagicLevel(lua_State* L) {
 	// player:setMagicLevel(level[, manaSpent])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t level = Lua::getNumber<uint16_t>(L, 2);
 		player->magLevel = level;
@@ -1555,7 +1555,7 @@ int PlayerFunctions::luaPlayerSetMagicLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetSkillLevel(lua_State* L) {
 	// player:setSkillLevel(skillType, level[, tries])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
 		const uint16_t level = Lua::getNumber<uint16_t>(L, 3);
@@ -1580,7 +1580,7 @@ int PlayerFunctions::luaPlayerSetSkillLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddOfflineTrainingTime(lua_State* L) {
 	// player:addOfflineTrainingTime(time)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const int32_t time = Lua::getNumber<int32_t>(L, 2);
 		player->addOfflineTrainingTime(time);
@@ -1594,7 +1594,7 @@ int PlayerFunctions::luaPlayerAddOfflineTrainingTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetOfflineTrainingTime(lua_State* L) {
 	// player:getOfflineTrainingTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getOfflineTrainingTime());
 	} else {
@@ -1605,7 +1605,7 @@ int PlayerFunctions::luaPlayerGetOfflineTrainingTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveOfflineTrainingTime(lua_State* L) {
 	// player:removeOfflineTrainingTime(time)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const int32_t time = Lua::getNumber<int32_t>(L, 2);
 		player->removeOfflineTrainingTime(time);
@@ -1619,7 +1619,7 @@ int PlayerFunctions::luaPlayerRemoveOfflineTrainingTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddOfflineTrainingTries(lua_State* L) {
 	// player:addOfflineTrainingTries(skillType, tries)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
 		const uint64_t tries = Lua::getNumber<uint64_t>(L, 3);
@@ -1632,7 +1632,7 @@ int PlayerFunctions::luaPlayerAddOfflineTrainingTries(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetOfflineTrainingSkill(lua_State* L) {
 	// player:getOfflineTrainingSkill()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getOfflineTrainingSkill());
 	} else {
@@ -1643,7 +1643,7 @@ int PlayerFunctions::luaPlayerGetOfflineTrainingSkill(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetOfflineTrainingSkill(lua_State* L) {
 	// player:setOfflineTrainingSkill(skillId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const int8_t skillId = Lua::getNumber<int8_t>(L, 2);
 		player->setOfflineTrainingSkill(skillId);
@@ -1656,7 +1656,7 @@ int PlayerFunctions::luaPlayerSetOfflineTrainingSkill(lua_State* L) {
 
 int PlayerFunctions::luaPlayerOpenStash(lua_State* L) {
 	// player:openStash(isNpc)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	const bool isNpc = Lua::getBoolean(L, 2, false);
 	if (player) {
 		player->sendOpenStash(isNpc);
@@ -1670,7 +1670,7 @@ int PlayerFunctions::luaPlayerOpenStash(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetItemCount(lua_State* L) {
 	// player:getItemCount(itemId[, subType = -1])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1694,7 +1694,7 @@ int PlayerFunctions::luaPlayerGetItemCount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStashItemCount(lua_State* L) {
 	// player:getStashItemCount(itemId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1723,7 +1723,7 @@ int PlayerFunctions::luaPlayerGetStashItemCount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetItemById(lua_State* L) {
 	// player:getItemById(itemId, deepSearch[, subType = -1])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1754,7 +1754,7 @@ int PlayerFunctions::luaPlayerGetItemById(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetVocation(lua_State* L) {
 	// player:getVocation()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushUserdata<Vocation>(L, player->getVocation());
 		Lua::setMetatable(L, -1, "Vocation");
@@ -1766,7 +1766,7 @@ int PlayerFunctions::luaPlayerGetVocation(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetVocation(lua_State* L) {
 	// player:setVocation(id or name or userdata)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1778,7 +1778,7 @@ int PlayerFunctions::luaPlayerSetVocation(lua_State* L) {
 	} else if (Lua::isString(L, 2)) {
 		vocation = g_vocations().getVocation(g_vocations().getVocationId(Lua::getString(L, 2)));
 	} else if (Lua::isUserdata(L, 2)) {
-		vocation = Lua::getUserdataShared<Vocation>(L, 2);
+		vocation = Lua::getUserdataShared<Vocation>(L, 2, "Vocation");
 	} else {
 		vocation = nullptr;
 	}
@@ -1800,7 +1800,7 @@ int PlayerFunctions::luaPlayerSetVocation(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsPromoted(lua_State* L) {
 	// player:isPromoted()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->isPromoted());
 	} else {
@@ -1811,7 +1811,7 @@ int PlayerFunctions::luaPlayerIsPromoted(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetSex(lua_State* L) {
 	// player:getSex()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getSex());
 	} else {
@@ -1822,7 +1822,7 @@ int PlayerFunctions::luaPlayerGetSex(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetSex(lua_State* L) {
 	// player:setSex(newSex)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const PlayerSex_t newSex = Lua::getNumber<PlayerSex_t>(L, 2);
 		player->setSex(newSex);
@@ -1835,7 +1835,7 @@ int PlayerFunctions::luaPlayerSetSex(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetPronoun(lua_State* L) {
 	// player:getPronoun()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getPronoun());
 	} else {
@@ -1846,7 +1846,7 @@ int PlayerFunctions::luaPlayerGetPronoun(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetPronoun(lua_State* L) {
 	// player:setPronoun(newPronoun)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const PlayerPronoun_t newPronoun = Lua::getNumber<PlayerPronoun_t>(L, 2);
 		player->setPronoun(newPronoun);
@@ -1859,7 +1859,7 @@ int PlayerFunctions::luaPlayerSetPronoun(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetTown(lua_State* L) {
 	// player:getTown()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushUserdata<Town>(L, player->getTown());
 		Lua::setMetatable(L, -1, "Town");
@@ -1871,13 +1871,13 @@ int PlayerFunctions::luaPlayerGetTown(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetTown(lua_State* L) {
 	// player:setTown(town)
-	const auto &town = Lua::getUserdataShared<Town>(L, 2);
+	const auto &town = Lua::getUserdataShared<Town>(L, 2, "Town");
 	if (!town) {
 		Lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setTown(town);
 		Lua::pushBoolean(L, true);
@@ -1889,7 +1889,7 @@ int PlayerFunctions::luaPlayerSetTown(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetGuild(lua_State* L) {
 	// player:getGuild()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -1908,13 +1908,13 @@ int PlayerFunctions::luaPlayerGetGuild(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetGuild(lua_State* L) {
 	// player:setGuild(guild)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &guild = Lua::getUserdataShared<Guild>(L, 2);
+	const auto &guild = Lua::getUserdataShared<Guild>(L, 2, "Guild");
 	player->setGuild(guild);
 
 	Lua::pushBoolean(L, true);
@@ -1923,7 +1923,7 @@ int PlayerFunctions::luaPlayerSetGuild(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetGuildLevel(lua_State* L) {
 	// player:getGuildLevel()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && player->getGuild()) {
 		lua_pushnumber(L, player->getGuildRank()->level);
 	} else {
@@ -1935,7 +1935,7 @@ int PlayerFunctions::luaPlayerGetGuildLevel(lua_State* L) {
 int PlayerFunctions::luaPlayerSetGuildLevel(lua_State* L) {
 	// player:setGuildLevel(level)
 	const uint8_t level = Lua::getNumber<uint8_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getGuild()) {
 		lua_pushnil(L);
 		return 1;
@@ -1954,7 +1954,7 @@ int PlayerFunctions::luaPlayerSetGuildLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetGuildNick(lua_State* L) {
 	// player:getGuildNick()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushString(L, player->getGuildNick());
 	} else {
@@ -1966,7 +1966,7 @@ int PlayerFunctions::luaPlayerGetGuildNick(lua_State* L) {
 int PlayerFunctions::luaPlayerSetGuildNick(lua_State* L) {
 	// player:setGuildNick(nick)
 	const std::string &nick = Lua::getString(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setGuildNick(nick);
 		Lua::pushBoolean(L, true);
@@ -1978,7 +1978,7 @@ int PlayerFunctions::luaPlayerSetGuildNick(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetGroup(lua_State* L) {
 	// player:getGroup()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushUserdata<Group>(L, player->getGroup());
 		Lua::setMetatable(L, -1, "Group");
@@ -1990,13 +1990,13 @@ int PlayerFunctions::luaPlayerGetGroup(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetGroup(lua_State* L) {
 	// player:setGroup(group)
-	const auto &group = Lua::getUserdataShared<Group>(L, 2);
+	const auto &group = Lua::getUserdataShared<Group>(L, 2, "Group");
 	if (!group) {
 		Lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setGroup(group);
 		Lua::pushBoolean(L, true);
@@ -2011,7 +2011,7 @@ int PlayerFunctions::luaPlayerSetSpecialContainersAvailable(lua_State* L) {
 	const bool supplyStashMenu = Lua::getBoolean(L, 2, false);
 	const bool marketMenu = Lua::getBoolean(L, 3, false);
 	const bool depotSearchMenu = Lua::getBoolean(L, 4, false);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setSpecialMenuAvailable(supplyStashMenu, marketMenu, depotSearchMenu);
 		Lua::pushBoolean(L, true);
@@ -2023,7 +2023,7 @@ int PlayerFunctions::luaPlayerSetSpecialContainersAvailable(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStamina(lua_State* L) {
 	// player:getStamina()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getStaminaMinutes());
 	} else {
@@ -2035,7 +2035,7 @@ int PlayerFunctions::luaPlayerGetStamina(lua_State* L) {
 int PlayerFunctions::luaPlayerSetStamina(lua_State* L) {
 	// player:setStamina(stamina)
 	const uint16_t stamina = Lua::getNumber<uint16_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->staminaMinutes = std::min<uint16_t>(2520, stamina);
 		player->sendStats();
@@ -2047,7 +2047,7 @@ int PlayerFunctions::luaPlayerSetStamina(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetSoul(lua_State* L) {
 	// player:getSoul()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getSoul());
 	} else {
@@ -2059,7 +2059,7 @@ int PlayerFunctions::luaPlayerGetSoul(lua_State* L) {
 int PlayerFunctions::luaPlayerAddSoul(lua_State* L) {
 	// player:addSoul(soulChange)
 	const int32_t soulChange = Lua::getNumber<int32_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->changeSoul(soulChange);
 		Lua::pushBoolean(L, true);
@@ -2071,7 +2071,7 @@ int PlayerFunctions::luaPlayerAddSoul(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMaxSoul(lua_State* L) {
 	// player:getMaxSoul()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && player->vocation) {
 		lua_pushnumber(L, player->vocation->getSoulMax());
 	} else {
@@ -2082,7 +2082,7 @@ int PlayerFunctions::luaPlayerGetMaxSoul(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBankBalance(lua_State* L) {
 	// player:getBankBalance()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getBankBalance());
 	} else {
@@ -2093,7 +2093,7 @@ int PlayerFunctions::luaPlayerGetBankBalance(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetBankBalance(lua_State* L) {
 	// player:setBankBalance(bankBalance)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2106,7 +2106,7 @@ int PlayerFunctions::luaPlayerSetBankBalance(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStorageValue(lua_State* L) {
 	// player:getStorageValue(key)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2121,7 +2121,7 @@ int PlayerFunctions::luaPlayerSetStorageValue(lua_State* L) {
 	// player:setStorageValue(key, value)
 	const int32_t value = Lua::getNumber<int32_t>(L, 3);
 	const uint32_t key = Lua::getNumber<uint32_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
 		std::ostringstream ss;
 		ss << "Accessing reserved range: " << key;
@@ -2146,7 +2146,7 @@ int PlayerFunctions::luaPlayerSetStorageValue(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStorageValueByName(lua_State* L) {
 	// player:getStorageValueByName(name)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -2161,7 +2161,7 @@ int PlayerFunctions::luaPlayerGetStorageValueByName(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetStorageValueByName(lua_State* L) {
 	// player:setStorageValueByName(storageName, value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -2179,7 +2179,7 @@ int PlayerFunctions::luaPlayerSetStorageValueByName(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddItem(lua_State* L) {
 	// player:addItem(itemId, count = 1, canDropOnMap = true, subType = 1, slot = CONST_SLOT_WHEREEVER, tier = 0)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::pushBoolean(L, false);
 		return 1;
@@ -2271,14 +2271,14 @@ int PlayerFunctions::luaPlayerAddItem(lua_State* L) {
 int PlayerFunctions::luaPlayerAddItemEx(lua_State* L) {
 	// player:addItemEx(item[, canDropOnMap = false[, index = INDEX_WHEREEVER[, flags = 0]]])
 	// player:addItemEx(item[, canDropOnMap = true[, slot = CONST_SLOT_WHEREEVER]])
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2310,7 +2310,7 @@ int PlayerFunctions::luaPlayerAddItemEx(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddItemStash(lua_State* L) {
 	// player:addItemStash(itemId, count = 1)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2326,7 +2326,7 @@ int PlayerFunctions::luaPlayerAddItemStash(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveStashItem(lua_State* L) {
 	// player:removeStashItem(itemId, count)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2356,7 +2356,7 @@ int PlayerFunctions::luaPlayerRemoveStashItem(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveItem(lua_State* L) {
 	// player:removeItem(itemId, count[, subType = -1[, ignoreEquipped = false]])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2382,13 +2382,13 @@ int PlayerFunctions::luaPlayerRemoveItem(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendContainer(lua_State* L) {
 	// player:sendContainer(container)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &container = Lua::getUserdataShared<Container>(L, 2);
+	const auto &container = Lua::getUserdataShared<Container>(L, 2, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -2401,13 +2401,13 @@ int PlayerFunctions::luaPlayerSendContainer(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendUpdateContainer(lua_State* L) {
 	// player:sendUpdateContainer(container)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &container = Lua::getUserdataShared<Container>(L, 2);
+	const auto &container = Lua::getUserdataShared<Container>(L, 2, "Container");
 	if (!container) {
 		Lua::reportErrorFunc("Container is nullptr");
 		return 1;
@@ -2420,7 +2420,7 @@ int PlayerFunctions::luaPlayerSendUpdateContainer(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetMoney(lua_State* L) {
 	// player:getMoney()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getMoney());
 	} else {
@@ -2432,7 +2432,7 @@ int PlayerFunctions::luaPlayerGetMoney(lua_State* L) {
 int PlayerFunctions::luaPlayerAddMoney(lua_State* L) {
 	// player:addMoney(money)
 	const uint64_t money = Lua::getNumber<uint64_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		g_game().addMoney(player, money);
 		Lua::pushBoolean(L, true);
@@ -2444,7 +2444,7 @@ int PlayerFunctions::luaPlayerAddMoney(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveMoney(lua_State* L) {
 	// player:removeMoney(money[, flags = 0[, useBank = true]])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint64_t money = Lua::getNumber<uint64_t>(L, 2);
 		const auto flags = Lua::getNumber<int32_t>(L, 3, 0);
@@ -2458,7 +2458,7 @@ int PlayerFunctions::luaPlayerRemoveMoney(lua_State* L) {
 
 int PlayerFunctions::luaPlayerShowTextDialog(lua_State* L) {
 	// player:showTextDialog(id or name or userdata[, text[, canWrite[, length]]])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2484,7 +2484,7 @@ int PlayerFunctions::luaPlayerShowTextDialog(lua_State* L) {
 			return 1;
 		}
 
-		item = Lua::getUserdataShared<Item>(L, 2);
+		item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	} else {
 		item = nullptr;
 	}
@@ -2515,7 +2515,7 @@ int PlayerFunctions::luaPlayerSendTextMessage(lua_State* L) {
 	// player:sendTextMessage(type, text[, position, primaryValue = 0, primaryColor = TEXTCOLOR_NONE[, secondaryValue = 0, secondaryColor = TEXTCOLOR_NONE]])
 	// player:sendTextMessage(type, text, channelId)
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2553,7 +2553,7 @@ int PlayerFunctions::luaPlayerSendTextMessage(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendChannelMessage(lua_State* L) {
 	// player:sendChannelMessage(author, text, type, channelId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2570,13 +2570,13 @@ int PlayerFunctions::luaPlayerSendChannelMessage(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendPrivateMessage(lua_State* L) {
 	// player:sendPrivateMessage(speaker, text[, type])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &speaker = Lua::getUserdataShared<Player>(L, 2);
+	const auto &speaker = Lua::getUserdataShared<Player>(L, 2, "Player");
 	const std::string &text = Lua::getString(L, 3);
 	const auto type = Lua::getNumber<SpeakClasses>(L, 4, TALKTYPE_PRIVATE_FROM);
 	player->sendPrivateMessage(speaker, type, text);
@@ -2586,7 +2586,7 @@ int PlayerFunctions::luaPlayerSendPrivateMessage(lua_State* L) {
 
 int PlayerFunctions::luaPlayerChannelSay(lua_State* L) {
 	// player:channelSay(speaker, type, text, channelId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2604,7 +2604,7 @@ int PlayerFunctions::luaPlayerChannelSay(lua_State* L) {
 int PlayerFunctions::luaPlayerOpenChannel(lua_State* L) {
 	// player:openChannel(channelId)
 	const uint16_t channelId = Lua::getNumber<uint16_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		g_game().playerOpenChannel(player->getID(), channelId);
 		Lua::pushBoolean(L, true);
@@ -2616,7 +2616,7 @@ int PlayerFunctions::luaPlayerOpenChannel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetSlotItem(lua_State* L) {
 	// player:getSlotItem(slot)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2641,7 +2641,7 @@ int PlayerFunctions::luaPlayerGetSlotItem(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetParty(lua_State* L) {
 	// player:getParty()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2659,7 +2659,7 @@ int PlayerFunctions::luaPlayerGetParty(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddOutfit(lua_State* L) {
 	// player:addOutfit(lookType or name, addon = 0)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		auto addon = Lua::getNumber<uint8_t>(L, 3, 0);
 		if (lua_isnumber(L, 2)) {
@@ -2684,7 +2684,7 @@ int PlayerFunctions::luaPlayerAddOutfit(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddOutfitAddon(lua_State* L) {
 	// player:addOutfitAddon(lookType, addon)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		const uint8_t addon = Lua::getNumber<uint8_t>(L, 3);
@@ -2698,7 +2698,7 @@ int PlayerFunctions::luaPlayerAddOutfitAddon(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveOutfit(lua_State* L) {
 	// player:removeOutfit(lookType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, player->removeOutfit(lookType));
@@ -2710,7 +2710,7 @@ int PlayerFunctions::luaPlayerRemoveOutfit(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveOutfitAddon(lua_State* L) {
 	// player:removeOutfitAddon(lookType, addon)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		const uint8_t addon = Lua::getNumber<uint8_t>(L, 3);
@@ -2723,7 +2723,7 @@ int PlayerFunctions::luaPlayerRemoveOutfitAddon(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasOutfit(lua_State* L) {
 	// player:hasOutfit(lookType[, addon = 0])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		const auto addon = Lua::getNumber<uint8_t>(L, 3, 0);
@@ -2736,7 +2736,7 @@ int PlayerFunctions::luaPlayerHasOutfit(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendOutfitWindow(lua_State* L) {
 	// player:sendOutfitWindow()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->sendOutfitWindow();
 		Lua::pushBoolean(L, true);
@@ -2748,7 +2748,7 @@ int PlayerFunctions::luaPlayerSendOutfitWindow(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddMount(lua_State* L) {
 	// player:addMount(mountId or mountName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2771,7 +2771,7 @@ int PlayerFunctions::luaPlayerAddMount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveMount(lua_State* L) {
 	// player:removeMount(mountId or mountName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2794,7 +2794,7 @@ int PlayerFunctions::luaPlayerRemoveMount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasMount(lua_State* L) {
 	// player:hasMount(mountId or mountName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -2817,7 +2817,7 @@ int PlayerFunctions::luaPlayerHasMount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddFamiliar(lua_State* L) {
 	// player:addFamiliar(lookType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->addFamiliar(Lua::getNumber<uint16_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -2829,7 +2829,7 @@ int PlayerFunctions::luaPlayerAddFamiliar(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveFamiliar(lua_State* L) {
 	// player:removeFamiliar(lookType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, player->removeFamiliar(lookType));
@@ -2841,7 +2841,7 @@ int PlayerFunctions::luaPlayerRemoveFamiliar(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasFamiliar(lua_State* L) {
 	// player:hasFamiliar(lookType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t lookType = Lua::getNumber<uint16_t>(L, 2);
 		Lua::pushBoolean(L, player->canFamiliar(lookType));
@@ -2853,7 +2853,7 @@ int PlayerFunctions::luaPlayerHasFamiliar(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetFamiliarLooktype(lua_State* L) {
 	// player:setFamiliarLooktype(lookType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setFamiliarLooktype(Lua::getNumber<uint16_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -2865,7 +2865,7 @@ int PlayerFunctions::luaPlayerSetFamiliarLooktype(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetFamiliarLooktype(lua_State* L) {
 	// player:getFamiliarLooktype()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->defaultOutfit.lookFamiliarsType);
 	} else {
@@ -2876,7 +2876,7 @@ int PlayerFunctions::luaPlayerGetFamiliarLooktype(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetPremiumDays(lua_State* L) {
 	// player:getPremiumDays()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player && player->getAccount()) {
 		lua_pushnumber(L, player->getAccount()->getPremiumRemainingDays());
 	} else {
@@ -2887,7 +2887,7 @@ int PlayerFunctions::luaPlayerGetPremiumDays(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddPremiumDays(lua_State* L) {
 	// player:addPremiumDays(days)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		lua_pushnil(L);
 		return 1;
@@ -2916,7 +2916,7 @@ int PlayerFunctions::luaPlayerAddPremiumDays(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemovePremiumDays(lua_State* L) {
 	// player:removePremiumDays(days)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		lua_pushnil(L);
 		return 1;
@@ -2945,7 +2945,7 @@ int PlayerFunctions::luaPlayerRemovePremiumDays(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetTibiaCoins(lua_State* L) {
 	// player:getTibiaCoins()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -2963,7 +2963,7 @@ int PlayerFunctions::luaPlayerGetTibiaCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddTibiaCoins(lua_State* L) {
 	// player:addTibiaCoins(coins)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -2989,7 +2989,7 @@ int PlayerFunctions::luaPlayerAddTibiaCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveTibiaCoins(lua_State* L) {
 	// player:removeTibiaCoins(coins)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -3014,7 +3014,7 @@ int PlayerFunctions::luaPlayerRemoveTibiaCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetTransferableCoins(lua_State* L) {
 	// player:getTransferableCoins()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -3032,7 +3032,7 @@ int PlayerFunctions::luaPlayerGetTransferableCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddTransferableCoins(lua_State* L) {
 	// player:addTransferableCoins(coins)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -3058,7 +3058,7 @@ int PlayerFunctions::luaPlayerAddTransferableCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveTransferableCoins(lua_State* L) {
 	// player:removeTransferableCoins(coins)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player || !player->getAccount()) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		lua_pushnil(L);
@@ -3084,7 +3084,7 @@ int PlayerFunctions::luaPlayerRemoveTransferableCoins(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendBlessStatus(lua_State* L) {
 	// player:sendBlessStatus()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3099,7 +3099,7 @@ int PlayerFunctions::luaPlayerSendBlessStatus(lua_State* L) {
 int PlayerFunctions::luaPlayerHasBlessing(lua_State* L) {
 	// player:hasBlessing(blessing)
 	const uint8_t blessing = Lua::getNumber<uint8_t>(L, 2);
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->hasBlessing(blessing));
 	} else {
@@ -3110,7 +3110,7 @@ int PlayerFunctions::luaPlayerHasBlessing(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddBlessing(lua_State* L) {
 	// player:addBlessing(blessing)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3127,7 +3127,7 @@ int PlayerFunctions::luaPlayerAddBlessing(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveBlessing(lua_State* L) {
 	// player:removeBlessing(blessing)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3148,7 +3148,7 @@ int PlayerFunctions::luaPlayerRemoveBlessing(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBlessingCount(lua_State* L) {
 	// player:getBlessingCount(index[, storeCount = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	uint8_t index = Lua::getNumber<uint8_t>(L, 2);
 	if (index == 0) {
 		index = 1;
@@ -3164,7 +3164,7 @@ int PlayerFunctions::luaPlayerGetBlessingCount(lua_State* L) {
 
 int PlayerFunctions::luaPlayerCanLearnSpell(lua_State* L) {
 	// player:canLearnSpell(spellName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3198,7 +3198,7 @@ int PlayerFunctions::luaPlayerCanLearnSpell(lua_State* L) {
 
 int PlayerFunctions::luaPlayerLearnSpell(lua_State* L) {
 	// player:learnSpell(spellName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const std::string &spellName = Lua::getString(L, 2);
 		player->learnInstantSpell(spellName);
@@ -3211,7 +3211,7 @@ int PlayerFunctions::luaPlayerLearnSpell(lua_State* L) {
 
 int PlayerFunctions::luaPlayerForgetSpell(lua_State* L) {
 	// player:forgetSpell(spellName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const std::string &spellName = Lua::getString(L, 2);
 		player->forgetInstantSpell(spellName);
@@ -3224,7 +3224,7 @@ int PlayerFunctions::luaPlayerForgetSpell(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasLearnedSpell(lua_State* L) {
 	// player:hasLearnedSpell(spellName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const std::string &spellName = Lua::getString(L, 2);
 		Lua::pushBoolean(L, player->hasLearnedInstantSpell(spellName));
@@ -3236,7 +3236,7 @@ int PlayerFunctions::luaPlayerHasLearnedSpell(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendTutorial(lua_State* L) {
 	// player:sendTutorial(tutorialId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint8_t tutorialId = Lua::getNumber<uint8_t>(L, 2);
 		player->sendTutorial(tutorialId);
@@ -3249,14 +3249,14 @@ int PlayerFunctions::luaPlayerSendTutorial(lua_State* L) {
 
 int PlayerFunctions::luaPlayerOpenImbuementWindow(lua_State* L) {
 	// player:openImbuementWindow(item)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3269,7 +3269,7 @@ int PlayerFunctions::luaPlayerOpenImbuementWindow(lua_State* L) {
 
 int PlayerFunctions::luaPlayerCloseImbuementWindow(lua_State* L) {
 	// player:closeImbuementWindow()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3282,7 +3282,7 @@ int PlayerFunctions::luaPlayerCloseImbuementWindow(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddMapMark(lua_State* L) {
 	// player:addMapMark(position, type, description)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const Position &position = Lua::getPosition(L, 2);
 		const uint8_t type = Lua::getNumber<uint8_t>(L, 3);
@@ -3297,7 +3297,7 @@ int PlayerFunctions::luaPlayerAddMapMark(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSave(lua_State* L) {
 	// player:save()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		if (!player->isOffline()) {
 			player->loginPosition = player->getPosition();
@@ -3311,7 +3311,7 @@ int PlayerFunctions::luaPlayerSave(lua_State* L) {
 
 int PlayerFunctions::luaPlayerPopupFYI(lua_State* L) {
 	// player:popupFYI(message)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const std::string &message = Lua::getString(L, 2);
 		player->sendFYIBox(message);
@@ -3324,7 +3324,7 @@ int PlayerFunctions::luaPlayerPopupFYI(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsPzLocked(lua_State* L) {
 	// player:isPzLocked()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->isPzLocked());
 	} else {
@@ -3335,7 +3335,7 @@ int PlayerFunctions::luaPlayerIsPzLocked(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetClient(lua_State* L) {
 	// player:getClient()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_createtable(L, 0, 2);
 		Lua::setField(L, "version", player->getProtocolVersion());
@@ -3348,7 +3348,7 @@ int PlayerFunctions::luaPlayerGetClient(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetHouse(lua_State* L) {
 	// player:getHouse()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3366,13 +3366,13 @@ int PlayerFunctions::luaPlayerGetHouse(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendHouseWindow(lua_State* L) {
 	// player:sendHouseWindow(house, listId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &house = Lua::getUserdataShared<House>(L, 2);
+	const auto &house = Lua::getUserdataShared<House>(L, 2, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -3386,13 +3386,13 @@ int PlayerFunctions::luaPlayerSendHouseWindow(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetEditHouse(lua_State* L) {
 	// player:setEditHouse(house, listId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &house = Lua::getUserdataShared<House>(L, 2);
+	const auto &house = Lua::getUserdataShared<House>(L, 2, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -3406,7 +3406,7 @@ int PlayerFunctions::luaPlayerSetEditHouse(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetGhostMode(lua_State* L) {
 	// player:setGhostMode(enabled)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3455,13 +3455,13 @@ int PlayerFunctions::luaPlayerSetGhostMode(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetContainerId(lua_State* L) {
 	// player:getContainerId(container)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &container = Lua::getUserdataShared<Container>(L, 2);
+	const auto &container = Lua::getUserdataShared<Container>(L, 2, "Container");
 	if (container) {
 		lua_pushnumber(L, player->getContainerID(container));
 	} else {
@@ -3472,7 +3472,7 @@ int PlayerFunctions::luaPlayerGetContainerId(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetContainerById(lua_State* L) {
 	// player:getContainerById(id)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3490,7 +3490,7 @@ int PlayerFunctions::luaPlayerGetContainerById(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetContainerIndex(lua_State* L) {
 	// player:getContainerIndex(id)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getContainerIndex(Lua::getNumber<uint8_t>(L, 2)));
 	} else {
@@ -3501,7 +3501,7 @@ int PlayerFunctions::luaPlayerGetContainerIndex(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetInstantSpells(lua_State* L) {
 	// player:getInstantSpells()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3526,8 +3526,8 @@ int PlayerFunctions::luaPlayerGetInstantSpells(lua_State* L) {
 
 int PlayerFunctions::luaPlayerCanCast(lua_State* L) {
 	// player:canCast(spell)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
-	const auto &spell = Lua::getUserdataShared<InstantSpell>(L, 2);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
+	const auto &spell = Lua::getUserdataShared<InstantSpell>(L, 2, "InstantSpell");
 	if (player && spell) {
 		Lua::pushBoolean(L, spell->canCast(player));
 	} else {
@@ -3538,7 +3538,7 @@ int PlayerFunctions::luaPlayerCanCast(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasChaseMode(lua_State* L) {
 	// player:hasChaseMode()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->chaseMode);
 	} else {
@@ -3549,7 +3549,7 @@ int PlayerFunctions::luaPlayerHasChaseMode(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasSecureMode(lua_State* L) {
 	// player:hasSecureMode()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->secureMode);
 	} else {
@@ -3560,7 +3560,7 @@ int PlayerFunctions::luaPlayerHasSecureMode(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetFightMode(lua_State* L) {
 	// player:getFightMode()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->fightMode);
 	} else {
@@ -3571,7 +3571,7 @@ int PlayerFunctions::luaPlayerGetFightMode(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBaseXpGain(lua_State* L) {
 	// player:getBaseXpGain()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getBaseXpGain());
 	} else {
@@ -3582,7 +3582,7 @@ int PlayerFunctions::luaPlayerGetBaseXpGain(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetBaseXpGain(lua_State* L) {
 	// player:setBaseXpGain(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setBaseXpGain(Lua::getNumber<uint16_t>(L, 2));
 		player->sendStats();
@@ -3595,7 +3595,7 @@ int PlayerFunctions::luaPlayerSetBaseXpGain(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetVoucherXpBoost(lua_State* L) {
 	// player:getVoucherXpBoost()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getVoucherXpBoost());
 	} else {
@@ -3606,7 +3606,7 @@ int PlayerFunctions::luaPlayerGetVoucherXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetVoucherXpBoost(lua_State* L) {
 	// player:setVoucherXpBoost(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setVoucherXpBoost(Lua::getNumber<uint16_t>(L, 2));
 		player->sendStats();
@@ -3619,7 +3619,7 @@ int PlayerFunctions::luaPlayerSetVoucherXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetGrindingXpBoost(lua_State* L) {
 	// player:getGrindingXpBoost()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getGrindingXpBoost());
 	} else {
@@ -3630,7 +3630,7 @@ int PlayerFunctions::luaPlayerGetGrindingXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetGrindingXpBoost(lua_State* L) {
 	// player:setGrindingXpBoost(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setGrindingXpBoost(Lua::getNumber<uint16_t>(L, 2));
 		player->sendStats();
@@ -3643,7 +3643,7 @@ int PlayerFunctions::luaPlayerSetGrindingXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetXpBoostPercent(lua_State* L) {
 	// player:getXpBoostPercent()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getXpBoostPercent());
 	} else {
@@ -3654,7 +3654,7 @@ int PlayerFunctions::luaPlayerGetXpBoostPercent(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetXpBoostPercent(lua_State* L) {
 	// player:setXpBoostPercent(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t percent = Lua::getNumber<uint16_t>(L, 2);
 		player->setXpBoostPercent(percent);
@@ -3667,7 +3667,7 @@ int PlayerFunctions::luaPlayerSetXpBoostPercent(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStaminaXpBoost(lua_State* L) {
 	// player:getStaminaXpBoost()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getStaminaXpBoost());
 	} else {
@@ -3678,7 +3678,7 @@ int PlayerFunctions::luaPlayerGetStaminaXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetStaminaXpBoost(lua_State* L) {
 	// player:setStaminaXpBoost(value)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		player->setStaminaXpBoost(Lua::getNumber<uint16_t>(L, 2));
 		player->sendStats();
@@ -3691,7 +3691,7 @@ int PlayerFunctions::luaPlayerSetStaminaXpBoost(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetXpBoostTime(lua_State* L) {
 	// player:setXpBoostTime(timeLeft)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		const uint16_t timeLeft = Lua::getNumber<uint16_t>(L, 2);
 		player->setXpBoostTime(timeLeft);
@@ -3705,7 +3705,7 @@ int PlayerFunctions::luaPlayerSetXpBoostTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetXpBoostTime(lua_State* L) {
 	// player:getXpBoostTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getXpBoostTime());
 	} else {
@@ -3716,7 +3716,7 @@ int PlayerFunctions::luaPlayerGetXpBoostTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetIdleTime(lua_State* L) {
 	// player:getIdleTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getIdleTime());
 	} else {
@@ -3727,7 +3727,7 @@ int PlayerFunctions::luaPlayerGetIdleTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetFreeBackpackSlots(lua_State* L) {
 	// player:getFreeBackpackSlots()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 	}
@@ -3737,7 +3737,7 @@ int PlayerFunctions::luaPlayerGetFreeBackpackSlots(lua_State* L) {
 }
 
 int PlayerFunctions::luaPlayerIsOffline(lua_State* L) {
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		Lua::pushBoolean(L, player->isOffline());
 	} else {
@@ -3749,7 +3749,7 @@ int PlayerFunctions::luaPlayerIsOffline(lua_State* L) {
 
 int PlayerFunctions::luaPlayerOpenMarket(lua_State* L) {
 	// player:openMarket()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -3763,7 +3763,7 @@ int PlayerFunctions::luaPlayerOpenMarket(lua_State* L) {
 // Forge
 int PlayerFunctions::luaPlayerOpenForge(lua_State* L) {
 	// player:openForge()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3777,7 +3777,7 @@ int PlayerFunctions::luaPlayerOpenForge(lua_State* L) {
 
 int PlayerFunctions::luaPlayerCloseForge(lua_State* L) {
 	// player:closeForge()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3791,7 +3791,7 @@ int PlayerFunctions::luaPlayerCloseForge(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddForgeDusts(lua_State* L) {
 	// player:addForgeDusts(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3805,7 +3805,7 @@ int PlayerFunctions::luaPlayerAddForgeDusts(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveForgeDusts(lua_State* L) {
 	// player:removeForgeDusts(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3819,7 +3819,7 @@ int PlayerFunctions::luaPlayerRemoveForgeDusts(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetForgeDusts(lua_State* L) {
 	// player:getForgeDusts()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3832,7 +3832,7 @@ int PlayerFunctions::luaPlayerGetForgeDusts(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetForgeDusts(lua_State* L) {
 	// player:setForgeDusts()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3846,7 +3846,7 @@ int PlayerFunctions::luaPlayerSetForgeDusts(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddForgeDustLevel(lua_State* L) {
 	// player:addForgeDustLevel(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3860,7 +3860,7 @@ int PlayerFunctions::luaPlayerAddForgeDustLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveForgeDustLevel(lua_State* L) {
 	// player:removeForgeDustLevel(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3874,7 +3874,7 @@ int PlayerFunctions::luaPlayerRemoveForgeDustLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetForgeDustLevel(lua_State* L) {
 	// player:getForgeDustLevel()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3887,7 +3887,7 @@ int PlayerFunctions::luaPlayerGetForgeDustLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetForgeSlivers(lua_State* L) {
 	// player:getForgeSlivers()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3901,7 +3901,7 @@ int PlayerFunctions::luaPlayerGetForgeSlivers(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetForgeCores(lua_State* L) {
 	// player:getForgeCores()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3915,7 +3915,7 @@ int PlayerFunctions::luaPlayerGetForgeCores(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetFaction(lua_State* L) {
 	// player:setFaction(factionId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player == nullptr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3930,7 +3930,7 @@ int PlayerFunctions::luaPlayerSetFaction(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetFaction(lua_State* L) {
 	// player:getFaction()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player == nullptr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3943,7 +3943,7 @@ int PlayerFunctions::luaPlayerGetFaction(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsUIExhausted(lua_State* L) {
 	// player:isUIExhausted()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3957,7 +3957,7 @@ int PlayerFunctions::luaPlayerIsUIExhausted(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUpdateUIExhausted(lua_State* L) {
 	// player:updateUIExhausted(exhaustionTime = 250)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3972,7 +3972,7 @@ int PlayerFunctions::luaPlayerUpdateUIExhausted(lua_State* L) {
 // Bosstiary Cooldown Timer
 int PlayerFunctions::luaPlayerBosstiaryCooldownTimer(lua_State* L) {
 	// player:sendBosstiaryCooldownTimer()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -3986,7 +3986,7 @@ int PlayerFunctions::luaPlayerBosstiaryCooldownTimer(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBosstiaryLevel(lua_State* L) {
 	// player:getBosstiaryLevel(name)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	    player) {
 		const auto &mtype = g_monsters().getMonsterType(Lua::getString(L, 2));
 		if (mtype) {
@@ -4008,7 +4008,7 @@ int PlayerFunctions::luaPlayerGetBosstiaryLevel(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBosstiaryKills(lua_State* L) {
 	// player:getBosstiaryKills(name)
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	    player) {
 		const auto &mtype = g_monsters().getMonsterType(Lua::getString(L, 2));
 		if (mtype) {
@@ -4030,7 +4030,7 @@ int PlayerFunctions::luaPlayerGetBosstiaryKills(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddBosstiaryKill(lua_State* L) {
 	// player:addBosstiaryKill(name[, amount = 1])
-	if (const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	    player) {
 		const auto &mtype = g_monsters().getMonsterType(Lua::getString(L, 2));
 		if (mtype) {
@@ -4047,7 +4047,7 @@ int PlayerFunctions::luaPlayerAddBosstiaryKill(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetBossPoints(lua_State* L) {
 	// player:setBossPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4061,7 +4061,7 @@ int PlayerFunctions::luaPlayerSetBossPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetRemoveBossTime(lua_State* L) {
 	// player:setRemoveBossTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4075,7 +4075,7 @@ int PlayerFunctions::luaPlayerSetRemoveBossTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetSlotBossId(lua_State* L) {
 	// player:getSlotBossId(slotId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4090,7 +4090,7 @@ int PlayerFunctions::luaPlayerGetSlotBossId(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetBossBonus(lua_State* L) {
 	// player:getBossBonus(slotId)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4112,7 +4112,7 @@ int PlayerFunctions::luaPlayerGetBossBonus(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendSingleSoundEffect(lua_State* L) {
 	// player:sendSingleSoundEffect(soundId[, actor = true])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4129,7 +4129,7 @@ int PlayerFunctions::luaPlayerSendSingleSoundEffect(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendDoubleSoundEffect(lua_State* L) {
 	// player:sendDoubleSoundEffect(mainSoundId, secondarySoundId[, actor = true])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4147,7 +4147,7 @@ int PlayerFunctions::luaPlayerSendDoubleSoundEffect(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetName(lua_State* L) {
 	// player:getName()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4160,7 +4160,7 @@ int PlayerFunctions::luaPlayerGetName(lua_State* L) {
 
 int PlayerFunctions::luaPlayerChangeName(lua_State* L) {
 	// player:changeName(newName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4178,7 +4178,7 @@ int PlayerFunctions::luaPlayerChangeName(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasGroupFlag(lua_State* L) {
 	// player:hasGroupFlag(flag)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4191,7 +4191,7 @@ int PlayerFunctions::luaPlayerHasGroupFlag(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetGroupFlag(lua_State* L) {
 	// player:setGroupFlag(flag)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4204,7 +4204,7 @@ int PlayerFunctions::luaPlayerSetGroupFlag(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveGroupFlag(lua_State* L) {
 	// player:removeGroupFlag(flag)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4218,7 +4218,7 @@ int PlayerFunctions::luaPlayerRemoveGroupFlag(lua_State* L) {
 // Hazard system
 int PlayerFunctions::luaPlayerAddHazardSystemPoints(lua_State* L) {
 	// player:setHazardSystemPoints(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
@@ -4232,7 +4232,7 @@ int PlayerFunctions::luaPlayerAddHazardSystemPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetHazardSystemPoints(lua_State* L) {
 	// player:getHazardSystemPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::pushBoolean(L, false);
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
@@ -4245,7 +4245,7 @@ int PlayerFunctions::luaPlayerGetHazardSystemPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetLoyaltyBonus(lua_State* L) {
 	// player:setLoyaltyBonus(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4258,7 +4258,7 @@ int PlayerFunctions::luaPlayerSetLoyaltyBonus(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLoyaltyBonus(lua_State* L) {
 	// player:getLoyaltyBonus()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4270,7 +4270,7 @@ int PlayerFunctions::luaPlayerGetLoyaltyBonus(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLoyaltyPoints(lua_State* L) {
 	// player:getLoyaltyPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4282,7 +4282,7 @@ int PlayerFunctions::luaPlayerGetLoyaltyPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetLoyaltyTitle(lua_State* L) {
 	// player:getLoyaltyTitle()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4294,7 +4294,7 @@ int PlayerFunctions::luaPlayerGetLoyaltyTitle(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetLoyaltyTitle(lua_State* L) {
 	// player:setLoyaltyTitle(name)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4308,7 +4308,7 @@ int PlayerFunctions::luaPlayerSetLoyaltyTitle(lua_State* L) {
 // Wheel of destiny system
 int PlayerFunctions::luaPlayerInstantSkillWOD(lua_State* L) {
 	// player:instantSkillWOD(name[, value])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4326,7 +4326,7 @@ int PlayerFunctions::luaPlayerInstantSkillWOD(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUpgradeSpellWOD(lua_State* L) {
 	// player:upgradeSpellsWOD([name[, add]])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4356,7 +4356,7 @@ int PlayerFunctions::luaPlayerUpgradeSpellWOD(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRevelationStageWOD(lua_State* L) {
 	// player:revelationStageWOD([name[, set]])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4382,7 +4382,7 @@ int PlayerFunctions::luaPlayerRevelationStageWOD(lua_State* L) {
 
 int PlayerFunctions::luaPlayerReloadData(lua_State* L) {
 	// player:reloadData()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4399,7 +4399,7 @@ int PlayerFunctions::luaPlayerReloadData(lua_State* L) {
 
 int PlayerFunctions::luaPlayerOnThinkWheelOfDestiny(lua_State* L) {
 	// player:onThinkWheelOfDestiny([force = false])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4412,7 +4412,7 @@ int PlayerFunctions::luaPlayerOnThinkWheelOfDestiny(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAvatarTimer(lua_State* L) {
 	// player:avatarTimer([value])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4429,7 +4429,7 @@ int PlayerFunctions::luaPlayerAvatarTimer(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetWheelSpellAdditionalArea(lua_State* L) {
 	// player:getWheelSpellAdditionalArea(spellname)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4456,7 +4456,7 @@ int PlayerFunctions::luaPlayerGetWheelSpellAdditionalArea(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetWheelSpellAdditionalTarget(lua_State* L) {
 	// player:getWheelSpellAdditionalTarget(spellname)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4483,7 +4483,7 @@ int PlayerFunctions::luaPlayerGetWheelSpellAdditionalTarget(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetWheelSpellAdditionalDuration(lua_State* L) {
 	// player:getWheelSpellAdditionalDuration(spellname)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4510,7 +4510,7 @@ int PlayerFunctions::luaPlayerGetWheelSpellAdditionalDuration(lua_State* L) {
 
 int PlayerFunctions::luaPlayerWheelUnlockScroll(lua_State* L) {
 	// player:wheelUnlockScroll(scrollName)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4530,7 +4530,7 @@ int PlayerFunctions::luaPlayerWheelUnlockScroll(lua_State* L) {
 
 int PlayerFunctions::luaPlayerUpdateConcoction(lua_State* L) {
 	// player:updateConcoction(itemid, timeLeft)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4542,7 +4542,7 @@ int PlayerFunctions::luaPlayerUpdateConcoction(lua_State* L) {
 
 int PlayerFunctions::luaPlayerClearSpellCooldowns(lua_State* L) {
 	// player:clearSpellCooldowns()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4554,7 +4554,7 @@ int PlayerFunctions::luaPlayerClearSpellCooldowns(lua_State* L) {
 
 int PlayerFunctions::luaPlayerIsVip(lua_State* L) {
 	// player:isVip()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4566,7 +4566,7 @@ int PlayerFunctions::luaPlayerIsVip(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetVipDays(lua_State* L) {
 	// player:getVipDays()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4579,7 +4579,7 @@ int PlayerFunctions::luaPlayerGetVipDays(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetVipTime(lua_State* L) {
 	// player:getVipTime()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4592,7 +4592,7 @@ int PlayerFunctions::luaPlayerGetVipTime(lua_State* L) {
 
 int PlayerFunctions::luaPlayerKV(lua_State* L) {
 	// player:kv()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -4606,7 +4606,7 @@ int PlayerFunctions::luaPlayerKV(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetStoreInbox(lua_State* L) {
 	// player:getStoreInbox()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4623,7 +4623,7 @@ int PlayerFunctions::luaPlayerGetStoreInbox(lua_State* L) {
 
 int PlayerFunctions::luaPlayerHasAchievement(lua_State* L) {
 	// player:hasAchievement(id or name)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4642,7 +4642,7 @@ int PlayerFunctions::luaPlayerHasAchievement(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddAchievement(lua_State* L) {
 	// player:addAchievement(id or name[, sendMessage = true])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4666,7 +4666,7 @@ int PlayerFunctions::luaPlayerAddAchievement(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveAchievement(lua_State* L) {
 	// player:removeAchievement(id or name)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4685,7 +4685,7 @@ int PlayerFunctions::luaPlayerRemoveAchievement(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetAchievementPoints(lua_State* L) {
 	// player:getAchievementPoints()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4697,7 +4697,7 @@ int PlayerFunctions::luaPlayerGetAchievementPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddAchievementPoints(lua_State* L) {
 	// player:addAchievementPoints(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4713,7 +4713,7 @@ int PlayerFunctions::luaPlayerAddAchievementPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveAchievementPoints(lua_State* L) {
 	// player:removeAchievementPoints(amount)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4729,7 +4729,7 @@ int PlayerFunctions::luaPlayerRemoveAchievementPoints(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddBadge(lua_State* L) {
 	// player:addBadge(id)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4742,7 +4742,7 @@ int PlayerFunctions::luaPlayerAddBadge(lua_State* L) {
 
 int PlayerFunctions::luaPlayerAddTitle(lua_State* L) {
 	// player:addTitle(id)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4755,7 +4755,7 @@ int PlayerFunctions::luaPlayerAddTitle(lua_State* L) {
 
 int PlayerFunctions::luaPlayerGetTitles(lua_State* L) {
 	// player:getTitles()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4777,7 +4777,7 @@ int PlayerFunctions::luaPlayerGetTitles(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSetCurrentTitle(lua_State* L) {
 	// player:setCurrentTitle(id)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4796,7 +4796,7 @@ int PlayerFunctions::luaPlayerSetCurrentTitle(lua_State* L) {
 
 int PlayerFunctions::luaPlayerCreateTransactionSummary(lua_State* L) {
 	// player:createTransactionSummary(type, amount[, id = 0])
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4818,7 +4818,7 @@ int PlayerFunctions::luaPlayerCreateTransactionSummary(lua_State* L) {
 
 int PlayerFunctions::luaPlayerTakeScreenshot(lua_State* L) {
 	// player:takeScreenshot(screenshotType)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4832,7 +4832,7 @@ int PlayerFunctions::luaPlayerTakeScreenshot(lua_State* L) {
 
 int PlayerFunctions::luaPlayerSendIconBakragore(lua_State* L) {
 	// player:sendIconBakragore()
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4846,7 +4846,7 @@ int PlayerFunctions::luaPlayerSendIconBakragore(lua_State* L) {
 
 int PlayerFunctions::luaPlayerRemoveIconBakragore(lua_State* L) {
 	// player:removeIconBakragore(iconType or nil for remove all bakragore icons)
-	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -4864,7 +4864,7 @@ int PlayerFunctions::luaPlayerRemoveIconBakragore(lua_State* L) {
 }
 
 int PlayerFunctions::luaPlayerSendCreatureAppear(lua_State* L) {
-	auto player = Lua::getUserdataShared<Player>(L, 1);
+	auto player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4877,7 +4877,7 @@ int PlayerFunctions::luaPlayerSendCreatureAppear(lua_State* L) {
 }
 
 int PlayerFunctions::luaPlayerAddAnimusMastery(lua_State* L) {
-	auto player = Lua::getUserdataShared<Player>(L, 1);
+	auto player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4889,7 +4889,7 @@ int PlayerFunctions::luaPlayerAddAnimusMastery(lua_State* L) {
 	return 1;
 }
 int PlayerFunctions::luaPlayerRemoveAnimusMastery(lua_State* L) {
-	auto player = Lua::getUserdataShared<Player>(L, 1);
+	auto player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;
@@ -4901,7 +4901,7 @@ int PlayerFunctions::luaPlayerRemoveAnimusMastery(lua_State* L) {
 	return 1;
 }
 int PlayerFunctions::luaPlayerHasAnimusMastery(lua_State* L) {
-	auto player = Lua::getUserdataShared<Player>(L, 1);
+	auto player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		return 1;

--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -67,7 +67,7 @@ int VocationFunctions::luaVocationCreate(lua_State* L) {
 
 int VocationFunctions::luaVocationGetId(lua_State* L) {
 	// vocation:getId()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getId());
 	} else {
@@ -78,7 +78,7 @@ int VocationFunctions::luaVocationGetId(lua_State* L) {
 
 int VocationFunctions::luaVocationGetClientId(lua_State* L) {
 	// vocation:getClientId()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getClientId());
 	} else {
@@ -89,7 +89,7 @@ int VocationFunctions::luaVocationGetClientId(lua_State* L) {
 
 int VocationFunctions::luaVocationGetBaseId(lua_State* L) {
 	// vocation:getBaseId()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getBaseId());
 	} else {
@@ -100,7 +100,7 @@ int VocationFunctions::luaVocationGetBaseId(lua_State* L) {
 
 int VocationFunctions::luaVocationGetName(lua_State* L) {
 	// vocation:getName()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		Lua::pushString(L, vocation->getVocName());
 	} else {
@@ -111,7 +111,7 @@ int VocationFunctions::luaVocationGetName(lua_State* L) {
 
 int VocationFunctions::luaVocationGetDescription(lua_State* L) {
 	// vocation:getDescription()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		Lua::pushString(L, vocation->getVocDescription());
 	} else {
@@ -122,7 +122,7 @@ int VocationFunctions::luaVocationGetDescription(lua_State* L) {
 
 int VocationFunctions::luaVocationGetRequiredSkillTries(lua_State* L) {
 	// vocation:getRequiredSkillTries(skillType, skillLevel)
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		const skills_t skillType = Lua::getNumber<skills_t>(L, 2);
 		const uint16_t skillLevel = Lua::getNumber<uint16_t>(L, 3);
@@ -135,7 +135,7 @@ int VocationFunctions::luaVocationGetRequiredSkillTries(lua_State* L) {
 
 int VocationFunctions::luaVocationGetRequiredManaSpent(lua_State* L) {
 	// vocation:getRequiredManaSpent(magicLevel)
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		const uint32_t magicLevel = Lua::getNumber<uint32_t>(L, 2);
 		lua_pushnumber(L, vocation->getReqMana(magicLevel));
@@ -147,7 +147,7 @@ int VocationFunctions::luaVocationGetRequiredManaSpent(lua_State* L) {
 
 int VocationFunctions::luaVocationGetCapacityGain(lua_State* L) {
 	// vocation:getCapacityGain()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getCapGain());
 	} else {
@@ -158,7 +158,7 @@ int VocationFunctions::luaVocationGetCapacityGain(lua_State* L) {
 
 int VocationFunctions::luaVocationGetHealthGain(lua_State* L) {
 	// vocation:getHealthGain()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getHPGain());
 	} else {
@@ -169,7 +169,7 @@ int VocationFunctions::luaVocationGetHealthGain(lua_State* L) {
 
 int VocationFunctions::luaVocationGetHealthGainTicks(lua_State* L) {
 	// vocation:getHealthGainTicks()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getHealthGainTicks());
 	} else {
@@ -180,7 +180,7 @@ int VocationFunctions::luaVocationGetHealthGainTicks(lua_State* L) {
 
 int VocationFunctions::luaVocationGetHealthGainAmount(lua_State* L) {
 	// vocation:getHealthGainAmount()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getHealthGainAmount());
 	} else {
@@ -191,7 +191,7 @@ int VocationFunctions::luaVocationGetHealthGainAmount(lua_State* L) {
 
 int VocationFunctions::luaVocationGetManaGain(lua_State* L) {
 	// vocation:getManaGain()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getManaGain());
 	} else {
@@ -202,7 +202,7 @@ int VocationFunctions::luaVocationGetManaGain(lua_State* L) {
 
 int VocationFunctions::luaVocationGetManaGainTicks(lua_State* L) {
 	// vocation:getManaGainTicks()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getManaGainTicks());
 	} else {
@@ -213,7 +213,7 @@ int VocationFunctions::luaVocationGetManaGainTicks(lua_State* L) {
 
 int VocationFunctions::luaVocationGetManaGainAmount(lua_State* L) {
 	// vocation:getManaGainAmount()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getManaGainAmount());
 	} else {
@@ -224,7 +224,7 @@ int VocationFunctions::luaVocationGetManaGainAmount(lua_State* L) {
 
 int VocationFunctions::luaVocationGetMaxSoul(lua_State* L) {
 	// vocation:getMaxSoul()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getSoulMax());
 	} else {
@@ -235,7 +235,7 @@ int VocationFunctions::luaVocationGetMaxSoul(lua_State* L) {
 
 int VocationFunctions::luaVocationGetSoulGainTicks(lua_State* L) {
 	// vocation:getSoulGainTicks()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getSoulGainTicks());
 	} else {
@@ -246,7 +246,7 @@ int VocationFunctions::luaVocationGetSoulGainTicks(lua_State* L) {
 
 int VocationFunctions::luaVocationGetBaseAttackSpeed(lua_State* L) {
 	// vocation:getBaseAttackSpeed()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getBaseAttackSpeed());
 	} else {
@@ -257,7 +257,7 @@ int VocationFunctions::luaVocationGetBaseAttackSpeed(lua_State* L) {
 
 int VocationFunctions::luaVocationGetAttackSpeed(lua_State* L) {
 	// vocation:getAttackSpeed()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getAttackSpeed());
 	} else {
@@ -268,7 +268,7 @@ int VocationFunctions::luaVocationGetAttackSpeed(lua_State* L) {
 
 int VocationFunctions::luaVocationGetBaseSpeed(lua_State* L) {
 	// vocation:getBaseSpeed()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (vocation) {
 		lua_pushnumber(L, vocation->getBaseSpeed());
 	} else {
@@ -279,7 +279,7 @@ int VocationFunctions::luaVocationGetBaseSpeed(lua_State* L) {
 
 int VocationFunctions::luaVocationGetDemotion(lua_State* L) {
 	// vocation:getDemotion()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (!vocation) {
 		lua_pushnil(L);
 		return 1;
@@ -303,7 +303,7 @@ int VocationFunctions::luaVocationGetDemotion(lua_State* L) {
 
 int VocationFunctions::luaVocationGetPromotion(lua_State* L) {
 	// vocation:getPromotion()
-	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1);
+	const auto &vocation = Lua::getUserdataShared<Vocation>(L, 1, "Vocation");
 	if (!vocation) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/events/action_functions.cpp
+++ b/src/lua/functions/events/action_functions.cpp
@@ -38,7 +38,7 @@ int ActionFunctions::luaCreateAction(lua_State* L) {
 
 int ActionFunctions::luaActionOnUse(lua_State* L) {
 	// action:onUse(callback)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		if (!action->loadScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -54,7 +54,7 @@ int ActionFunctions::luaActionOnUse(lua_State* L) {
 
 int ActionFunctions::luaActionRegister(lua_State* L) {
 	// action:register()
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		if (!action->isLoadedScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -71,7 +71,7 @@ int ActionFunctions::luaActionRegister(lua_State* L) {
 
 int ActionFunctions::luaActionItemId(lua_State* L) {
 	// action:id(ids)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -91,7 +91,7 @@ int ActionFunctions::luaActionItemId(lua_State* L) {
 
 int ActionFunctions::luaActionActionId(lua_State* L) {
 	// action:aid(aids)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -111,7 +111,7 @@ int ActionFunctions::luaActionActionId(lua_State* L) {
 
 int ActionFunctions::luaActionUniqueId(lua_State* L) {
 	// action:uid(uids)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -135,7 +135,7 @@ int ActionFunctions::luaActionPosition(lua_State* L) {
 	 * @param itemId or @param itemName = if item id or string name is set, the item is created on position (if not exists), this variable is nil by default
 	 * action:position(positions, itemId or name)
 	 */
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (!action) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -192,7 +192,7 @@ int ActionFunctions::luaActionPosition(lua_State* L) {
 
 int ActionFunctions::luaActionAllowFarUse(lua_State* L) {
 	// action:allowFarUse(bool)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		action->setAllowFarUse(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -205,7 +205,7 @@ int ActionFunctions::luaActionAllowFarUse(lua_State* L) {
 
 int ActionFunctions::luaActionBlockWalls(lua_State* L) {
 	// action:blockWalls(bool)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		action->setCheckLineOfSight(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -218,7 +218,7 @@ int ActionFunctions::luaActionBlockWalls(lua_State* L) {
 
 int ActionFunctions::luaActionCheckFloor(lua_State* L) {
 	// action:checkFloor(bool)
-	const auto &action = Lua::getUserdataShared<Action>(L, 1);
+	const auto &action = Lua::getUserdataShared<Action>(L, 1, "Action");
 	if (action) {
 		action->setCheckFloor(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);

--- a/src/lua/functions/events/creature_event_functions.cpp
+++ b/src/lua/functions/events/creature_event_functions.cpp
@@ -42,7 +42,7 @@ int CreatureEventFunctions::luaCreateCreatureEvent(lua_State* L) {
 
 int CreatureEventFunctions::luaCreatureEventType(lua_State* L) {
 	// creatureevent:type(callback)
-	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1);
+	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1, "CreatureEvent");
 	if (creatureEvent) {
 		std::string typeName = Lua::getString(L, 2);
 		const std::string tmpStr = asLowerCaseString(typeName);
@@ -86,7 +86,7 @@ int CreatureEventFunctions::luaCreatureEventType(lua_State* L) {
 
 int CreatureEventFunctions::luaCreatureEventRegister(lua_State* L) {
 	// creatureevent:register()
-	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1);
+	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1, "CreatureEvent");
 	if (creatureEvent) {
 		if (!creatureEvent->isLoadedScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -101,7 +101,7 @@ int CreatureEventFunctions::luaCreatureEventRegister(lua_State* L) {
 
 int CreatureEventFunctions::luaCreatureEventOnCallback(lua_State* L) {
 	// creatureevent:onLogin / logout / etc. (callback)
-	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1);
+	const auto &creatureEvent = Lua::getUserdataShared<CreatureEvent>(L, 1, "CreatureEvent");
 	if (creatureEvent) {
 		if (!creatureEvent->loadScriptId()) {
 			Lua::pushBoolean(L, false);

--- a/src/lua/functions/events/event_callback_functions.cpp
+++ b/src/lua/functions/events/event_callback_functions.cpp
@@ -47,7 +47,7 @@ int EventCallbackFunctions::luaEventCallbackCreate(lua_State* luaState) {
 }
 
 int EventCallbackFunctions::luaEventCallbackType(lua_State* luaState) {
-	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1);
+	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1, "EventCallback");
 	if (!callback) {
 		Lua::reportErrorFunc("EventCallback is nil");
 		return 0;
@@ -78,7 +78,7 @@ int EventCallbackFunctions::luaEventCallbackType(lua_State* luaState) {
 }
 
 int EventCallbackFunctions::luaEventCallbackRegister(lua_State* luaState) {
-	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1);
+	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1, "EventCallback");
 	if (!callback) {
 		return 0;
 	}
@@ -99,7 +99,7 @@ int EventCallbackFunctions::luaEventCallbackRegister(lua_State* luaState) {
 
 // Callback functions
 int EventCallbackFunctions::luaEventCallbackLoad(lua_State* luaState) {
-	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1);
+	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1, "EventCallback");
 	if (!callback) {
 		return 1;
 	}

--- a/src/lua/functions/events/global_event_functions.cpp
+++ b/src/lua/functions/events/global_event_functions.cpp
@@ -40,7 +40,7 @@ int GlobalEventFunctions::luaCreateGlobalEvent(lua_State* L) {
 
 int GlobalEventFunctions::luaGlobalEventType(lua_State* L) {
 	// globalevent:type(callback)
-	const auto &global = Lua::getUserdataShared<GlobalEvent>(L, 1);
+	const auto &global = Lua::getUserdataShared<GlobalEvent>(L, 1, "GlobalEvent");
 	if (global) {
 		const std::string typeName = Lua::getString(L, 2);
 		const std::string tmpStr = asLowerCaseString(typeName);
@@ -70,7 +70,7 @@ int GlobalEventFunctions::luaGlobalEventType(lua_State* L) {
 
 int GlobalEventFunctions::luaGlobalEventRegister(lua_State* L) {
 	// globalevent:register()
-	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1);
+	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1, "GlobalEvent");
 	if (globalevent) {
 		if (!globalevent->isLoadedScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -90,7 +90,7 @@ int GlobalEventFunctions::luaGlobalEventRegister(lua_State* L) {
 
 int GlobalEventFunctions::luaGlobalEventOnCallback(lua_State* L) {
 	// globalevent:onThink / record / etc. (callback)
-	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1);
+	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1, "GlobalEvent");
 	if (globalevent) {
 		if (!globalevent->loadScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -105,7 +105,7 @@ int GlobalEventFunctions::luaGlobalEventOnCallback(lua_State* L) {
 
 int GlobalEventFunctions::luaGlobalEventTime(lua_State* L) {
 	// globalevent:time(time)
-	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1);
+	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1, "GlobalEvent");
 	if (globalevent) {
 		std::string timer = Lua::getString(L, 2);
 		const std::vector<int32_t> params = vectorAtoi(explodeString(timer, ":"));
@@ -168,7 +168,7 @@ int GlobalEventFunctions::luaGlobalEventTime(lua_State* L) {
 
 int GlobalEventFunctions::luaGlobalEventInterval(lua_State* L) {
 	// globalevent:interval(interval)
-	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1);
+	const auto &globalevent = Lua::getUserdataShared<GlobalEvent>(L, 1, "GlobalEvent");
 	if (globalevent) {
 		globalevent->setInterval(Lua::getNumber<uint32_t>(L, 2));
 		globalevent->setNextExecution(OTSYS_TIME() + Lua::getNumber<uint32_t>(L, 2));

--- a/src/lua/functions/events/move_event_functions.cpp
+++ b/src/lua/functions/events/move_event_functions.cpp
@@ -45,7 +45,7 @@ int MoveEventFunctions::luaCreateMoveEvent(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventType(lua_State* L) {
 	// moveevent:type(callback)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		std::string typeName = Lua::getString(L, 2);
 		const std::string tmpStr = asLowerCaseString(typeName);
@@ -82,7 +82,7 @@ int MoveEventFunctions::luaMoveEventType(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventRegister(lua_State* L) {
 	// moveevent:register()
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		// If not scripted, register item event
 		// Example: unscripted_equipments.lua
@@ -100,7 +100,7 @@ int MoveEventFunctions::luaMoveEventRegister(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventOnCallback(lua_State* L) {
 	// moveevent:onEquip / deEquip / etc. (callback)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		if (!moveevent->loadScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -116,7 +116,7 @@ int MoveEventFunctions::luaMoveEventOnCallback(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventSlot(lua_State* L) {
 	// moveevent:slot(slot)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (!moveevent) {
 		lua_pushnil(L);
 		return 1;
@@ -161,7 +161,7 @@ int MoveEventFunctions::luaMoveEventSlot(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventLevel(lua_State* L) {
 	// moveevent:level(lvl)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		moveevent->setRequiredLevel(Lua::getNumber<uint32_t>(L, 2));
 		moveevent->setWieldInfo(WIELDINFO_LEVEL);
@@ -174,7 +174,7 @@ int MoveEventFunctions::luaMoveEventLevel(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventMagLevel(lua_State* L) {
 	// moveevent:magicLevel(lvl)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		moveevent->setRequiredMagLevel(Lua::getNumber<uint32_t>(L, 2));
 		moveevent->setWieldInfo(WIELDINFO_MAGLV);
@@ -187,7 +187,7 @@ int MoveEventFunctions::luaMoveEventMagLevel(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventPremium(lua_State* L) {
 	// moveevent:premium(bool)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		moveevent->setNeedPremium(Lua::getBoolean(L, 2));
 		moveevent->setWieldInfo(WIELDINFO_PREMIUM);
@@ -200,7 +200,7 @@ int MoveEventFunctions::luaMoveEventPremium(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventVocation(lua_State* L) {
 	// moveevent:vocation(vocName[, showInDescription = false, lastVoc = false])
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		moveevent->addVocEquipMap(Lua::getString(L, 2));
 		moveevent->setWieldInfo(WIELDINFO_VOCREQ);
@@ -239,7 +239,7 @@ int MoveEventFunctions::luaMoveEventVocation(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventItemId(lua_State* L) {
 	// moveevent:id(ids)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -258,7 +258,7 @@ int MoveEventFunctions::luaMoveEventItemId(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventActionId(lua_State* L) {
 	// moveevent:aid(ids)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -277,7 +277,7 @@ int MoveEventFunctions::luaMoveEventActionId(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventUniqueId(lua_State* L) {
 	// moveevent:uid(ids)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {
@@ -296,7 +296,7 @@ int MoveEventFunctions::luaMoveEventUniqueId(lua_State* L) {
 
 int MoveEventFunctions::luaMoveEventPosition(lua_State* L) {
 	// moveevent:position(positions)
-	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1);
+	const auto &moveevent = Lua::getUserdataShared<MoveEvent>(L, 1, "MoveEvent");
 	if (moveevent) {
 		const int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
 		if (parameters > 1) {

--- a/src/lua/functions/events/talk_action_functions.cpp
+++ b/src/lua/functions/events/talk_action_functions.cpp
@@ -45,7 +45,7 @@ int TalkActionFunctions::luaCreateTalkAction(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionOnSay(lua_State* L) {
 	// talkAction:onSay(callback)
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -62,7 +62,7 @@ int TalkActionFunctions::luaTalkActionOnSay(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionGroupType(lua_State* L) {
 	// talkAction:groupType(GroupType = GROUP_TYPE_NORMAL)
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -107,7 +107,7 @@ int TalkActionFunctions::luaTalkActionGroupType(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionRegister(lua_State* L) {
 	// talkAction:register()
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -132,7 +132,7 @@ int TalkActionFunctions::luaTalkActionRegister(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionSeparator(lua_State* L) {
 	// talkAction:separator(sep)
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -146,7 +146,7 @@ int TalkActionFunctions::luaTalkActionSeparator(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionGetName(lua_State* L) {
 	// local name = talkAction:getName()
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -159,7 +159,7 @@ int TalkActionFunctions::luaTalkActionGetName(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionGetDescription(lua_State* L) {
 	// local description = talkAction:getDescription()
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -172,7 +172,7 @@ int TalkActionFunctions::luaTalkActionGetDescription(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionSetDescription(lua_State* L) {
 	// local description = talkAction:setDescription()
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -186,7 +186,7 @@ int TalkActionFunctions::luaTalkActionSetDescription(lua_State* L) {
 
 int TalkActionFunctions::luaTalkActionGetGroupType(lua_State* L) {
 	// local groupType = talkAction:getGroupType()
-	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1);
+	const auto &talkactionSharedPtr = Lua::getUserdataShared<TalkAction>(L, 1, "TalkAction");
 	if (!talkactionSharedPtr) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_TALK_ACTION_NOT_FOUND));
 		Lua::pushBoolean(L, false);

--- a/src/lua/functions/items/container_functions.cpp
+++ b/src/lua/functions/items/container_functions.cpp
@@ -51,7 +51,7 @@ int ContainerFunctions::luaContainerCreate(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetSize(lua_State* L) {
 	// container:getSize()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		lua_pushnumber(L, container->size());
 	} else {
@@ -62,7 +62,7 @@ int ContainerFunctions::luaContainerGetSize(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetMaxCapacity(lua_State* L) {
 	// container:getMaxCapacity()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		lua_pushnumber(L, container->getMaxCapacity());
 	} else {
@@ -73,7 +73,7 @@ int ContainerFunctions::luaContainerGetMaxCapacity(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetCapacity(lua_State* L) {
 	// container:getCapacity()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		lua_pushnumber(L, container->capacity());
 	} else {
@@ -84,7 +84,7 @@ int ContainerFunctions::luaContainerGetCapacity(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetEmptySlots(lua_State* L) {
 	// container:getEmptySlots([recursive = false])
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -105,7 +105,7 @@ int ContainerFunctions::luaContainerGetEmptySlots(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetItemHoldingCount(lua_State* L) {
 	// container:getItemHoldingCount()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		lua_pushnumber(L, container->getItemHoldingCount());
 	} else {
@@ -116,7 +116,7 @@ int ContainerFunctions::luaContainerGetItemHoldingCount(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetItem(lua_State* L) {
 	// container:getItem(index)
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -135,8 +135,8 @@ int ContainerFunctions::luaContainerGetItem(lua_State* L) {
 
 int ContainerFunctions::luaContainerHasItem(lua_State* L) {
 	// container:hasItem(item)
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		Lua::pushBoolean(L, container->isHoldingItem(item));
 	} else {
@@ -147,7 +147,7 @@ int ContainerFunctions::luaContainerHasItem(lua_State* L) {
 
 int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 	// container:addItem(itemId[, count/subType = 1[, index = INDEX_WHEREEVER[, flags = 0]]])
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		Lua::reportErrorFunc("Container is nullptr");
@@ -195,13 +195,13 @@ int ContainerFunctions::luaContainerAddItem(lua_State* L) {
 
 int ContainerFunctions::luaContainerAddItemEx(lua_State* L) {
 	// container:addItemEx(item[, index = INDEX_WHEREEVER[, flags = 0]])
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -225,7 +225,7 @@ int ContainerFunctions::luaContainerAddItemEx(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetCorpseOwner(lua_State* L) {
 	// container:getCorpseOwner()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		lua_pushnumber(L, container->getCorpseOwner());
 	} else {
@@ -236,7 +236,7 @@ int ContainerFunctions::luaContainerGetCorpseOwner(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetItemCountById(lua_State* L) {
 	// container:getItemCountById(itemId[, subType = -1])
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -260,7 +260,7 @@ int ContainerFunctions::luaContainerGetItemCountById(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetContentDescription(lua_State* L) {
 	// container:getContentDescription([oldProtocol])
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (container) {
 		Lua::pushString(L, container->getContentDescription(Lua::getBoolean(L, 2, false)));
 	} else {
@@ -271,7 +271,7 @@ int ContainerFunctions::luaContainerGetContentDescription(lua_State* L) {
 
 int ContainerFunctions::luaContainerGetItems(lua_State* L) {
 	// container:getItems([recursive = false])
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -294,7 +294,7 @@ int ContainerFunctions::luaContainerGetItems(lua_State* L) {
 
 int ContainerFunctions::luaContainerRegisterReward(lua_State* L) {
 	// container:registerReward()
-	const auto &container = Lua::getUserdataShared<Container>(L, 1);
+	const auto &container = Lua::getUserdataShared<Container>(L, 1, "Container");
 	if (!container) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -116,13 +116,13 @@ int ItemFunctions::luaItemCreate(lua_State* L) {
 
 int ItemFunctions::luaItemIsItem(lua_State* L) {
 	// item:isItem()
-	Lua::pushBoolean(L, Lua::getUserdataShared<const Item>(L, 1) != nullptr);
+	Lua::pushBoolean(L, Lua::getUserdataShared<Item>(L, 1, "Item") != nullptr);
 	return 1;
 }
 
 int ItemFunctions::luaItemGetContainer(lua_State* L) {
 	// item:getContainer()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -141,7 +141,7 @@ int ItemFunctions::luaItemGetContainer(lua_State* L) {
 
 int ItemFunctions::luaItemGetParent(lua_State* L) {
 	// item:getParent()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -159,7 +159,7 @@ int ItemFunctions::luaItemGetParent(lua_State* L) {
 
 int ItemFunctions::luaItemGetTopParent(lua_State* L) {
 	// item:getTopParent()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -177,7 +177,7 @@ int ItemFunctions::luaItemGetTopParent(lua_State* L) {
 
 int ItemFunctions::luaItemGetId(lua_State* L) {
 	// item:getId()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, item->getID());
 	} else {
@@ -188,7 +188,7 @@ int ItemFunctions::luaItemGetId(lua_State* L) {
 
 int ItemFunctions::luaItemClone(lua_State* L) {
 	// item:clone()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -257,7 +257,7 @@ int ItemFunctions::luaItemSplit(lua_State* L) {
 
 int ItemFunctions::luaItemRemove(lua_State* L) {
 	// item:remove([count = -1])
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		const auto count = Lua::getNumber<int32_t>(L, 2, -1);
 		Lua::pushBoolean(L, g_game().internalRemoveItem(item, count) == RETURNVALUE_NOERROR);
@@ -269,7 +269,7 @@ int ItemFunctions::luaItemRemove(lua_State* L) {
 
 int ItemFunctions::luaItemGetUniqueId(lua_State* L) {
 	// item:getUniqueId()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		uint32_t uniqueId = item->getAttribute<uint16_t>(ItemAttribute_t::UNIQUEID);
 		if (uniqueId == 0) {
@@ -284,7 +284,7 @@ int ItemFunctions::luaItemGetUniqueId(lua_State* L) {
 
 int ItemFunctions::luaItemGetActionId(lua_State* L) {
 	// item:getActionId()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		const auto actionId = item->getAttribute<uint16_t>(ItemAttribute_t::ACTIONID);
 		lua_pushnumber(L, actionId);
@@ -297,7 +297,7 @@ int ItemFunctions::luaItemGetActionId(lua_State* L) {
 int ItemFunctions::luaItemSetActionId(lua_State* L) {
 	// item:setActionId(actionId)
 	const uint16_t actionId = Lua::getNumber<uint16_t>(L, 2);
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		item->setAttribute(ItemAttribute_t::ACTIONID, actionId);
 		Lua::pushBoolean(L, true);
@@ -309,7 +309,7 @@ int ItemFunctions::luaItemSetActionId(lua_State* L) {
 
 int ItemFunctions::luaItemGetCount(lua_State* L) {
 	// item:getCount()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, item->getItemCount());
 	} else {
@@ -320,7 +320,7 @@ int ItemFunctions::luaItemGetCount(lua_State* L) {
 
 int ItemFunctions::luaItemGetCharges(lua_State* L) {
 	// item:getCharges()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, item->getCharges());
 	} else {
@@ -331,7 +331,7 @@ int ItemFunctions::luaItemGetCharges(lua_State* L) {
 
 int ItemFunctions::luaItemGetFluidType(lua_State* L) {
 	// item:getFluidType()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, static_cast<lua_Number>(item->getAttribute<uint16_t>(ItemAttribute_t::FLUIDTYPE)));
 	} else {
@@ -342,7 +342,7 @@ int ItemFunctions::luaItemGetFluidType(lua_State* L) {
 
 int ItemFunctions::luaItemGetWeight(lua_State* L) {
 	// item:getWeight()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, item->getWeight());
 	} else {
@@ -353,7 +353,7 @@ int ItemFunctions::luaItemGetWeight(lua_State* L) {
 
 int ItemFunctions::luaItemGetSubType(lua_State* L) {
 	// item:getSubType()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		lua_pushnumber(L, item->getSubType());
 	} else {
@@ -364,7 +364,7 @@ int ItemFunctions::luaItemGetSubType(lua_State* L) {
 
 int ItemFunctions::luaItemGetName(lua_State* L) {
 	// item:getName()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		Lua::pushString(L, item->getName());
 	} else {
@@ -375,7 +375,7 @@ int ItemFunctions::luaItemGetName(lua_State* L) {
 
 int ItemFunctions::luaItemGetPluralName(lua_State* L) {
 	// item:getPluralName()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		Lua::pushString(L, item->getPluralName());
 	} else {
@@ -386,7 +386,7 @@ int ItemFunctions::luaItemGetPluralName(lua_State* L) {
 
 int ItemFunctions::luaItemGetArticle(lua_State* L) {
 	// item:getArticle()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		Lua::pushString(L, item->getArticle());
 	} else {
@@ -397,7 +397,7 @@ int ItemFunctions::luaItemGetArticle(lua_State* L) {
 
 int ItemFunctions::luaItemGetPosition(lua_State* L) {
 	// item:Lua::getPosition()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		Lua::pushPosition(L, item->getPosition());
 	} else {
@@ -408,7 +408,7 @@ int ItemFunctions::luaItemGetPosition(lua_State* L) {
 
 int ItemFunctions::luaItemGetTile(lua_State* L) {
 	// item:getTile()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -426,7 +426,7 @@ int ItemFunctions::luaItemGetTile(lua_State* L) {
 
 int ItemFunctions::luaItemHasAttribute(lua_State* L) {
 	// item:hasAttribute(key)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -447,7 +447,7 @@ int ItemFunctions::luaItemHasAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemGetAttribute(lua_State* L) {
 	// item:getAttribute(key)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -479,7 +479,7 @@ int ItemFunctions::luaItemGetAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemSetAttribute(lua_State* L) {
 	// item:setAttribute(key, value)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -538,7 +538,7 @@ int ItemFunctions::luaItemSetAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemRemoveAttribute(lua_State* L) {
 	// item:removeAttribute(key)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -570,7 +570,7 @@ int ItemFunctions::luaItemRemoveAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemGetCustomAttribute(lua_State* L) {
 	// item:getCustomAttribute(key)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -596,7 +596,7 @@ int ItemFunctions::luaItemGetCustomAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemSetCustomAttribute(lua_State* L) {
 	// item:setCustomAttribute(key, value)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -637,7 +637,7 @@ int ItemFunctions::luaItemSetCustomAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemRemoveCustomAttribute(lua_State* L) {
 	// item:removeCustomAttribute(key)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -655,7 +655,7 @@ int ItemFunctions::luaItemRemoveCustomAttribute(lua_State* L) {
 
 int ItemFunctions::luaItemCanBeMoved(lua_State* L) {
 	// item:canBeMoved()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		Lua::pushBoolean(L, item->canBeMoved());
 	} else {
@@ -666,7 +666,7 @@ int ItemFunctions::luaItemCanBeMoved(lua_State* L) {
 
 int ItemFunctions::luaItemSerializeAttributes(lua_State* L) {
 	// item:serializeAttributes()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -700,13 +700,13 @@ int ItemFunctions::luaItemMoveTo(lua_State* L) {
 		const LuaData_t type = Lua::getUserdataType(L, 2);
 		switch (type) {
 			case LuaData_t::Container:
-				toCylinder = Lua::getUserdataShared<Container>(L, 2);
+				toCylinder = Lua::getUserdataShared<Container>(L, 2, "Container");
 				break;
 			case LuaData_t::Player:
-				toCylinder = Lua::getUserdataShared<Player>(L, 2);
+				toCylinder = Lua::getUserdataShared<Player>(L, 2, "Player");
 				break;
 			case LuaData_t::Tile:
-				toCylinder = Lua::getUserdataShared<Tile>(L, 2);
+				toCylinder = Lua::getUserdataShared<Tile>(L, 2, "Tile");
 				break;
 			default:
 				toCylinder = nullptr;
@@ -796,7 +796,7 @@ int ItemFunctions::luaItemTransform(lua_State* L) {
 
 int ItemFunctions::luaItemDecay(lua_State* L) {
 	// item:decay(decayId)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		if (Lua::isNumber(L, 2)) {
 			ItemType &it = Item::items.getItemType(item->getID());
@@ -813,13 +813,13 @@ int ItemFunctions::luaItemDecay(lua_State* L) {
 
 int ItemFunctions::luaItemMoveToSlot(lua_State* L) {
 	// item:moveToSlot(player, slot)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item || item->isRemoved()) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &player = Lua::getUserdataShared<Player>(L, 2);
+	const auto &player = Lua::getUserdataShared<Player>(L, 2, "Player");
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -835,7 +835,7 @@ int ItemFunctions::luaItemMoveToSlot(lua_State* L) {
 
 int ItemFunctions::luaItemGetDescription(lua_State* L) {
 	// item:getDescription(distance)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		const int32_t distance = Lua::getNumber<int32_t>(L, 2);
 		Lua::pushString(L, item->getDescription(distance));
@@ -847,7 +847,7 @@ int ItemFunctions::luaItemGetDescription(lua_State* L) {
 
 int ItemFunctions::luaItemHasProperty(lua_State* L) {
 	// item:hasProperty(property)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (item) {
 		const ItemProperty property = Lua::getNumber<ItemProperty>(L, 2);
 		Lua::pushBoolean(L, item->hasProperty(property));
@@ -859,7 +859,7 @@ int ItemFunctions::luaItemHasProperty(lua_State* L) {
 
 int ItemFunctions::luaItemGetImbuement(lua_State* L) {
 	// item:getImbuement()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -890,7 +890,7 @@ int ItemFunctions::luaItemGetImbuement(lua_State* L) {
 
 int ItemFunctions::luaItemGetImbuementSlot(lua_State* L) {
 	// item:getImbuementSlot()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -904,7 +904,7 @@ int ItemFunctions::luaItemGetImbuementSlot(lua_State* L) {
 int ItemFunctions::luaItemSetDuration(lua_State* L) {
 	// item:setDuration(minDuration, maxDuration = 0, decayTo = 0, showDuration = true)
 	// Example: item:setDuration(10000, 20000, 2129, false) = random duration from range 10000/20000
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -941,7 +941,7 @@ int ItemFunctions::luaItemSetDuration(lua_State* L) {
 
 int ItemFunctions::luaItemIsInsideDepot(lua_State* L) {
 	// item:isInsideDepot([includeInbox = false])
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -954,7 +954,7 @@ int ItemFunctions::luaItemIsInsideDepot(lua_State* L) {
 
 int ItemFunctions::luaItemIsContainer(lua_State* L) {
 	// item:isContainer()
-	const auto &item = Lua::getUserdataShared<const Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -968,7 +968,7 @@ int ItemFunctions::luaItemIsContainer(lua_State* L) {
 
 int ItemFunctions::luaItemGetTier(lua_State* L) {
 	// item:getTier()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -981,7 +981,7 @@ int ItemFunctions::luaItemGetTier(lua_State* L) {
 
 int ItemFunctions::luaItemSetTier(lua_State* L) {
 	// item:setTier(tier)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -995,7 +995,7 @@ int ItemFunctions::luaItemSetTier(lua_State* L) {
 
 int ItemFunctions::luaItemGetClassification(lua_State* L) {
 	// item:getClassification()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1008,7 +1008,7 @@ int ItemFunctions::luaItemGetClassification(lua_State* L) {
 
 int ItemFunctions::luaItemCanReceiveAutoCarpet(lua_State* L) {
 	// item:canReceiveAutoCarpet()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		Lua::pushBoolean(L, false);
@@ -1021,14 +1021,14 @@ int ItemFunctions::luaItemCanReceiveAutoCarpet(lua_State* L) {
 
 int ItemFunctions::luaItemSetOwner(lua_State* L) {
 	// item:setOwner(creature|creatureId)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 0;
 	}
 
 	if (Lua::isUserdata(L, 2)) {
-		const auto &creature = Lua::getUserdataShared<Creature>(L, 2);
+		const auto &creature = Lua::getUserdataShared<Creature>(L, 2, "Creature");
 		if (!creature) {
 			Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 			return 0;
@@ -1051,7 +1051,7 @@ int ItemFunctions::luaItemSetOwner(lua_State* L) {
 
 int ItemFunctions::luaItemGetOwnerId(lua_State* L) {
 	// item:getOwner()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 0;
@@ -1068,14 +1068,14 @@ int ItemFunctions::luaItemGetOwnerId(lua_State* L) {
 
 int ItemFunctions::luaItemIsOwner(lua_State* L) {
 	// item:isOwner(creature|creatureId)
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 0;
 	}
 
 	if (Lua::isUserdata(L, 2)) {
-		const auto &creature = Lua::getUserdataShared<Creature>(L, 2);
+		const auto &creature = Lua::getUserdataShared<Creature>(L, 2, "Creature");
 		if (!creature) {
 			Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 			return 0;
@@ -1096,7 +1096,7 @@ int ItemFunctions::luaItemIsOwner(lua_State* L) {
 
 int ItemFunctions::luaItemGetOwnerName(lua_State* L) {
 	// item:getOwnerName()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 0;
@@ -1113,7 +1113,7 @@ int ItemFunctions::luaItemGetOwnerName(lua_State* L) {
 
 int ItemFunctions::luaItemHasOwner(lua_State* L) {
 	// item:hasOwner()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 1;
@@ -1125,7 +1125,7 @@ int ItemFunctions::luaItemHasOwner(lua_State* L) {
 
 int ItemFunctions::luaItemActor(lua_State* L) {
 	// item:actor()
-	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	const auto &item = Lua::getUserdataShared<Item>(L, 1, "Item");
 	if (!item) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		return 1;

--- a/src/lua/functions/items/weapon_functions.cpp
+++ b/src/lua/functions/items/weapon_functions.cpp
@@ -95,7 +95,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 
 int WeaponFunctions::luaWeaponAction(lua_State* L) {
 	// weapon:action(callback)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		std::string typeName = Lua::getString(L, 2);
 		const std::string tmpStr = asLowerCaseString(typeName);
@@ -124,11 +124,11 @@ int WeaponFunctions::luaWeaponRegister(lua_State* L) {
 	if (weaponPtr && *weaponPtr) {
 		WeaponShared_ptr weapon = *weaponPtr;
 		if (weapon->weaponType == WEAPON_DISTANCE || weapon->weaponType == WEAPON_AMMO || weapon->weaponType == WEAPON_MISSILE) {
-			weapon = Lua::getUserdataShared<WeaponDistance>(L, 1);
+			weapon = Lua::getUserdataShared<WeaponDistance>(L, 1, "WeaponDistance");
 		} else if (weapon->weaponType == WEAPON_WAND) {
-			weapon = Lua::getUserdataShared<WeaponWand>(L, 1);
+			weapon = Lua::getUserdataShared<WeaponWand>(L, 1, "WeaponWand");
 		} else {
-			weapon = Lua::getUserdataShared<WeaponMelee>(L, 1);
+			weapon = Lua::getUserdataShared<WeaponMelee>(L, 1, "WeaponMelee");
 		}
 
 		const uint16_t id = weapon->getID();
@@ -153,7 +153,7 @@ int WeaponFunctions::luaWeaponRegister(lua_State* L) {
 
 int WeaponFunctions::luaWeaponOnUseWeapon(lua_State* L) {
 	// weapon:onUseWeapon(callback)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		if (!weapon->loadScriptId()) {
 			Lua::pushBoolean(L, false);
@@ -169,7 +169,7 @@ int WeaponFunctions::luaWeaponOnUseWeapon(lua_State* L) {
 
 int WeaponFunctions::luaWeaponUnproperly(lua_State* L) {
 	// weapon:wieldedUnproperly(bool)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setWieldUnproperly(Lua::getBoolean(L, 2));
 		Lua::pushBoolean(L, true);
@@ -181,7 +181,7 @@ int WeaponFunctions::luaWeaponUnproperly(lua_State* L) {
 
 int WeaponFunctions::luaWeaponLevel(lua_State* L) {
 	// weapon:level(lvl)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setRequiredLevel(Lua::getNumber<uint32_t>(L, 2));
 		weapon->setWieldInfo(WIELDINFO_LEVEL);
@@ -194,7 +194,7 @@ int WeaponFunctions::luaWeaponLevel(lua_State* L) {
 
 int WeaponFunctions::luaWeaponMagicLevel(lua_State* L) {
 	// weapon:magicLevel(lvl)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setRequiredMagLevel(Lua::getNumber<uint32_t>(L, 2));
 		weapon->setWieldInfo(WIELDINFO_MAGLV);
@@ -207,7 +207,7 @@ int WeaponFunctions::luaWeaponMagicLevel(lua_State* L) {
 
 int WeaponFunctions::luaWeaponMana(lua_State* L) {
 	// weapon:mana(mana)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setMana(Lua::getNumber<uint32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -219,7 +219,7 @@ int WeaponFunctions::luaWeaponMana(lua_State* L) {
 
 int WeaponFunctions::luaWeaponManaPercent(lua_State* L) {
 	// weapon:manaPercent(percent)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setManaPercent(Lua::getNumber<uint32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -231,7 +231,7 @@ int WeaponFunctions::luaWeaponManaPercent(lua_State* L) {
 
 int WeaponFunctions::luaWeaponHealth(lua_State* L) {
 	// weapon:health(health)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setHealth(Lua::getNumber<int32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -243,7 +243,7 @@ int WeaponFunctions::luaWeaponHealth(lua_State* L) {
 
 int WeaponFunctions::luaWeaponHealthPercent(lua_State* L) {
 	// weapon:healthPercent(percent)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setHealthPercent(Lua::getNumber<uint32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -255,7 +255,7 @@ int WeaponFunctions::luaWeaponHealthPercent(lua_State* L) {
 
 int WeaponFunctions::luaWeaponSoul(lua_State* L) {
 	// weapon:soul(soul)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setSoul(Lua::getNumber<uint32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -267,7 +267,7 @@ int WeaponFunctions::luaWeaponSoul(lua_State* L) {
 
 int WeaponFunctions::luaWeaponBreakChance(lua_State* L) {
 	// weapon:breakChance(percent)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setBreakChance(Lua::getNumber<uint32_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -279,7 +279,7 @@ int WeaponFunctions::luaWeaponBreakChance(lua_State* L) {
 
 int WeaponFunctions::luaWeaponWandDamage(lua_State* L) {
 	// weapon:damage(damage[min, max]) only use this if the weapon is a wand!
-	const auto &weapon = Lua::getUserdataShared<WeaponWand>(L, 1);
+	const auto &weapon = Lua::getUserdataShared<WeaponWand>(L, 1, "WeaponWand");
 	if (weapon) {
 		weapon->setMinChange(Lua::getNumber<uint32_t>(L, 2));
 		if (lua_gettop(L) > 2) {
@@ -296,7 +296,7 @@ int WeaponFunctions::luaWeaponWandDamage(lua_State* L) {
 
 int WeaponFunctions::luaWeaponElement(lua_State* L) {
 	// weapon:element(combatType)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		if (!Lua::getNumber<CombatType_t>(L, 2)) {
 			std::string element = Lua::getString(L, 2);
@@ -330,7 +330,7 @@ int WeaponFunctions::luaWeaponElement(lua_State* L) {
 
 int WeaponFunctions::luaWeaponPremium(lua_State* L) {
 	// weapon:premium(bool)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setNeedPremium(Lua::getBoolean(L, 2));
 		weapon->setWieldInfo(WIELDINFO_PREMIUM);
@@ -343,7 +343,7 @@ int WeaponFunctions::luaWeaponPremium(lua_State* L) {
 
 int WeaponFunctions::luaWeaponVocation(lua_State* L) {
 	// weapon:vocation(vocName[, showInDescription = false, lastVoc = false])
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->addVocWeaponMap(Lua::getString(L, 2));
 		weapon->setWieldInfo(WIELDINFO_VOCREQ);
@@ -382,7 +382,7 @@ int WeaponFunctions::luaWeaponVocation(lua_State* L) {
 
 int WeaponFunctions::luaWeaponId(lua_State* L) {
 	// weapon:id(id)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		weapon->setID(Lua::getNumber<uint16_t>(L, 2));
 		Lua::pushBoolean(L, true);
@@ -394,7 +394,7 @@ int WeaponFunctions::luaWeaponId(lua_State* L) {
 
 int WeaponFunctions::luaWeaponAttack(lua_State* L) {
 	// weapon:attack(atk)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -408,7 +408,7 @@ int WeaponFunctions::luaWeaponAttack(lua_State* L) {
 
 int WeaponFunctions::luaWeaponDefense(lua_State* L) {
 	// weapon:defense(defense[, extraDefense])
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -425,7 +425,7 @@ int WeaponFunctions::luaWeaponDefense(lua_State* L) {
 
 int WeaponFunctions::luaWeaponRange(lua_State* L) {
 	// weapon:range(range)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -439,7 +439,7 @@ int WeaponFunctions::luaWeaponRange(lua_State* L) {
 
 int WeaponFunctions::luaWeaponCharges(lua_State* L) {
 	// weapon:charges(charges[, showCharges = true])
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		bool showCharges = true;
 		if (lua_gettop(L) > 2) {
@@ -458,7 +458,7 @@ int WeaponFunctions::luaWeaponCharges(lua_State* L) {
 
 int WeaponFunctions::luaWeaponDuration(lua_State* L) {
 	// weapon:duration(duration[, showDuration = true])
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		bool showDuration = true;
 		if (lua_gettop(L) > 2) {
@@ -477,7 +477,7 @@ int WeaponFunctions::luaWeaponDuration(lua_State* L) {
 
 int WeaponFunctions::luaWeaponDecayTo(lua_State* L) {
 	// weapon:decayTo([itemid = 0]
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		uint16_t itemid = 0;
 		if (lua_gettop(L) > 1) {
@@ -495,7 +495,7 @@ int WeaponFunctions::luaWeaponDecayTo(lua_State* L) {
 
 int WeaponFunctions::luaWeaponTransformEquipTo(lua_State* L) {
 	// weapon:transformEquipTo(itemid)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -509,7 +509,7 @@ int WeaponFunctions::luaWeaponTransformEquipTo(lua_State* L) {
 
 int WeaponFunctions::luaWeaponTransformDeEquipTo(lua_State* L) {
 	// weapon:transformDeEquipTo(itemid)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -523,7 +523,7 @@ int WeaponFunctions::luaWeaponTransformDeEquipTo(lua_State* L) {
 
 int WeaponFunctions::luaWeaponShootType(lua_State* L) {
 	// weapon:shootType(type)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -537,7 +537,7 @@ int WeaponFunctions::luaWeaponShootType(lua_State* L) {
 
 int WeaponFunctions::luaWeaponSlotType(lua_State* L) {
 	// weapon:slotType(slot)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -557,7 +557,7 @@ int WeaponFunctions::luaWeaponSlotType(lua_State* L) {
 
 int WeaponFunctions::luaWeaponAmmoType(lua_State* L) {
 	// weapon:ammoType(type)
-	const auto &weapon = Lua::getUserdataShared<WeaponDistance>(L, 1);
+	const auto &weapon = Lua::getUserdataShared<WeaponDistance>(L, 1, "WeaponDistance");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -583,7 +583,7 @@ int WeaponFunctions::luaWeaponAmmoType(lua_State* L) {
 
 int WeaponFunctions::luaWeaponHitChance(lua_State* L) {
 	// weapon:hitChance(chance)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -597,7 +597,7 @@ int WeaponFunctions::luaWeaponHitChance(lua_State* L) {
 
 int WeaponFunctions::luaWeaponMaxHitChance(lua_State* L) {
 	// weapon:maxHitChance(max)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);
@@ -611,7 +611,7 @@ int WeaponFunctions::luaWeaponMaxHitChance(lua_State* L) {
 
 int WeaponFunctions::luaWeaponExtraElement(lua_State* L) {
 	// weapon:extraElement(atk, combatType)
-	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1);
+	const WeaponShared_ptr &weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		const ItemType &it = Item::items.getItemType(id);

--- a/src/lua/functions/lua_functions_loader.cpp
+++ b/src/lua/functions/lua_functions_loader.cpp
@@ -493,22 +493,22 @@ std::shared_ptr<Thing> Lua::getThing(lua_State* L, int32_t arg) {
 		lua_rawgeti(L, -1, 't');
 		switch (getNumber<LuaData_t>(L, -1)) {
 			case LuaData_t::Item:
-				thing = getUserdataShared<Item>(L, arg);
+				thing = Lua::getUserdataShared<Item>(L, arg, "Item");
 				break;
 			case LuaData_t::Container:
-				thing = getUserdataShared<Container>(L, arg);
+				thing = Lua::getUserdataShared<Container>(L, arg, "Container");
 				break;
 			case LuaData_t::Teleport:
-				thing = getUserdataShared<Teleport>(L, arg);
+				thing = Lua::getUserdataShared<Teleport>(L, arg, "Teleport");
 				break;
 			case LuaData_t::Player:
-				thing = getUserdataShared<Player>(L, arg);
+				thing = Lua::getUserdataShared<Player>(L, arg, "Player");
 				break;
 			case LuaData_t::Monster:
-				thing = getUserdataShared<Monster>(L, arg);
+				thing = Lua::getUserdataShared<Monster>(L, arg, "Monster");
 				break;
 			case LuaData_t::Npc:
-				thing = getUserdataShared<Npc>(L, arg);
+				thing = Lua::getUserdataShared<Npc>(L, arg, "Npc");
 				break;
 			default:
 				thing = nullptr;
@@ -523,14 +523,14 @@ std::shared_ptr<Thing> Lua::getThing(lua_State* L, int32_t arg) {
 
 std::shared_ptr<Creature> Lua::getCreature(lua_State* L, int32_t arg) {
 	if (isUserdata(L, arg)) {
-		return getUserdataShared<Creature>(L, arg);
+		return Lua::getUserdataShared<Creature>(L, arg, "Creature");
 	}
 	return g_game().getCreatureByID(getNumber<uint32_t>(L, arg));
 }
 
 std::shared_ptr<Player> Lua::getPlayer(lua_State* L, int32_t arg, bool allowOffline /* = false */) {
 	if (isUserdata(L, arg)) {
-		return getUserdataShared<Player>(L, arg);
+		return Lua::getUserdataShared<Player>(L, arg, "Player");
 	} else if (isNumber(L, arg)) {
 		return g_game().getPlayerByID(getNumber<uint64_t>(L, arg), allowOffline);
 	} else if (isString(L, arg)) {
@@ -542,7 +542,7 @@ std::shared_ptr<Player> Lua::getPlayer(lua_State* L, int32_t arg, bool allowOffl
 
 std::shared_ptr<Guild> Lua::getGuild(lua_State* L, int32_t arg, bool allowOffline /* = false */) {
 	if (isUserdata(L, arg)) {
-		return getUserdataShared<Guild>(L, arg);
+		return Lua::getUserdataShared<Guild>(L, arg, "Guild");
 	} else if (isNumber(L, arg)) {
 		return g_game().getGuild(getNumber<uint64_t>(L, arg), allowOffline);
 	} else if (isString(L, arg)) {

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -216,8 +216,9 @@ public:
 	}
 
 	template <class T>
-	static std::shared_ptr<T> getUserdataShared(lua_State* L, int32_t arg) {
-		auto userdata = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
+	static std::shared_ptr<T> getUserdataShared(lua_State* L, int32_t arg, const char* metatableName) {
+		// Verify that the userdata at 'arg' has the correct metatable.
+		auto userdata = static_cast<std::shared_ptr<T>*>(luaL_testudata(L, arg, metatableName));
 		if (!userdata) {
 			return nullptr;
 		}

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -215,6 +215,26 @@ public:
 		scriptEnv[scriptEnvIndex--].resetEnv();
 	}
 
+	/**
+	 * @brief Retrieves a shared pointer to a userdata object from the Lua stack.
+	 *
+	 * This function attempts to extract a `std::shared_ptr<T>` from the given Lua stack index.
+	 * It ensures that the userdata at the specified index has the expected metatable before
+	 * attempting to retrieve it. This validation prevents crashes due to invalid or outdated
+	 * Lua bindings, ensuring that only correctly-typed userdata is accessed.
+	 *
+	 * @tparam T The C++ class type of the userdata.
+	 * @param L The Lua state.
+	 * @param arg The index of the Lua stack where the userdata is expected to be.
+	 * @param metatableName The expected metatable name associated with the userdata.
+	 *                      This ensures that the retrieved object is of the correct type.
+	 *                      The metatable name should match the one assigned when the userdata
+	 *                      was originally pushed into Lua.
+	 *
+	 * @return std::shared_ptr<T> A valid shared pointer to the requested object if the userdata
+	 *         exists and has the correct metatable. If the userdata is missing or has an incorrect
+	 *         metatable, returns nullptr.
+	 */
 	template <class T>
 	static std::shared_ptr<T> getUserdataShared(lua_State* L, int32_t arg, const char* metatableName) {
 		// Verify that the userdata at 'arg' has the correct metatable.

--- a/src/lua/functions/map/house_functions.cpp
+++ b/src/lua/functions/map/house_functions.cpp
@@ -69,7 +69,7 @@ int HouseFunctions::luaHouseCreate(lua_State* L) {
 
 int HouseFunctions::luaHouseGetId(lua_State* L) {
 	// house:getId()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getId());
 	} else {
 		lua_pushnil(L);
@@ -79,7 +79,7 @@ int HouseFunctions::luaHouseGetId(lua_State* L) {
 
 int HouseFunctions::luaHouseGetName(lua_State* L) {
 	// house:getName()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		Lua::pushString(L, house->getName());
 	} else {
 		lua_pushnil(L);
@@ -89,7 +89,7 @@ int HouseFunctions::luaHouseGetName(lua_State* L) {
 
 int HouseFunctions::luaHouseGetTown(lua_State* L) {
 	// house:getTown()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -106,7 +106,7 @@ int HouseFunctions::luaHouseGetTown(lua_State* L) {
 
 int HouseFunctions::luaHouseGetExitPosition(lua_State* L) {
 	// house:getExitPosition()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		Lua::pushPosition(L, house->getEntryPosition());
 	} else {
 		lua_pushnil(L);
@@ -116,7 +116,7 @@ int HouseFunctions::luaHouseGetExitPosition(lua_State* L) {
 
 int HouseFunctions::luaHouseGetRent(lua_State* L) {
 	// house:getRent()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getRent());
 	} else {
 		lua_pushnil(L);
@@ -126,7 +126,7 @@ int HouseFunctions::luaHouseGetRent(lua_State* L) {
 
 int HouseFunctions::luaHouseGetPrice(lua_State* L) {
 	// house:getPrice()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		Lua::reportErrorFunc("House not found");
 		lua_pushnumber(L, 0);
@@ -139,7 +139,7 @@ int HouseFunctions::luaHouseGetPrice(lua_State* L) {
 
 int HouseFunctions::luaHouseGetOwnerGuid(lua_State* L) {
 	// house:getOwnerGuid()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getOwner());
 	} else {
 		lua_pushnil(L);
@@ -149,7 +149,7 @@ int HouseFunctions::luaHouseGetOwnerGuid(lua_State* L) {
 
 int HouseFunctions::luaHouseSetHouseOwner(lua_State* L) {
 	// house:setHouseOwner(guid[, updateDatabase = true])
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		Lua::reportErrorFunc("House not found");
 		lua_pushnil(L);
@@ -165,7 +165,7 @@ int HouseFunctions::luaHouseSetHouseOwner(lua_State* L) {
 
 int HouseFunctions::luaHouseSetNewOwnerGuid(lua_State* L) {
 	// house:setNewOwnerGuid(guid[, updateDatabase = true])
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (house) {
 		auto isTransferOnRestart = g_configManager().getBoolean(TOGGLE_HOUSE_TRANSFER_ON_SERVER_RESTART);
 		if (isTransferOnRestart && house->hasNewOwnership()) {
@@ -188,7 +188,7 @@ int HouseFunctions::luaHouseSetNewOwnerGuid(lua_State* L) {
 
 int HouseFunctions::luaHouseHasItemOnTile(lua_State* L) {
 	// house:hasItemOnTile()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		Lua::reportErrorFunc("House not found");
 		lua_pushnil(L);
@@ -201,7 +201,7 @@ int HouseFunctions::luaHouseHasItemOnTile(lua_State* L) {
 
 int HouseFunctions::luaHouseHasNewOwnership(lua_State* L) {
 	// house:hasNewOwnership(guid)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		Lua::reportErrorFunc("House not found");
 		lua_pushnil(L);
@@ -215,9 +215,9 @@ int HouseFunctions::luaHouseHasNewOwnership(lua_State* L) {
 
 int HouseFunctions::luaHouseStartTrade(lua_State* L) {
 	// house:startTrade(player, tradePartner)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
-	const auto &player = Lua::getUserdataShared<Player>(L, 2);
-	const auto &tradePartner = Lua::getUserdataShared<Player>(L, 3);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
+	const auto &player = Lua::getUserdataShared<Player>(L, 2, "Player");
+	const auto &tradePartner = Lua::getUserdataShared<Player>(L, 3, "Player");
 
 	if (!player || !tradePartner || !house) {
 		lua_pushnil(L);
@@ -269,7 +269,7 @@ int HouseFunctions::luaHouseStartTrade(lua_State* L) {
 
 int HouseFunctions::luaHouseGetBeds(lua_State* L) {
 	// house:getBeds()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -289,7 +289,7 @@ int HouseFunctions::luaHouseGetBeds(lua_State* L) {
 
 int HouseFunctions::luaHouseGetBedCount(lua_State* L) {
 	// house:getBedCount()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getBedCount());
 	} else {
 		lua_pushnil(L);
@@ -299,7 +299,7 @@ int HouseFunctions::luaHouseGetBedCount(lua_State* L) {
 
 int HouseFunctions::luaHouseGetDoors(lua_State* L) {
 	// house:getDoors()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -319,7 +319,7 @@ int HouseFunctions::luaHouseGetDoors(lua_State* L) {
 
 int HouseFunctions::luaHouseGetDoorCount(lua_State* L) {
 	// house:getDoorCount()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getDoors().size());
 	} else {
 		lua_pushnil(L);
@@ -329,7 +329,7 @@ int HouseFunctions::luaHouseGetDoorCount(lua_State* L) {
 
 int HouseFunctions::luaHouseGetDoorIdByPosition(lua_State* L) {
 	// house:getDoorIdByPosition(position)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -346,7 +346,7 @@ int HouseFunctions::luaHouseGetDoorIdByPosition(lua_State* L) {
 
 int HouseFunctions::luaHouseGetTiles(lua_State* L) {
 	// house:getTiles()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -366,7 +366,7 @@ int HouseFunctions::luaHouseGetTiles(lua_State* L) {
 
 int HouseFunctions::luaHouseGetItems(lua_State* L) {
 	// house:getItems()
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -391,7 +391,7 @@ int HouseFunctions::luaHouseGetItems(lua_State* L) {
 
 int HouseFunctions::luaHouseGetTileCount(lua_State* L) {
 	// house:getTileCount()
-	if (const auto &house = Lua::getUserdataShared<House>(L, 1)) {
+	if (const auto &house = Lua::getUserdataShared<House>(L, 1, "House")) {
 		lua_pushnumber(L, house->getTiles().size());
 	} else {
 		lua_pushnil(L);
@@ -401,7 +401,7 @@ int HouseFunctions::luaHouseGetTileCount(lua_State* L) {
 
 int HouseFunctions::luaHouseCanEditAccessList(lua_State* L) {
 	// house:canEditAccessList(listId, player)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -421,7 +421,7 @@ int HouseFunctions::luaHouseCanEditAccessList(lua_State* L) {
 
 int HouseFunctions::luaHouseGetAccessList(lua_State* L) {
 	// house:getAccessList(listId)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -439,7 +439,7 @@ int HouseFunctions::luaHouseGetAccessList(lua_State* L) {
 
 int HouseFunctions::luaHouseSetAccessList(lua_State* L) {
 	// house:setAccessList(listId, list)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -454,7 +454,7 @@ int HouseFunctions::luaHouseSetAccessList(lua_State* L) {
 
 int HouseFunctions::luaHouseKickPlayer(lua_State* L) {
 	// house:kickPlayer(player, targetPlayer)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -478,7 +478,7 @@ int HouseFunctions::luaHouseKickPlayer(lua_State* L) {
 
 int HouseFunctions::luaHouseIsInvited(lua_State* L) {
 	// house:isInvited(player)
-	const auto &house = Lua::getUserdataShared<House>(L, 1);
+	const auto &house = Lua::getUserdataShared<House>(L, 1, "House");
 	if (!house) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/map/teleport_functions.cpp
+++ b/src/lua/functions/map/teleport_functions.cpp
@@ -38,7 +38,7 @@ int TeleportFunctions::luaTeleportCreate(lua_State* L) {
 
 int TeleportFunctions::luaTeleportGetDestination(lua_State* L) {
 	// teleport:getDestination()
-	const auto &teleport = Lua::getUserdataShared<Teleport>(L, 1);
+	const auto &teleport = Lua::getUserdataShared<Teleport>(L, 1, "Teleport");
 	if (teleport) {
 		Lua::pushPosition(L, teleport->getDestPos());
 	} else {
@@ -49,7 +49,7 @@ int TeleportFunctions::luaTeleportGetDestination(lua_State* L) {
 
 int TeleportFunctions::luaTeleportSetDestination(lua_State* L) {
 	// teleport:setDestination(position)
-	const auto &teleport = Lua::getUserdataShared<Teleport>(L, 1);
+	const auto &teleport = Lua::getUserdataShared<Teleport>(L, 1, "Teleport");
 	if (teleport) {
 		teleport->setDestPos(Lua::getPosition(L, 2));
 		Lua::pushBoolean(L, true);

--- a/src/lua/functions/map/tile_functions.cpp
+++ b/src/lua/functions/map/tile_functions.cpp
@@ -82,7 +82,7 @@ int TileFunctions::luaTileCreate(lua_State* L) {
 
 int TileFunctions::luaTileGetPosition(lua_State* L) {
 	// tile:Lua::getPosition()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (tile) {
 		Lua::pushPosition(L, tile->getPosition());
 	} else {
@@ -93,7 +93,7 @@ int TileFunctions::luaTileGetPosition(lua_State* L) {
 
 int TileFunctions::luaTileGetGround(lua_State* L) {
 	// tile:getGround()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (tile && tile->getGround()) {
 		Lua::pushUserdata<Item>(L, tile->getGround());
 		Lua::setItemMetatable(L, -1, tile->getGround());
@@ -106,7 +106,7 @@ int TileFunctions::luaTileGetGround(lua_State* L) {
 int TileFunctions::luaTileGetThing(lua_State* L) {
 	// tile:getThing(index)
 	const int32_t index = Lua::getNumber<int32_t>(L, 2);
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -132,7 +132,7 @@ int TileFunctions::luaTileGetThing(lua_State* L) {
 
 int TileFunctions::luaTileGetThingCount(lua_State* L) {
 	// tile:getThingCount()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (tile) {
 		lua_pushnumber(L, tile->getThingCount());
 	} else {
@@ -144,7 +144,7 @@ int TileFunctions::luaTileGetThingCount(lua_State* L) {
 int TileFunctions::luaTileGetTopVisibleThing(lua_State* L) {
 	// tile:getTopVisibleThing(creature)
 	const auto &creature = Lua::getCreature(L, 2);
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -170,7 +170,7 @@ int TileFunctions::luaTileGetTopVisibleThing(lua_State* L) {
 
 int TileFunctions::luaTileGetTopTopItem(lua_State* L) {
 	// tile:getTopTopItem()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -188,7 +188,7 @@ int TileFunctions::luaTileGetTopTopItem(lua_State* L) {
 
 int TileFunctions::luaTileGetTopDownItem(lua_State* L) {
 	// tile:getTopDownItem()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -206,7 +206,7 @@ int TileFunctions::luaTileGetTopDownItem(lua_State* L) {
 
 int TileFunctions::luaTileGetFieldItem(lua_State* L) {
 	// tile:getFieldItem()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -224,7 +224,7 @@ int TileFunctions::luaTileGetFieldItem(lua_State* L) {
 
 int TileFunctions::luaTileGetItemById(lua_State* L) {
 	// tile:getItemById(itemId[, subType = -1])
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -254,7 +254,7 @@ int TileFunctions::luaTileGetItemById(lua_State* L) {
 
 int TileFunctions::luaTileGetItemByType(lua_State* L) {
 	// tile:getItemByType(itemType)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -318,7 +318,7 @@ int TileFunctions::luaTileGetItemByType(lua_State* L) {
 
 int TileFunctions::luaTileGetItemByTopOrder(lua_State* L) {
 	// tile:getItemByTopOrder(topOrder)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -339,7 +339,7 @@ int TileFunctions::luaTileGetItemByTopOrder(lua_State* L) {
 
 int TileFunctions::luaTileGetItemCountById(lua_State* L) {
 	// tile:getItemCountById(itemId[, subType = -1])
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -364,7 +364,7 @@ int TileFunctions::luaTileGetItemCountById(lua_State* L) {
 
 int TileFunctions::luaTileGetBottomCreature(lua_State* L) {
 	// tile:getBottomCreature()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -383,7 +383,7 @@ int TileFunctions::luaTileGetBottomCreature(lua_State* L) {
 
 int TileFunctions::luaTileGetTopCreature(lua_State* L) {
 	// tile:getTopCreature()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -402,7 +402,7 @@ int TileFunctions::luaTileGetTopCreature(lua_State* L) {
 
 int TileFunctions::luaTileGetBottomVisibleCreature(lua_State* L) {
 	// tile:getBottomVisibleCreature(creature)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -426,7 +426,7 @@ int TileFunctions::luaTileGetBottomVisibleCreature(lua_State* L) {
 
 int TileFunctions::luaTileGetTopVisibleCreature(lua_State* L) {
 	// tile:getTopVisibleCreature(creature)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -450,7 +450,7 @@ int TileFunctions::luaTileGetTopVisibleCreature(lua_State* L) {
 
 int TileFunctions::luaTileGetItems(lua_State* L) {
 	// tile:getItems()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -475,7 +475,7 @@ int TileFunctions::luaTileGetItems(lua_State* L) {
 
 int TileFunctions::luaTileGetItemCount(lua_State* L) {
 	// tile:getItemCount()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -487,7 +487,7 @@ int TileFunctions::luaTileGetItemCount(lua_State* L) {
 
 int TileFunctions::luaTileGetDownItemCount(lua_State* L) {
 	// tile:getDownItemCount()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (tile) {
 		lua_pushnumber(L, tile->getDownItemCount());
 	} else {
@@ -498,7 +498,7 @@ int TileFunctions::luaTileGetDownItemCount(lua_State* L) {
 
 int TileFunctions::luaTileGetTopItemCount(lua_State* L) {
 	// tile:getTopItemCount()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -510,7 +510,7 @@ int TileFunctions::luaTileGetTopItemCount(lua_State* L) {
 
 int TileFunctions::luaTileGetCreatures(lua_State* L) {
 	// tile:getCreatures()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -535,7 +535,7 @@ int TileFunctions::luaTileGetCreatures(lua_State* L) {
 
 int TileFunctions::luaTileGetCreatureCount(lua_State* L) {
 	// tile:getCreatureCount()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -547,7 +547,7 @@ int TileFunctions::luaTileGetCreatureCount(lua_State* L) {
 
 int TileFunctions::luaTileHasProperty(lua_State* L) {
 	// tile:hasProperty(property[, item])
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -555,7 +555,7 @@ int TileFunctions::luaTileHasProperty(lua_State* L) {
 
 	std::shared_ptr<Item> item;
 	if (lua_gettop(L) >= 3) {
-		item = Lua::getUserdataShared<Item>(L, 3);
+		item = Lua::getUserdataShared<Item>(L, 3, "Item");
 	} else {
 		item = nullptr;
 	}
@@ -571,7 +571,7 @@ int TileFunctions::luaTileHasProperty(lua_State* L) {
 
 int TileFunctions::luaTileGetThingIndex(lua_State* L) {
 	// tile:getThingIndex(thing)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -588,7 +588,7 @@ int TileFunctions::luaTileGetThingIndex(lua_State* L) {
 
 int TileFunctions::luaTileHasFlag(lua_State* L) {
 	// tile:hasFlag(flag)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (tile) {
 		TileFlags_t flag = Lua::getNumber<TileFlags_t>(L, 2);
 		Lua::pushBoolean(L, tile->hasFlag(flag));
@@ -600,7 +600,7 @@ int TileFunctions::luaTileHasFlag(lua_State* L) {
 
 int TileFunctions::luaTileQueryAdd(lua_State* L) {
 	// tile:queryAdd(thing[, flags])
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -618,7 +618,7 @@ int TileFunctions::luaTileQueryAdd(lua_State* L) {
 
 int TileFunctions::luaTileAddItem(lua_State* L) {
 	// tile:addItem(itemId[, count/subType = 1[, flags = 0]])
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -658,13 +658,13 @@ int TileFunctions::luaTileAddItem(lua_State* L) {
 
 int TileFunctions::luaTileAddItemEx(lua_State* L) {
 	// tile:addItemEx(item[, flags = 0])
-	const auto &item = Lua::getUserdataShared<Item>(L, 2);
+	const auto &item = Lua::getUserdataShared<Item>(L, 2, "Item");
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -687,7 +687,7 @@ int TileFunctions::luaTileAddItemEx(lua_State* L) {
 
 int TileFunctions::luaTileGetHouse(lua_State* L) {
 	// tile:getHouse()
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -704,7 +704,7 @@ int TileFunctions::luaTileGetHouse(lua_State* L) {
 
 int TileFunctions::luaTileSweep(lua_State* L) {
 	// tile:sweep(actor)
-	const auto &tile = Lua::getUserdataShared<Tile>(L, 1);
+	const auto &tile = Lua::getUserdataShared<Tile>(L, 1, "Tile");
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;

--- a/src/lua/functions/map/town_functions.cpp
+++ b/src/lua/functions/map/town_functions.cpp
@@ -44,7 +44,7 @@ int TownFunctions::luaTownCreate(lua_State* L) {
 
 int TownFunctions::luaTownGetId(lua_State* L) {
 	// town:getId()
-	if (const auto &town = Lua::getUserdataShared<Town>(L, 1)) {
+	if (const auto &town = Lua::getUserdataShared<Town>(L, 1, "Town")) {
 		lua_pushnumber(L, town->getID());
 	} else {
 		lua_pushnil(L);
@@ -54,7 +54,7 @@ int TownFunctions::luaTownGetId(lua_State* L) {
 
 int TownFunctions::luaTownGetName(lua_State* L) {
 	// town:getName()
-	if (const auto &town = Lua::getUserdataShared<Town>(L, 1)) {
+	if (const auto &town = Lua::getUserdataShared<Town>(L, 1, "Town")) {
 		Lua::pushString(L, town->getName());
 	} else {
 		lua_pushnil(L);
@@ -64,7 +64,7 @@ int TownFunctions::luaTownGetName(lua_State* L) {
 
 int TownFunctions::luaTownGetTemplePosition(lua_State* L) {
 	// town:getTemplePosition()
-	if (const auto &town = Lua::getUserdataShared<Town>(L, 1)) {
+	if (const auto &town = Lua::getUserdataShared<Town>(L, 1, "Town")) {
 		Lua::pushPosition(L, town->getTemplePosition());
 	} else {
 		lua_pushnil(L);


### PR DESCRIPTION
# Description

Refactored `getUserdataShared<T>` to validate userdata before dereferencing, preventing crashes caused by invalid or outdated Lua bindings. This fix ensures that instead of a crash, an error message is logged in the console.

Applied this change across multiple occurrences, potentially fixing other crashes beyond the `openImbuementWindow` function. Also included a regex pattern to help others update their codebase easily.

### Regular Expression:
### **Find:**
(?:Lua::)?getUserdataShared<\s*(?:const\s+)?([\w\d_]+)\s*>\(\s*([\w\d_]+)\s*,\s*([\w\d_]+)\s*\)

### **Replace:**
Lua::getUserdataShared<$1>($2, $3, "$1")

## Behaviour
### **Actual**
Calling `getUserdataShared<T>` with invalid or outdated Lua bindings could cause a crash due to dereferencing invalid userdata.

### **Expected**
Instead of crashing, an error message is logged in the console.

### Fixes #3418 

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

  - [x] Validated against multiple Lua scripts using `getUserdataShared<T>`.
  - [x] Ensured that invalid userdata no longer crashes the system.
  - [x] Checked log output to confirm proper error handling.

## Checklist

  - [x] My code follows the style guidelines of this project.
  - [x] I have performed a self-review of my own code.
  - [x] I checked the PR checks reports.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [x] I have made corresponding changes to the documentation.
  - [x] My changes generate no new warnings.
  - [x] I have added tests that prove my fix is effective or that my feature works.
