### PR TITLE
fix: ebb and flow memory leak

### DIFF
--- a/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -1,3 +1,5 @@
+local eventCallbacks = {}
+
 local function updateWaterPoolsSize()
 	for _, pos in ipairs(SoulWarQuest.ebbAndFlow.poolPositions) do
 		local tile = Tile(pos)
@@ -5,19 +7,51 @@ local function updateWaterPoolsSize()
 			local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
 			if item then
 				item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
-				-- Starts another timer for filling after an additional 40 seconds
-				addEvent(function()
-					local item = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
-					if item then
-						item:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
+				local eventId = addEvent(function()
+					local tile = Tile(pos)
+					if tile then
+						local item = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
+						if item then
+							item:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
+						end
 					end
 				end, 40000) -- 40 seconds
+				
+				-- Store the event ID for new cleanup
+				if not SoulWarQuest.ebbAndFlow.pendingEvents then
+					SoulWarQuest.ebbAndFlow.pendingEvents = {}
+				end
+				table.insert(SoulWarQuest.ebbAndFlow.pendingEvents, eventId)
 			end
 		end
 	end
 end
 
+-- Helper function to clear all pending events
+local function clearPendingEvents()
+	if SoulWarQuest.ebbAndFlow.pendingEvents then
+		for _, eventId in ipairs(SoulWarQuest.ebbAndFlow.pendingEvents) do
+			stopEvent(eventId)
+		end
+		SoulWarQuest.ebbAndFlow.pendingEvents = {}
+	end
+end
+
+-- Helper function to unregister all event callbacks
+local function unregisterEventCallbacks()
+	for name, callback in pairs(eventCallbacks) do
+		if callback and callback.unregister then
+			callback:unregister()
+		end
+	end
+	eventCallbacks = {}
+end
+
 local function loadMapEmpty()
+	-- Clean up previous events before loading a new map
+	clearPendingEvents()
+	unregisterEventCallbacks()
+	
 	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
 	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
 	if playersInZone > 0 or monstersInZone > 0 then
@@ -55,11 +89,17 @@ local function loadMapEmpty()
 	end
 
 	updatePlayers:register()
+	-- Store reference for later cleanup
+	eventCallbacks["UpdatePlayersEmptyEbbFlowMap"] = updatePlayers
 
-	addEvent(function()
-		-- Change the appearance of puddles to indicate the next filling
+	local eventId = addEvent(function()
 		updateWaterPoolsSize()
 	end, 80000) -- 80 seconds
+	
+	if not SoulWarQuest.ebbAndFlow.pendingEvents then
+		SoulWarQuest.ebbAndFlow.pendingEvents = {}
+	end
+	table.insert(SoulWarQuest.ebbAndFlow.pendingEvents, eventId)
 end
 
 local function getDistance(pos1, pos2)
@@ -80,6 +120,9 @@ local function findNearestRoomPosition(playerPosition)
 end
 
 local function loadMapInundate()
+	clearPendingEvents()
+	unregisterEventCallbacks()
+	
 	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
 	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
 	if playersInZone > 0 or monstersInZone > 0 then
@@ -121,11 +164,14 @@ local function loadMapInundate()
 	end
 
 	updatePlayers:register()
+	eventCallbacks["UpdatePlayersInundateEbbFlowMap"] = updatePlayers
 end
 
 local loadEmptyMap = GlobalEvent("SoulWarQuest.ebbAndFlow")
 
 function loadEmptyMap.onStartup()
+	SoulWarQuest.ebbAndFlow.pendingEvents = {}
+	
 	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
 	loadMapEmpty()
 	SoulWarQuest.ebbAndFlow.updateZonePlayers()
@@ -149,3 +195,13 @@ end
 
 eddAndFlowInundate:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
 eddAndFlowInundate:register()
+
+local cleanupOnSave = GlobalEvent("EbbFlowCleanupOnSave")
+
+function cleanupOnSave.onSave()
+	clearPendingEvents()
+	unregisterEventCallbacks()
+	return true
+end
+
+cleanupOnSave:register()

--- a/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-otservbr-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -16,7 +16,7 @@ local function updateWaterPoolsSize()
 						end
 					end
 				end, 40000) -- 40 seconds
-				
+
 				-- Store the event ID for new cleanup
 				if not SoulWarQuest.ebbAndFlow.pendingEvents then
 					SoulWarQuest.ebbAndFlow.pendingEvents = {}
@@ -51,7 +51,7 @@ local function loadMapEmpty()
 	-- Clean up previous events before loading a new map
 	clearPendingEvents()
 	unregisterEventCallbacks()
-	
+
 	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
 	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
 	if playersInZone > 0 or monstersInZone > 0 then
@@ -95,7 +95,7 @@ local function loadMapEmpty()
 	local eventId = addEvent(function()
 		updateWaterPoolsSize()
 	end, 80000) -- 80 seconds
-	
+
 	if not SoulWarQuest.ebbAndFlow.pendingEvents then
 		SoulWarQuest.ebbAndFlow.pendingEvents = {}
 	end
@@ -122,7 +122,7 @@ end
 local function loadMapInundate()
 	clearPendingEvents()
 	unregisterEventCallbacks()
-	
+
 	local playersInZone = SoulWarQuest.ebbAndFlow.getZone():countPlayers()
 	local monstersInZone = SoulWarQuest.ebbAndFlow.getZone():countMonsters()
 	if playersInZone > 0 or monstersInZone > 0 then
@@ -171,7 +171,7 @@ local loadEmptyMap = GlobalEvent("SoulWarQuest.ebbAndFlow")
 
 function loadEmptyMap.onStartup()
 	SoulWarQuest.ebbAndFlow.pendingEvents = {}
-	
+
 	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
 	loadMapEmpty()
 	SoulWarQuest.ebbAndFlow.updateZonePlayers()


### PR DESCRIPTION
# Description

This PR addresses a critical memory leak in the Ebb and Flow map system that occurs over time. The memory leak manifests especially with the default Canary packet size (25), causing server instability during extended runtime and even a crash.

This will also maintain the possibility of staying with 25 packet per second and maintaining all functionalities the same way it was.

## Behaviour
### **Actual**

When map changes, there is memory leak causing players to disconnect and/or crash the server.

### **Expected**

With this changes you can go in ebb regardless of where you are standing you will not lag or the server crashing due memory leak.

### Fixes #3373

## Changes

### Event Callback Management
- Implemented a tracking system for event callbacks in a centralized table
- Added `unregisterEventCallbacks()` function to properly clean up registered callbacks before loading new maps
- Prevented accumulation of registered callbacks during map transitions

### Timer Event Management
- Created a tracking system for all `addEvent()` timer IDs in `SoulWarQuest.ebbAndFlow.pendingEvents`
- Implemented `clearPendingEvents()` function to cancel pending timers before loading new maps
- Eliminated orphaned timers that were previously continuing to run and consume memory

### Enhanced Cleanup Mechanisms
- Added systematic cleanup routines that execute before each map change
- Created a dedicated cleanup function tied to server saves to ensure periodic resource freeing

### Scope and Reference Improvements
- Refreshed tile references within timers to avoid keeping references to outdated objects
- Fixed scope issues in anonymous functions to prevent capturing variables unnecessarily

## Alternative Approaches Considered
While increasing the packet size was considered as a potential workaround, this PR addresses the root cause of the memory leak through resource management, which is the preferred long-term solution.

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] God Account / Normal Account
  - [X] On rafts
  - [X] In Rooms
  - [X] Hallways and floor+1

**Test Configuration**:

  - Server Version: Most Recent.
  - Client: 14.05
  - Operating System: Linux / Windows.

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [X] I have commented my code, particularly in new areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
