### PR TITLE
feature: gamestore 'new' flag in home offers

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -2308,6 +2308,7 @@ GameStore.Categories = {
 				addon = 3,
 				description = "{character}\n{info} colours can be changed using the Outfit dialog\n{info} includes basic outfit and 2 addons which can be selected individually\n\n<i>Armoured Archers are the epitome of invisible danger. Silently and nimbly, they advance in the background. For hours, they wait patiently, almost motionless, for the decisive moment. Just to be perfectly present in a deadly second.</i>",
 				type = GameStore.OfferTypes.OFFER_TYPE_OUTFIT,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -4317,6 +4318,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -6592,7 +6594,6 @@ GameStore.Categories = {
 			{
 				icons = { "Name_Change.png" },
 				name = "Character Name Change",
-				home = true,
 				price = 250,
 				id = 65002,
 				description = "<i>Tired of your current character name? Purchase a new one!</i>\n\n{character}\n{info} relog required after purchase to finalise the name change",
@@ -6855,6 +6856,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -6865,6 +6867,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -6875,6 +6878,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -6885,6 +6889,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{
@@ -6895,6 +6900,7 @@ GameStore.Categories = {
 				count = 1,
 				description = "{house}\n{box}\n{storeinbox}\n{use}\n{backtoinbox}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				state = GameStore.States.STATE_NEW,
 				home = true,
 			},
 			{

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -2231,7 +2231,20 @@ function sendHomePage(playerId)
 			offer.disabledReadonIndex = nil -- Reseting the table to nil disable reason
 		end
 
-		msg:addByte(0x00)
+		if offer.state then
+			if offer.state == GameStore.States.STATE_SALE then
+				local daySub = offer.validUntil - os.date("*t").day
+				if daySub >= 0 then
+					msg:addByte(offer.state)
+				else
+					msg:addByte(GameStore.States.STATE_NONE)
+				end
+			else
+				msg:addByte(offer.state)
+			end
+		else
+			msg:addByte(GameStore.States.STATE_NONE)
+		end
 
 		local type = convertType(offer.type)
 


### PR DESCRIPTION
# Description

<img width="38" height="39" alt="image" src="https://github.com/user-attachments/assets/c1be8723-4689-4136-b66c-8f59bff23c4a" />
Fix GameStore homepage offer state display inconsistency by implementing proper state validation logic in sendHomePage() function. This change aligns the homepage behavior with other GameStore functions that already implement correct offer state handling.

credits: @Caiozord

## Behaviour
### **Actual**

GameStore homepage always displays offers without proper state indication (always sends 0x00 / STATE_NONE), regardless of whether offers are on sale or have expired.

### **Expected**

GameStore homepage should display correct offer states, showing sale indicators for active promotions and properly handling expired offers by displaying them as STATE_NONE.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Verified logic consistency with existing sendShowStoreOffers() and sendShowStoreOffersOnOldProtocol() implementations
  - [ ] Confirmed proper state validation for GameStore.States.STATE_SALE and date expiration logic

**Test Configuration**:

  - Server Version: Canary latest
  - Client: 14.12
  - Operating System: Windows 10

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
