### PR TITLE
fix: reset exp boosts at server initialization

### DIFF
--- a/data/scripts/globalevents/server_initialization.lua
+++ b/data/scripts/globalevents/server_initialization.lua
@@ -10,7 +10,8 @@ local function cleanupDatabase()
 	db.query("DELETE FROM `player_storage` WHERE `key` IN (" .. Global.Storage.FamiliarSummonEvent10 .. ", " .. Global.Storage.FamiliarSummonEvent60 .. ")")
 
 	db.query("UPDATE `players` SET `isreward` = " .. DAILY_REWARD_NOTCOLLECTED)
-	db.query("UPDATE `player_storage` SET `value` = 0 WHERE `player_storage`.`key` = 51052")
+	-- db.query("UPDATE `player_storage` SET `value` = 0 WHERE `player_storage`.`key` = 51052")
+	db.query("DELETE FROM `kv_store` WHERE `key_name` LIKE 'player%.exp-boost-count'")
 end
 
 -- Function to move expired bans to ban history


### PR DESCRIPTION
# Description

Saw this piece of code in this comment: https://github.com/opentibiabr/canary/pull/3515#issuecomment-3045266861
Tested it and it's working, but the user haven't made a new PR with it so here it is, credits to him.

## Behaviour
### **Actual**

If you buy exp boost and the server restarts it doesnt reset the count of the bought exp boosts by the player.

### **Expected**

Exp boost count should reset and player could buy again exp boost that cost 30 TC and 45 TC as in Global Tibia.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
