### PR TITLE
fix: update outfit cache storage reference for golden outfit

### DIFF
--- a/data-otservbr-global/scripts/actions/other/outfit_memorial.lua
+++ b/data-otservbr-global/scripts/actions/other/outfit_memorial.lua
@@ -26,7 +26,7 @@ end
 local outfitMemorial = Action()
 
 function outfitMemorial.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	goldenOutfitCache, lastUpdatedGolden = updateOutfitCache(Storage.OutfitQuest.GoldenOutfit, goldenOutfitCache, lastUpdatedGolden)
+	goldenOutfitCache, lastUpdatedGolden = updateOutfitCache(Storage.Quest.U12_15.GoldenOutfit, goldenOutfitCache, lastUpdatedGolden)
 	royalOutfitCache, lastUpdatedRoyal = updateOutfitCache(Storage.OutfitQuest.RoyalCostumeOutfit, royalOutfitCache, lastUpdatedRoyal)
 	local response = NetworkMessage()
 	response:addByte(0xB0)

--- a/data-otservbr-global/scripts/actions/other/outfit_memorial.lua
+++ b/data-otservbr-global/scripts/actions/other/outfit_memorial.lua
@@ -26,7 +26,7 @@ end
 local outfitMemorial = Action()
 
 function outfitMemorial.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	goldenOutfitCache, lastUpdatedGolden = updateOutfitCache(Storage.Quest.U12_15.GoldenOutfit, goldenOutfitCache, lastUpdatedGolden)
+	goldenOutfitCache, lastUpdatedGolden = updateOutfitCache(Storage.Quest.U12_15.GoldenOutfits, goldenOutfitCache, lastUpdatedGolden)
 	royalOutfitCache, lastUpdatedRoyal = updateOutfitCache(Storage.OutfitQuest.RoyalCostumeOutfit, royalOutfitCache, lastUpdatedRoyal)
 	local response = NetworkMessage()
 	response:addByte(0xB0)


### PR DESCRIPTION
Changed the golden outfit cache reference in outfit_memorial.lua to use Storage.Quest.U12_15.GoldenOutfits (46801) instead of the old storage, ensuring correct player progress tracking.

# Description

Updated the golden outfit cache logic in outfit_memorial.lua to use the correct storage key. This fixes an issue where players who completed the golden outfit were not properly tracked or displayed in the memorial.

## Behaviour
### **Actual**

Players who completed the golden outfit were not shown in the memorial due to an incorrect storage reference.

### **Expected**

Players who complete the golden outfit are now correctly tracked and displayed in the memorial.

### Fixes #issuenumber

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

  - [x] Manual test: Obtained the golden outfit and verified that the player appears in the memorial list after cache refresh.

**Test Configuration**:

  - Server Version: [14.12]
  - Client: [14.12]
  - Operating System: [Windows, Linux]

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
