### PR TITLE
fix: incorrect NPC interaction handling in The Djinn War Quest

### DIFF
--- a/data-otservbr-global/npc/alesar.lua
+++ b/data-otservbr-global/npc/alesar.lua
@@ -95,19 +95,22 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
-		npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
-	end
+	--Checks if the player has completed the quest
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Mission03) ~= 3 then
+		if not MsgContains(message, "djanni'hah") then
+			npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
-		npcHandler:say({
-			"Hahahaha! ...",
-			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
-		}, npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
+		if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
+			npcHandler:say({
+				"Hahahaha! ...",
+				"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
+			}, npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 	end
 
 	npcHandler:say("What do you want from me, |PLAYERNAME|?", npc, creature)

--- a/data-otservbr-global/npc/alesar.lua
+++ b/data-otservbr-global/npc/alesar.lua
@@ -101,7 +101,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/baa_leal.lua
+++ b/data-otservbr-global/npc/baa_leal.lua
@@ -65,7 +65,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/bo_ques.lua
+++ b/data-otservbr-global/npc/bo_ques.lua
@@ -67,7 +67,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/fa_hradin.lua
+++ b/data-otservbr-global/npc/fa_hradin.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/gabel.lua
+++ b/data-otservbr-global/npc/gabel.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/haroun.lua
+++ b/data-otservbr-global/npc/haroun.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/haroun.lua
+++ b/data-otservbr-global/npc/haroun.lua
@@ -55,19 +55,22 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
-		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
-	end
+	--Checks if the player has completed the quest
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Mission03) ~= 3 then
+		if not MsgContains(message, "djanni'hah") then
+			npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
-		npcHandler:say({
-			"Hahahaha! ...",
-			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
-		}, npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
+		if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
+			npcHandler:say({
+				"Hahahaha! ...",
+				"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
+			}, npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 	end
 
 	npcHandler:say("Be greeted, human |PLAYERNAME|. How can a humble djinn be of service?", npc, creature)

--- a/data-otservbr-global/npc/malor.lua
+++ b/data-otservbr-global/npc/malor.lua
@@ -70,7 +70,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/nah_bob.lua
+++ b/data-otservbr-global/npc/nah_bob.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/nah_bob.lua
+++ b/data-otservbr-global/npc/nah_bob.lua
@@ -55,19 +55,22 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
-		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
-	end
+	--Checks if the player has completed the quest
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Mission03) ~= 3 then
+		if not MsgContains(message, "djanni'hah") then
+			npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
-		npcHandler:say({
-			"Hahahaha! ...",
-			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
-		}, npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
+		if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
+			npcHandler:say({
+				"Hahahaha! ...",
+				"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
+			}, npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 	end
 
 	npcHandler:say("<Sighs> Another {customer}! I've only just sat down! What is it, |PLAYERNAME|?", npc, creature)

--- a/data-otservbr-global/npc/ubaid.lua
+++ b/data-otservbr-global/npc/ubaid.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/umar.lua
+++ b/data-otservbr-global/npc/umar.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/yaman.lua
+++ b/data-otservbr-global/npc/yaman.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 		return false
 	end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) <= 0 then
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
 		npcHandler:say({
 			"Hahahaha! ...",
 			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",

--- a/data-otservbr-global/npc/yaman.lua
+++ b/data-otservbr-global/npc/yaman.lua
@@ -55,19 +55,22 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
-		npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
-	end
+	--Checks if the player has completed the quest
+	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Mission03) ~= 3 then
+		if not MsgContains(message, "djanni'hah") then
+			npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 
-	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
-		npcHandler:say({
-			"Hahahaha! ...",
-			"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
-		}, npc, creature)
-		endConversationWithDelay(npcHandler, npc, creature)
-		return false
+		if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Start) == 1 then
+			npcHandler:say({
+				"Hahahaha! ...",
+				"|PLAYERNAME|, that almost sounded like the word of greeting. Humans - cute they are!",
+			}, npc, creature)
+			endConversationWithDelay(npcHandler, npc, creature)
+			return false
+		end
 	end
 
 	npcHandler:say("Be greeted, human |PLAYERNAME|. How can a humble djinn be of service?", npc, creature)


### PR DESCRIPTION
# Description

After completing PR #3471 , I noticed that the interaction with NPCs in The Djinn War Quest was still not correct. In this PR, the system check to identify whether the player was following the Efreet or Marid path was improperly changed. That section prevents a player who has Efreet from talking to Marid NPCs, for example, so I reverted the changes made in this PR.

In addition, I noticed that even with the quests completed, it was not possible to talk to NPCs with "hi" or "hello", only with "DJANNI'HAH". To fix this, I added a quest completion check before the existing greeting checks (the same check made to make it possible to "trade" with the NPC).

## Behaviour
### **Actual**

1 - Players who chose one path of the quest are able to talk to NPCs from the other path.
2 - Even with the quest completed, it is not possible to talk to the NPC with "hi", only with the quest keyword "DJANNI'HAH".

### **Expected**

1 - Players who chose 1 path of the quest can only talk to NPCs on that path.
2 - Players who completed the quest can talk to the NPC with "hi".

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Player with both quests completed
I added both quests through freequests.lua and talked to NPCs from both factions using "hi" and "trade".
- [x] Player with 1 quest completed
I only added 1 quest through freequests.lua. I was able to say "hi" and "trade" to the NPCs of the faction of the quest I added and was denied by the other faction with both "hi" and "DJANNI'HAH".

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13.40
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
