### PR TITLE
fix: hotkey swaps, house potion use, and loot pouch equip handling

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3433,10 +3433,10 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 
 	const auto &slotItem = player->getInventoryItem(slot);
 	auto equipItem = searchForItem(backpack, it.id, hasTier, tier);
- 	if (!equipItem) {
- 		const auto &lootPouch = player->getLootPouch();
- 		equipItem = searchForItem(lootPouch, it.id, hasTier, tier);
- 	}
+	if (!equipItem) {
+		const auto &lootPouch = player->getLootPouch();
+		equipItem = searchForItem(lootPouch, it.id, hasTier, tier);
+	}
 	ReturnValue ret = RETURNVALUE_NOERROR;
 
 	if (slotItem && slotItem->getID() == it.id && (!it.stackable || slotItem->getItemCount() == slotItem->getStackSize() || !equipItem)) {
@@ -4037,13 +4037,13 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 	}
 
 	bool canUseHouseItem = !g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, __FUNCTION__) || InternalGame::playerCanUseItemOnHouseTile(player, item);
- 	if (!canUseHouseItem && item->hasOwner() && !item->isOwner(player)) {
- 		player->sendCancelMessage(RETURNVALUE_ITEMISNOTYOURS);
- 		return;
- 	} else if (!canUseHouseItem) {
- 		player->sendCancelMessage(RETURNVALUE_ITEMCANNOTBEMOVEDTHERE);
- 		return;
- 	}
+	if (!canUseHouseItem && item->hasOwner() && !item->isOwner(player)) {
+		player->sendCancelMessage(RETURNVALUE_ITEMISNOTYOURS);
+		return;
+	} else if (!canUseHouseItem) {
+		player->sendCancelMessage(RETURNVALUE_ITEMCANNOTBEMOVEDTHERE);
+		return;
+	}
 
 	const ItemType &it = Item::items[item->getID()];
 	bool canTriggerExhaustion = it.triggerExhaustion();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4036,7 +4036,7 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 		return;
 	}
 
