### PR TITLE
enhancement: add reported missing corpses

### DIFF
--- a/data-otservbr-global/monster/aquatics/quara_looter.lua
+++ b/data-otservbr-global/monster/aquatics/quara_looter.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 1,
-	Locations = "Podzilla Bottom, Podzilla Underwater ",
+	Locations = "Podzilla Bottom, Podzilla Underwater",
 }
 
 monster.health = 11500
 monster.maxHealth = 11500
 monster.race = "undead"
-monster.corpse = 48276
+monster.corpse = 48277
 monster.speed = 210
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/aquatics/quara_plunderer.lua
+++ b/data-otservbr-global/monster/aquatics/quara_plunderer.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 1,
-	Locations = "Podzilla Bottom, Podzilla Underwater ",
+	Locations = "Podzilla Bottom, Podzilla Underwater",
 }
 
 monster.health = 13500
 monster.maxHealth = 13500
 monster.race = "undead"
-monster.corpse = 48388
+monster.corpse = 48389
 monster.speed = 205
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/aquatics/quara_raider.lua
+++ b/data-otservbr-global/monster/aquatics/quara_raider.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 1,
-	Locations = "Podzilla Bottom, Podzilla Underwater ",
+	Locations = "Podzilla Bottom, Podzilla Underwater",
 }
 
 monster.health = 12500
 monster.maxHealth = 12500
 monster.race = "undead"
-monster.corpse = 48392
+monster.corpse = 48393
 monster.speed = 215
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/extra_dimensional/mitmah_scout.lua
+++ b/data-otservbr-global/monster/extra_dimensional/mitmah_scout.lua
@@ -29,7 +29,7 @@ monster.Bestiary = {
 monster.health = 3940
 monster.maxHealth = 3940
 monster.race = "venom"
-monster.corpse = 44666
+monster.corpse = 44667
 monster.speed = 140
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/extra_dimensional/mitmah_seer.lua
+++ b/data-otservbr-global/monster/extra_dimensional/mitmah_seer.lua
@@ -29,7 +29,7 @@ monster.Bestiary = {
 monster.health = 4620
 monster.maxHealth = 4620
 monster.race = "venom"
-monster.corpse = 44670
+monster.corpse = 44671
 monster.speed = 140
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/humanoids/bulltaur_alchemist.lua
+++ b/data-otservbr-global/monster/humanoids/bulltaur_alchemist.lua
@@ -30,7 +30,7 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Bulltaurs Lair.",
+	Locations = "Bulltaurs Lair",
 }
 
 monster.changeTarget = {

--- a/data-otservbr-global/monster/humanoids/bulltaur_brute.lua
+++ b/data-otservbr-global/monster/humanoids/bulltaur_brute.lua
@@ -30,7 +30,7 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Bulltaurs Lair.",
+	Locations = "Bulltaurs Lair",
 }
 
 monster.changeTarget = {

--- a/data-otservbr-global/monster/humanoids/bulltaur_forgepriest.lua
+++ b/data-otservbr-global/monster/humanoids/bulltaur_forgepriest.lua
@@ -30,7 +30,7 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Bulltaurs Lair.",
+	Locations = "Bulltaurs Lair",
 }
 
 monster.changeTarget = {

--- a/data-otservbr-global/monster/plants/rootthing_amber_shaper.lua
+++ b/data-otservbr-global/monster/plants/rootthing_amber_shaper.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Podzilla Stalk.",
+	Locations = "Podzilla Stalk",
 }
 
 monster.health = 15000
 monster.maxHealth = 15000
 monster.race = "venom"
-monster.corpse = 48401
+monster.corpse = 48402
 monster.speed = 185
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/plants/rootthing_bug_tracker.lua
+++ b/data-otservbr-global/monster/plants/rootthing_bug_tracker.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Podzilla Stalk.",
+	Locations = "Podzilla Stalk",
 }
 
 monster.health = 12500
 monster.maxHealth = 12500
 monster.race = "venom"
-monster.corpse = 48405
+monster.corpse = 48406
 monster.speed = 195
 monster.manaCost = 0
 

--- a/data-otservbr-global/monster/plants/rootthing_nutshell.lua
+++ b/data-otservbr-global/monster/plants/rootthing_nutshell.lua
@@ -23,13 +23,13 @@ monster.Bestiary = {
 	CharmsPoints = 50,
 	Stars = 4,
 	Occurrence = 0,
-	Locations = "Podzilla Stalk.",
+	Locations = "Podzilla Stalk",
 }
 
 monster.health = 13500
 monster.maxHealth = 13500
 monster.race = "venom"
-monster.corpse = 48396
+monster.corpse = 48397
 monster.speed = 190
 monster.manaCost = 0
 

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -76890,6 +76890,72 @@ Granted by TibiaGoals.com"/>
 		<attribute key="decayTo" value="44662"/>
 		<attribute key="containersize" value="10"/>
 	</item>
