### PR TITLE
fix: killing in the name of quest boss kill count

### DIFF
--- a/data-otservbr-global/scripts/quests/killing_in_the_name_of/creaturescripts_boss_kill.lua
+++ b/data-otservbr-global/scripts/quests/killing_in_the_name_of/creaturescripts_boss_kill.lua
@@ -40,7 +40,7 @@ function deathEvent.onDeath(creature, _corpse, _lastHitKiller, mostDamageKiller)
 	local targetName = creature:getName():lower()
 
 	onDeathForParty(creature, mostDamageKiller, function(creature, player)
-		for i, bossName in ipairs(taskBoss) do
+		for i, bossName in pairs(taskBoss) do
 			if targetName == bossName then
 				if player:getStorageValue(bossKillCount + i) == 0 then
 					player:setStorageValue(bossKillCount + i, 1)


### PR DESCRIPTION
# Description

Fixes a bug where boss kill counts for entries keyed at index 0 were never recorded.
In Lua, ipairs iterates only over consecutive integer keys starting from 1. Our taskBoss map includes a valid boss at key 0 ("the snapper"), so the loop skipped it.

## Behaviour
### **Actual**

When killing The Snapper, no storage is updated and the kill does not count towards the task.

### **Expected**

When killing The Snapper, the corresponding storage is set (from 0 to 1) and the kill counts towards the task.

### Fixes #issuenumber
#3708 
## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

<img width="788" height="356" alt="image" src="https://github.com/user-attachments/assets/585b6265-b121-4c1a-99ab-eb65352bcc1e" />

**Test Configuration**:

  - Server Version: canary 3.2.0
  - Client: mehah
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
