### PR TITLE
refactor: player login container and hotkey handling

### DIFF
--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -538,11 +538,9 @@ void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &pl
 		return;
 	}
 
-	bool oldProtocol = g_configManager().getBoolean(OLD_PROTOCOL) && player->getProtocolVersion() < 1200;
 	auto query = fmt::format("SELECT pid, sid, itemtype, count, attributes FROM player_items WHERE player_id = {} ORDER BY sid DESC", player->getGUID());
 
 	ItemsMap inventoryItems;
-	std::vector<std::pair<uint8_t, std::shared_ptr<Container>>> openContainersList;
 	std::vector<std::shared_ptr<Item>> itemsToStartDecaying;
 
 	try {
@@ -576,12 +574,6 @@ void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &pl
 
 				const std::shared_ptr<Container> &itemContainer = item->getContainer();
 				if (itemContainer) {
-					if (!oldProtocol) {
-						auto cid = item->getAttribute<int64_t>(ItemAttribute_t::OPENCONTAINER);
-						if (cid > 0) {
-							openContainersList.emplace_back(cid, itemContainer);
-						}
-					}
 					for (const bool isLootContainer : { true, false }) {
 						const auto checkAttribute = isLootContainer ? ItemAttribute_t::QUICKLOOTCONTAINER : ItemAttribute_t::OBTAINCONTAINER;
 						if (item->hasAttribute(checkAttribute)) {
@@ -601,17 +593,6 @@ void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &pl
 		// Now that all items and containers have been added and parent chain is established, start decay
 		for (const auto &item : itemsToStartDecaying) {
 			item->startDecaying();
-		}
-
-		if (!oldProtocol) {
-			std::ranges::sort(openContainersList.begin(), openContainersList.end(), [](const std::pair<uint8_t, std::shared_ptr<Container>> &left, const std::pair<uint8_t, std::shared_ptr<Container>> &right) {
-				return left.first < right.first;
-			});
-
-			for (auto &it : openContainersList) {
-				player->addContainer(it.first - 1, it.second);
-				player->onSendContainer(it.second);
-			}
 		}
 
 	} catch (const std::exception &e) {

--- a/src/lua/functions/events/event_callback_functions.cpp
+++ b/src/lua/functions/events/event_callback_functions.cpp
@@ -36,7 +36,7 @@ int EventCallbackFunctions::luaEventCallbackCreate(lua_State* luaState) {
 	const auto &callbackName = Lua::getString(luaState, 2);
 	if (callbackName.empty()) {
 		Lua::reportErrorFunc("Invalid callback name");
-		return 1;
+		return 0;
 	}
 
 	bool skipDuplicationCheck = Lua::getBoolean(luaState, 3, false);
@@ -71,6 +71,7 @@ int EventCallbackFunctions::luaEventCallbackType(lua_State* luaState) {
 	if (!found) {
 		g_logger().error("[{}] No valid event name: {}", __func__, typeName);
 		Lua::pushBoolean(luaState, false);
+		return 1;
 	}
 
 	Lua::pushBoolean(luaState, true);
@@ -101,12 +102,12 @@ int EventCallbackFunctions::luaEventCallbackRegister(lua_State* luaState) {
 int EventCallbackFunctions::luaEventCallbackLoad(lua_State* luaState) {
 	const auto &callback = Lua::getUserdataShared<EventCallback>(luaState, 1, "EventCallback");
 	if (!callback) {
-		return 1;
+		return 0;
 	}
 
 	if (!callback->loadScriptId()) {
 		Lua::reportErrorFunc("Cannot load callback");
-		return 1;
+		return 0;
 	}
 
 	Lua::pushBoolean(luaState, true);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7123,7 +7123,6 @@ void ProtocolGame::sendAddCreature(const std::shared_ptr<Creature> &creature, co
 
 	if (isLogin) {
 		sendMagicEffect(pos, CONST_ME_TELEPORT);
-		sendHotkeyPreset();
 		sendDisableLoginMusic();
 	}
 
@@ -7197,8 +7196,8 @@ void ProtocolGame::sendAddCreature(const std::shared_ptr<Creature> &creature, co
 	player->sendGameNews();
 	player->sendIcons();
 
-	// We need to manually send the open containers on player login, on IOLoginData it won't work.
-	if (isLogin && oldProtocol) {
+	// Send open containers after login.
+	if (isLogin) {
 		player->openPlayerContainers();
 	}
 }
@@ -9794,20 +9793,6 @@ void ProtocolGame::sendDisableLoginMusic() {
 	msg.addByte(0x00);
 	msg.addByte(0x00);
 	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendHotkeyPreset() {
-	if (!player || oldProtocol) {
-		return;
-	}
-
-	auto vocation = g_vocations().getVocation(player->getVocation()->getBaseId());
-	if (vocation) {
-		NetworkMessage msg;
-		msg.addByte(0x9D);
-		msg.add<uint32_t>(vocation->getClientId());
-		writeToOutputBuffer(msg);
-	}
 }
 
 void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType) {

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -567,7 +567,6 @@ private:
 	void sendSingleSoundEffect(const Position &pos, SoundEffect_t id, SourceEffect_t source);
 	void sendDoubleSoundEffect(const Position &pos, SoundEffect_t mainSoundId, SourceEffect_t mainSource, SoundEffect_t secondarySoundId, SourceEffect_t secondarySource);
 
-	void sendHotkeyPreset();
 	void sendTakeScreenshot(Screenshot_t screenshotType);
 	void sendDisableLoginMusic();
 


### PR DESCRIPTION
Removed protocol version checks and open container logic from IOLoginDataLoad, moving container opening to ProtocolGame::sendAddCreature for all logins. Also removed the unused sendHotkeyPreset function and its call, simplifying login flow and improving code clarity. Fixed Lua event callback functions to return correct values on error.

Fix: #3611 