### PR TITLE
fix: delete requirement of exact players to start cults of tibia bosses

### DIFF
--- a/data-otservbr-global/scripts/quests/cults_of_tibia/actions_bosses_levers.lua
+++ b/data-otservbr-global/scripts/quests/cults_of_tibia/actions_bosses_levers.lua
@@ -164,11 +164,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 				end
 			end
 
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
-			end
-
 			if isPlayerInArea(frompos, topos) then
 				player:sendCancelMessage("The room is full.")
 				return true
@@ -216,11 +211,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 				end
 			end
 
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
-			end
-
 			if isPlayerInArea(frompos, topos) then
 				player:sendCancelMessage("The room is full.")
 				return true
@@ -266,11 +256,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 					teleport = teleport + 1
 					table.insert(playersInArea, nplayer)
 				end
-			end
-
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
 			end
 
 			if isPlayerInArea(frompos, topos) then
@@ -326,11 +311,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 				end
 			end
 
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
-			end
-
 			if isPlayerInArea(frompos, topos) then
 				player:sendCancelMessage("It looks like there is someone inside.")
 				return true
@@ -374,11 +354,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 					teleport = teleport + 1
 					table.insert(playersInArea, nplayer)
 				end
-			end
-
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
 			end
 
 			if isPlayerInArea(frompos, topos) then
@@ -469,11 +444,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 				end
 			end
 
-			if teleport ~= 5 then
-				player:sendCancelMessage("You need exactly 5 players to start this challenge.")
-				return true
-			end
-
 			if isPlayerInArea(frompos, topos) then
 				player:sendCancelMessage("It looks like there is someone inside.")
 				return true
@@ -537,11 +507,6 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 						table.insert(playersInArea, nplayer)
 					end
 				end
-			end
-
-			if teleport ~= 10 then
-				player:sendCancelMessage("You need exactly 10 players to start this challenge.")
-				return true
 			end
 
 			if isPlayerInArea(frompos, topos) then

--- a/data-otservbr-global/scripts/quests/cults_of_tibia/movements_boss_timer.lua
+++ b/data-otservbr-global/scripts/quests/cults_of_tibia/movements_boss_timer.lua
@@ -33,27 +33,78 @@ local setting = {
 
 local bossTimer = MoveEvent()
 
+-- Utility function to localize time
+local function formatTimeLeft(seconds)
+	if seconds <= 0 then
+		return "a few seconds"
+	end
+
+	local days = math.floor(seconds / 86400)
+	local hours = math.floor((seconds % 86400) / 3600)
+	local minutes = math.floor((seconds % 3600) / 60)
+	local secs = seconds % 60
+
+	local parts = {}
+
+	if days > 0 then
+		table.insert(parts, days .. " day" .. (days > 1 and "s" or ""))
+	end
+	if hours > 0 then
+		table.insert(parts, hours .. " hour" .. (hours > 1 and "s" or ""))
+	end
+	if minutes > 0 then
+		table.insert(parts, minutes .. " minute" .. (minutes > 1 and "s" or ""))
+	end
+	if secs > 0 and days == 0 then -- Only show seconds if cooldown is less than a day
+		table.insert(parts, secs .. " second" .. (secs > 1 and "s" or ""))
+	end
+
+	-- Build readable string
+	local message = ""
+	for i = 1, #parts do
+		message = message .. parts[i]
+		if i < #parts - 1 then
+			message = message .. ", "
+		elseif i == #parts - 1 then
+			message = message .. " and "
+		end
+	end
+	return message
+end
+
 function bossTimer.onStepIn(creature, item, position, fromPosition)
 	local player = creature:getPlayer()
 	if not player then
 		return true
 	end
-	for b = 1, #setting do
-		if player:getPosition() == Position(setting[b].tpPos) then
-			if not player:canFightBoss(setting[b].boss) then
-				player:sendCancelMessage("You need to wait for 20 hours to face this boss again.")
+
+	for _, config in ipairs(setting) do
+		if player:getPosition() == Position(config.tpPos) then
+			if not player:canFightBoss(config.boss) then
+				local cooldownTimestamp = player:getBossCooldown(config.boss)
+				local timeLeft = cooldownTimestamp - os.time()
+
+				if timeLeft > 0 then
+					local timeString = formatTimeLeft(timeLeft)
+					player:sendCancelMessage("You need to wait " .. timeString .. " before facing " .. config.boss .. " again.")
+				else
+					player:sendCancelMessage("You cannot face this boss yet.")
+				end
+
 				player:teleportTo(fromPosition)
 				return false
 			end
-			player:teleportTo(Position(setting[b].tpDestination))
+
+			player:teleportTo(Position(config.tpDestination))
 			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+			break
 		end
 	end
 	return true
 end
 
-for a = 1, #setting do
-	bossTimer:position(setting[a].tpPos)
+for _, config in ipairs(setting) do
+	bossTimer:position(config.tpPos)
 end
 
 bossTimer:register()


### PR DESCRIPTION
# Description

Actually there's no mandatory to have exact quantity of players to start bosses of Cults Of Tibia

## Behaviour
### **Actual**

You need exact 5 or 10 players to start the bosses.

### **Expected**

You can do this bosses alone.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
