### PR TITLE
fix: add tile null checks in combat and spell logic

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -252,7 +252,7 @@ ReturnValue Combat::canTargetCreature(const std::shared_ptr<Player> &player, con
 }
 
 ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Tile> &tile, bool aggressive) {
-	if (!aggressive) {
+	if (!aggressive || !tile) {
 		return RETURNVALUE_NOERROR;
 	}
 

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -556,6 +556,14 @@ bool Spell::playerInstantSpellCheck(const std::shared_ptr<Player> &player, const
 	}
 
 	const auto &tile = g_game().map.getOrCreateTile(toPos);
+	if (!tile) {
+		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
+		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		g_logger().error("[Spell::playerInstantSpellCheck] - Invalid tile at position: {}, player: {}",
+			toPos.toString(), player->getName());
+		return false;
+	}
+
 	if (blockingCreature && tile->getBottomVisibleCreature(player) != nullptr) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -595,6 +603,8 @@ bool Spell::playerRuneSpellCheck(const std::shared_ptr<Player> &player, const Po
 	if (!tile) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
+		g_logger().error("[Spell::playerRuneSpellCheck] - Invalid tile at position: {}, player: {}",
+			toPos.toString(), player->getName());
 		return false;
 	}
 

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -559,8 +559,7 @@ bool Spell::playerInstantSpellCheck(const std::shared_ptr<Player> &player, const
 	if (!tile) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		g_logger().error("[Spell::playerInstantSpellCheck] - Invalid tile at position: {}, player: {}",
-			toPos.toString(), player->getName());
+		g_logger().error("[Spell::playerInstantSpellCheck] - Invalid tile at position: {}, player: {}", toPos.toString(), player->getName());
 		return false;
 	}
 
@@ -603,8 +602,7 @@ bool Spell::playerRuneSpellCheck(const std::shared_ptr<Player> &player, const Po
 	if (!tile) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		g_game().addMagicEffect(player->getPosition(), CONST_ME_POFF);
-		g_logger().error("[Spell::playerRuneSpellCheck] - Invalid tile at position: {}, player: {}",
-			toPos.toString(), player->getName());
+		g_logger().error("[Spell::playerRuneSpellCheck] - Invalid tile at position: {}, player: {}", toPos.toString(), player->getName());
 		return false;
 	}
 


### PR DESCRIPTION
Added explicit null checks for tile pointers in combat and spell functions to prevent invalid access. Improved error handling and logging when spells are cast on invalid tiles, providing better feedback to players and easier debugging.

Fixes: [crash-tile.log](https://github.com/user-attachments/files/21139304/crash-tile.log)
