### PR TITLE
fix: add null and bounds checks in replaceThing method

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -776,6 +776,14 @@ void Container::updateThing(const std::shared_ptr<Thing> &thing, uint16_t itemId
 }
 
 void Container::replaceThing(uint32_t index, const std::shared_ptr<Thing> &thing) {
+	if (!thing) {
+		return;
+	}
+
+	if (index >= itemlist.size()) {
+		return;
+	}
+
 	const auto &item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;


### PR DESCRIPTION
Added checks to ensure the 'thing' pointer is not null and the index is within the bounds of 'itemlist' before proceeding in Container::replaceThing. This prevents potential crashes or undefined behavior due to invalid input.

Fixes: [crash-container-replace-thing.log](https://github.com/user-attachments/files/21148007/crash-container-replace-thing.log)