### PR TITLE
fix: exit destination of gnomprona boss tp

### DIFF
--- a/data-otservbr-global/scripts/movements/teleport/gnomprona.lua
+++ b/data-otservbr-global/scripts/movements/teleport/gnomprona.lua
@@ -4,7 +4,7 @@ local teleports = {
 	{ position = Position(33658, 32919, 15), destination = Position(33669, 32933, 15) },
 	{ position = Position(33714, 32797, 14), destination = Position(33556, 32754, 14), access = Storage.Quest.U12_90.PrimalOrdeal.Bosses.MagmaBubbleKilled },
 	{ position = Position(33558, 32754, 14), destination = Position(33714, 32799, 14) },
-	{ position = Position(33567, 32758, 15), destination = Position(33555, 32752, 14) },
+	{ position = Position(33567, 32758, 15), destination = Position(33520, 32871, 15) },
 }
 
 local gnomprona = MoveEvent()


### PR DESCRIPTION
# Description

Change destination of gnomprona boss tp like in tibia global.

## Behaviour
### **Actual**

It tps to the lever boss room instead of where it should.

### **Expected**

Exit to destination where tibia global does.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
