### PR TITLE
Fix exercise training weapons action

### DIFF
--- a/data/scripts/actions/items/exercise_training_weapons.lua
+++ b/data/scripts/actions/items/exercise_training_weapons.lua
@@ -47,7 +47,6 @@ local function leaveExerciseTraining(playerId, targetItem)
 	if player then
 		player:setTraining(false)
 		if targetItem then
-			targetItem:actor(false)
 		end
 	end
 	return
@@ -194,7 +193,6 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 		if not _G.OnExerciseTraining[playerId].event then
 			_G.OnExerciseTraining[playerId].event = addEvent(exerciseTrainingEvent, 0, playerId, targetPos, item.itemid, targetId)
 			_G.OnExerciseTraining[playerId].dummyPos = targetPos
-			targetItem:actor(true)
 			player:setTraining(true)
 			player:setExhaustion("training-exhaustion", exhaustionTime)
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have started training on an exercise dummy.")


### PR DESCRIPTION
# Description

Error when using training weapons. When pressing "use" on the dummy, the training did not start and the console displayed a LUA error.

## Behaviour
### **Actual**

When clicking "use" on the dummy, the training did not start and the server log displayed the message "you have stopped training". The console displayed a LUA error when executing the action.

**House Dummie Test**

![house_dummie](https://github.com/user-attachments/assets/2719b017-a3e9-4f56-b217-0c7e01fa42f3)

**Game Dummie Test**

![game_dummie](https://github.com/user-attachments/assets/6f532912-37e5-4d3d-aed0-aab9d6040029)

**Console Error**

![console_error](https://github.com/user-attachments/assets/34de2c7e-6425-4f60-ba35-9e07428a628f)


### **Expected**

When you click "use" on the dummy, the training starts correctly and the console does not display any errors.

**House Dummie Test**

![house_dummie](https://github.com/user-attachments/assets/e2845b30-8922-4362-b0ee-7a564f4d4b9c)

**Game Dummie Test**

![game_dummie](https://github.com/user-attachments/assets/38e5a118-b35e-4207-b120-763ccc4da476)

**Console**

![console](https://github.com/user-attachments/assets/6206171e-e0be-4637-b477-728dd3479160)


## Type of change

Please delete options that are not relevant.

  - [ X ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested

locally tested

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.4
  - Operating System: Windows

## Checklist

  - [ X ] My code follows the style guidelines of this project
  - [ X ] I have performed a self-review of my own code
  - [ X ] I checked the PR checks reports
  - [ X ] My changes generate no new warnings
  - [ X ] I have added tests that prove my fix is effective or that my feature works