+	<item id="44664" article="a" name="dead mitmah scout">
+		<attribute key="duration" value="60"/>
+		<attribute key="decayTo" value="0"/>
+	</item>
+	<item id="44665" article="a" name="dead mitmah scout">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44664"/>
+		<attribute key="containersize" value="10"/>
+	</item>
+	<item id="44666" article="a" name="dead mitmah scout">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44665"/>
+		<attribute key="containersize" value="20"/>
+	</item>
+	<item id="44667" article="a" name="dead mitmah scout">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="44666"/>
+		<attribute key="containersize" value="20"/>
+	</item>
+	<item id="44668" article="a" name="dead mitmah seer">
+		<attribute key="duration" value="60"/>
+		<attribute key="decayTo" value="0"/>
+	</item>
+	<item id="44669" article="a" name="dead mitmah seer">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44668"/>
+		<attribute key="containersize" value="10"/>
+	</item>
+	<item id="44670" article="a" name="dead mitmah seer">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44669"/>
+		<attribute key="containersize" value="20"/>
+	</item>
+	<item id="44671" article="a" name="dead mitmah seer">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="44670"/>
+		<attribute key="containersize" value="20"/>
+	</item>
+	<item id="44684" article="" name="remains of mitmah vanguard">
+		<attribute key="duration" value="60"/>
+		<attribute key="decayTo" value="0"/>
+	</item>
+	<item id="44685" article="" name="remains of mitmah vanguard">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44684"/>
+		<attribute key="containersize" value="10"/>
+	</item>
+	<item id="44686" article="" name="remains of mitmah vanguard">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="decayTo" value="44685"/>
+		<attribute key="containersize" value="20"/>
+	</item>
+	<item id="44687" article="" name="remains of mitmah vanguard">
+		<attribute key="fluidsource" value="blood"/>
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="44686"/>
+		<attribute key="containersize" value="20"/>
+	</item>
 	<item id="44706" article="a" name="dead bulltaur brute">
 		<attribute key="decayTo" value="0"/>
 		<attribute key="duration" value="60"/>
@@ -76904,6 +76970,12 @@ Granted by TibiaGoals.com"/>
 	<item id="44708" article="a" name="dead bulltaur brute">
 		<attribute key="containerSize" value="30"/>
 		<attribute key="decayTo" value="44707"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="44709" article="a" name="dead bulltaur brute">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="44708"/>
 		<attribute key="duration" value="300"/>
 		<attribute key="fluidSource" value="blood"/>
 	</item>
@@ -76924,6 +76996,12 @@ Granted by TibiaGoals.com"/>
 		<attribute key="duration" value="300"/>
 		<attribute key="fluidSource" value="blood"/>
 	</item>
+	<item id="44713" article="a" name="dead bulltaur alchemist">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="44712"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
 	<item id="44714" article="a" name="dead bulltaur forgepriest">
 		<attribute key="decayTo" value="0"/>
 		<attribute key="duration" value="60"/>
@@ -76938,6 +77016,12 @@ Granted by TibiaGoals.com"/>
 	<item id="44716" article="a" name="dead bulltaur forgepriest">
 		<attribute key="containerSize" value="30"/>
 		<attribute key="decayTo" value="44715"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="44717" article="a" name="dead bulltaur forgepriest">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="44716"/>
 		<attribute key="duration" value="300"/>
 		<attribute key="fluidSource" value="blood"/>
 	</item>
@@ -80303,6 +80387,144 @@ Granted by TibiaGoals.com"/>
 		<attribute key="loottype" value="creature products" />
 		<attribute key="primarytype" value="food"/>
 		<attribute key="weight" value="20"/>
+	</item>
+	<item id="48274" article="a" name="dead quara looter">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48275" article="a" name="dead quara looter">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48274"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48276" article="a" name="dead quara looter">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48275"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48277" article="a" name="dead quara looter">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48276"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48386" article="a" name="dead quara plunderer">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48387" article="a" name="dead quara plunderer">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48386"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48388" article="a" name="dead quara plunderer">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48387"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48389" article="a" name="dead quara plunderer">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48388"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48390" article="a" name="dead quara raider">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48391" article="a" name="dead quara raider">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48390"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48392" article="a" name="dead quara raider">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48391"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48393" article="a" name="dead quara raider">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48392"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48394" article="a" name="dead rootthing nutshell">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48395" article="a" name="dead rootthing nutshell">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48394"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48396" article="a" name="dead rootthing nutshell">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48395"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48397" article="a" name="dead rootthing nutshell">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48396"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48399" article="a" name="dead rootthing amber shaper">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48400" article="a" name="dead rootthing amber shaper">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48399"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48401" article="a" name="dead rootthing amber shaper">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48400"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48402" article="a" name="dead rootthing amber shaper">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48401"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48403" article="a" name="dead rootthing bug tracker">
+		<attribute key="decayTo" value="0"/>
+		<attribute key="duration" value="60"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48404" article="a" name="dead rootthing bug tracker">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48403"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48405" article="a" name="dead rootthing bug tracker">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48404"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
+	</item>
+	<item id="48406" article="a" name="dead rootthing bug tracker">
+		<attribute key="containerSize" value="30"/>
+		<attribute key="decayTo" value="48405"/>
+		<attribute key="duration" value="300"/>
+		<attribute key="fluidSource" value="blood"/>
 	</item>
 	<item id="48413" article="an" name="amber sickle">
 		<attribute key="primarytype" value="other items"/>


### PR DESCRIPTION
# Description

Closes: https://github.com/opentibiabr/canary/issues/3408

These creature corpses were missing from items.xml therefor they were not decaying.

quara plunderer
quara raider
quara looter

rootthing nutshell
rootthing bug tracker
roothing amber sharper

bulltaur brute
bulltaur forgeprist
bulltaur alchemist

mitmah seer
mitmah scout
mitmah vanguard

## Behaviour
### **Actual**

Those listed corpses doesn't decay to anything.

### **Expected**

They should have their decay process.

### Fixes #3408

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
