### PR TITLE
fix: update quaidDen ID for grave danger quest

### DIFF
--- a/data-otservbr-global/scripts/quests/grave_danger_quest/movements_quaidDen.lua
+++ b/data-otservbr-global/scripts/quests/grave_danger_quest/movements_quaidDen.lua
@@ -13,5 +13,5 @@ function quaidDen.onStepIn(creature, item, position, fromPosition)
 	return true
 end
 
-quaidDen:id(31636)
+quaidDen:id(31733)
 quaidDen:register()


### PR DESCRIPTION
The itemid of the movement that grants access to the boss Guard Captain Quaid was changed. The previous ID was incorrect—it matched the corpse of Cobra Scouts instead of the intended fog barrier. As a result, players stepping on dead Cobra Scout bodies were unintentionally teleported to the movement’s fallback position when they didn’t meet the entry requirements. The fog mechanic failed to function properly due to this mismatch.

# Description

Changed the movement script for Guard Captain Quaid's den to use the correct itemid for the fog barrier. This fixes an issue where the movement was triggered by Cobra Scout corpses instead of the intended fog, causing unintended teleports and breaking the fog mechanic.

## Behaviour
### **Actual**

Players stepping on Cobra Scout corpses were teleported away if they didn't meet the requirements, instead of being blocked by the fog barrier.

### **Expected**

Only the intended fog barrier triggers the movement, properly blocking players who don't meet the requirements and preventing unintended teleports from corpses.

### Fixes #issuenumber

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

  - [x] Manual test: Verified that only the fog barrier triggers the movement and the mechanic works as intended.

**Test Configuration**:

  - Server Version: [14.12]
  - Client: [14.12]
  - Operating System: [Windows, Linux]

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
