### PR TITLE
fix: rahemos tomb

### DIFF
--- a/data-otservbr-global/scripts/quests/the_ancient_tombs/actions_oasis_lever_door.lua
+++ b/data-otservbr-global/scripts/quests/the_ancient_tombs/actions_oasis_lever_door.lua
@@ -15,7 +15,7 @@ end
 local theAncientOasisLever = Action()
 function theAncientOasisLever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 1662 then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You first must find the Carrot under one of the three hats to get the access!")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You first must find the Carrot under one of the three hats to get the access!")		
 		return true
 	end
 
@@ -28,15 +28,19 @@ function theAncientOasisLever.onUse(player, item, fromPosition, target, toPositi
 		hatPosition:sendMagicEffect(CONST_ME_MAGIC_GREEN)
 		doorPosition:sendMagicEffect(CONST_ME_MAGIC_GREEN)
 		Game.createItem(3595, 1, hatPosition)
+		player:setStorageValue(Storage.Quest.U7_4.TheAncientTombs.RahemosTreasure, 1)
+	-- AID Door changer
+		item:setActionId(12108)
+
+	-- TEMPORARY SOLUTION / AID FOR THE DOOR MUST BE CHANGED FROM 1207 TO 1208 / It could also stay like this to make the mechanic to be more alike
+	local doorItem = Tile(doorPosition):getItemById(1662)
+		if doorItem then
+			doorItem:setActionId(12108)
+		end
 
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You found the carrot! The door is open!")
 		item:transform(2773)
 		addEvent(revertCarrotAndLever, 4 * 1000, toPosition, hatPosition)
-
-		local doorItem = Tile(doorPosition):getItemById(1662)
-		if doorItem then
-			doorItem:transform(1663)
-		end
 		return true
 	end
 

--- a/data-otservbr-global/scripts/quests/the_ancient_tombs/actions_oasis_lever_door.lua
+++ b/data-otservbr-global/scripts/quests/the_ancient_tombs/actions_oasis_lever_door.lua
@@ -15,7 +15,7 @@ end
 local theAncientOasisLever = Action()
 function theAncientOasisLever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 1662 then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You first must find the Carrot under one of the three hats to get the access!")		
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You first must find the Carrot under one of the three hats to get the access!")
 		return true
 	end
 
@@ -29,11 +29,11 @@ function theAncientOasisLever.onUse(player, item, fromPosition, target, toPositi
 		doorPosition:sendMagicEffect(CONST_ME_MAGIC_GREEN)
 		Game.createItem(3595, 1, hatPosition)
 		player:setStorageValue(Storage.Quest.U7_4.TheAncientTombs.RahemosTreasure, 1)
-	-- AID Door changer
+		-- AID Door changer
 		item:setActionId(12108)
 
-	-- TEMPORARY SOLUTION / AID FOR THE DOOR MUST BE CHANGED FROM 1207 TO 1208 / It could also stay like this to make the mechanic to be more alike
-	local doorItem = Tile(doorPosition):getItemById(1662)
+		-- TEMPORARY SOLUTION / AID FOR THE DOOR MUST BE CHANGED FROM 1207 TO 1208 / It could also stay like this to make the mechanic to be more alike
+		local doorItem = Tile(doorPosition):getItemById(1662)
 		if doorItem then
 			doorItem:setActionId(12108)
 		end


### PR DESCRIPTION
# Description

This PR fixes the rahemos tomb door/lever/teleport.
As a temporary fix im changing the aid to the door itself. there was a conflict between lever/door, we could change the actionid of the door to 12108 and we could simplify the script, but having like this has the mechanics from global. so it might not be necessary.

## Behaviour
### **Actual**

Before the tomb couldn't be accessed at all

### **Expected**

Now everything should work as expected. Following the spoiler.

### Fixes #3453

## Changes:

- Sets storage when getting the carrot
- Changes aid on door due conflict with the lever
- Teleport to the tomb work as expected using the right storage.

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Tested with GOD Account
  - [X] Tested with Normal Account

**Test Configuration**:

  - Server Version: Most Recent
  - Client: 14.05
  - Operating System: Windows / Linux

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
