### PR TITLE
fix: missing return after unknown immunity in Lua functions

### DIFF
--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -870,6 +870,7 @@ int MonsterTypeFunctions::luaMonsterTypeCombatImmunities(lua_State* L) {
 		                "Unknown immunity name {} for monster: {}",
 		                immunity, monsterType->name);
 		lua_pushnil(L);
+		return 1;
 	}
 
 	monsterType->info.m_damageImmunities.set(combatTypeToIndex(combatType), true);
@@ -928,6 +929,7 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 		                "Unknown immunity name: {} for monster: {}",
 		                immunity, monsterType->name);
 		lua_pushnil(L);
+		return 1;
 	}
 
 	monsterType->info.m_conditionImmunities[static_cast<size_t>(conditionType)] = true;


### PR DESCRIPTION
Adds a missing 'return 1;' after pushing nil to the Lua stack when an unknown immunity name is encountered in luaMonsterTypeCombatImmunities and luaMonsterTypeConditionImmunities. This prevents further code execution in error cases and ensures correct Lua behavior.
