### PR TITLE
 fix: use-after-free in Lua garbage collection of shared objects

### DIFF
--- a/src/lua/functions/lua_functions_loader.cpp
+++ b/src/lua/functions/lua_functions_loader.cpp
@@ -810,7 +810,7 @@ void Lua::registerSharedClass(lua_State* L, const std::string &className, const 
 int Lua::luaGarbageCollection(lua_State* L) {
 	const auto objPtr = static_cast<std::shared_ptr<SharedObject>*>(lua_touserdata(L, 1));
 	if (objPtr) {
-		objPtr->reset();
+		objPtr->~shared_ptr<SharedObject>();
 	}
 	return 0;
 }


### PR DESCRIPTION
This fixes a critical use-after-free issue caused by the premature destruction of SharedObject instances managed via std::shared_ptr during Lua’s __gc finalization.

Previously, the luaGarbageCollection function called reset() directly on the shared pointer, which could destroy the underlying object while it was still in use by C++ code — potentially leading to heap corruption and runtime crashes.

[crash_gc.log](https://github.com/user-attachments/files/20469783/crash_gc.log)

Changes:

- Replaces objPtr->reset() with an explicit call to the shared pointer's destructor, ensuring that destruction only occurs when the object is no longer in use.
- Prevents undefined behavior and improves memory safety when integrating shared C++ objects with Lua.

# Description

This change resolves a memory safety issue involving Lua-managed shared C++ objects (`SharedObject`). 
The root cause was `reset()` being called from `__gc`, which could deallocate the object while still in use elsewhere in the engine.
This patch ensures proper destruction sequencing without breaking Lua integration.

## Behaviour
### **Actual**

Lua garbage collector frees shared object immediately via `reset()`, causing use-after-free when accessed later in C++.

### **Expected**

Lua triggers cleanup, but actual object is only destroyed when no references remain, preventing invalid memory access.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested

  - [x] Reproduced crash scenario with Lua shared object garbage collection
  - [x] Verified object lifecycle no longer triggers premature destruction
  - [x] Ran Canary server and Lua interaction scripts without crash or heap errors

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
