### PR TITLE
fix: add taint experience boost for Soul War monsters

### DIFF
--- a/data-otservbr-global/lib/quests/soul_war.lua
+++ b/data-otservbr-global/lib/quests/soul_war.lua
@@ -23,6 +23,14 @@ SoulWarQuest = {
 		[34007] = 0.10, -- 10% for the smallest pool
 	},
 
+	taintExperienceBoostMap = { -- Experience Boost per taint (In percentage %)
+		[1] = { boost = 4.5 },
+		[2] = { boost = 9.2 },
+		[3] = { boost = 14.1 },
+		[4] = { boost = 19.2 },
+		[5] = { boost = 24.6 },
+	},
+
 	timeToIncreaseCrueltyDefense = 15, -- In seconds, it will increase every 15 seconds if don't use mortal essence in greedy maw
 	useGreedMawCooldown = 30, -- In seconds
 	goshnarsCrueltyDefenseChange = 2, -- Defense change, the amount that will decrease or increase defense, the defense cannot decrease more than the monster's original defense amount

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -582,6 +582,18 @@ function Player:onGainExperience(target, exp, rawExp)
 		end
 	end
 
+	-- Soul War Experience by Taint
+	if SoulWarQuest then
+		local monsterType = target:getType()
+		if monsterType and monsterType:getName() and table.contains(SoulWarQuest.bagYouDesireMonsters, monsterType:getName()) then
+			local taintLevel = self:getTaintLevel()
+			if taintLevel > 0 then
+				local taintBoost = SoulWarQuest.taintExperienceBoostMap[taintLevel] and SoulWarQuest.taintExperienceBoostMap[taintLevel].boost or 0
+				exp = exp * (1 + taintBoost / 100)
+			end
+		end
+	end
+
 	-- Final Adjustments: Low Level Bonus and Base Rate
 	local lowLevelBonusExp = self:getFinalLowLevelBonus()
 	local baseRateExp = self:getFinalBaseRateExperience()


### PR DESCRIPTION
# Description

This PR introduces a fix and enhancement for the experience boost system related to the Soul War quest. Specifically, it ensures that the taint level of the player is correctly factored into the experience calculation when defeating monsters listed in the SoulWarQuest.bagYouDesireMonsters.

## Behaviour
### **Actual**
The taint level boost was not applied correctly in some cases.
Experience calculation did not account for edge cases where the taint level or boost map might be undefined.

### **Expected**

The taint level boost is applied consistently and correctly.
Experience calculation handles edge cases gracefully.

## Type of change

  - [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

  - [x] Hunt any SoulWar monster and see the EXP increasing with different taint levels.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
