### PR TITLE
fix: destinations of rotten blood bosses exits

### DIFF
--- a/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_chagorz_lever.lua
+++ b/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_chagorz_lever.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(33034, 32357, 15),
 		to = Position(33052, 32376, 15),
 	},
-	exit = Position(33043, 32344, 15),
+	exit = Position(34093, 32007, 14),
 }
 
 local lever = BossLever(config)

--- a/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_murcion_lever.lua
+++ b/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_murcion_lever.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(32999, 32359, 15),
 		to = Position(33019, 32376, 15),
 	},
-	exit = Position(33009, 32374, 15),
+	exit = Position(34093, 31980, 14),
 }
 
 local lever = BossLever(config)

--- a/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_vemiath_lever.lua
+++ b/data-otservbr-global/scripts/quests/rotten_blood_quest/actions_vemiath_lever.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(33035, 32327, 15),
 		to = Position(33053, 32345, 15),
 	},
-	exit = Position(33043, 32344, 15),
+	exit = Position(34119, 32009, 15),
 }
 
 local lever = BossLever(config)


### PR DESCRIPTION
# Description

Update exit destinations of rotten blood bosses exits.

## Behaviour
### **Actual**

The position of the exit teleport was set on exit and not the destination.

### **Expected**

The destination should be on exit field

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
