### PR TITLE
fix: add nullptr check to function Bank::deposit(destination, amount)

### DIFF
--- a/src/game/bank/bank.cpp
+++ b/src/game/bank/bank.cpp
@@ -156,10 +156,11 @@ bool Bank::deposit(const std::shared_ptr<Bank> &destination) {
 	if (!bankable) {
 		return false;
 	}
-	if (bankable->getPlayer() == nullptr) {
+	auto player = bankable->getPlayer();
+	if (!player) {
 		return false;
 	}
-	auto amount = bankable->getPlayer()->getMoney();
+	auto amount = player->getMoney();
 	return deposit(destination, amount);
 }
 
@@ -171,11 +172,13 @@ bool Bank::deposit(const std::shared_ptr<Bank> &destination, uint64_t amount) {
 	if (!bankable) {
 		return false;
 	}
-	if (!g_game().removeMoney(bankable->getPlayer(), amount)) {
+	auto player = bankable->getPlayer();
+	if (!player) {
 		return false;
 	}
-	if (bankable->getPlayer() != nullptr) {
-		g_metrics().addCounter("balance_decrease", amount, { { "player", bankable->getPlayer()->getName() }, { "context", "bank_deposit" } });
+	if (!g_game().removeMoney(player, amount)) {
+		return false;
 	}
+	g_metrics().addCounter("balance_decrease", amount, { { "player", player->getName() }, { "context", "bank_deposit" } });
 	return destination->credit(amount);
 }

--- a/src/game/bank/bank.cpp
+++ b/src/game/bank/bank.cpp
@@ -172,7 +172,7 @@ bool Bank::deposit(const std::shared_ptr<Bank> &destination, uint64_t amount) {
 	if (!bankable) {
 		return false;
 	}
-	auto player = bankable->getPlayer();
+	const auto &player = bankable->getPlayer();
 	if (!player) {
 		return false;
 	}


### PR DESCRIPTION
Added protection to the bank deposit so it only grabs the player pointer once and aborts if it’s null, preventing crashes from invalid access and a possible deposit exploit.

_This exploit is used on some servers nowadays._

ps:
Alternatively, there’s the option to rollback the deposit if any credit step fails. However, whether this is appropriate or not is up to someone with more expertise...

```
bool Bank::deposit(const std::shared_ptr<Bank>& destination, uint64_t amount) {
	if (!destination) {
		return false;
	}
	auto bankable = getBankable();
	if (!bankable) {
		return false;
	}
	const auto &player = bankable->getPlayer();
	if (!player) {
		return false;
	}
	const uint64_t playerBalance = player->getMoney();
	if (!g_game().removeMoney(player, amount)) {
		return false;
	}
	if (!destination->credit(amount)) {
		g_logger().error("Bank::deposit: failed to credit destination for player {} (balance: {}, amount: {})", player->getName(), playerBalance, amount);
		g_game().addMoney(player, amount);
		return false;
	}
	g_metrics().addCounter("balance_decrease", amount, { { "player", player->getName() }, { "context", "bank_deposit" } });
	return true;
}
```