### PR TITLE
fix: critical damage in single target

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2352,10 +2352,8 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 			// If is single target, apply the damage directly
 			if (isSingleCombat) {
 				damage = targetDamage;
-				continue;
 			}
 
-			// If is multi target, apply the damage to each target
 			targetCreature->setCombatDamage(targetDamage);
 		}
 	} else if (monster) {


### PR DESCRIPTION
# Description

This change fixes a bug where spells (especially AoE) would occasionally not apply any damage when the caster and the target were the only entities on screen. This occurred due to missing critical damage propagation when only one target was present in the area.

## Behaviour
### **Actual**

When casting a spell with only one creature in range (e.g., a single boss), the damage would sometimes not be applied at all, especially if the combat was supposed to apply critical or fatal bonuses.

### **Expected**

Damage (including critical/fatal) is applied properly regardless of the number of affected targets. Single-target spells and AoEs with one target now work consistently.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Casted AoE spells in an empty area with only one boss and verified the damage applied properly
  - [x] Tested with and without critical/fatal chance
  - [x] Reproduced the bug on previous version and confirmed it's fixed with the patch

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
