### PR TITLE
enhancement: add functionality to items used to obtain the second familiar

### DIFF
--- a/data/scripts/actions/items/bladespark_figurine.lua
+++ b/data/scripts/actions/items/bladespark_figurine.lua
@@ -1,0 +1,25 @@
+local bladesparkFigurine = Action()
+
+function bladesparkFigurine.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if player:getVocation():getBaseId() ~= VOCATION.BASE_ID.SORCERER then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Only sorcerers can use this item.")
+		return true
+	end
+	if player:getLevel() < 200 and not player:isPremium() then
+		return true
+	end
+	if player:getFamiliarLooktype() == 0 then
+		player:setFamiliarLooktype(1367) -- Bladespark looktype
+	end
+	if not player:hasFamiliar(1367) then
+		player:addFamiliar(1367) -- Bladespark looktype
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have summoned a Bladespark.")
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already have a Bladespark.")
+	end
+	item:remove(1)
+	return true
+end
+
+bladesparkFigurine:id(35592)
+bladesparkFigurine:register()

--- a/data/scripts/actions/items/mossmasher_figurine.lua
+++ b/data/scripts/actions/items/mossmasher_figurine.lua
@@ -1,0 +1,25 @@
+local mossmasherFigurine = Action()
+
+function mossmasherFigurine.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if player:getVocation():getBaseId() ~= VOCATION.BASE_ID.DRUID then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Only druids can use this item.")
+		return true
+	end
+	if player:getLevel() < 200 and not player:isPremium() then
+		return true
+	end
+	if player:getFamiliarLooktype() == 0 then
+		player:setFamiliarLooktype(1364) -- Mossmasher looktype
+	end
+	if not player:hasFamiliar(1364) then
+		player:addFamiliar(1364) -- Mossmasher looktype
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have summoned a Mossmasher.")
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already have a Mossmasher.")
+	end
+	item:remove(1)
+	return true
+end
+
+mossmasherFigurine:id(35591)
+mossmasherFigurine:register()

--- a/data/scripts/actions/items/sandscourge_figurine.lua
+++ b/data/scripts/actions/items/sandscourge_figurine.lua
@@ -1,0 +1,25 @@
+local sandscourgeFigurine = Action()
+
+function sandscourgeFigurine.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if player:getVocation():getBaseId() ~= VOCATION.BASE_ID.PALADIN then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Only paladins can use this item.")
+		return true
+	end
+	if player:getLevel() < 200 and not player:isPremium() then
+		return true
+	end
+	if player:getFamiliarLooktype() == 0 then
+		player:setFamiliarLooktype(1366) -- Sandscourge looktype
+	end
+	if not player:hasFamiliar(1366) then
+		player:addFamiliar(1366) -- Sandscourge looktype
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have summoned a Sandscourge.")
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already have a Sandscourge.")
+	end
+	item:remove(1)
+	return true
+end
+
+sandscourgeFigurine:id(35590)
+sandscourgeFigurine:register()

--- a/data/scripts/actions/items/snowbash_figurine.lua
+++ b/data/scripts/actions/items/snowbash_figurine.lua
@@ -1,0 +1,25 @@
+local snowbashFigurine = Action()
+
+function snowbashFigurine.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if player:getVocation():getBaseId() ~= VOCATION.BASE_ID.KNIGHT then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Only knights can use this item.")
+		return true
+	end
+	if player:getLevel() < 200 and not player:isPremium() then
+		return true
+	end
+	if player:getFamiliarLooktype() == 0 then
+		player:setFamiliarLooktype(1365) -- Snowbash looktype
+	end
+	if not player:hasFamiliar(1365) then
+		player:addFamiliar(1365) -- Snowbash looktype
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have summoned a Snowbash.")
+	else
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already have a Snowbash.")
+	end
+	item:remove(1)
+	return true
+end
+
+snowbashFigurine:id(35589)
+snowbashFigurine:register()


### PR DESCRIPTION
# Description

Closes: https://github.com/opentibiabr/canary/issues/1094

Adds functionality to the items used to obtain the second familiar, it removes the item after used.

## Behaviour
### **Actual**

Items doesnt do anything.

### **Expected**

Give the second familiar to player.

### Fixes #1094

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
