### PR TITLE
fix: fix missing mana regen

### DIFF
--- a/data-otservbr-global/monster/trainers/training_machine.lua
+++ b/data-otservbr-global/monster/trainers/training_machine.lua
@@ -50,6 +50,7 @@ monster.loot = {}
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = -2, maxDamage = -7, attack = 130 },
+	{ name = "combat", type = COMBAT_MANADRAIN, interval = 10000, chance = 100, minDamage = 300, maxDamage = 300, effect = CONST_ME_MAGIC_BLUE },
 }
 
 monster.defenses = {


### PR DESCRIPTION
# Description

fixes mana regen on the training dummy

## Behaviour
### **Actual**

missing mana regen

### **Expected**

should regen mana

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

used in the trainers. it works.

**Test Configuration**:

  - Server Version: Canary 3.21
  - Client: 13.40 Cipsoft
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
