### PR TITLE
fix: type safety on raid checks

### DIFF
--- a/data/scripts/globalevents/global_server_save.lua
+++ b/data/scripts/globalevents/global_server_save.lua
@@ -12,6 +12,12 @@ local function ServerSave()
 
 	-- Update daily reward next server save timestamp
 	UpdateDailyRewardGlobalStorage(DailyReward.storages.lastServerSave, os.time())
+
+	-- Reset raid daily counters
+	for name, raid in pairs(Raid.registry) do
+		raid.kv:set("checks-today", 0)
+		raid.kv:set("last-check-date", os.date("%Y%m%d"))
+	end
 end
 
 local function ServerSaveWarning(time)


### PR DESCRIPTION
This shouldn't happen, but if you happen to have some uninitialized state in the database you can run into raid check exceptions like the following:

```
[2025-31-08 09:34:43.520] [thread 140345198] [error] Lua Script Error Detected
---------------------------------------
Interface: Scripts Interface
Script ID: data/scripts/globalevents/raids.lua:callback
Error Description: data/libs/systems/raids.lua:87: attempt to perform arithmetic on local 'checksToday' (a nil value)
stack traceback:
        [C]: in function '__add'
        data/libs/systems/raids.lua:87: in function 'canStart'
        data/libs/systems/raids.lua:51: in function 'tryStart'
        data/scripts/globalevents/raids.lua:11: in function <data/scripts/globalevents/raids.lua:5>
---------------------------------------
```