### PR TITLE
feat: drop connection with talkaction (!fps)

### DIFF
--- a/data/scripts/talkactions/player/fps.lua
+++ b/data/scripts/talkactions/player/fps.lua
@@ -1,0 +1,15 @@
+local fps = TalkAction("!fps")
+
+function fps.onSay(player, words, param)
+    if player:hasExhaustion("fps-cooldown") then
+        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You need to wait 10 seconds before using it again.")
+        return false
+    end
+
+    player:setExhaustion("fps-cooldown", 10)
+	player:dropConnection()
+	return true
+end
+
+fps:groupType("normal")
+fps:register()

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -410,6 +410,9 @@ void PlayerFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Player", "removeCustomOutfit", PlayerFunctions::luaPlayerRemoveCustomOutfit);
 	Lua::registerMethod(L, "Player", "addCustomOutfit", PlayerFunctions::luaPlayerAddCustomOutfit);
 
+	// !fps
+	Lua::registerMethod(L, "Player", "dropConnection", PlayerFunctions::luaPlayerDropConnection);
+
 	GroupFunctions::init(L);
 	GuildFunctions::init(L);
 	MountFunctions::init(L);
@@ -4985,5 +4988,15 @@ int PlayerFunctions::luaPlayerRemoveCustomOutfit(lua_State* L) {
 	}
 
 	Lua::pushBoolean(L, player->attachedEffects().removeCustomOutfit(type, idOrName));
+	return 1;
+}
+
+int PlayerFunctions::luaPlayerDropConnection(lua_State* L) {
+    std::shared_ptr<Player> player = Lua::getUserdataShared<Player>(L, 1);
+	if (player) {
+		player->disconnect();
+	} else {
+		lua_pushnil(L);
+	}
 	return 1;
 }

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -392,6 +392,6 @@ class PlayerFunctions {
 	static int luaPlayerSetMapShader(lua_State* L);
 	static int luaPlayerAddCustomOutfit(lua_State* L);
 	static int luaPlayerRemoveCustomOutfit(lua_State* L);
-
+	static int luaPlayerDropConnection(lua_State* L);
 	friend class CreatureFunctions;
 };


### PR DESCRIPTION
### Feature: DropConnection Command

Adiciona o comando !fps que derruba a conexão do jogador para fins de limpeza de cache ou melhoria de desempenho.
nem todos servidores tem a necessidade desta feature.

#### Mudanças:
- Adiciona talkaction `fps.lua`
- Cria método `dropConnection()` em `Player`
