### PR TITLE
fix: podium of renown description

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4464,7 +4464,7 @@ void Game::playerSetShowOffSocket(uint32_t playerId, Outfit_t &outfit, const Pos
 	// Change Podium name
 	if (outfit.lookType != 0 || outfit.lookMount != 0) {
 		std::ostringstream name;
-		name << item->getName() << " displaying the ";
+		name << Item::items[item->getID()].name << " displaying the ";
 		bool outfited = false;
 		if (outfit.lookType != 0) {
 			const auto &outfitInfo = Outfits::getInstance().getOutfitByLookType(player, outfit.lookType);


### PR DESCRIPTION
# Description

This PR addresses an issue where the item name "Podium of Renown" was accumulating as a player changed the displayed outfit.

## Behaviour
### **Actual**
The item's name would repeatedly append itself (e.g., "Podium of Renown showing Citizen") when the player changed its outfit.
![image](https://github.com/user-attachments/assets/87246540-f5fe-48ce-89af-02143ce7367c)

### **Expected**
The item's name should display correctly and consistently, regardless of outfit changes.
![image](https://github.com/user-attachments/assets/2c66167b-1717-4843-9590-6efda0a0281c)

(After changing it again..)
![image](https://github.com/user-attachments/assets/d786cbb2-7b73-4c4c-ab5d-bc7a7ebed48e)


## Type of change
  - [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Create a Podium of Renown inside a house and change its outfit twice.

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove my fix is effective or that my feature works
