### PR TITLE
fix: only push player if vocation is valid

### DIFF
--- a/src/creatures/players/components/player_badge.cpp
+++ b/src/creatures/players/components/player_badge.cpp
@@ -139,8 +139,9 @@ std::vector<std::shared_ptr<Player>> PlayerBadge::getPlayersInfoByAccount(const 
 			auto player = std::make_shared<Player>(nullptr);
 			player->setName(result->getString("name"));
 			player->setLevel(result->getNumber<uint32_t>("level"));
-			player->setVocation(result->getNumber<uint16_t>("vocation"));
-			players.push_back(player);
+			if (player->setVocation(result->getNumber<uint16_t>("vocation"))) {
+				players.push_back(player);
+			}
 		} while (result->next());
 	}
 


### PR DESCRIPTION
This pull request updates the logic for populating the list of players in the `PlayerBadge::getPlayersInfoByAccount` method. Now, only players for whom `setVocation` succeeds are added to the result list, which helps ensure data integrity.
