### PR TITLE
enhancement: add ability to give minor charms to players as god

### DIFF
--- a/data/scripts/talkactions/god/charms.lua
+++ b/data/scripts/talkactions/god/charms.lua
@@ -34,9 +34,9 @@ addCharm:register()
 
 ---------------- // ----------------
 
-local addCharm = TalkAction("/addminorcharms")
+local addMinorCharm = TalkAction("/addminorcharms")
 
-function addCharm.onSay(player, words, param)
+function addMinorCharm.onSay(player, words, param)
 	-- create log
 	logCommand(player, words, param)
 
@@ -64,9 +64,9 @@ function addCharm.onSay(player, words, param)
 	target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 end
 
-addCharm:separator(" ")
-addCharm:groupType("god")
-addCharm:register()
+addMinorCharm:separator(" ")
+addMinorCharm:groupType("god")
+addMinorCharm:register()
 
 ---------------- // ----------------
 

--- a/data/scripts/talkactions/god/charms.lua
+++ b/data/scripts/talkactions/god/charms.lua
@@ -33,6 +33,43 @@ addCharm:groupType("god")
 addCharm:register()
 
 ---------------- // ----------------
+
+local addCharm = TalkAction("/addminorcharms")
+
+function addCharm.onSay(player, words, param)
+	-- create log
+	logCommand(player, words, param)
+
+	local usage = "/addminorcharms PLAYER NAME,AMOUNT"
+	if param == "" then
+		player:sendCancelMessage("Command param required. Usage: " .. usage)
+		return true
+	end
+	local split = param:split(",")
+	if not split[2] then
+		player:sendCancelMessage("Insufficient parameters. Usage: " .. usage)
+		return true
+	end
+	local target = Player(split[1])
+	if not target then
+		player:sendCancelMessage("A player with that name is not online.")
+		return true
+	end
+
+	split[2] = split[2]:trimSpace()
+
+	player:sendCancelMessage("Added " .. split[2] .. " minor charm points to character '" .. target:getName() .. "'.")
+	target:sendCancelMessage("Received " .. split[2] .. " minor charm points!")
+	target:addMinorCharmEchoes(tonumber(split[2]))
+	target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
+end
+
+addCharm:separator(" ")
+addCharm:groupType("god")
+addCharm:register()
+
+---------------- // ----------------
+
 local resetCharm = TalkAction("/resetcharms")
 
 function resetCharm.onSay(player, words, param)


### PR DESCRIPTION
# Description

This is just an improvement to the `/addcharms` talkaction file, adding `/addminorcharms`

## Behaviour
### **Actual**

There's no way to add minor charms to players with command.

### **Expected**

Add `/addminorcharms` to give minor charms to players.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
