### PR TITLE
fix: infinite loop in the replaceString function

### DIFF
--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -247,7 +247,7 @@ std::string generateToken(const std::string &key, uint32_t ticks) {
 }
 
 void replaceString(std::string &str, const std::string &sought, const std::string &replacement) {
-	if (str.empty()) {
+	if (str.empty() || sought.empty()) {
 		return;
 	}
 


### PR DESCRIPTION
Implement safeguards in the `replaceString` function to prevent the occurrence of an infinite loop when the function is invoked with an empty search term. This change can be achieved by validating the input parameters before processing, ensuring that the search term is neither empty nor null, thus allowing the function to exit gracefully without causing any unintended repetitive behavior.