### PR TITLE
fix: stamina exploit

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -10741,6 +10741,26 @@ void Game::playerCheckActivity(const std::string &playerName, int interval) {
 		return;
 	}
 
+	if (player->getIP() == 0 && !player->isDead()) {
+		g_logger().info("Player '{}' has no IP and is alive. Scheduling kick in 5 seconds (logout in combat)", player->getName());
+
+		const std::string playerNameCopy = player->getName();
+
+		g_dispatcher().scheduleEvent(
+			5000,
+			[this, playerNameCopy] {
+				const auto& p = getPlayerByName(playerNameCopy);
+				if (p) {
+					removeCreature(p, true);
+					p->disconnect();
+					g_logger().info("Player '{}' was disconnected after 5 seconds delay (logout in combat)", playerNameCopy);
+				}
+			},
+			"Game::playerCheckActivity::kickNoIP"
+		);
+		return;
+	}
+
 	if (player->getIP() == 0) {
 		g_game().removeDeadPlayer(playerName);
 		g_logger().info("Player with name '{}' has logged out due to exited in death screen", player->getName());
@@ -10748,7 +10768,7 @@ void Game::playerCheckActivity(const std::string &playerName, int interval) {
 		return;
 	}
 
-	if (!player->isDead() || player->client == nullptr) {
+	if (!player->isDead() || !player->hasClient()) {
 		return;
 	}
 
@@ -10764,7 +10784,9 @@ void Game::playerCheckActivity(const std::string &playerName, int interval) {
 	}
 
 	g_dispatcher().scheduleEvent(
-		1000, [this, playerName, interval] { playerCheckActivity(playerName, interval); }, "Game::playerCheckActivity"
+		1000,
+		[this, playerName, interval] { playerCheckActivity(playerName, interval); },
+		"Game::playerCheckActivity::recursiveCheck"
 	);
 }
 


### PR DESCRIPTION
# Description

This pull fixes the stamina exploit, when a player (with low stamina) who is in battle against another monster close client with exit being close to death, the monster will stop attacking him for a few seconds and then attack him again and kill the player, when the player logs back into his character, the stamina will be fully recovered
fix: https://github.com/opentibiabr/canary/issues/3576


  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  - Server Version: last
  - Client: 14
  - Operating System: ubuntu

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
