### PR TITLE
fix: update player stats skill bar on boost add/end

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2802,6 +2802,7 @@ uint16_t Player::getDisplayXpBoostPercent() const {
 
 void Player::setXpBoostPercent(uint16_t percent) {
 	xpBoostPercent = percent;
+	sendStats();
 }
 
 uint16_t Player::getStaminaXpBoost() const {


### PR DESCRIPTION
Resolves #3423

This sent update for the "stats skills" player when add/end.