### PR TITLE
enhancement: set boss cooldown when teleporting players to boss rooms

### DIFF
--- a/data/libs/functions/boss_lever.lua
+++ b/data/libs/functions/boss_lever.lua
@@ -247,6 +247,7 @@ function BossLever:onUse(player)
 			end
 		end
 		lever:teleportPlayers()
+		lever:setCooldownAllPlayers(self.name, os.time() + self.timeToFightAgain)
 		if self.encounter then
 			local encounter = Encounter(self.encounter)
 			encounter:reset()


### PR DESCRIPTION
# Description

This adds the cooldowns to all players entering to a boss and it will display the boss in Boss Cooldowns window,

## Behaviour
### **Actual**

Just some bosses display on boss cooldowns window.

### **Expected**

All bosses where you enter using a lever should appear on your boss cooldowns list.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
