### PR TITLE
fix: teleport effect when using rope's and shovel's

### DIFF
--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -323,7 +323,7 @@ function onUseRope(player, item, fromPosition, target, toPosition, isHotkey)
 
 	local tile = Tile(toPosition)
 	if tile and tile:isRopeSpot() then
-		player:teleportTo(toPosition:moveUpstairs())
+		player:teleportTo(toPosition:moveUpstairs(), true)
 		if target.itemid == 7762 then
 			if player:getStorageValue(Storage.Quest.U8_2.TheBeginningQuest.TutorialHintsStorage) < 22 then
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have successfully used your rope to climb out of the hole. Congratulations! Now continue to the east.")
@@ -406,7 +406,7 @@ function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 			player:sendCancelMessage(RETURNVALUE_PLAYERISPZLOCKED)
 			return true
 		end
-		player:teleportTo(toPosition, false)
+		player:teleportTo(toPosition, true)
 		player:addAchievementProgress("The Undertaker", 500)
 	elseif target.itemid == 1822 and target:getPosition() == Position(33222, 31100, 7) then
 		player:teleportTo(Position(33223, 31100, 8))


### PR DESCRIPTION
# Description

After PR #3066  was merged, I noticed that when using rope or shovel in any hole, a teleport effect occurs, which does not normally happen in Global. I made an adjustment so that this does not happen anymore specifically when using these items. I'm not sure what other files could be changed or other items that should also be checked (e.g. pick or Secret Service pocket knives).

## Behaviour
### **Actual**

When using a rope or a shovel, a teleport visual effect occurs.

### **Expected**

When using these items, no effect should appear.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

I used Rope, Magic Rope, Shovel and Light Shovel to go up and down floors, the effect no longer happened.
Other forms of locomotion were not changed, such as stairs, manholes and boat trips.

**Test Configuration**:

  - Server Version: 3.1.2
  - Client: 13:40
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
