### PR TITLE
chore: setup ctest from root

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
-          configurePresetAdditionalArgs: "['-DBUILD_TESTS=ON']"
 
       - name: Create and Upload Artifact
         uses: actions/upload-artifact@main
@@ -107,10 +106,8 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/unit
-          ctest --verbose
+          ctest -V -R unit
 
 #      - name: Run Integration Tests
 #        run: |
-#          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/integration
-#          ctest --verbose
+#          ctest -V -R integration

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -101,7 +101,6 @@ jobs:
         with:
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
-          configurePresetAdditionalArgs: "['-DBUILD_TESTS=ON']"
 
       - name: Create and Upload Artifact
         uses: actions/upload-artifact@main
@@ -112,10 +111,8 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/unit
-          ctest --verbose
+          ctest -V -R unit
 
 #      - name: Run Integration Tests
 #        run: |
-#          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/integration
-#          ctest --verbose
+#          ctest -V -R integration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,18 +97,16 @@ if(OPTIONS_ENABLE_SCCACHE)
     endif()
 endif()
 
-option(BUILD_TESTS "Build tests" OFF) # By default, tests will not be built
-option(RUN_TESTS_AFTER_BUILD "Run tests when building" OFF) # By default, tests will only run if requested
-
 # *****************************************************************************
 # Add project
 # *****************************************************************************
 add_subdirectory(src)
 
-if(BUILD_TESTS OR PACKAGE_TESTS)
+include(CTest)
+if(BUILD_TESTING)
     log_option_enabled("tests")
     add_subdirectory(tests)
-    add_compile_definitions(BUILD_TESTS)
+    enable_testing()
 else()
     log_option_disabled("tests")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,8 @@
         "BUILD_STATIC_LIBRARY": "ON",
         "SPEED_UP_BUILD_UNITY": "ON",
         "OPTIONS_ENABLE_SCCACHE": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "BUILD_TESTING": "OFF"
       }
     },
     {
@@ -25,7 +26,8 @@
       "displayName": "Windows - Release",
       "description": "Windows Release Build",
       "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+        "BUILD_TESTING": "OFF"
       },
       "architecture": {
         "value": "x64",
@@ -41,7 +43,8 @@
         "ASAN_ENABLED": "ON",
         "DEBUG_LOG": "ON",
         "BUILD_STATIC_LIBRARY": "OFF",
-        "VCPKG_TARGET_TRIPLET": "x64-windows"
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "BUILD_TESTING": "ON"
       }
     },
     {
@@ -55,7 +58,8 @@
         "ASAN_ENABLED": "OFF",
         "BUILD_STATIC_LIBRARY": "OFF",
         "SPEED_UP_BUILD_UNITY": "OFF",
-        "VCPKG_TARGET_TRIPLET": "x64-windows"
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "BUILD_TESTING": "ON"
       }
     },
     {
@@ -68,7 +72,7 @@
           "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
           "type": "FILEPATH"
         },
