### PR TITLE
fix: underflow in container slot search for non-stackables

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4605,7 +4605,7 @@ std::shared_ptr<Cylinder> Player::queryDestination(int32_t &index, const std::sh
 			std::shared_ptr<Container> tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				const uint32_t containerCapacity = tmpContainer->capacity();
-				const uint32_t containerSize  = tmpContainer->size();
+				const uint32_t containerSize = tmpContainer->size();
 
 				// Avoid underflow in the loop below
 				if (containerSize >= containerCapacity) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -4604,16 +4604,21 @@ std::shared_ptr<Cylinder> Player::queryDestination(int32_t &index, const std::sh
 		while (i < containers.size()) {
 			std::shared_ptr<Container> tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
-				// we need to find first empty container as fast as we can for non-stackable items
-				uint32_t n = tmpContainer->capacity() - tmpContainer->size();
-				while (n) {
-					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
-						index = tmpContainer->capacity() - n;
+				const uint32_t containerCapacity = tmpContainer->capacity();
+				const uint32_t containerSize  = tmpContainer->size();
+
+				// Avoid underflow in the loop below
+				if (containerSize >= containerCapacity) {
+					continue;
+				}
+
+				for (uint32_t pos = 0; pos < containerCapacity; ++pos) {
+					auto rv = tmpContainer->queryAdd(pos, item, item->getItemCount(), flags);
+					if (rv == RETURNVALUE_NOERROR) {
+						index = pos;
 						destItem = nullptr;
 						return tmpContainer;
 					}
-
-					n--;
 				}
 
 				for (const auto &tmpContainerItem : tmpContainer->getItemList()) {


### PR DESCRIPTION
Refactored the loop that searches for an empty slot in containers for non-stackable items to prevent unsigned underflow and infinity loops. The new implementation iterates from 0 to container capacity, ensuring safe and correct behavior when the container is full.
