### PR TITLE
fix: concurrency crash in spectators wheel

### DIFF
--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -2712,7 +2712,7 @@ bool PlayerWheel::checkBattleInstinct() {
 	setOnThinkTimer(WheelOnThink_t::BATTLE_INSTINCT, OTSYS_TIME() + 2000);
 	bool updateClient = false;
 	m_creaturesNearby = 0;
-	uint16_t creaturesNearby = Spectators().find<Monster>(m_player.getPosition(), false, 1, 1, 1, 1).excludePlayerMaster().size();
+	uint16_t creaturesNearby = Spectators().find<Monster>(m_player.getPosition(), false, 1, 1, 1, 1, false).excludePlayerMaster().size();
 	if (creaturesNearby >= 5) {
 		m_creaturesNearby = creaturesNearby;
 		creaturesNearby -= 4;
@@ -2736,7 +2736,7 @@ bool PlayerWheel::checkPositionalTactics() {
 	setOnThinkTimer(WheelOnThink_t::POSITIONAL_TACTICS, OTSYS_TIME() + 2000);
 	m_creaturesNearby = 0;
 	bool updateClient = false;
-	uint16_t creaturesNearby = Spectators().find<Monster>(m_player.getPosition(), false, 1, 1, 1, 1).excludePlayerMaster().size();
+	uint16_t creaturesNearby = Spectators().find<Monster>(m_player.getPosition(), false, 1, 1, 1, 1, false).excludePlayerMaster().size();
 	constexpr uint16_t holyMagicSkill = 3;
 	constexpr uint16_t healingMagicSkill = 3;
 	constexpr uint16_t distanceSkill = 3;


### PR DESCRIPTION
Disable spectators cache for async functions.
Resolves: [crash.txt](https://github.com/user-attachments/files/19329850/crash2.txt)
