### PR TITLE
fix: server startup loop on "Running with x threads" step

### DIFF
--- a/src/canary_server.hpp
+++ b/src/canary_server.hpp
@@ -50,7 +50,9 @@ private:
 	RSA &rsa;
 	ServiceManager &serviceManager;
 
-	std::atomic<LoaderStatus> loaderStatus = LoaderStatus::LOADING;
+	LoaderStatus loaderStatus = LoaderStatus::LOADING;
+	std::mutex loaderMutex;
+	std::condition_variable loaderCV;
 
 	void logInfos();
 	static void toggleForceCloseButton();

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -22,8 +22,13 @@ Dispatcher &Dispatcher::getInstance() {
 void Dispatcher::init() {
 	UPDATE_OTSYS_TIME();
 
-	threadPool.detach_task([this] {
+	auto dispatcherStarted = std::make_shared<std::promise<void>>();
+	auto futureStarted = dispatcherStarted->get_future();
+
+	threadPool.detach_task([this, dispatcherStarted]() mutable {
 		std::unique_lock asyncLock(dummyMutex);
+
+		dispatcherStarted->set_value();
 
 		while (!threadPool.isStopped()) {
 			UPDATE_OTSYS_TIME();
@@ -37,6 +42,10 @@ void Dispatcher::init() {
 			}
 		}
 	});
+
+	if (futureStarted.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
+		throw std::runtime_error("Failed to initialize dispatcher: timeout waiting for thread start");
+	}
 }
 
 void Dispatcher::executeSerialEvents(const uint8_t groupId) {

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -44,7 +44,7 @@ void Dispatcher::init() {
 	});
 
 	if (futureStarted.wait_for(std::chrono::seconds(5)) != std::future_status::ready) {
-		throw std::runtime_error("Failed to initialize dispatcher: timeout waiting for thread start");
+		throw std::logic_error("Failed to initialize dispatcher: timeout waiting for thread start");
 	}
 }
 


### PR DESCRIPTION
Add dispatcher start validation and loading monitoring
This fixes a loop in the server start (breaks on "Running with 16 threads." step)

Dispatcher:
• Added promise/future in init() to ensure dispatcher thread is fully started before proceeding.
• Added 5s timeout when waiting for dispatcher initialization.

CanaryServer
• Replaced blocking wait() on LoaderStatus with an active wait loop.
• Added soft warning logs every 2 minutes during startup.
• Added a 10 minutes startup timeout with graceful shutdown on failure.
• Minor cleanup in load order and improved robustness of server start sequence.

Overall: server startup is now safer, with better feedback if the process is slow or stuck.
