### PR TITLE
fix: the ape city quest mission 7

### DIFF
--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -918,15 +918,15 @@ function onUseCrowbar(player, item, fromPosition, target, toPosition, isHotkey)
 				player:setStorageValue(Storage.Quest.U7_24.ThePostmanMissions.Mission02, 2)
 				toPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 			end
-		elseif target:getActionId() == 40041 and target.itemid == 4848 then
-			-- The ape city - mission 7
-			local apeCityStorage = player:getStorageValue(Storage.Quest.U7_6.TheApeCity.Casks)
-			if apeCityStorage < 3 then
-				player:setStorageValue(Storage.Quest.U7_6.TheApeCity.Casks, math.max(0, apeCityStorage) + 1)
-				target:transform(3134)
-				toPosition:sendMagicEffect(CONST_ME_EXPLOSIONAREA)
-				addEvent(revertCask, 3 * 60 * 1000, toPosition)
-			end
+		end
+	elseif target:getActionId() == 40041 and target.itemid == 4848 then
+		-- The ape city - mission 7
+		local apeCityStorage = player:getStorageValue(Storage.Quest.U7_6.TheApeCity.Casks)
+		if apeCityStorage < 3 then
+			player:setStorageValue(Storage.Quest.U7_6.TheApeCity.Casks, math.max(0, apeCityStorage) + 1)
+			target:transform(3134)
+			toPosition:sendMagicEffect(CONST_ME_EXPLOSIONAREA)
+			addEvent(revertCask, 3 * 60 * 1000, toPosition)
 		end
 	elseif target.actionid == 12566 and player:getStorageValue(Storage.Quest.U8_1.SecretService.TBIMission06) == 1 then
 		-- Secret service quest


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

The player cannot destroy the barrels in mission 7 of Ape City with a crowbar.

### **Expected**

The player should be able to destroy the barrels with a crowbar.

### Fixes #issuenumber
Resolves #3498 

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
    position :  32859, 32496, 9   used storage: 40613,13  and  40619,1
    I added storage that you receive when you take mission 7, and after entering through the door, I was able to destroy the 
    barrels, complete the mission, and take the next one.
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.05
  - Client: 14.05
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
