### PR TITLE
chore(macos): setup compilation on macos/clang

### DIFF
--- a/.github/workflows/build-macos-dummy.yml
+++ b/.github/workflows/build-macos-dummy.yml
@@ -1,0 +1,23 @@
+---
+name: Build - macOS (dummy)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "src/**"
+
+jobs:
+  job:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: macos-${{ matrix.buildtype }}
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [macos-release, macos-debug]
+
+    steps:
+      - run: echo "This is a dummy job to satisfy branch protection checks"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,114 @@
+---
+name: Build - macOS
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "src/**"
+  merge_group:
+  push:
+    paths:
+      - "src/**"
+    branches:
+      - main
+
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  MAKEFLAGS: "-j 4"
+
+jobs:
+  cancel-runs:
+    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+  job:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: macos-${{ matrix.buildtype }}
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [macos-release, macos-debug]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+
+      - name: Setup Latest Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install macOS Dependencies
+        run: |
+          brew install autoconf automake libtool ccache pkg-config ninja
+
+      - name: Validate Build Environment
+        run: |
+          echo "Validating build tools..."
+          which cmake || (echo "cmake not found" && exit 1)
+          which autoconf || (echo "autoconf not found" && exit 1)
+          which automake || (echo "automake not found" && exit 1)
+          which libtool || (echo "libtool not found" && exit 1)
+          which ninja || (echo "ninja not found" && exit 1)
+          echo "Xcode version: $(xcodebuild -version)"
+          echo "Architecture: $(uname -m)"
+
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          max-size: "1G"
+          key: ccache-macos-${{ matrix.buildtype }}
+          restore-keys: |
+            ccache-macos
+
+      - name: Setup Build Environment
+        run: |
+          # Required for ARM64 builds - must be set before vcpkg
+          echo "VCPKG_FORCE_SYSTEM_BINARIES=1" >> "$GITHUB_ENV"
+
+          # Extract vcpkg commit ID
+          vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')
+          echo "vcpkg commit ID: $vcpkgCommitId"
+          echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" >> "$GITHUB_ENV"
+
+      - name: Get vcpkg commit id from vcpkg.json
+        uses: lukka/run-vcpkg@main
+        with:
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
+
+      - name: Get latest CMake and ninja
+        uses: lukka/get-cmake@main
+
+      - name: Run CMake
+        uses: lukka/run-cmake@main
+        with:
+          configurePreset: ${{ matrix.buildtype }}
+          buildPreset: ${{ matrix.buildtype }}
+          configurePresetAdditionalArgs: "['-DBUILD_TESTS=ON']"
+
+      - name: Create and Upload Artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: canary-macos-${{ matrix.buildtype }}-${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/build/${{ matrix.buildtype }}/bin/
+
+      - name: Run Unit Tests
+        run: |
+          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/unit
+          ctest --verbose
+
+#      - name: Run Integration Tests
+#        run: |
+#          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/integration
+#          ctest --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,4 @@ database_backup
 
 # CLION
 cmake-build-*
+compile_commands.json

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,9 @@
 {
-    "workspace.maxPreload": 10000
+  "workspace.maxPreload": 10000,
+  "workspace.ignoreDir": ["build", ".git", "vcpkg_installed"],
+  "workspace.preloadFileSize": 50,
+  "workspace.checkThirdParty": false,
+  "diagnostics.disable": ["lowercase-global", "undefined-global"],
+  "diagnostics.workspaceDelay": 5000,
+  "telemetry.enable": false
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,20 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 # Configure build options for compatibility with commodity CPUs
 if(NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+        # ARM64 specific flags for compatibility
+        if(APPLE)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=apple-a14")
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=apple-a14")
+        else()
+            # Generic ARM64 flags for Linux/other systems
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a -mtune=generic")
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a -mtune=generic")
+        endif()
+    endif()
 endif()
 
 # *****************************************************************************

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -108,6 +108,46 @@
       "cacheVariables": {
         "BUILD_TESTS": "ON"
       }
+    },
+    {
+      "name": "macos-release",
+      "inherits": "base",
+      "displayName": "macOS - Release",
+      "description": "macOS Release Build with Apple Clang",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "DEBUG_LOG": "ON",
+        "VCPKG_TARGET_TRIPLET": "arm64-osx",
+        "RUN_TESTS_AFTER_BUILD": "OFF"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "macos-debug",
+      "inherits": "macos-release",
+      "displayName": "macOS - Debug Build",
+      "description": "macOS Debug Build with Apple Clang",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "DEBUG_LOG": "ON",
+        "BUILD_STATIC_LIBRARY": "OFF",
+        "SPEED_UP_BUILD_UNITY": "OFF"
+      }
+    },
+    {
+      "name": "macos-test",
+      "inherits": "macos-release",
+      "displayName": "macOS - Test Build",
+      "description": "macOS Build with Tests",
+      "cacheVariables": {
+        "BUILD_TESTS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -134,6 +174,18 @@
     {
       "name": "windows-Xdebug",
       "configurePreset": "windows-debug"
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos-release"
+    },
+    {
+      "name": "macos-debug",
+      "configurePreset": "macos-debug"
+    },
+    {
+      "name": "macos-test",
+      "configurePreset": "macos-test"
     }
   ]
 }

--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -530,7 +530,7 @@ bool Spell::playerSpellCheck(const std::shared_ptr<Player> &player) const {
 
 	if (g_game().getWorldType() == WORLD_TYPE_NO_PVP && !player->isFirstOnStack()) {
 		const auto &instantSpell = g_spells().getInstantSpell(getName());
-		if (instantSpell && !instantSpell->getNeedCasterTargetOrDirection() || !getNeedTarget()) {
+		if ((instantSpell && !instantSpell->getNeedCasterTargetOrDirection()) || !getNeedTarget()) {
 			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 			return false;
 		}

--- a/src/creatures/interactions/chat.cpp
+++ b/src/creatures/interactions/chat.cpp
@@ -10,6 +10,7 @@
 #include "creatures/interactions/chat.hpp"
 
 #include "config/configmanager.hpp"
+#include "creatures/combat/condition.hpp"
 #include "creatures/players/player.hpp"
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -454,7 +454,7 @@ bool PlayerWheel::canPlayerSelectPointOnSlot(WheelSlots_t slot, bool recursive) 
 			return true;
 		}
 	} else if (slot == WheelSlots_t::SLOT_GREEN_50) {
-		return (recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true;
+		return ((recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true);
 	}
 
 	// Red quadrant
@@ -581,7 +581,7 @@ bool PlayerWheel::canPlayerSelectPointOnSlot(WheelSlots_t slot, bool recursive) 
 			return true;
 		}
 	} else if (slot == WheelSlots_t::SLOT_RED_50) {
-		return (recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true;
+		return ((recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true);
 	}
 
 	// Purple quadrant
@@ -708,7 +708,7 @@ bool PlayerWheel::canPlayerSelectPointOnSlot(WheelSlots_t slot, bool recursive) 
 			return true;
 		}
 	} else if (slot == WheelSlots_t::SLOT_PURPLE_50) {
-		return (recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true;
+		return ((recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true);
 	}
 
 	// Blue quadrant
@@ -835,7 +835,7 @@ bool PlayerWheel::canPlayerSelectPointOnSlot(WheelSlots_t slot, bool recursive) 
 			return true;
 		}
 	} else if (slot == WheelSlots_t::SLOT_BLUE_50) {
-		return (recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true;
+		return ((recursive && (getPointsBySlotType(slot) == getMaxPointsPerSlot(slot))) || true);
 	}
 
 	return false;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -56,7 +56,7 @@ class Npc;
 
 struct ModalWindow;
 struct Achievement;
-struct VIPGroup;
+class VIPGroup;
 struct Mount;
 struct Wing;
 struct Effect;

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -142,7 +142,8 @@ void Database::createDatabaseBackup(bool compress) const {
 				for (const auto &file : std::filesystem::directory_iterator(entry)) {
 					if (file.path().extension() == ".gz") {
 						auto fileTime = std::filesystem::last_write_time(file);
-						auto fileTimeSystemClock = std::chrono::clock_cast<std::chrono::system_clock>(fileTime);
+						auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(fileTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+						auto fileTimeSystemClock = std::chrono::system_clock::time_point { sctp.time_since_epoch() };
 
 						if (fileTimeSystemClock < sevenDaysAgo) {
 							std::filesystem::remove(file);

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -141,6 +141,11 @@ public:
 				else if constexpr (std::is_same_v<T, int64_t>) {
 					// Use std::stoll to convert string to int64_t
 					data = static_cast<T>(std::stoll(row[it->second]));
+				}
+				// Check if the type T is time_t
+				else if constexpr (std::is_same_v<T, time_t>) {
+					// Use std::stoll to convert string to time_t (usually long long)
+					data = static_cast<T>(std::stoll(row[it->second]));
 				} else {
 					// Throws exception indicating that type T is invalid
 					g_logger().error("Invalid signed type T");

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -8617,7 +8617,7 @@ void Game::playerLeaveParty(uint32_t playerId) {
 	}
 
 	std::shared_ptr<Party> party = player->getParty();
-	if (!party || (player->hasCondition(CONDITION_INFIGHT) && !player->getZoneType() == ZONE_PROTECTION)) {
+	if (!party || (player->hasCondition(CONDITION_INFIGHT) && player->getZoneType() != ZONE_PROTECTION)) {
 		player->sendTextMessage(TextMessage(MESSAGE_FAILURE, "You cannot leave party, contact the administrator."));
 		return;
 	}

--- a/src/io/ioprey.hpp
+++ b/src/io/ioprey.hpp
@@ -18,10 +18,6 @@ class TaskHuntingOption;
 class NetworkMessage;
 class Player;
 
-static const std::unique_ptr<PreySlot> &PreySlotNull {};
-static const std::unique_ptr<TaskHuntingSlot> &TaskHuntingSlotNull {};
-static const std::unique_ptr<TaskHuntingOption> &TaskHuntingOptionNull {};
-
 enum PreySlot_t : uint8_t {
 	PreySlot_One = 0,
 	PreySlot_Two = 1,
@@ -214,6 +210,10 @@ public:
 	uint16_t firstReward = 0;
 	uint16_t secondReward = 0;
 };
+
+static const std::unique_ptr<PreySlot> &PreySlotNull {};
+static const std::unique_ptr<TaskHuntingSlot> &TaskHuntingSlotNull {};
+static const std::unique_ptr<TaskHuntingOption> &TaskHuntingOptionNull {};
 
 class IOPrey {
 public:

--- a/src/items/weapons/weapons.hpp
+++ b/src/items/weapons/weapons.hpp
@@ -315,6 +315,7 @@ private:
 class WeaponWand : public Weapon {
 public:
 	explicit WeaponWand();
+	virtual ~WeaponWand() = default;
 
 	void configureWeapon(const ItemType &it) override;
 

--- a/src/lua/creature/actions.hpp
+++ b/src/lua/creature/actions.hpp
@@ -23,6 +23,7 @@ struct Position;
 class Action {
 public:
 	explicit Action();
+	virtual ~Action() = default;
 
 	// Scripting
 	virtual bool executeUse(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item, const Position &fromPosition, const std::shared_ptr<Thing> &target, const Position &toPosition, bool isHotkey);

--- a/src/lua/functions/events/action_functions.cpp
+++ b/src/lua/functions/events/action_functions.cpp
@@ -172,7 +172,7 @@ int ActionFunctions::luaActionPosition(lua_State* L) {
 
 	if (createItem) {
 		if (!Item::items.hasItemType(itemId)) {
-			Lua::reportErrorFunc("Not found item with id: " + itemId);
+			Lua::reportErrorFunc("Not found item with id: " + std::to_string(itemId));
 			Lua::pushBoolean(L, false);
 			return 1;
 		}

--- a/src/server/network/message/networkmessage.hpp
+++ b/src/server/network/message/networkmessage.hpp
@@ -20,6 +20,8 @@ class RSA;
 
 class NetworkMessage {
 public:
+	virtual ~NetworkMessage() = default;
+
 	using MsgSize_t = uint16_t;
 	// Headers:
 	// 2 bytes for unencrypted message size

--- a/src/server/network/message/outputmessage.hpp
+++ b/src/server/network/message/outputmessage.hpp
@@ -17,6 +17,7 @@ class Protocol;
 class OutputMessage : public NetworkMessage {
 public:
 	OutputMessage() = default;
+	virtual ~OutputMessage() = default;
 
 	// non-copyable
 	OutputMessage(const OutputMessage &) = delete;

--- a/src/server/network/webhook/webhook.hpp
+++ b/src/server/network/webhook/webhook.hpp
@@ -14,6 +14,9 @@
 struct WebhookTask {
 	std::string payload;
 	std::string url;
+
+	WebhookTask(std::string p, std::string u) :
+		payload(std::move(p)), url(std::move(u)) { }
 };
 
 class Webhook {

--- a/src/utils/pugicast.hpp
+++ b/src/utils/pugicast.hpp
@@ -49,4 +49,31 @@ namespace pugi {
 		// Return a default value if no exception is thrown
 		return T {};
 	}
+
+	// Template specialization for floating point types on macOS where std::from_chars might not support them
+	template <>
+	inline float cast<float>(const pugi::char_t* str) {
+		try {
+			float value = std::stof(str);
+			return std::clamp(value, std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max());
+		} catch (const std::invalid_argument &) {
+			logError(fmt::format("[{}] Invalid argument {}", __FUNCTION__, str));
+		} catch (const std::out_of_range &) {
+			logError(fmt::format("[{}] Result out of range: {}", __FUNCTION__, str));
+		}
+		return 0.0f;
+	}
+
+	template <>
+	inline double cast<double>(const pugi::char_t* str) {
+		try {
+			double value = std::stod(str);
+			return std::clamp(value, std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max());
+		} catch (const std::invalid_argument &) {
+			logError(fmt::format("[{}] Invalid argument {}", __FUNCTION__, str));
+		} catch (const std::out_of_range &) {
+			logError(fmt::format("[{}] Result out of range: {}", __FUNCTION__, str));
+		}
+		return 0.0;
+	}
 }

--- a/tests/unit/account/account_test.cpp
+++ b/tests/unit/account/account_test.cpp
@@ -23,7 +23,7 @@ using namespace boost::ut;
 using namespace std;
 
 template <typename T, typename U>
-bool eqEnum(const T& lhs, const U& rhs) {
+bool eqEnum(const T &lhs, const U &rhs) {
 	if constexpr (std::is_enum_v<T> && std::is_enum_v<U>) {
 		return enumToValue(lhs) == enumToValue(rhs);
 	} else if constexpr (std::is_enum_v<T>) {
@@ -36,7 +36,7 @@ bool eqEnum(const T& lhs, const U& rhs) {
 }
 
 suite<"account"> accountTest = [] {
-	InjectionFixture injectionFixture{};
+	InjectionFixture injectionFixture {};
 
 	test("Account::Account default constructors") = [] {
 		shared_ptr<Account> byId = make_shared<Account>(1);
@@ -46,9 +46,9 @@ suite<"account"> accountTest = [] {
 		expect(eq(byDescriptor->getID(), 0));
 
 		expect(byId->getDescriptor().empty());
-		expect(eq(byDescriptor->getDescriptor(), string{"canary@test.com"}));
+		expect(eq(byDescriptor->getDescriptor(), string { "canary@test.com" }));
 
-		for (auto& account : { byId, byDescriptor }) {
+		for (auto &account : { byId, byDescriptor }) {
 			expect(eq(account->getPremiumRemainingDays(), 0));
 			expect(eq(account->getPremiumLastDay(), 0));
 			expect(eqEnum(account->getAccountType(), AccountType::ACCOUNT_TYPE_NORMAL));
@@ -61,17 +61,17 @@ suite<"account"> accountTest = [] {
 		AccountErrors_t expectedError;
 	};
 
-	vector<AccountLoadTestCase> accountLoadTestCases{
-		{"returns by id if exists", make_shared<Account>(1), AccountErrors_t::Ok},
-		{"returns by descriptor if exists", make_shared<Account>("canary@test.com"), AccountErrors_t::Ok},
-		{"returns error if id is not valid", make_shared<Account>(2), AccountErrors_t::LoadingAccount},
-		{"returns error if descriptor is not valid", make_shared<Account>("not@valid.com"), AccountErrors_t::LoadingAccount}
+	vector<AccountLoadTestCase> accountLoadTestCases {
+		{ "returns by id if exists", make_shared<Account>(1), AccountErrors_t::Ok },
+		{ "returns by descriptor if exists", make_shared<Account>("canary@test.com"), AccountErrors_t::Ok },
+		{ "returns error if id is not valid", make_shared<Account>(2), AccountErrors_t::LoadingAccount },
+		{ "returns error if descriptor is not valid", make_shared<Account>("not@valid.com"), AccountErrors_t::LoadingAccount }
 	};
 
-	for (auto& testCase : accountLoadTestCases) {
+	for (auto &testCase : accountLoadTestCases) {
 		test(testCase.description) = [&injectionFixture, &testCase] {
 			auto [accountRepository] = injectionFixture.get<AccountRepository>();
-			accountRepository.addAccount("canary@test.com", AccountInfo{1, 1, 1, AccountType::ACCOUNT_TYPE_GOD});
+			accountRepository.addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
 			expect(eqEnum(testCase.account->load(), testCase.expectedError)) << testCase.description;
 		};
 	}
@@ -89,7 +89,7 @@ suite<"account"> accountTest = [] {
 		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
 		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GOD));
 
-		accountRepository.addAccount("canary2@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
+		accountRepository.addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
 
 		expect(eqEnum(acc.reload(), AccountErrors_t::Ok));
 		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
@@ -368,7 +368,7 @@ suite<"account"> accountTest = [] {
 
 		auto [type, coins, coinType, description] = accountRepository.coinsTransactions_[1][0];
 		expect(eq(coins, 100));
-		expect(eqEnum(coinType,CoinType::Normal));
+		expect(eqEnum(coinType, CoinType::Normal));
 		expect(eqEnum(type, CoinTransactionType::Remove));
 		expect(eq(description, std::string { "REMOVE Coins" }));
 
@@ -421,9 +421,9 @@ suite<"account"> accountTest = [] {
 		accountRepository.addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
 
 		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eq(std::string{}, acc.getPassword()));
-		expect(eq(std::string{"error"}, logger.logs[0].level));
-		expect(eq(std::string{"Failed to get password for account[1]!"}, logger.logs[0].message));
+		expect(eq(std::string {}, acc.getPassword()));
+		expect(eq(std::string { "error" }, logger.logs[0].level));
+		expect(eq(std::string { "Failed to get password for account[1]!" }, logger.logs[0].message));
 	};
 
 	test("Account::addPremiumDays sets premium remaining days") = [] {
@@ -514,8 +514,8 @@ suite<"account"> accountTest = [] {
 		Account acc { 1 };
 		accountRepository.addAccount(
 			"canary@test.com",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, {{ "Canary", 1 }, { "Canary2", 2 }} }
- 		);
+			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } } }
+		);
 
 		expect(acc.load() == AccountErrors_t::Ok);
 		auto [players, error] = acc.getAccountPlayers();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "gmp",
-      "platform": "linux"
+      "platform": "linux | osx"
     },
     {
       "name": "mpir",


### PR DESCRIPTION
Sets up compilation for macOS with the clang compiler. Had to fix some issues with type casting for lua/database and hit a few warnings along the way so fixed those as well.

# Changes
- Added `macos-*` presets
- Added macos github workflow
- Fixes a few high-priority clang warnings
