### PR TITLE
fix: add coordinate validation in getTile method

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -179,6 +179,11 @@ std::shared_ptr<Tile> Map::getLoadedTile(uint16_t x, uint16_t y, uint8_t z) {
 }
 
 std::shared_ptr<Tile> Map::getTile(uint16_t x, uint16_t y, uint8_t z) {
+	// Check if the coordinates are valid
+	if (x == 0 && y == 0 && z == 0) {
+		return;
+	}
+
 	if (z >= MAP_MAX_LAYERS) {
 		return nullptr;
 	}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -181,7 +181,7 @@ std::shared_ptr<Tile> Map::getLoadedTile(uint16_t x, uint16_t y, uint8_t z) {
 std::shared_ptr<Tile> Map::getTile(uint16_t x, uint16_t y, uint8_t z) {
 	// Check if the coordinates are valid
 	if (x == 0 && y == 0 && z == 0) {
-		return;
+		return nullptr;
 	}
 
 	if (z >= MAP_MAX_LAYERS) {


### PR DESCRIPTION
Added a check in Map::getTile to return early if x, y, and z are all zero, preventing invalid tile access.

fix #3375