### PR TITLE
fix: adjust hotkey flow to respect item tiers

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3455,7 +3455,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 	}
 	ReturnValue ret = RETURNVALUE_NOERROR;
 
-	if (slotItem && slotItem->getID() == it.id && (!it.stackable || slotItem->getItemCount() == slotItem->getStackSize() || !equipItem)) {
+	if (slotItem && slotItem->getID() == it.id && (!hasTier || slotItem->getTier() == tier) && !equipItem) {
 		ret = internalCollectManagedItems(player, slotItem, getObjectCategory(slotItem), false);
 	} else if (equipItem) {
 		// Shield slot item


### PR DESCRIPTION
# Description

Adjusted the hotkey flow to prevent automatically removing the equipped item when another item with the same **ID** but a different **tier** exists.  
The new logic ensures the swap respects the **tier** value provided by the client, improving consistency when managing items through hotkeys.

## Behaviour
### **Actual**

When using hotkeys, if there are two items with the same ID but different tiers, the currently equipped item may be removed automatically, ignoring the tier difference.

### **Expected**

When using hotkeys, the system should respect the item’s **tier** and correctly swap items based on the client-provided tier value, without incorrectly removing the equipped one.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Equipped an item with a given tier.  
- Added another item with the same ID but different tier to the inventory.  
- Triggered a hotkey action to swap items.  
- Verified that the equipped item is no longer removed incorrectly and the swap respects the tier provided by the client.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings
