### PR TITLE
fix: prevent task flood caused by double OTSYS_TIME() subtraction in action delay

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3422,7 +3422,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 			return;
 		}
 	} else if (!player->canDoAction()) {
-		uint32_t delay = player->getNextActionTime() - OTSYS_TIME();
+		uint32_t delay = player->getNextActionTime();
 		if (delay > 0) {
 			const auto &task = createPlayerTask(
 				delay,


### PR DESCRIPTION
# Description

Fixes a bug where `Game::playerEquipItem` incorrectly subtracted `OTSYS_TIME()` from a delay that had already been normalized inside `Player::getNextActionTime()`.  
This caused negative or extremely large delay values (up to ~28 days), which led to the Dispatcher scheduling massive amounts of future tasks that would never execute.  

Over time, this behavior caused exponential growth in the `Dispatcher::scheduledTasks` queue, consuming memory and degrading server performance.

## Behaviour

### **Actual**

When using equip hotkey while `exhausted`, tasks are scheduled with huge delays and flood the dispatcher queue.

### **Expected**

Only a single delayed task should be scheduled within the correct cooldown interval.

### Fixes

Internal logic flaw – no GitHub issue ID.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

To reproduce:

- Set a high `timeBetweenActions` delay.
- Spam equip hotkey during `exhausted` state.
- Log `Dispatcher::scheduledTasks.size()` or inspect via debugger.
- Observe exponential growth in pending tasks.
- After applying fix, the queue stabilizes as tasks are properly delayed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
