### PR TITLE
fix: potential deadlocks in KVStore by enforcing safe lock ordering

### DIFF
--- a/src/kv/kv.hpp
+++ b/src/kv/kv.hpp
@@ -87,8 +87,8 @@ public:
 	std::optional<ValueWrapper> get(const std::string &key, bool forceLoad = false) override;
 
 	void flush() override {
-		std::scoped_lock lock(mutex_);
 		KV::flush();
+		std::scoped_lock lock(mutex_);
 		store_.clear();
 	}
 


### PR DESCRIPTION
# Description

This PR fixes potential deadlocks in KVStore caused by lock inversion between KVStore::mutex_ and Database::recursive_mutex.

The change ensures that all database operations (save, load, loadPrefix) are executed outside of the KVStore lock, enforcing a consistent lock hierarchy.

## Behaviour
### **Actual**

Under load, server can deadlock when threads access KVStore while holding Database recursive_mutex, and vice-versa.

### **Expected**

Server no longer deadlocks. All KVStore operations follow safe lock ordering.

### Fixes: [deadlock kv.txt](https://github.com/user-attachments/files/20630521/deadlock.kv.txt)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Manual tests:

- Ran full server under load with high concurrent usage of KVStore and database transactions.
- Confirmed no deadlocks observed after stress testing.

- [x] Test A: Simulated concurrent player logouts and KVStore access.
- [x] Test B: Simulated large database transactions in parallel with KVStore updates.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