-	bool canUseHouseItem = !g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, __FUNCTION__) || InternalGame::playerCanUseItemOnHouseTile(player, item);
+	bool canUseHouseItem = !g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS) || InternalGame::playerCanUseItemOnHouseTile(player, item);
 	if (!canUseHouseItem && item->hasOwner() && !item->isOwner(player)) {
 		player->sendCancelMessage(RETURNVALUE_ITEMISNOTYOURS);
 		return;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3348,6 +3348,10 @@ uint64_t Game::getItemMarketPrice(const std::map<uint16_t, uint64_t> &itemMap, b
 }
 
 std::shared_ptr<Item> searchForItem(const std::shared_ptr<Container> &container, uint16_t itemId, bool hasTier /* = false*/, uint8_t tier /* = 0*/) {
+	if (!container) {
+		return nullptr;
+	}
+
 	for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 		if ((*it)->getID() == itemId && (!hasTier || (*it)->getTier() == tier)) {
 			return *it;
@@ -3425,27 +3429,18 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 	}
 
 	const auto &item = player->getInventoryItem(CONST_SLOT_BACKPACK);
-	if (!item) {
-		return;
-	}
-
-	const std::shared_ptr<Container> &backpack = item->getContainer();
-	if (!backpack) {
-		return;
-	}
-
-	if (player->getFreeBackpackSlots() == 0) {
-		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
-		return;
-	}
+	const auto &backpack = item ? item->getContainer() : nullptr;
 
 	const auto &slotItem = player->getInventoryItem(slot);
-	const auto &equipItem = searchForItem(backpack, it.id, hasTier, tier);
+	auto equipItem = searchForItem(backpack, it.id, hasTier, tier);
+ 	if (!equipItem) {
+ 		const auto &lootPouch = player->getLootPouch();
+ 		equipItem = searchForItem(lootPouch, it.id, hasTier, tier);
+ 	}
 	ReturnValue ret = RETURNVALUE_NOERROR;
 
 	if (slotItem && slotItem->getID() == it.id && (!it.stackable || slotItem->getItemCount() == slotItem->getStackSize() || !equipItem)) {
-		ret = internalMoveItem(slotItem->getParent(), player, CONST_SLOT_WHEREEVER, slotItem, slotItem->getItemCount(), nullptr);
-		g_logger().debug("Item {} was unequipped", slotItem->getName());
+		ret = internalCollectManagedItems(player, slotItem, getObjectCategory(slotItem), false);
 	} else if (equipItem) {
 		// Shield slot item
 		const auto &rightItem = player->getInventoryItem(CONST_SLOT_RIGHT);
@@ -3475,9 +3470,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 			if (slot == CONST_SLOT_RIGHT && rightItem && rightItem->isQuiver() && it.isQuiver()) {
 				// Replace the existing quiver with the new one
 				ret = internalMoveItem(rightItem->getParent(), player, INDEX_WHEREEVER, rightItem, rightItem->getItemCount(), nullptr);
-				if (ret == RETURNVALUE_NOERROR) {
-					g_logger().debug("Quiver {} was unequipped to equip new quiver", rightItem->getName());
-				} else {
+				if (ret != RETURNVALUE_NOERROR) {
 					player->sendCancelMessage(ret);
 					return;
 				}
@@ -3486,9 +3479,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 				if (slot == CONST_SLOT_RIGHT && leftItem && leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
 					// Unequip the two-handed weapon from the left slot
 					ret = internalMoveItem(leftItem->getParent(), player, INDEX_WHEREEVER, leftItem, leftItem->getItemCount(), nullptr);
-					if (ret == RETURNVALUE_NOERROR) {
-						g_logger().debug("Two-handed weapon {} was unequipped to equip shield", leftItem->getName());
-					} else {
+					if (ret != RETURNVALUE_NOERROR) {
 						player->sendCancelMessage(ret);
 						return;
 					}
@@ -3496,14 +3487,10 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 			}
 
 			if (slotItem) {
-				ret = internalMoveItem(slotItem->getParent(), player, INDEX_WHEREEVER, slotItem, slotItem->getItemCount(), nullptr);
-				g_logger().debug("Item {} was moved back to player", slotItem->getName());
+				ret = internalCollectManagedItems(player, slotItem, getObjectCategory(slotItem), false);
 			}
 
 			ret = internalMoveItem(equipItem->getParent(), player, slot, equipItem, equipItem->getItemCount(), nullptr);
-			if (ret == RETURNVALUE_NOERROR) {
-				g_logger().debug("Item {} was equipped", equipItem->getName());
-			}
 		}
 	}
 
@@ -4049,15 +4036,14 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 		return;
 	}
 
-	if (g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (std::shared_ptr<HouseTile> houseTile = std::dynamic_pointer_cast<HouseTile>(item->getTile())) {
-			const auto &house = houseTile->getHouse();
-			if (house && item->getRealParent() && item->getRealParent() != player && (!house->isInvited(player) || house->getHouseAccessLevel(player) == HOUSE_GUEST)) {
-				player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
-				return;
-			}
-		}
-	}
+	bool canUseHouseItem = !g_configManager().getBoolean(ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS, __FUNCTION__) || InternalGame::playerCanUseItemOnHouseTile(player, item);
+ 	if (!canUseHouseItem && item->hasOwner() && !item->isOwner(player)) {
+ 		player->sendCancelMessage(RETURNVALUE_ITEMISNOTYOURS);
+ 		return;
+ 	} else if (!canUseHouseItem) {
+ 		player->sendCancelMessage(RETURNVALUE_ITEMCANNOTBEMOVEDTHERE);
+ 		return;
+ 	}
 
 	const ItemType &it = Item::items[item->getID()];
 	bool canTriggerExhaustion = it.triggerExhaustion();

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3488,6 +3488,10 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 
 			if (slotItem) {
 				ret = internalCollectManagedItems(player, slotItem, getObjectCategory(slotItem), false);
+				// If the item is not collected, move it to any available container slot
+				if (ret != RETURNVALUE_NOERROR) {
+					ret = internalMoveItem(slotItem->getParent(), player, INDEX_WHEREEVER, slotItem, slotItem->getItemCount(), nullptr);
+				}
 			}
 
 			ret = internalMoveItem(equipItem->getParent(), player, slot, equipItem, equipItem->getItemCount(), nullptr);


### PR DESCRIPTION
# Description

This update includes several fixes and improvements to item management in the game, ensuring a more intuitive and consistent experience. 

## Behaviour
### **Actual**
- Item swaps via hotkey ignore the container settings defined in Manage Containers (Obtain).
- Guests in houses are unable to use potions via hotkey.
- Equipping an item from the Loot Pouch does not possible and not send the previously equipped item to the correct container.

### **Expected**
- Item swaps via hotkey should respect the container settings in Manage Containers.
- Guests in houses should be able to use potions via hotkey.
- Equipping an item from the Loot Pouch should correctly place the swapped item in the designated container.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

  - [x] Verified item swapping respects Manage Containers settings.
  - [x] Tested potion usage by guests in houses.
  - [x] Ensured correct behavior when equipping items from Loot Pouch.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works

## Fixes and Improvements:
- **Hotkey Item Swap:** Now respects the container settings in Manage Containers (Obtain). If a container is set for rings, swapping a ring will place it directly into that container instead of the main backpack.
- **Potion Usage Fix:** Guests in houses can now use potions via hotkey as expected.
- **Loot Pouch Equipment Handling:** Equipping an item from the Loot Pouch will now correctly send the previously equipped item to the main backpack or the designated container in Manage Containers.