-        "RUN_TESTS_AFTER_BUILD": "OFF"
+        "BUILD_TESTING": "OFF"
       },
       "condition": {
         "type": "equals",
@@ -79,34 +83,27 @@
     {
       "name": "linux-debug",
       "inherits": "linux-release",
-      "displayName": "Linux - Debug Build",
+      "displayName": "Linux - Debug",
       "description": "Build Debug Mode",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "DEBUG_LOG": "ON",
-        "SPEED_UP_BUILD_UNITY": "OFF"
+        "SPEED_UP_BUILD_UNITY": "OFF",
+        "BUILD_TESTING": "ON"
       }
     },
     {
       "name": "linux-debug-asan",
       "inherits": "linux-release",
-      "displayName": "Linux - Debug Build",
+      "displayName": "Linux - Debug w/ Address Sanitizer",
       "description": "Build Debug Mode With ASAN Enable",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "DEBUG_LOG": "ON",
         "ASAN_ENABLED": "ON",
-        "SPEED_UP_BUILD_UNITY": "OFF"
-      }
-    },
-    {
-      "name": "linux-test",
-      "inherits": "linux-release",
-      "displayName": "Linux - Test Build",
-      "description": "Build Tests",
-      "cacheVariables": {
-        "BUILD_TESTS": "ON"
+        "SPEED_UP_BUILD_UNITY": "OFF",
+        "BUILD_TESTING": "ON"
       }
     },
     {
@@ -119,7 +116,7 @@
         "CMAKE_C_COMPILER": "/usr/bin/clang",
         "DEBUG_LOG": "ON",
         "VCPKG_TARGET_TRIPLET": "arm64-osx",
-        "RUN_TESTS_AFTER_BUILD": "OFF"
+        "BUILD_TESTING": "OFF"
       },
       "condition": {
         "type": "equals",
@@ -130,62 +127,60 @@
     {
       "name": "macos-debug",
       "inherits": "macos-release",
-      "displayName": "macOS - Debug Build",
+      "displayName": "macOS - Debug",
       "description": "macOS Debug Build with Apple Clang",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "DEBUG_LOG": "ON",
         "BUILD_STATIC_LIBRARY": "OFF",
-        "SPEED_UP_BUILD_UNITY": "OFF"
-      }
-    },
-    {
-      "name": "macos-test",
-      "inherits": "macos-release",
-      "displayName": "macOS - Test Build",
-      "description": "macOS Build with Tests",
-      "cacheVariables": {
-        "BUILD_TESTS": "ON"
+        "SPEED_UP_BUILD_UNITY": "OFF",
+        "BUILD_TESTING": "ON"
       }
     }
   ],
   "buildPresets": [
-    {
-      "name": "linux-release",
-      "configurePreset": "linux-release"
-    },
-    {
-      "name": "linux-debug",
-      "configurePreset": "linux-debug"
-    },
-    {
-      "name": "linux-test",
-      "configurePreset": "linux-test"
-    },
-    {
-      "name": "windows-release",
-      "configurePreset": "windows-release"
-    },
+    { "name": "linux-release", "configurePreset": "linux-release" },
+    { "name": "linux-debug", "configurePreset": "linux-debug" },
+    { "name": "windows-release", "configurePreset": "windows-release" },
     {
       "name": "windows-release-asan",
       "configurePreset": "windows-release-asan"
     },
+    { "name": "windows-debug", "configurePreset": "windows-debug" },
+    { "name": "macos-release", "configurePreset": "macos-release" },
+    { "name": "macos-debug", "configurePreset": "macos-debug" }
+  ],
+  "testPresets": [
     {
-      "name": "windows-Xdebug",
-      "configurePreset": "windows-debug"
+      "name": "windows-release-asan",
+      "configurePreset": "windows-release-asan",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
     },
     {
-      "name": "macos-release",
-      "configurePreset": "macos-release"
+      "name": "windows-debug",
+      "configurePreset": "windows-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
+    },
+    {
+      "name": "linux-debug",
+      "configurePreset": "linux-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
+    },
+    {
+      "name": "linux-debug-asan",
+      "configurePreset": "linux-debug-asan",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
     },
     {
       "name": "macos-debug",
-      "configurePreset": "macos-debug"
-    },
-    {
-      "name": "macos-test",
-      "configurePreset": "macos-test"
+      "configurePreset": "macos-debug",
+      "output": { "outputOnFailure": true },
+      "execution": { "noTestsAction": "error" }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,26 @@ our [customized tools](https://docs.opentibiabr.com/opentibiabr/downloads/tools)
 
 ## Getting Started
 
-* [Gitbook](https://docs.opentibiabr.com/opentibiabr/projects/canary).
-* [Wiki](https://github.com/opentibiabr/canary/wiki).
+- [Gitbook](https://docs.opentibiabr.com/opentibiabr/projects/canary).
+- [Wiki](https://github.com/opentibiabr/canary/wiki).
+
+## Running Tests
+
+Tests can be run directly from the repository root using CMake test presets:
+
+```bash
+# Configure and build tests for your platform
+cmake --preset linux-debug && cmake --build --preset linux-debug
+
+# Run all tests
+ctest --preset linux-debug
+
+# For other platforms use:
+# ctest --preset macos-debug
+# ctest --preset windows-debug
+```
+
+For detailed testing information including adding tests and framework usage, see [tests/README.md](tests/README.md).
 
 ## Support
 
@@ -26,8 +44,8 @@ If you need help, please visit our [discord](https://discord.gg/gvTj5sh9Mp). Our
 
 Here are some ways you can contribute:
 
-* [Issue Tracker](https://github.com/opentibiabr/canary/issues/new/choose).
-* [Pull Request](https://github.com/opentibiabr/canary/pulls).
+- [Issue Tracker](https://github.com/opentibiabr/canary/issues/new/choose).
+- [Pull Request](https://github.com/opentibiabr/canary/pulls).
 
 You are subject to our code of conduct, read at [this link](https://github.com/opentibiabr/canary/blob/main/CODE_OF_CONDUCT.md).
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,40 +1,67 @@
-find_package(ut CONFIG REQUIRED)
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+# --- boost::ut (handle common package/target name variants) ---
+# Try the canonical package name first (as used by the project),
+# then fall back to popular alt names in package managers.
+set(_ut_targets)
+find_package(Boost.UT CONFIG QUIET)
+if(Boost.UT_FOUND)
+    list(APPEND _ut_targets Boost::ut)
+else()
+    find_package(boost_ut CONFIG QUIET) # some distros
+    if(boost_ut_FOUND)
+        list(APPEND _ut_targets boost::ut)
+    else()
+        find_package(ut CONFIG QUIET) # your original
+        if(ut_FOUND)
+            # guessing an imported target name; adjust if your toolchain differs
+            list(APPEND _ut_targets Boost::ut)
+        endif()
+    endif()
+endif()
+
+if(NOT _ut_targets)
+    message(
+        FATAL_ERROR "Could not find boost::ut. Try installing via vcpkg (boost-ut) or add FetchContent in the root."
+    )
+endif()
+
+# Utility to pick the first found target (Boost::ut OR boost::ut)
+list(GET _ut_targets 0 UT_IMPORTED_TARGET)
 
 enable_testing()
 
+# ---------------------------
+# Helper: define one test exe
+# ---------------------------
 function(setup_test TARGET_NAME DIR)
-    add_executable(${TARGET_NAME} main.cpp)
+    add_executable(${TARGET_NAME} ${CMAKE_CURRENT_LIST_DIR}/main.cpp)
 
+    # Your project-specific knobs
     target_compile_definitions(${TARGET_NAME} PUBLIC -DDEBUG_LOG -DBUILD_TESTS)
-    target_link_libraries(${TARGET_NAME}  PRIVATE Boost::ut ${PROJECT_NAME}_lib)
-    target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/tests/fixture PRIVATE ${CMAKE_SOURCE_DIR}/tests/${DIR})
-
-    setup_target(${TARGET_NAME})
-
-    set_target_properties(${TARGET_NAME} PROPERTIES
-        UNITY_BUILD OFF
-        INTERPROCEDURAL_OPTIMIZATION OFF
+    target_link_libraries(${TARGET_NAME} PRIVATE ${UT_IMPORTED_TARGET} ${PROJECT_NAME}_lib)
+    target_include_directories(
+        ${TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/tests/fixture ${CMAKE_SOURCE_DIR}/tests/${DIR}
     )
-    log_option_disabled("Build unity")
+    target_compile_features(${TARGET_NAME} PRIVATE cxx_std_20)
 
+    # Keep your hooks
+    setup_target(${TARGET_NAME})
     configure_linking(${TARGET_NAME})
 
-    add_test(NAME ${DIR} COMMAND ${TARGET_NAME} --reporter console --success)
-    set_tests_properties(${DIR} PROPERTIES
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/${DIR}
-        ENVIRONMENT "CATCH_CONFIG_CONSOLE_WIDTH=160"
-        TIMEOUT 120
-    )
+    # Turn OFF unity/IPO for tests (tests benefit from fast rebuilds & debugging)
+    set_target_properties(${TARGET_NAME} PROPERTIES UNITY_BUILD OFF INTERPROCEDURAL_OPTIMIZATION OFF)
+    log_option_disabled("Build unity")
 
-    if(RUN_TESTS_AFTER_BUILD)
-        add_custom_command(
-                TARGET ${TARGET_NAME} POST_BUILD
-                COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --output-on-failure --tests-regex "^${DIR}$"
-                COMMENT "Running ctest ${DIR} after building ${TARGET_NAME}"
-                WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        )
-    endif (RUN_TESTS_AFTER_BUILD)
+    # Register with ctest. boost::ut doesn’t use Catch2-style CLI; just run the binary.
+    add_test(NAME ${DIR} COMMAND ${TARGET_NAME})
+
+    # Per-test runtime context
+    set_tests_properties(${DIR} PROPERTIES WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/${DIR} TIMEOUT 120)
 endfunction()
 
+# Suites (each subdir calls setup_test(...) for its cases)
 add_subdirectory(unit)
 add_subdirectory(integration)

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,31 +2,34 @@
 
 ### Running tests
 
-To run the tests, you need to compile with the flag `BUILD_TESTS` enabled (`-DBUILD_TESTS:BOOL=ON`).
-This will build all tests within the `tests` directory and generate a `tests` folder in the build directory, which contains the test executable.
+Tests can be run directly from the repository root using CMake test presets. First, configure and build tests for your platform:
 
-Once the executable is generated, you can run the tests with the following command:
 ```bash
-cd build/{build_type}/tests/unit
-./canary_ut
+# Configure and build tests
+cmake --preset linux-debug && cmake --build --preset linux-debug
 
-cd build/{build_type}/tests/integration
-./canary_it
+# Run all tests
+ctest --preset linux-debug
+
+# Run only unit tests
+ctest --preset linux-debug -R unit
+
+# Run only integration tests
+ctest --preset linux-debug -R integration
+
+# Use -VV for verbose output showing individual test cases
+ctest --preset linux-debug -VV
 ```
 
-#### Running tests with CTest
+Replace `linux-debug` with `macos-debug` or `windows-debug` for other platforms.
 
-You can also run the tests using CTest:
+#### Direct executable access
+
+You can also run test executables directly if needed:
+
 ```bash
--- from the build/{build_type} directory
--- to run all tests 
-ctest --verbose
-
--- to run only unit tests
-ctest --verbose -R unit
-
--- to run only integration tests
-ctest --verbose -R integration
+./build/linux-debug/tests/unit/canary_ut
+./build/linux-debug/tests/integration/canary_it
 ```
 
 ### Adding tests
@@ -49,13 +52,14 @@ As much as possible, tests should be added in the same folder as the code they a
 
 ### Boost::ut
 
-Tests are written using the Boost::ut framework.  We've chosen this framework because it is simple, macro-free, intuitive, and easy to use.
+Tests are written using the Boost::ut framework. We've chosen this framework because it is simple, macro-free, intuitive, and easy to use.
 In this section, we will go over the basics of the framework, but you can find more information in the [Boost::ut documentation](https://boost-ext.github.io/ut/).
 There are many ways to write tests, and we encourage you to read the documentation to find the way that works best for you.
 
 #### Suites
 
 Tests needs to be encapsulated by suites, which are defined using `suite<>` structure.
+
 ```cpp
 suite<"foo"> test_foo = [] {
     // Tests go here
@@ -71,6 +75,7 @@ Avoid creating tests directly in the main function, as this will put them in the
 #### Tests
 
 Tests can be defined using the `test()` lambda or the `_test` operator:
+
 ```cpp
 suite<"foo"> test_foo = [] {
     "test 1"_test = [] {
@@ -89,6 +94,7 @@ Both are equivalent, the received argument is the description of the test.
 The description is used to identify the test in the output, and should be unique within a suite.
 
 Assertions are done using the `expect()` function:
+
 ```cpp
 suite<"foo"> test_foo = [] {
     "test 1"_test = [] {


### PR DESCRIPTION
Makes running test with `ctest` a bit easier.

Key changesL
- drop `*-test` build/config presets to simplify setup
- `*-debug` presets now always build in testing
- added test presets for `*-debug` that can be used with `ctest`

## Running tests

Tests can be run directly from the repository root using CMake test presets:

```bash
# Configure and build tests for your platform
cmake --preset linux-debug && cmake --build --preset linux-debug

# Run all tests
ctest --preset linux-debug

# For other platforms use:
# ctest --preset macos-debug
# ctest --preset windows-debug
```

