### PR TITLE
fix: boss race id for ascending ferumbras

### DIFF
--- a/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ascending_ferumbras.lua
+++ b/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ascending_ferumbras.lua
@@ -25,6 +25,11 @@ monster.changeTarget = {
 	chance = 20,
 }
 
+monster.bosstiary = {
+	bossRaceId = 1204,
+	bossRace = RARITY_NEMESIS,
+}
+
 monster.strategiesTarget = {
 	nearest = 70,
 	health = 10,

--- a/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ferumbras_mortal_shell.lua
+++ b/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ferumbras_mortal_shell.lua
@@ -29,11 +29,6 @@ monster.changeTarget = {
 	chance = 8,
 }
 
-monster.bosstiary = {
-	bossRaceId = 1204,
-	bossRace = RARITY_NEMESIS,
-}
-
 monster.strategiesTarget = {
 	nearest = 70,
 	health = 10,

--- a/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ferumbras_soul_splinter.lua
+++ b/data-otservbr-global/monster/quests/ferumbras_ascension/bosses/ferumbras_soul_splinter.lua
@@ -80,7 +80,7 @@ monster.attacks = {
 	-- poison
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -250, maxDamage = -520, radius = 6, effect = CONST_ME_POISONAREA, target = false },
 	{ name = "ferumbras electrify", interval = 2000, chance = 18, target = false },
-	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_MANADRAIN, minDamage = -225, maxDamage = -410, radius = 6, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_MANADRAIN, minDamage = -185, maxDamage = -310, radius = 6, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_LIFEDRAIN, minDamage = -200, maxDamage = -450, radius = 6, effect = CONST_ME_POFF, target = false },
 	{ name = "ferumbras soulfire", interval = 2000, chance = 20, range = 7, target = false },
 	{ name = "combat", interval = 2000, chance = 17, type = COMBAT_LIFEDRAIN, minDamage = -590, maxDamage = -1050, length = 8, spread = 0, effect = CONST_ME_HITBYPOISON, target = false },

--- a/data-otservbr-global/monster/quests/ferumbras_ascension/summons/rift_invader.lua
+++ b/data-otservbr-global/monster/quests/ferumbras_ascension/summons/rift_invader.lua
@@ -73,7 +73,7 @@ monster.attacks = {
 	{ name = "combat", interval = 2000, chance = 33, type = COMBAT_ENERGYDAMAGE, minDamage = -450, maxDamage = -550, range = 7, radius = 5, effect = CONST_ME_ENERGYAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 7, type = COMBAT_ENERGYDAMAGE, minDamage = -210, maxDamage = -300, range = 1, radius = 2, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
 	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_DEATHDAMAGE, minDamage = -200, maxDamage = -300, range = 7, radius = 3, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_MORTAREA, target = true },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -300, maxDamage = -480, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -180, maxDamage = -280, target = true },
 }
 
 monster.defenses = {


### PR DESCRIPTION
# Description

Ascending ferumbras isnt displaying in boss cooldowns, this PR changes the bosstiary to the correct boss file to fix it.

## Behaviour
### **Actual**

You enter Ascending Ferumbras room with the lever and it doesnt displays Ascending Ferumbras in the Boss Cooldowns window.

### **Expected**

Display Ascending Ferumbras when entering the room.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
