### PR TITLE
fix: ferumbras ascension quest

### DIFF
--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_rift_invader_death.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_rift_invader_death.lua
@@ -23,26 +23,26 @@ function riftInvaderDeath.onDeath(creature, corpse, lasthitkiller, mostdamagekil
 	for i = 1, #crystals do
 		local crystal = crystals[i]
 		if creature:getPosition():isInRange(crystal.fromPosition, crystal.toPosition) then
-			if player:getStorageValue(crystal.globalStorage) > 8 then
+			if lasthitkiller:getStorageValue(crystal.globalStorage) > 8 then
 				local item = Tile(crystal.crystalPosition):getItemById(14955)
 				if not item then
 					return true
 				end
 				item:transform(14961)
-				player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals, player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) + 1)
+				lasthitkiller:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals, lasthitkiller:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) + 1)
 			end
-			if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) == 8 then
+			if lasthitkiller:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) == 8 then
 				local creature = Tile(config.bossPos):getTopCreature()
 				creature:say("NOOOOOOOOOOO!", TALKTYPE_MONSTER_YELL)
 				creature:say("FERUMBRAS BURSTS INTO SOUL SPLINTERS!", TALKTYPE_MONSTER_YELL, nil, nil, Position(33392, 31475, 14))
 				creature:remove()
 				for a = 1, #crystals do
-					local crystalEffect = crystals[i]
+					local crystalEffect = crystals[a]
 					crystalEffect.crystalPosition:sendMagicEffect(CONST_ME_FERUMBRAS)
 					Game.createMonster("Ferumbras Soul Splinter", Position(33392, 31473, 14), false, true)
 				end
 			end
-			player:setStorageValue(crystal.globalStorage, player:getStorageValue(crystal.globalStorage) + 1)
+			lasthitkiller:setStorageValue(crystal.globalStorage, lasthitkiller:getStorageValue(crystal.globalStorage) + 1)
 			lasthitkiller:say("The negative energy of the rift creature is absorbed by the crystal!", TALKTYPE_MONSTER_SAY, nil, nil, crystal.crystalPosition)
 			lasthitkiller:say("ARGH!", TALKTYPE_MONSTER_SAY, nil, nil, Position(33392, 31473, 14))
 		end

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_rift_invader_death.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_rift_invader_death.lua
@@ -23,15 +23,15 @@ function riftInvaderDeath.onDeath(creature, corpse, lasthitkiller, mostdamagekil
 	for i = 1, #crystals do
 		local crystal = crystals[i]
 		if creature:getPosition():isInRange(crystal.fromPosition, crystal.toPosition) then
-			if lasthitkiller:getStorageValue(crystal.globalStorage) > 8 then
+			if Game.getStorageValue(crystal.globalStorage) > 8 then
 				local item = Tile(crystal.crystalPosition):getItemById(14955)
 				if not item then
 					return true
 				end
 				item:transform(14961)
-				lasthitkiller:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals, lasthitkiller:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) + 1)
+				Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) + 1)
 			end
-			if lasthitkiller:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) == 8 then
+			if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.Crystals.AllCrystals) == 8 then
 				local creature = Tile(config.bossPos):getTopCreature()
 				creature:say("NOOOOOOOOOOO!", TALKTYPE_MONSTER_YELL)
 				creature:say("FERUMBRAS BURSTS INTO SOUL SPLINTERS!", TALKTYPE_MONSTER_YELL, nil, nil, Position(33392, 31475, 14))
@@ -42,7 +42,7 @@ function riftInvaderDeath.onDeath(creature, corpse, lasthitkiller, mostdamagekil
 					Game.createMonster("Ferumbras Soul Splinter", Position(33392, 31473, 14), false, true)
 				end
 			end
-			lasthitkiller:setStorageValue(crystal.globalStorage, lasthitkiller:getStorageValue(crystal.globalStorage) + 1)
+			Game.setStorageValue(crystal.globalStorage, Game.getStorageValue(crystal.globalStorage) + 1)
 			lasthitkiller:say("The negative energy of the rift creature is absorbed by the crystal!", TALKTYPE_MONSTER_SAY, nil, nil, crystal.crystalPosition)
 			lasthitkiller:say("ARGH!", TALKTYPE_MONSTER_SAY, nil, nil, Position(33392, 31473, 14))
 		end

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/movements_vortex.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/movements_vortex.lua
@@ -10,8 +10,8 @@ function vortex.onStepIn(creature, item, position, fromPosition)
 
 	monster:remove()
 	position:sendMagicEffect(CONST_ME_POFF)
-	player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence, player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence) + 1)
-	if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence) >= 8 then
+	Game.setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence, Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence) + 1)
+	if Game.getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.FerumbrasEssence) >= 8 then
 		Game.createMonster("Destabilized Ferumbras", config.bossPos, true, true)
 		for i = 1, config.maxSummon do
 			Game.createMonster("Rift Fragment", Position(math.random(33381, 33403), math.random(31462, 31483), 14), true, true)


### PR DESCRIPTION
# Description

Crystals in Ferumbras Ascension boss room are not changing to continue boss mechanics.

## Behaviour
### **Actual**

The script is using `player:` which is undefined in the script so crystals never change and boss room gets bugged.

### **Expected**

Crystals in Ferumbras Ascension boss room should change when a quantity of rift invaders are killed around them

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
