### PR TITLE
fix: show more than one creature icon

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2503,20 +2503,27 @@ bool Monster::isChallenged() const {
 }
 
 std::vector<CreatureIcon> Monster::getIcons() const {
+	std::vector<CreatureIcon> icons;
+
 	auto creatureIcons = Creature::getIcons();
-	if (!creatureIcons.empty()) {
-		return creatureIcons;
-	}
+	// this add pre existing icons, such as from forge system
+	icons.insert(icons.end(), creatureIcons.begin(), creatureIcons.end());
 
 	using enum CreatureIconModifications_t;
+
 	if (challengeMeleeDuration > 0 && m_monsterType->info.targetDistance > targetDistance) {
-		return { CreatureIcon(TurnedMelee) };
-	} else if (varBuffs[BUFF_DAMAGERECEIVED] > 100) {
-		return { CreatureIcon(HigherDamageReceived) };
-	} else if (varBuffs[BUFF_DAMAGEDEALT] < 100) {
-		return { CreatureIcon(LowerDamageDealt) };
+		icons.emplace_back(CreatureIcon(TurnedMelee));
 	}
-	return {};
+
+	if (varBuffs[BUFF_DAMAGERECEIVED] > 100) {
+		icons.emplace_back(CreatureIcon(HigherDamageReceived));
+	}
+
+	if (varBuffs[BUFF_DAMAGEDEALT] < 100) {
+		icons.emplace_back(CreatureIcon(LowerDamageDealt));
+	}
+
+	return icons;
 }
 
 bool Monster::isImmune(ConditionType_t conditionType) const {


### PR DESCRIPTION
# Description

This change is intended to improve the visualization of creature icons and make the player's life easier.
## Behaviour
### **Actual**

Today, creature icons only show the last "spell" that player use to debuff/turn melee or if has Influenced/Fiendish do not change to your debuff spell

### **Expected**

Now up to three icons are displayed on monsters (Client limitations) in `ProtocolGame::addCreatureIcon`

[Video Here](https://github.com/user-attachments/assets/db3346e2-fcf4-4ed5-a78e-310297ada1de) 
![image](https://github.com/user-attachments/assets/ab1ba8a3-3458-4064-bf66-ecf59c0e99b5)
![image](https://github.com/user-attachments/assets/1a025974-8c95-4415-92b3-e9a9b4c1b1c4)
![image](https://github.com/user-attachments/assets/1cbae505-ac9c-4e1c-b84a-26614f51d567)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Use two debuff spells and only one it will be display

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings
