### PR TITLE
fix: condition suppression removal logic on equip/de-equip

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -269,17 +269,38 @@ bool Player::isSuppress(ConditionType_t conditionType, bool attackerPlayer) cons
 		return true;
 	}
 
-	return m_conditionSuppressions[static_cast<size_t>(conditionType)];
+	auto conditionId = static_cast<size_t>(conditionType);
+	return (m_conditionSuppressionCount[conditionId] > 0);
 }
 
 void Player::addConditionSuppressions(const std::array<ConditionType_t, ConditionType_t::CONDITION_COUNT> &addConditions) {
-	for (const auto &conditionType : addConditions) {
-		m_conditionSuppressions[static_cast<size_t>(conditionType)] = true;
+	for (auto conditionType : addConditions) {
+		auto conditionId = static_cast<size_t>(conditionType);
+		if (conditionId >= ConditionType_t::CONDITION_COUNT) {
+			continue;
+		}
+		if (m_conditionSuppressionCount[conditionId] < UINT8_MAX) {
+			m_conditionSuppressionCount[conditionId]++;
+		}
 	}
 }
 
-void Player::removeConditionSuppressions() {
-	m_conditionSuppressions.reset();
+void Player::removeConditionSuppressions(const std::vector<ConditionType_t> &toRemoveConditions) {
+	for (auto conditionType : toRemoveConditions) {
+		if (conditionType == ConditionType_t::CONDITION_NONE) {
+			continue;
+		}
+		auto conditionSize = static_cast<size_t>(conditionType);
+		if (conditionSize >= ConditionType_t::CONDITION_COUNT) {
+			continue;
+		}
+		if (m_conditionSuppressionCount[conditionSize] > 0) {
+			m_conditionSuppressionCount[conditionSize]--;
+			if (m_conditionSuppressionCount[conditionSize] == 0) {
+				sendIcons();
+			}
+		}
+	}
 }
 
 std::shared_ptr<Item> Player::getWeapon(Slots_t slot, bool ignoreAmmo) const {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -561,7 +561,7 @@ public:
 	int32_t getDefaultStats(stats_t stat) const;
 
 	void addConditionSuppressions(const std::array<ConditionType_t, ConditionType_t::CONDITION_COUNT> &addCondition);
-	void removeConditionSuppressions();
+	void removeConditionSuppressions(const std::vector<ConditionType_t> &toRemoveConditions);
 
 	std::shared_ptr<Reward> getReward(uint64_t rewardId, bool autoCreate);
 	void removeReward(uint64_t rewardId);
@@ -1500,7 +1500,7 @@ private:
 
 	std::bitset<CombatType_t::COMBAT_COUNT> m_damageImmunities;
 	std::bitset<ConditionType_t::CONDITION_COUNT> m_conditionImmunities;
-	std::bitset<ConditionType_t::CONDITION_COUNT> m_conditionSuppressions;
+	std::array<uint8_t, ConditionType_t::CONDITION_COUNT> m_conditionSuppressionCount {};
 
 	uint32_t level = 1;
 	uint32_t magLevel = 0;

--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -691,8 +691,17 @@ uint32_t MoveEvent::DeEquipItem(const std::shared_ptr<MoveEvent> &, const std::s
 		g_game().changePlayerSpeed(player, -item->getSpeed());
 	}
 
-	player->removeConditionSuppressions();
-	player->sendIcons();
+	std::vector<ConditionType_t> toRemove;
+	for (auto cond : it.abilities->conditionSuppressions) {
+		if (cond == ConditionType_t::CONDITION_NONE) {
+			continue;
+		}
+		toRemove.emplace_back(cond);
+	}
+	if (!toRemove.empty()) {
+		player->removeConditionSuppressions(toRemove);
+		player->sendIcons();
+	}
 
 	if (it.transformDeEquipTo != 0) {
 		g_game().transformItem(item, it.transformDeEquipTo);


### PR DESCRIPTION
Ensure only relevant condition suppressions are decremented when de-equipping items. Prevents removing suppressions still active from other sources.

Fix: #3267