### PR TITLE
fix: crash on shopPlayers cleanup in closeAllShopWindows

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -817,7 +817,10 @@ void Npc::closeAllShopWindows() {
 		if (player) {
 			player->closeShopWindow();
 		}
-		it = shopPlayers.erase(it);
+	}
+
+	if (!shopPlayers.empty()) {
+		shopPlayers.clear();
 	}
 }
 


### PR DESCRIPTION
Refactors the cleanup logic in Npc::closeAllShopWindows to ensure shopPlayers is cleared only after all player shop windows are closed. This prevents iterator invalidation and ensures proper resource management.

Fixes: [npc_crash.txt](https://github.com/user-attachments/files/20960677/npc_crash.txt)
