### PR TITLE
build: update to recent vcpkg to fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 
-# CMAKE
-# apt install build-essential git
-# git clone https://github.com/Kitware/CMake/; cd CMake
-# ./bootstrap && make && sudo make install
-
 # VCPKG
 # cmake -DCMAKE_TOOLCHAIN_FILE=/opt/workspace/vcpkg/scripts/buildsystems/vcpkg.cmake ..
 # Needed libs are in file vcpkg.json

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -24,7 +24,7 @@
 #endif
 
 ThreadPool::ThreadPool(Logger &logger, const uint32_t threadCount /*= std::thread::hardware_concurrency()*/) :
-	BS::thread_pool<BS::tp::none>(threadCount), logger(logger) {
+	BS::thread_pool<BS::tp::none>(threadCount > 0 ? threadCount : std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS)), logger(logger) {
 	start();
 }
 

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -23,8 +23,8 @@
 	#define DEFAULT_NUMBER_OF_THREADS 4
 #endif
 
-ThreadPool::ThreadPool(Logger &logger) :
-	BS::thread_pool(std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS)), logger(logger) {
+ThreadPool::ThreadPool(Logger &logger, const uint32_t threadCount /*= std::thread::hardware_concurrency()*/) :
+	BS::thread_pool<BS::tp::none>(threadCount), logger(logger) {
 	start();
 }
 

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -11,9 +11,9 @@
 
 #include "BS_thread_pool.hpp"
 
-class ThreadPool : public BS::thread_pool {
+class ThreadPool : public BS::thread_pool<BS::tp::none> {
 public:
-	explicit ThreadPool(Logger &logger);
+	explicit ThreadPool(Logger &logger, const uint32_t threadCount = std::thread::hardware_concurrency());
 
 	// Ensures that we don't accidentally copy it
 	ThreadPool(const ThreadPool &) = delete;

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -116,7 +116,7 @@ format_as(E e) {
  */
 #define MAGIC_ENUM_RANGE_MIN -500
 #define MAGIC_ENUM_RANGE_MAX 500
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 
 // Memory Mapped File
 #include <mio/mmap.hpp>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -34,5 +34,5 @@
       "platform": "windows"
     }
   ],
-  "builtin-baseline": "9558037875497b9db8cf38fcd7db68ec661bffe7"
+  "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c"
 }


### PR DESCRIPTION
Update ThreadPool and magic_enum includes for vcpkg compatibility

- Adapt ThreadPool implementation to the updated BS::thread_pool v5.0.0 interface:
  - Changed inheritance from `BS::thread_pool` to `BS::thread_pool<BS::tp::none>`.

- Updated magic_enum include directives following recent vcpkg changes:
  - Changed from `<magic_enum.hpp>` to `<magic_enum/magic_enum.hpp>`.

These updates resolve compilation issues arising after recent vcpkg dependency updates.