### PR TITLE
fix The Hidden City of Beregar quest

### DIFF
--- a/data/scripts/actions/tools/pick.lua
+++ b/data/scripts/actions/tools/pick.lua
@@ -4,5 +4,5 @@ function pick.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	return onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 end
 
-pick:id(3456)
+pick:id(31615)
 pick:register()


### PR DESCRIPTION
# Description

The pick ID is incorrect, which causes an error in The Hidden City of Beregar and maybe in other places
fix: https://github.com/opentibiabr/canary/issues/3534

## Behaviour
### **Actual**

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Once you have the correct storage, when you use the pickaxe, the hole will open, now it is possible.

  - Server Version: last
  - Client: 14.05
  - Operating System: ubuntu

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports

