### PR TITLE
fix: spirit of purity mount

### DIFF
--- a/data/scripts/actions/items/spiritual_horseshoe.lua
+++ b/data/scripts/actions/items/spiritual_horseshoe.lua
@@ -1,0 +1,41 @@
+local config = {
+	requiredItems = {
+		[44048] = { key = "spiritual-horseshoe", count = 4 },
+	},
+	mountId = 217,
+}
+
+local spiritualHorseshoe = Action()
+
+function spiritualHorseshoe.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	local itemInfo = config.requiredItems[item:getId()]
+	if not itemInfo then
+		return true
+	end
+
+	if player:hasMount(config.mountId) then
+		return true
+	end
+
+	local currentCount = (player:kv():get(itemInfo.key) or 0) + 1
+	player:kv():set(itemInfo.key, currentCount)
+	player:getPosition():sendMagicEffect(CONST_ME_HOLYDAMAGE)
+	item:remove(1)
+
+	for _, info in pairs(config.requiredItems) do
+		if (player:kv():get(info.key) or 0) < info.count then
+			return true
+		end
+	end
+
+	player:addMount(config.mountId)
+	player:addAchievement("The Spirit of Purity")
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Spirit of Purity is now yours!")
+	return true
+end
+
+for itemId, _ in pairs(config.requiredItems) do
+	spiritualHorseshoe:id(itemId)
+end
+
+spiritualHorseshoe:register()


### PR DESCRIPTION
# Description

Using 4 spiritual horseshoe should give you the mount Spirit of Purity.

## Behaviour
### **Actual**

When using the item nothing happens.

### **Expected**

It should be used and until used 4 it adds you the mount.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
