### PR TITLE
fix: docker build

### DIFF
--- a/cmake/modules/BaseConfig.cmake
+++ b/cmake/modules/BaseConfig.cmake
@@ -61,7 +61,7 @@ endif()
 # *****************************************************************************
 # Options
 # *****************************************************************************
-option(TOGGLE_BIN_FOLDER "Use build/bin folder for generate compilation files" OFF)
+option(TOGGLE_BIN_FOLDER "Use build/bin folder for generate compilation files" ON)
 option(OPTIONS_ENABLE_OPENMP "Enable Open Multi-Processing support." ON)
 option(DEBUG_LOG "Enable Debug Log" OFF)
 option(ASAN_ENABLED "Build this target with AddressSanitizer" OFF)


### PR DESCRIPTION
Docker expects the file to be on the bin folder, so we need to keep this option enable otherwise we will have to update the docker files to search for the binary in another place.