### PR TITLE
fix: candia races and fluids

### DIFF
--- a/data-otservbr-global/monster/magicals/candy_horror.lua
+++ b/data-otservbr-global/monster/magicals/candy_horror.lua
@@ -30,7 +30,7 @@ monster.Bestiary = {
 
 monster.health = 3100
 monster.maxHealth = 3100
-monster.race = "blood"
+monster.race = "chocolate"
 monster.corpse = 48267
 monster.speed = 115
 monster.manaCost = 0

--- a/data-otservbr-global/monster/magicals/nibblemaw.lua
+++ b/data-otservbr-global/monster/magicals/nibblemaw.lua
@@ -30,7 +30,7 @@ monster.Bestiary = {
 
 monster.health = 2900
 monster.maxHealth = 2900
-monster.race = "blood"
+monster.race = "candy"
 monster.corpse = 48259
 monster.speed = 118
 monster.manaCost = 0

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -672,6 +672,14 @@ bool Creature::dropCorpse(const std::shared_ptr<Creature> &lastHitCreature, cons
 				splash = Item::CreateItem(ITEM_FULLSPLASH, FLUID_INK);
 				break;
 
+			case RACE_CHOCOLATE:
+				splash = Item::CreateItem(ITEM_FULLSPLASH, FLUID_CHOCOLATE);
+				break;
+
+			case RACE_CANDY:
+				splash = Item::CreateItem(ITEM_FULLSPLASH, FLUID_CANDY);
+				break;
+
 			default:
 				splash = nullptr;
 				break;

--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -452,6 +452,8 @@ enum RaceType_t : uint8_t {
 	RACE_FIRE,
 	RACE_ENERGY,
 	RACE_INK,
+	RACE_CHOCOLATE,
+	RACE_CANDY,
 };
 
 enum BlockType_t : uint8_t {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6978,7 +6978,7 @@ void Game::combatGetTypeInfo(CombatType_t combatType, const std::shared_ptr<Crea
 					break;
 				case RACE_CANDY:
 					color = TEXTCOLOR_DARKRED;
-					effect = CONST_ME_SIRUP;
+					effect = CONST_ME_SIURP;
 					splash = Item::CreateItem(ITEM_SMALLSPLASH, FLUID_CANDY);
 					break;
 				case RACE_INK:

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6957,6 +6957,16 @@ void Game::combatGetTypeInfo(CombatType_t combatType, const std::shared_ptr<Crea
 						}
 					}
 					break;
+				case RACE_CHOCOLATE:
+					color = TEXTCOLOR_LIGHTGREY;
+					effect = CONST_ME_CACAO;
+					splash = Item::CreateItem(ITEM_SMALLSPLASH, FLUID_CHOCOLATE);
+					break;
+				case RACE_CANDY:
+					color = TEXTCOLOR_DARKRED;
+					effect = CONST_ME_SIRUP;
+					splash = Item::CreateItem(ITEM_SMALLSPLASH, FLUID_CANDY);
+					break;
 				case RACE_INK:
 					color = TEXTCOLOR_LIGHTGREY;
 					effect = CONST_ME_HITAREA;

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -1385,6 +1385,10 @@ int MonsterTypeFunctions::luaMonsterTypeRace(lua_State* L) {
 				monsterType->info.race = RACE_ENERGY;
 			} else if (race == "ink") {
 				monsterType->info.race = RACE_INK;
+			} else if (race == "chocolate") {
+				monsterType->info.race = RACE_CHOCOLATE;
+			} else if (race == "candy") {
+				monsterType->info.race = RACE_CANDY;
 			} else {
 				g_logger().warn("[MonsterTypeFunctions::luaMonsterTypeRace] - "
 				                "Unknown race type {}",


### PR DESCRIPTION
The race types of Candia monsters (in Tibia Global) are different (not all of them), including some of them:
- Nibblemaw --> race: type 'candy'
- Honey Elemental --> race: type 'candy'
- Candy Horror --> race: type 'chocolate'
- Chocolate Blob --> race: type 'chocolate'

And the fluids they release when hitting monsters with a physical weapon are:
- Chocolate Race -> Fluid Chocolate
- Candy Race -> Fluid Candy


![image](https://github.com/user-attachments/assets/f66e2dca-dcb6-4a57-aff8-7b6cf7f3abbf)
![image](https://github.com/user-attachments/assets/25615c2f-eea4-4234-84af-6ecbdb8ba7d9)
(images from youtube)