### PR TITLE
fix: ensure stats are only applied when imbuement is successfully added

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -34,6 +34,7 @@
 #include "game/game.hpp"
 #include "game/modal_window/modal_window.hpp"
 #include "game/scheduling/dispatcher.hpp"
+
 #include "game/scheduling/save_manager.hpp"
 #include "game/scheduling/task.hpp"
 #include "grouping/familiars.hpp"
@@ -2321,6 +2322,12 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 				return;
 			}
 		}
+
+		if (imbuementInfo.imbuement == imbuement) {
+			g_logger().error("[Player::onApplyImbuement] - Duplicate imbuement application detected for '{}'", imbuement->getName());
+			sendImbuementResult("This imbuement is already applied to this item.");
+			return;
+		}
 	}
 
 	const auto &items = imbuement->getItems();
@@ -2381,9 +2388,13 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 	if (canAddImbuement) {
 		// Update imbuement stats item if the item is equipped
 		if (item->getParent() == thisPlayer) {
-			addItemImbuementStats(imbuement);
+		    ImbuementInfo oldImb;
+		    if (item->getImbuementInfo(slot, &oldImb) && oldImb.imbuement) {
+		        removeItemImbuementStats(oldImb.imbuement);
+		    }
+		
+		    addItemImbuementStats(imbuement);
 		}
-
 		item->setImbuement(slot, imbuement->getID(), baseImbuement->duration);
 	}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2388,12 +2388,12 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 	if (canAddImbuement) {
 		// Update imbuement stats item if the item is equipped
 		if (item->getParent() == thisPlayer) {
-		    ImbuementInfo oldImb;
-		    if (item->getImbuementInfo(slot, &oldImb) && oldImb.imbuement) {
-		        removeItemImbuementStats(oldImb.imbuement);
-		    }
-		
-		    addItemImbuementStats(imbuement);
+			ImbuementInfo oldImb;
+			if (item->getImbuementInfo(slot, &oldImb) && oldImb.imbuement) {
+				removeItemImbuementStats(oldImb.imbuement);
+			}
+
+			addItemImbuementStats(imbuement);
 		}
 		item->setImbuement(slot, imbuement->getID(), baseImbuement->duration);
 	}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2380,7 +2380,7 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 
 	if (canAddImbuement) {
 		// Update imbuement stats item if the item is equipped
-		if (item->getParent() == getPlayer()) {
+		if (item->getParent() == thisPlayer) {
 			addItemImbuementStats(imbuement);
 		}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2378,7 +2378,6 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 		return;
 	}
 
-
 	if (canAddImbuement) {
 		// Update imbuement stats item if the item is equipped
 		if (item->getParent() == getPlayer()) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2295,10 +2295,9 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 		return;
 	}
 
-	auto itemSlots = item->getImbuementSlot();
-	if (slot >= itemSlots) {
-		g_logger().error("[Player::onApplyImbuement] - Player {} attempted to apply imbuement in an invalid slot ({})", this->getName(), slot);
-		this->sendImbuementResult("Invalid slot selection.");
+	const auto &thisPlayer = getPlayer();
+	bool canAddImbuement = item->canAddImbuement(slot, thisPlayer, imbuement);
+	if (!canAddImbuement) {
 		return;
 	}
 
@@ -2327,7 +2326,7 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 	const auto &items = imbuement->getItems();
 	for (auto &[key, value] : items) {
 		const ItemType &itemType = Item::items[key];
-		if (static_self_cast<Player>()->getItemTypeCount(key) + this->getStashItemCount(itemType.id) < value) {
+		if (getItemTypeCount(key) + this->getStashItemCount(itemType.id) < value) {
 			this->sendImbuementResult("You don't have all necessary items.");
 			return;
 		}
@@ -2341,7 +2340,7 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 	uint32_t price = baseImbuement->price;
 	price += protectionCharm ? baseImbuement->protectionPrice : 0;
 
-	if (!g_game().removeMoney(static_self_cast<Player>(), price, 0, true)) {
+	if (!g_game().removeMoney(thisPlayer, price, 0, true)) {
 		const std::string message = fmt::format("You don't have {} gold coins.", price);
 
 		g_logger().error("[Player::onApplyImbuement] - An error occurred while player with name {} try to apply imbuement, player do not have money", this->getName());
@@ -2379,12 +2378,16 @@ void Player::onApplyImbuement(const Imbuement* imbuement, const std::shared_ptr<
 		return;
 	}
 
-	// Update imbuement stats item if the item is equipped
-	if (item->getParent() == getPlayer()) {
-		addItemImbuementStats(imbuement);
+
+	if (canAddImbuement) {
+		// Update imbuement stats item if the item is equipped
+		if (item->getParent() == getPlayer()) {
+			addItemImbuementStats(imbuement);
+		}
+
+		item->setImbuement(slot, imbuement->getID(), baseImbuement->duration);
 	}
 
-	item->addImbuement(slot, imbuement->getID(), baseImbuement->duration);
 	openImbuementWindow(item);
 }
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -133,32 +133,28 @@ void Item::setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 	setCustomAttribute(std::to_string(ITEM_IMBUEMENT_SLOT + slot), valueDuration);
 }
 
-void Item::addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
-	const auto &player = getHoldingPlayer();
-	if (!player) {
-		return;
-	}
-
-	// Get imbuement by the id
-	const Imbuement* imbuement = g_imbuements().getImbuement(imbuementId);
-	if (!imbuement) {
-		return;
+bool Item::canAddImbuement(uint8_t slot, const std::shared_ptr<Player> &player, const Imbuement *imbuement) {
+	auto itemSlots = getImbuementSlot();
+	if (itemSlots == 0 || slot >= itemSlots) {
+		g_logger().error("[Player::onApplyImbuement] - Player {} attempted to apply imbuement in an invalid slot ({})", player->getName(), slot);
+		player->sendImbuementResult("Invalid slot selection.");
+		return false;
 	}
 
 	// Get category imbuement for acess category id
 	const CategoryImbuement* categoryImbuement = g_imbuements().getCategoryByID(imbuement->getCategory());
 	if (!hasImbuementType(static_cast<ImbuementTypes_t>(categoryImbuement->id), imbuement->getBaseID())) {
-		return;
+		return false;
 	}
 
 	// Checks if the item already has the imbuement category id
 	if (hasImbuementCategoryId(categoryImbuement->id)) {
 		g_logger().error("[Item::setImbuement] - An error occurred while player with name {} try to apply imbuement, item already contains imbuement of the same type: {}", player->getName(), imbuement->getName());
 		player->sendImbuementResult("An error ocurred, please reopen imbuement window.");
-		return;
+		return false;
 	}
 
-	setImbuement(slot, imbuementId, duration);
+	return true;
 }
 
 bool Item::hasImbuementCategoryId(uint16_t categoryId) const {

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -133,7 +133,7 @@ void Item::setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration) {
 	setCustomAttribute(std::to_string(ITEM_IMBUEMENT_SLOT + slot), valueDuration);
 }
 
-bool Item::canAddImbuement(uint8_t slot, const std::shared_ptr<Player> &player, const Imbuement *imbuement) {
+bool Item::canAddImbuement(uint8_t slot, const std::shared_ptr<Player> &player, const Imbuement* imbuement) {
 	auto itemSlots = getImbuementSlot();
 	if (itemSlots == 0 || slot >= itemSlots) {
 		g_logger().error("[Player::onApplyImbuement] - Player {} attempted to apply imbuement in an invalid slot ({})", player->getName(), slot);

--- a/src/items/item.hpp
+++ b/src/items/item.hpp
@@ -661,7 +661,7 @@ public:
 	 * @return false
 	 */
 	bool getImbuementInfo(uint8_t slot, ImbuementInfo* imbuementInfo) const;
-	void addImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);
+	bool canAddImbuement(uint8_t slot, const std::shared_ptr<Player> &player, const Imbuement* imbuement);
 	/**
 	 * @brief Decay imbuement time duration, only use this for decay the imbuement time
 	 *
@@ -675,6 +675,7 @@ public:
 	void clearImbuement(uint8_t slot, uint16_t imbuementId) {
 		return setImbuement(slot, imbuementId, 0);
 	}
+	void setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);
 	bool hasImbuementType(ImbuementTypes_t imbuementType, uint16_t imbuementTier) const {
 		const auto it = items[id].imbuementTypes.find(imbuementType);
 		if (it != items[id].imbuementTypes.end()) {
@@ -733,7 +734,6 @@ protected:
 	bool m_hasActor = false;
 
 private:
-	void setImbuement(uint8_t slot, uint16_t imbuementId, uint32_t duration);
 	// Don't add variables here, use the ItemAttribute class.
 	std::string getWeightDescription(uint32_t weight) const;
 


### PR DESCRIPTION
Apply stat bonuses only after confirming that the imbuement has been successfully added to the item.

Previously, the stat effects were applied independently of the imbuement result, allowing bonuses to be granted even when the imbuement failed—such as due to chance or item incompatibility.

# Description

This change ensures that stat bonuses from imbuements are only applied after the imbuement is successfully added to the item. It fixes a bug where players could receive stat bonuses without actually having the imbuement applied, such as when using no protection charm and the imbuement fails.

## Behaviour
### **Actual**

Imbuement stats are applied even if the imbuement fails or is rejected.

### **Expected**

Stats are only applied if the imbuement is actually added to the item.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Manual testing was performed by attempting to apply imbuements with and without protection charms, and checking the resulting stats only when success occurs.

  - [x] Tested imbuement success case
  - [x] Tested imbuement fail case with and without protection charm
  - [x] Tested application on compatible and incompatible items

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
