### PR TITLE
fix: mysterious scroll action and ferumbras ascension quest storage

### DIFF
--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_mysterious_scroll.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/actions_mysterious_scroll.lua
@@ -1,13 +1,21 @@
 local ferumbrasAscendantMysterious = Action()
+
 function ferumbrasAscendantMysterious.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if player:getStorageValue(Storage.Quest.U10_90.FerumbrasAscension.RiftRunner) >= 1 or player:getStorageValue(24850) < 1 then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "No matter how often you try, you cannot decipher anything.")
 		return true
-	else
-		player:addMount(87)
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You decipher something! You get a rift runner to accompany you on your journey.")
-		player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.RiftRunner, 1)
 	end
+
+	if player:hasMount(87) then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already have this mount.")
+		player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.RiftRunner, 1)
+		return true
+	end
+
+	player:addMount(87)
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You decipher something! You get a rift runner to accompany you on your journey.")
+	player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.RiftRunner, 1)
+	item:remove(1)
 	return true
 end
 

--- a/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_bosses_kill.lua
+++ b/data-otservbr-global/scripts/quests/ferumbras_ascension/creaturescripts_bosses_kill.lua
@@ -137,6 +137,7 @@ function ascendantBossesKill.onDeath(creature)
 	-- Special case for Ferumbras Mortal Shell
 	if creature:getName():lower() == "ferumbras mortal shell" then
 		onDeathForDamagingPlayers(creature, function(creature, player)
+			player:setStorageValue(Storage.Quest.U10_90.FerumbrasAscension.RiftRunner, 0)
 			addEvent(function(playerId)
 				local player = Player(playerId)
 				if player then


### PR DESCRIPTION
# Description

This PR fixes the use of mysterious scroll and adds a validation to check if player already have the mount.

## Behaviour
### **Actual**

It can be used multiple times as item doesnt remove

### **Expected**

Item should remove after use and cant be used again if player have the mount already 

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 14.12
  - Client: Tibia Client
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
