### PR TITLE
fix: add uint8_t limit to cyclopedia tracker list, preventing client crash (#3693)

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -812,7 +812,7 @@ void Player::addMonsterToCyclopediaTrackerList(const std::shared_ptr<MonsterType
 
 	const uint16_t raceId = mtype ? mtype->info.raceid : 0;
 	auto &tracker = isBoss ? m_bosstiaryMonsterTracker : m_bestiaryMonsterTracker;
-	if (tracker.emplace(mtype).second) {
+	if (tracker.size() < static_cast<size_t>(std::numeric_limits<uint8_t>::max()) && tracker.emplace(mtype).second) {
 		if (reloadClient && raceId != 0) {
 			if (isBoss) {
 				client->parseSendBosstiary();


### PR DESCRIPTION
# Description

Added a `uint8_t` limit to the bestiary tracker to ensure that no values above `255` can be sent.  
This prevents the client from crashing when a higher value is attempted.

Thanks to @cjaker for the report.

## Behaviour
### **Actual**

The bestiary tracker could grow beyond the safe range of `uint8_t`.  
If a value greater than `255` was sent, it could cause the client to crash.

### **Expected**

The bestiary tracker should never exceed the `uint8_t` maximum (`255`).  
Any attempt to insert values beyond this limit is now prevented safely.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
