### PR TITLE
refactor: test env setup and logger injection in tests

### DIFF
--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -3,6 +3,7 @@
 #include "account/account_repository_db.hpp"
 #include "account/account_info.hpp"
 #include "enums/account_type.hpp"
+#include "lib/logging/in_memory_logger.hpp"
 #include "test_env.hpp"
 #include "utils/tools.hpp"
 
@@ -123,9 +124,8 @@ namespace it_account_repo_db {
 	}
 
 	inline suite<"AccountRepositoryDB"> suite_all = [] {
-		auto &env = TestEnv::instance();
-		auto &db = *env.db;
-		auto &logger = *env.logger;
+		auto &db = g_database();
+		auto &logger = dynamic_cast<InMemoryLogger &>(g_logger());
 
 		register_loadByID(db);
 		register_loadByEmailOrName(db);

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -1,5 +1,21 @@
 #include <boost/ut.hpp>
+#include "config/configmanager.hpp"
+#include "database/database.hpp"
+#include "lib/di/container.hpp"
+#include "lib/logging/in_memory_logger.hpp"
+#include "test_database.hpp"
 
 using namespace boost::ut;
 
-int main() { }
+int main() {
+	di::extension::injector<> injector {};
+	InMemoryLogger::install(injector);
+	DI::setTestContainer(&injector);
+
+	TestDatabase::init();
+	(void)g_logger();
+	(void)g_configManager();
+	(void)g_database();
+
+	return cfg<>.run();
+}

--- a/tests/integration/player_storage/player_storage_repository_db_it.cpp
+++ b/tests/integration/player_storage/player_storage_repository_db_it.cpp
@@ -78,8 +78,7 @@ namespace it_player_storage_repo_db {
 	}
 
 	inline suite<"DbPlayerStorageRepository"> suite_all = [] {
-		auto &env = TestEnv::instance();
-		auto &db = *env.db;
+		auto &db = g_database();
 
 		register_load(db);
 		register_deleteKeys(db);

--- a/tests/integration/test_env.hpp
+++ b/tests/integration/test_env.hpp
@@ -2,46 +2,8 @@
 
 #include <exception>
 #include <functional>
-#include <string>
 
 #include "database/database.hpp"
-#include "lib/di/container.hpp"
-#include "lib/logging/in_memory_logger.hpp"
-#include "test_database.hpp"
-
-struct TestEnv final {
-	di::extension::injector<> injector {};
-	InMemoryLogger* logger;
-	Database* db;
-
-	TestEnv();
-
-	static TestEnv &instance();
-
-private:
-	InMemoryLogger* initLogger();
-	Database* initDb();
-};
-
-inline TestEnv::TestEnv() :
-	injector {}, logger(initLogger()), db(initDb()) { }
-
-inline InMemoryLogger* TestEnv::initLogger() {
-	InMemoryLogger::install(injector);
-	DI::setTestContainer(&injector);
-	return &dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
-}
-
-inline Database* TestEnv::initDb() {
-	TestDatabase::init();
-	return &g_database();
-}
-
-inline TestEnv testEnvInstance {};
-
-inline TestEnv &TestEnv::instance() {
-	return testEnvInstance;
-}
 
 inline auto databaseTest(Database &db, const std::function<void(void)> &load) {
 	return [&db, load] {

--- a/tests/unit/lib/logging/in_memory_logger.hpp
+++ b/tests/unit/lib/logging/in_memory_logger.hpp
@@ -51,7 +51,7 @@ public:
 		return false;
 	}
 
-	void setLevel(const std::string &name) override {
+	void setLevel(const std::string &name) const override {
 		// For the stub, setting a level might not have any behavior.
 		// But you can implement level filtering if you like.
 	}
@@ -61,9 +61,34 @@ public:
 		return "DEBUG";
 	}
 
-	virtual void log(const std::string &lvl, fmt::basic_string_view<char> msg) const override {
-		logs.push_back({ lvl, { msg.data(), msg.size() } });
+	void info(const std::string &msg) const override {
+		logs.push_back({ "info", msg });
 	}
+
+	void warn(const std::string &msg) const override {
+		logs.push_back({ "warning", msg });
+	}
+
+	void error(const std::string &msg) const override {
+		logs.push_back({ "error", msg });
+	}
+
+	void critical(const std::string &msg) const override {
+		logs.push_back({ "critical", msg });
+	}
+
+#if defined(DEBUG_LOG)
+	void debug(const std::string &msg) const override {
+		logs.push_back({ "debug", msg });
+	}
+
+	void trace(const std::string &msg) const override {
+		logs.push_back({ "trace", msg });
+	}
+#else
+	void debug(const std::string &) const override { }
+	void trace(const std::string &) const override { }
+#endif
 
 	// Helper methods for testing
 	size_t logCount() const {

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -1,5 +1,19 @@
 #include <boost/ut.hpp>
+#include "config/configmanager.hpp"
+#include "database/database.hpp"
+#include "lib/di/container.hpp"
+#include "lib/logging/in_memory_logger.hpp"
 
 using namespace boost::ut;
 
-int main() { }
+int main() {
+	di::extension::injector<> injector {};
+	InMemoryLogger::install(injector);
+	DI::setTestContainer(&injector);
+
+	(void)g_logger();
+	(void)g_configManager();
+	(void)g_database();
+
+	return cfg<>.run();
+}


### PR DESCRIPTION
Removes the TestEnv singleton and updates integration and unit tests to use global dependency injection for logger, config manager, and database. Refactors InMemoryLogger to override log level methods directly and updates test main entry points to initialize dependencies explicitly. This simplifies test setup and improves consistency across test suites.
