### PR TITLE
fix: use correct tibia coins when buying store items.

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -7026,7 +7026,7 @@ for k, category in ipairs(GameStore.Categories) do
 				offer.type = GameStore.OfferTypes.OFFER_TYPE_NONE
 			end
 			if not offer.coinType then
-				offer.coinType = GameStore.CoinType.Transferable
+				offer.coinType = GameStore.CoinType.Coin
 			end
 		end
 	end

--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -247,6 +247,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Great_Mana_Cask.png" },
@@ -256,6 +257,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to refill your mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Great_Spirit_Cask.png" },
@@ -265,6 +267,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points and mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Health_Cask.png" },
@@ -274,6 +277,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Mana_Cask.png" },
@@ -283,6 +287,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to refill your mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Strong_Health_Cask.png" },
@@ -292,6 +297,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Strong_Mana_Cask.png" },
@@ -301,6 +307,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to refill your mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Supreme_Health_Cask.png" },
@@ -310,6 +317,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Ultimate_Health_Cask.png" },
@@ -319,6 +327,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Ultimate_Mana_Cask.png" },
@@ -328,6 +337,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to refill your mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 			{
 				icons = { "Ultimate_Spirit_Cask.png" },
@@ -337,6 +347,7 @@ GameStore.Categories = {
 				count = 1000,
 				description = "<i>Place it in your house and fill up potions to restore your hit points and mana!</i>\n\n{house}\n{box}\n{storeinbox}\n{usablebyallicon} can be used to fill up potions by all characters that have access to the house\n{storeinboxicon} potions created from this cask will be sent to your Store inbox and can only be stored there and in depot box\n{backtoinbox}\n{info} usable 1000 times a piece\n{transferableprice}",
 				type = GameStore.OfferTypes.OFFER_TYPE_HOUSE,
+				coinType = GameStore.CoinType.Transferable
 			},
 		},
 	},

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9308,6 +9308,7 @@ void Game::playerCreateMarketOffer(uint32_t playerId, uint8_t type, uint16_t ite
 
 			// Do not register a transaction for coins creating an offer
 			player->getAccount()->removeCoins(CoinType::Transferable, static_cast<uint32_t>(amount), "");
+			player->getAccount()->removeCoins(CoinType::Normal, static_cast<uint32_t>(amount), "");
 		} else {
 			if (!removeOfferItems(player, depotLocker, it, amount, tier, offerStatus)) {
 				g_logger().error("[{}] failed to remove item with id {}, from player {}, errorcode: {}", __FUNCTION__, it.id, player->getName(), offerStatus.str());


### PR DESCRIPTION
# Description

Ensure store purchases consume transferable Tibia Coins first, then fall back to regular Tibia Coins for any remainder.
Previously, the deduction order could consume either regular coins or transferable coins.

## Behaviour
### **Actual**

When purchasing a store offer, regular coins may be deducted while transferable coins remain unused or vice versa depending on the coinType set for the game store.

### **Expected**

When purchasing a store offer:
- Transferable coins are deducted first up to the offer price.
- Any remainder is deducted from regular coins.
- If combined balances are insufficient, the purchase is denied without performing partial deductions.

### Fixes #issuenumber
#3505
#2071

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Manual testing

**Test Configuration**:

  - Server Version: Canary 3.2.0
  - Client: Mehah
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
