### PR TITLE
fix: teleport nullptr and effect

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -413,6 +413,7 @@ void Map::moveCreature(const std::shared_ptr<Creature> &creature, const std::sha
 	// send to client
 	size_t i = 0;
 	for (const auto &spectator : playersSpectators) {
+		// Use the correct stackpos
 		const int32_t stackpos = oldStackPosVector[i++];
 		if (stackpos != -1) {
 			const auto &player = spectator->getPlayer();


### PR DESCRIPTION
The idea is to avoid a potential nullptr and fix the effect that was being forced on all scripted teleports (like those using UID/AID).
These should respect the effect defined in the script, and not always force CONST_ME_TELEPORT.