### PR TITLE
fix: avoid duplicated call onrefreshCyclopediaMonsterTracker method

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -839,6 +839,10 @@ bool Player::isBossOnBosstiaryTracker(const std::shared_ptr<MonsterType> &monste
 	return monsterType ? m_bosstiaryMonsterTracker.contains(monsterType) : false;
 }
 
+bool Player::isMonsterOnBestiaryTracker(const std::shared_ptr<MonsterType> &monsterType) const {
+	return monsterType ? m_bestiaryMonsterTracker.contains(monsterType) : false;
+}
+
 std::shared_ptr<Vocation> Player::getVocation() const {
 	return vocation;
 }

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -296,6 +296,8 @@ public:
 
 	bool isBossOnBosstiaryTracker(const std::shared_ptr<MonsterType> &monsterType) const;
 
+	bool isMonsterOnBestiaryTracker(const std::shared_ptr<MonsterType> &monsterType) const;
+
 	std::shared_ptr<Vocation> getVocation() const;
 
 	OperatingSystem_t getOperatingSystem() const;

--- a/src/io/io_bosstiary.cpp
+++ b/src/io/io_bosstiary.cpp
@@ -182,7 +182,9 @@ void IOBosstiary::addBosstiaryKill(const std::shared_ptr<Player> &player, const 
 
 	auto oldBossLevel = getBossCurrentLevel(player, bossId);
 	player->addBestiaryKillCount(bossId, amount);
-	player->refreshCyclopediaMonsterTracker(true);
+	if (player->isBossOnBosstiaryTracker(mtype)) {
+		player->refreshCyclopediaMonsterTracker(true);
+	}
 	auto newBossLevel = getBossCurrentLevel(player, bossId);
 	if (oldBossLevel == newBossLevel) {
 		return;

--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -402,8 +402,10 @@ void IOBestiary::addBestiaryKill(const std::shared_ptr<Player> &player, const st
 		}
 	}
 
-	// Reload bestiary tracker
-	player->refreshCyclopediaMonsterTracker();
+	// Reload bestiary tracker only if the monster is being tracked
+	if (player->isMonsterOnBestiaryTracker(mtype)) {
+		player->refreshCyclopediaMonsterTracker();
+	}
 }
 
 PlayerCharmsByMonster IOBestiary::getCharmFromTarget(const std::shared_ptr<Player> &player, const std::shared_ptr<MonsterType> &mtype, charmCategory_t category /* = CHARM_ALL */) {


### PR DESCRIPTION
# Description

- Introduced a new method isMonsterOnBestiaryTracker to verify if a monster is currently tracked before sending updates
- Updated bestiary and bosstiary kill handlers to refresh the client tracker only when the slain monster is part of the player’s tracking set


## Behaviour
### **Actual**

Each monster slain trigger the `refreshCyclopediaMonsterTracker` method. So, if the player `kill 20 rotworms`, it will call this method 20 times **even though rotworm isn't in tracker set**.

### **Expected**

Only trigger `refreshCyclopediaMonsterTracker` if the player has check `Track Kills` in Cyclopedia -> Bestiary

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
