### PR TITLE
enhancement: add winged druid outfit to store

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -2724,6 +2724,15 @@ GameStore.Categories = {
 				type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
 			},
 			{
+				icons = { "Outfit_Winged_Druid_Male_Addon_3.png", "Outfit_Winged_Druid_Female_Addon_3.png" },
+				name = "Full Winged Druid Outfit",
+				price = 870,
+				sexId = { female = 1832, male = 1831 },
+				addon = 3,
+				description = "{character}\n{info} colours can be changed using the Outfit dialog\n{info} includes basic outfit and 2 addons which can be selected individually\n\n<i>Winged Druids are figures of both grace and menace. Wings that cut through the air like blades and an aura of unshakable determination make them a true force to be reckoned with. Harness the raw fury of nature and unleash its vengeance upon those who threaten it!</i>",
+				type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+			},
+			{
 				icons = { "Outfit_Retro_Citizen_Male.png", "Outfit_Retro_Citizen_Female.png" },
 				name = "Retro Citizen",
 				price = 870,


### PR DESCRIPTION
# Description

Full Winged Druid Outfit was missing in gamestore.lua and it wasn't displaying at store but it was in the players' outfit screen and it couldn't be bought.

## Behaviour
### **Actual**

There's no possibility to buy Full Winged Druid Outfit

### **Expected**

Now it's possible to buy it by players at Store

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
