### PR TITLE
feat: export whole combat damage to lua

### DIFF
--- a/src/lua/functions/lua_functions_loader.cpp
+++ b/src/lua/functions/lua_functions_loader.cpp
@@ -602,6 +602,89 @@ void Lua::pushCombatDamage(lua_State* L, const CombatDamage &damage) {
 	lua_pushnumber(L, damage.origin);
 }
 
+void Lua::pushFullCombatDamage(lua_State* L, const CombatDamage &damage) {
+	if (validateDispatcherContext(__FUNCTION__)) {
+		return;
+	}
+
+	// Create the main table for damage
+	lua_newtable(L);
+
+	lua_newtable(L);
+	lua_pushnumber(L, damage.primary.value);
+	lua_setfield(L, -2, "value");
+	lua_pushnumber(L, damage.primary.type);
+	lua_setfield(L, -2, "type");
+	lua_setfield(L, -2, "primary");
+
+	lua_newtable(L);
+	lua_pushnumber(L, damage.secondary.value);
+	lua_setfield(L, -2, "value");
+	lua_pushnumber(L, damage.secondary.type);
+	lua_setfield(L, -2, "type");
+	lua_setfield(L, -2, "secondary");
+
+	lua_pushnumber(L, damage.origin);
+	lua_setfield(L, -2, "origin");
+
+	lua_pushboolean(L, damage.critical);
+	lua_setfield(L, -2, "critical");
+
+	lua_pushnumber(L, damage.affected);
+	lua_setfield(L, -2, "affected");
+
+	lua_pushboolean(L, damage.extension);
+	lua_setfield(L, -2, "extension");
+
+	lua_pushstring(L, damage.exString.c_str());
+	lua_setfield(L, -2, "exString");
+
+	lua_pushboolean(L, damage.fatal);
+	lua_setfield(L, -2, "fatal");
+
+	lua_pushboolean(L, damage.hazardDodge);
+	lua_setfield(L, -2, "hazardDodge");
+
+	lua_pushnumber(L, damage.criticalDamage);
+	lua_setfield(L, -2, "criticalDamage");
+
+	lua_pushnumber(L, damage.criticalChance);
+	lua_setfield(L, -2, "criticalChance");
+
+	lua_pushnumber(L, damage.damageMultiplier);
+	lua_setfield(L, -2, "damageMultiplier");
+
+	lua_pushnumber(L, damage.damageReductionMultiplier);
+	lua_setfield(L, -2, "damageReductionMultiplier");
+
+	lua_pushnumber(L, damage.healingMultiplier);
+	lua_setfield(L, -2, "healingMultiplier");
+
+	lua_pushnumber(L, damage.manaLeech);
+	lua_setfield(L, -2, "manaLeech");
+
+	lua_pushnumber(L, damage.manaLeechChance);
+	lua_setfield(L, -2, "manaLeechChance");
+
+	lua_pushnumber(L, damage.lifeLeech);
+	lua_setfield(L, -2, "lifeLeech");
+
+	lua_pushnumber(L, damage.lifeLeechChance);
+	lua_setfield(L, -2, "lifeLeechChance");
+
+	lua_pushnumber(L, damage.healingLink);
+	lua_setfield(L, -2, "healingLink");
+
+	lua_pushstring(L, damage.instantSpellName.c_str());
+	lua_setfield(L, -2, "instantSpellName");
+
+	lua_pushstring(L, damage.runeSpellName.c_str());
+	lua_setfield(L, -2, "runeSpellName");
+
+	lua_pushboolean(L, damage.isEmpty());
+	lua_setfield(L, -2, "isEmpty");
+}
+
 void Lua::pushInstantSpell(lua_State* L, const InstantSpell &spell) {
 	if (validateDispatcherContext(__FUNCTION__)) {
 		return;

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -173,6 +173,7 @@ public:
 
 	static void pushBoolean(lua_State* L, bool value);
 	static void pushCombatDamage(lua_State* L, const CombatDamage &damage);
+	static void pushFullCombatDamage(lua_State* L, const CombatDamage &damage);
 	static void pushInstantSpell(lua_State* L, const InstantSpell &spell);
 	static void pushPosition(lua_State* L, const Position &position, int32_t stackpos = 0);
 	static void pushOutfit(lua_State* L, const Outfit_t &outfit);


### PR DESCRIPTION
# Description

This PR introduces the possibility to export the whole `CombatDamage` from the source (C++) to lua as it is in the source.

Currently the `pushCombatDamage` function is used to export only some values from `CombatDamage` to lua (`damage.primary.value`, `damage.primary.type`, `damage.secondary.value`, `damage.secondary.type` and `damage.origin`) as parameters.
These changes add the possibility to export the `CombatDamage` as it is accessed from the source being able to access in lua like: `damage.primary.value`, `damage.instantSpellName`, etc.

Example:

```lua
function AccessingCombatDamage(damage)
  logger.info("PrimaryValue: {}, isCritical: {}, isFatal: {}", damage.primary.value, damage.critical, damage.fatal)
end
```

## Type of change

Please delete options that are not relevant.
  - [x] New feature (non-breaking change which adds functionality)

**Test Configuration**:

  - Server Version: Latest
  - Client: Latest
  - Operating System: Windows 11

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
