### PR TITLE
fix: remove duplicated include of `io/iobestiary.hpp`

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -15,7 +15,6 @@
 #include "creatures/players/player.hpp"
 #include "game/game.hpp"
 #include "game/scheduling/dispatcher.hpp"
-#include "io/iobestiary.hpp"
 #include "items/tile.hpp"
 #include "lua/callbacks/event_callback.hpp"
 #include "lua/callbacks/events_callbacks.hpp"


### PR DESCRIPTION
# Description

Remove duplicate include of `io/iobestiary.hpp`