### PR TITLE
fix: clear player target on logout/removal

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4176,6 +4176,7 @@ void Player::addList() {
 }
 
 void Player::removePlayer(bool displayEffect, bool forced /*= true*/) {
+	setAttackedCreature(nullptr);
 	g_creatureEvents().playerLogout(static_self_cast<Player>());
 	if (client) {
 		client->logout(displayEffect, forced);


### PR DESCRIPTION
Fix #3565