### PR TITLE
improve creature pushing

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1467,7 +1467,7 @@ bool Monster::pushCreature(const std::shared_ptr<Creature> &creature) {
 	return false;
 }
 
-void Monster::pushCreatures(const std::shared_ptr<Tile>& tile) {
+void Monster::pushCreatures(const std::shared_ptr<Tile> &tile) {
 	if (!tile) {
 		return;
 	}
@@ -1486,7 +1486,7 @@ void Monster::pushCreatures(const std::shared_ptr<Tile>& tile) {
 			continue;
 		}
 
-		const auto& creature = currentCreatures->at(i);
+		const auto &creature = currentCreatures->at(i);
 		if (!creature) {
 			continue;
 		}

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1467,32 +1467,45 @@ bool Monster::pushCreature(const std::shared_ptr<Creature> &creature) {
 	return false;
 }
 
-void Monster::pushCreatures(const std::shared_ptr<Tile> &tile) {
-	// We can not use iterators here since we can push a creature to another tile
-	// which will invalidate the iterator.
-	if (const CreatureVector* creatures = tile->getCreatures()) {
-		uint32_t removeCount = 0;
-		std::shared_ptr<Monster> lastPushedMonster = nullptr;
+void Monster::pushCreatures(const std::shared_ptr<Tile>& tile) {
+	if (!tile) {
+		return;
+	}
 
-		for (size_t i = 0; i < creatures->size();) {
-			const auto &monster = creatures->at(i)->getMonster();
-			if (monster && monster->isPushable()) {
-				if (monster != lastPushedMonster && Monster::pushCreature(monster)) {
-					lastPushedMonster = monster;
-					continue;
-				}
+	const CreatureVector* creatures = tile->getCreatures();
+	if (!creatures || creatures->empty()) {
+		return;
+	}
 
-				monster->changeHealth(-monster->getHealth());
-				monster->setDropLoot(true);
-				removeCount++;
+	uint32_t removeCount = 0;
+	std::shared_ptr<Monster> lastPushedMonster = nullptr;
+
+	for (int i = static_cast<int>(creatures->size()) - 1; i >= 0; --i) {
+		const CreatureVector* currentCreatures = tile->getCreatures();
+		if (!currentCreatures || i >= static_cast<int>(currentCreatures->size())) {
+			continue;
+		}
+
+		const auto& creature = currentCreatures->at(i);
+		if (!creature) {
+			continue;
+		}
+
+		const std::shared_ptr<Monster> monster = creature->getMonster();
+		if (monster && monster->isPushable()) {
+			if (monster != lastPushedMonster && Monster::pushCreature(monster)) {
+				lastPushedMonster = monster;
+				continue;
 			}
 
-			++i;
+			monster->changeHealth(-monster->getHealth());
+			monster->setDropLoot(true);
+			removeCount++;
 		}
+	}
 
-		if (removeCount > 0) {
-			g_game().addMagicEffect(tile->getPosition(), CONST_ME_BLOCKHIT);
-		}
+	if (removeCount > 0) {
+		g_game().addMagicEffect(tile->getPosition(), CONST_ME_BLOCKHIT);
 	}
 }
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1477,16 +1477,12 @@ void Monster::pushCreatures(const std::shared_ptr<Tile> &tile) {
 		return;
 	}
 
-	uint32_t removeCount = 0;
+	CreatureVector creaturesCopy = *creatures;
+	uint32_t killedCount = 0;
 	std::shared_ptr<Monster> lastPushedMonster = nullptr;
 
-	for (int i = static_cast<int>(creatures->size()) - 1; i >= 0; --i) {
-		const CreatureVector* currentCreatures = tile->getCreatures();
-		if (!currentCreatures || i >= static_cast<int>(currentCreatures->size())) {
-			continue;
-		}
-
-		const auto &creature = currentCreatures->at(i);
+	for (int i = static_cast<int>(creaturesCopy.size()) - 1; i >= 0; --i) {
+		const auto &creature = creaturesCopy[i];
 		if (!creature) {
 			continue;
 		}
@@ -1500,11 +1496,11 @@ void Monster::pushCreatures(const std::shared_ptr<Tile> &tile) {
 
 			monster->changeHealth(-monster->getHealth());
 			monster->setDropLoot(true);
-			removeCount++;
+			killedCount++;
 		}
 	}
 
-	if (removeCount > 0) {
+	if (killedCount > 0) {
 		g_game().addMagicEffect(tile->getPosition(), CONST_ME_BLOCKHIT);
 	}
 }


### PR DESCRIPTION
Fixed a potential infinite loop, added null checks, and made creature pushing safer by looping backwards.

- Switched to a reverse loop (for (i = size - 1; i >= 0; --i)) so that moving creatures doesn’t mess up the indexes. (memyleak)
- Added safety checks for tile, the creature list, and individual creature. (crash)
- after pushing or killing a monster, the code won’t accidentally process the same creature again. (loop).

