### PR TITLE
fix: outfit monster value

### DIFF
--- a/data-otservbr-global/monster/demons/herald_of_gloom.lua
+++ b/data-otservbr-global/monster/demons/herald_of_gloom.lua
@@ -97,7 +97,7 @@ monster.defenses = {
 	{ name = "invisible", interval = 5000, chance = 20, effect = CONST_ME_MAGIC_RED },
 	{ name = "outfit", interval = 1500, chance = 20, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "nightstalker" },
 	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "werewolf" },
-	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "the count =" },
+	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "the count" },
 	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "grim reaper" },
 	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "tarantula" },
 	{ name = "outfit", interval = 1500, chance = 10, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000, outfitMonster = "ferumbras" },


### PR DESCRIPTION
# Description

Fix outfit spell condition

## Behaviour
### **Actual**

2025-07-18 23:01:25 -  [2025-18-07 23:01:25.313] [error] [ConditionOutfit::startCondition] Monster the count = does not exist 

### **Expected**

After removing `=` the condition works as you can see below
![cliente_local_fHcMt61utU](https://github.com/user-attachments/assets/43115e4f-3edb-410f-8bb6-65b4b34a5d9a)

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Fixed the name and the error doesn't appear in log anymore

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
