### PR TITLE
fix: library final boss room access teleports

### DIFF
--- a/data-otservbr-global/scripts/quests/the_secret_library_quest/movement_teleport.lua
+++ b/data-otservbr-global/scripts/quests/the_secret_library_quest/movement_teleport.lua
@@ -1,0 +1,37 @@
+local setting = {
+	[32672] = {
+		pos = Position(32672, 32736, 11),
+		effectTeleport = CONST_ME_TELEPORT,
+		newPosition = Position(32480, 32597, 15),
+	},
+	[32480] = {
+		pos = Position(32480, 32601, 15),
+		effectTeleport = CONST_ME_TELEPORT,
+		newPosition = Position(32674, 32738, 11),
+	},
+}
+local library = MoveEvent()
+function library.onStepIn(creature, item, position, fromPosition)
+	local player = creature:getPlayer()
+	if not player then
+		return true
+	end
+
+	for _, teleport in pairs(setting) do
+		if teleport.pos == position then
+			player:teleportTo(teleport.newPosition)
+			fromPosition:sendMagicEffect(teleport.effectTeleport)
+			teleport.newPosition:sendMagicEffect(teleport.effectTeleport)
+			break
+		end
+	end
+	return true
+end
+
+library:type("stepin")
+
+for _, value in pairs(setting) do
+	library:position(value.pos)
+end
+
+library:register()


### PR DESCRIPTION
# Description

Teleports to access the final boss on Library aren't working.

## Behaviour
### **Actual**

Teleports to get to final boss room aren't working.

### **Expected**

Entering the teleports should get you to the final boss room.

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
