### PR TITLE
fix: add missing column participants in the player_deaths table

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -577,6 +577,7 @@ CREATE TABLE IF NOT EXISTS `player_deaths` (
     `mostdamage_is_player` tinyint(1) NOT NULL DEFAULT '0',
     `unjustified` tinyint(1) NOT NULL DEFAULT '0',
     `mostdamage_unjustified` tinyint(1) NOT NULL DEFAULT '0',
+    `participants` varchar(255) NOT NULL,
     INDEX `player_id` (`player_id`),
     INDEX `killed_by` (`killed_by`),
     INDEX `mostdamage_by` (`mostdamage_by`),


### PR DESCRIPTION
# Description

Adds missing column `participants` in the player_deaths table.

## Behaviour
### **Actual**

Upon death, a mysql error will be thrown about a missing column in player_deaths.

### **Expected**

it should record the death data correctly.

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

  - Server Version: Canary 3.2.1
  - Client: cipsoft 13.40
  - Operating System: Windows
  - AAC: MyAAC 1.5

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works