### PR TITLE
Fix: Critical hits by monsters

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2409,7 +2409,11 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 
 			targetCreature->setCombatDamage(targetDamage);
 		}
-	} else if (monster) {
+
+		return; // Prevent monster logic from executing
+	}
+
+	if (monster) {
 		baseChance = monster->getCriticalChance() * 100;
 		baseBonus = monster->getCriticalDamage() * 100;
 		baseBonus += damage.criticalDamage;


### PR DESCRIPTION
# Description

Simple fix, adding missing return to prevent monster logic from executing

based on fix suggestion:
https://github.com/opentibiabr/canary/pull/3545#issuecomment-3008901115


## Behaviour
### **Actual**

"When a player casts a spell/attack, the damage calculation incorrectly continues execution into the monster logic section, causing monster critical damage modifiers to be applied on top of player damage calculations. This results in significantly higher damage than intended."

### **Expected**

Proper monster critical damage calculation

### Fixes #issuenumber
https://github.com/opentibiabr/canary/issues/3600
## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

  - Server Version: Canary - Version 3.2.1
  - Client: 14.12
  - Operating System: windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
