### PR TITLE
improve: change default option TOGGLE_BIN_FOLDER to OFF

### DIFF
--- a/cmake/modules/BaseConfig.cmake
+++ b/cmake/modules/BaseConfig.cmake
@@ -132,7 +132,7 @@ endif()
 option(
     TOGGLE_BIN_FOLDER
     "Use build/bin folder for generate compilation files"
-    ON
+    OFF
 )
 option(
     OPTIONS_ENABLE_OPENMP


### PR DESCRIPTION
This makes a small configuration change to the `cmake/modules/BaseConfig.cmake` file. The default value of the `TOGGLE_BIN_FOLDER` option has been switched from `ON` to `OFF`, which changes the behavior for generating compilation files in the build process.