### PR TITLE
refactor: migrate tests from boost::ut to GoogleTest

### DIFF
--- a/src/lib/di/container.hpp
+++ b/src/lib/di/container.hpp
@@ -29,6 +29,10 @@ public:
 		testContainer = container;
 	}
 
+	inline static di::extension::injector<>* getTestContainer() {
+		return testContainer;
+	}
+
 	/**
 	 * Create will always return a new instance, it's used for unique instances or non-shared
 	 * states. This can only be used by classes that allow being copied, cloned and moved.

--- a/src/lib/di/container.hpp
+++ b/src/lib/di/container.hpp
@@ -28,7 +28,6 @@ public:
 	inline static void setTestContainer(di::extension::injector<>* container) {
 		testContainer = container;
 	}
-
 	inline static di::extension::injector<>* getTestContainer() {
 		return testContainer;
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,105 +2,50 @@ if(NOT BUILD_TESTING)
     return()
 endif()
 
-# --- boost::ut (handle common package/target name variants) ---
-# Try the canonical package name first (as used by the project), then fall back
-# to popular alt names in package managers.
-set(_ut_targets)
 find_package(
-    Boost.UT
+    GTest
     CONFIG
-    QUIET
-)
-if(Boost.UT_FOUND)
-    list(
-        APPEND
-        _ut_targets
-        Boost::ut
-    )
-else()
-    find_package(
-        boost_ut
-        CONFIG
-        QUIET
-    ) # some distros
-    if(boost_ut_FOUND)
-        list(
-            APPEND
-            _ut_targets
-            boost::ut
-        )
-    else()
-        find_package(
-            ut
-            CONFIG
-            QUIET
-        ) # your original
-        if(ut_FOUND)
-            # guessing an imported target name; adjust if your toolchain differs
-            list(
-                APPEND
-                _ut_targets
-                Boost::ut
-            )
-        endif()
-    endif()
-endif()
-
-if(NOT _ut_targets)
-    message(
-        FATAL_ERROR
-            "Could not find boost::ut. Try installing via vcpkg (boost-ut) or add FetchContent in the root."
-    )
-endif()
-
-# Utility to pick the first found target (Boost::ut OR boost::ut)
-list(
-    GET
-    _ut_targets
-    0
-    UT_IMPORTED_TARGET
+    REQUIRED
 )
 
-enable_testing()
+include(GoogleTest)
 
-# ---------------------------
-# Helper: define one test exe
-# ---------------------------
 function(
     setup_test
     TARGET_NAME
     DIR
 )
-    add_executable(
+    add_executable(${TARGET_NAME})
+
+    target_sources(
         ${TARGET_NAME}
-        ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+        PRIVATE ${CMAKE_SOURCE_DIR}/tests/${DIR}/main.cpp
     )
 
-    # Your project-specific knobs
     target_compile_definitions(
         ${TARGET_NAME}
         PUBLIC -DDEBUG_LOG -DBUILD_TESTS
     )
+
     target_link_libraries(
         ${TARGET_NAME}
-        PRIVATE ${UT_IMPORTED_TARGET} ${PROJECT_NAME}_lib
+        PRIVATE ${PROJECT_NAME}_lib GTest::gtest
     )
+
     target_include_directories(
         ${TARGET_NAME}
         PRIVATE ${CMAKE_SOURCE_DIR}/tests/fixture
                 ${CMAKE_SOURCE_DIR}/tests/${DIR}
     )
+
     target_compile_features(
         ${TARGET_NAME}
         PRIVATE cxx_std_20
     )
 
-    # Keep your hooks
     setup_target(${TARGET_NAME})
     configure_linking(${TARGET_NAME})
 
-    # Turn OFF unity/IPO for tests (tests benefit from fast rebuilds &
-    # debugging)
     set_target_properties(
         ${TARGET_NAME}
         PROPERTIES UNITY_BUILD OFF
@@ -108,23 +53,13 @@ function(
     )
     log_option_disabled("Build unity")
 
-    # Register with ctest. boost::ut doesn’t use Catch2-style CLI; just run the
-    # binary.
-    add_test(
-        NAME ${DIR}
-        COMMAND ${TARGET_NAME}
-    )
-
-    # Per-test runtime context
-    set_tests_properties(
-        ${DIR}
-        PROPERTIES WORKING_DIRECTORY
-                   ${CMAKE_BINARY_DIR}/tests/${DIR}
-                   TIMEOUT
-                   120
+    gtest_discover_tests(
+        ${TARGET_NAME}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/${DIR}
+        PROPERTIES
+        TIMEOUT 120
     )
 endfunction()
 
-# Suites (each subdir calls setup_test(...) for its cases)
 add_subdirectory(unit)
 add_subdirectory(integration)

--- a/tests/fixture/injection_fixture.hpp
+++ b/tests/fixture/injection_fixture.hpp
@@ -4,14 +4,10 @@
 
 #pragma once
 
-#include <boost/ut.hpp>
-
 #include "account/in_memory_account_repository.hpp"
 #include "kv/in_memory_kv.hpp"
 #include "test_injection.hpp"
 #include "lib/logging/in_memory_logger.hpp"
-
-using namespace boost::ut;
 
 struct InjectionFixture {
 	di::extension::injector<> injector {};

--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -1,4 +1,4 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "account/account_repository_db.hpp"
 #include "account/account_info.hpp"
@@ -9,102 +9,122 @@
 
 #include <exception>
 
-using namespace boost::ut;
-
 namespace it_account_repo_db {
+
+	class AccountRepositoryDBTest : public ::testing::Test {
+	protected:
+		static void SetUpTestSuite() {
+			logger = &dynamic_cast<InMemoryLogger &>(g_logger());
+		}
+
+		static InMemoryLogger* logger;
+	};
+
+	InMemoryLogger* AccountRepositoryDBTest::logger = nullptr;
 
 	inline void createAccount(Database &db) {
 		auto lastDay = getTimeNow() + 11 * 86400;
-		db.executeQuery(fmt::format("INSERT INTO `accounts` "
-		                            "(`id`, `name`, `email`, `password`, `type`, `premdays`, `lastday`, `premdays_purchased`, `creation`) "
-		                            "VALUES(111, 'test', '@test', '', 3, 11, {}, 11, 42183281)",
-		                            lastDay));
-		db.executeQuery(fmt::format("INSERT INTO `account_sessions` (`id`, `account_id`, `expires`) "
-		                            "VALUES ('{}', 111, 1337)",
-		                            transformToSHA1("test")));
+		db.executeQuery(fmt::format(
+			"INSERT INTO `accounts` "
+			"(`id`, `name`, `email`, `password`, `type`, `premdays`, `lastday`, `premdays_purchased`, `creation`) "
+			"VALUES(111, 'test', '@test', '', 3, 11, {}, 11, 42183281)",
+			lastDay
+		));
+		db.executeQuery(fmt::format(
+			"INSERT INTO `account_sessions` (`id`, `account_id`, `expires`) "
+			"VALUES ('{}', 111, 1337)",
+			transformToSHA1("test")
+		));
 	}
 
 	inline void assertAccountLoad(const AccountInfo &acc) {
-		expect(eq(acc.id, 111));
-		expect(eq(acc.accountType, AccountType::ACCOUNT_TYPE_SENIORTUTOR));
-		expect(eq(acc.premiumRemainingDays, 11));
-		expect(approx(acc.premiumLastDay, getTimeNow() + 11 * 86400, 60));
-		expect(eq(acc.players.size(), 0u));
-		expect(eq(acc.oldProtocol, false));
-		expect(eq(acc.premiumDaysPurchased, 11));
-		expect(approx(acc.creationTime, 42183281, 60 * 60 * 1000));
+		EXPECT_EQ(111, acc.id);
+		EXPECT_EQ(AccountType::ACCOUNT_TYPE_SENIORTUTOR, acc.accountType);
+		EXPECT_EQ(11, acc.premiumRemainingDays);
+		EXPECT_NEAR(static_cast<double>(acc.premiumLastDay), static_cast<double>(getTimeNow() + 11 * 86400), 60.0);
+		EXPECT_EQ(0u, acc.players.size());
+		EXPECT_FALSE(acc.oldProtocol);
+		EXPECT_EQ(11, acc.premiumDaysPurchased);
+		EXPECT_NEAR(static_cast<double>(acc.creationTime), 42183281.0, 60.0 * 60.0 * 1000.0);
 	}
 
-	inline void register_loadByID(Database &db) {
-		test("AccountRepositoryDB::loadByID") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, LoadByID) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			createAccount(db);
 			auto acc = std::make_unique<AccountInfo>();
 			accRepo.loadByID(111, acc);
 			assertAccountLoad(*acc);
-			expect(eq(acc->sessionExpires, 0));
-		});
+			EXPECT_EQ(0, acc->sessionExpires);
+		})();
 	}
 
-	inline void register_loadByEmailOrName(Database &db) {
-		test("AccountRepositoryDB::loadByEmailOrName") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, LoadByEmailOrName) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			createAccount(db);
 			auto acc = std::make_unique<AccountInfo>();
 			accRepo.loadByEmailOrName(false, "@test", acc);
 			assertAccountLoad(*acc);
-			expect(eq(acc->sessionExpires, 0));
-		});
+			EXPECT_EQ(0, acc->sessionExpires);
+		})();
 	}
 
-	inline void register_loadBySession(Database &db) {
-		test("AccountRepositoryDB::loadBySession") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, LoadBySession) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			createAccount(db);
 			auto acc = std::make_unique<AccountInfo>();
 			accRepo.loadBySession("test", acc);
 			assertAccountLoad(*acc);
-			expect(eq(acc->sessionExpires, 1337));
-		});
+			EXPECT_EQ(1337, acc->sessionExpires);
+		})();
 	}
 
-	inline void register_premiumPurchasedSync(Database &db) {
-		test("AccountRepositoryDB premiumDaysPurchased sync") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, PremiumDaysPurchasedSync) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			auto acc = std::make_unique<AccountInfo>();
 			accRepo.loadByID(1, acc);
 			acc->premiumLastDay = getTimeNow() + 10 * 86400;
 			acc->premiumRemainingDays = 10;
 			acc->premiumDaysPurchased = 0;
-			expect(accRepo.save(acc));
+			EXPECT_TRUE(accRepo.save(acc));
 			accRepo.loadByID(1, acc);
-			expect(eq(acc->premiumDaysPurchased, 10));
-		});
+			EXPECT_EQ(10, acc->premiumDaysPurchased);
+		})();
 	}
 
-	inline void register_getPassword(Database &db) {
-		test("AccountRepositoryDB::getPassword") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, GetPassword) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			std::string password {};
-			expect(accRepo.getPassword(1, password));
-			expect(eq(password, std::string { "21298df8a3277357ee55b01df9530b535cf08ec1" }));
-		});
+			EXPECT_TRUE(accRepo.getPassword(1, password));
+			EXPECT_EQ(std::string { "21298df8a3277357ee55b01df9530b535cf08ec1" }, password);
+		})();
 	}
 
-	inline void register_getPassword_logs(Database &db, InMemoryLogger &logger) {
-		test("AccountRepositoryDB::getPassword logs on failure") = databaseTest(db, [&db, &logger] {
+	TEST_F(AccountRepositoryDBTest, GetPasswordLogsOnFailure) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			std::string password {};
-			logger.logs.clear();
-			expect(!accRepo.getPassword(891237, password));
-			expect(logger.logs.size() >= 1_u);
-			expect(eq(logger.logs.back().level, std::string { "error" }));
-			expect(eq(logger.logs.back().message, std::string { "Failed to get account:[891237] password!" }));
-		});
+			logger->logs.clear();
+			EXPECT_FALSE(accRepo.getPassword(891237, password));
+			EXPECT_FALSE(logger->logs.empty());
+			EXPECT_EQ(std::string { "error" }, logger->logs.back().level);
+			EXPECT_EQ(std::string { "Failed to get account:[891237] password!" }, logger->logs.back().message);
+		})();
 	}
 
-	inline void register_save(Database &db) {
-		test("AccountRepositoryDB::save") = databaseTest(db, [&db] {
+	TEST_F(AccountRepositoryDBTest, Save) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			auto acc = std::make_unique<AccountInfo>();
 			acc->id = 1;
@@ -112,28 +132,15 @@ namespace it_account_repo_db {
 			acc->premiumRemainingDays = 10;
 			acc->premiumLastDay = getTimeNow() + acc->premiumRemainingDays * 86400;
 			acc->sessionExpires = 99999999;
-			expect(accRepo.save(acc));
+			EXPECT_TRUE(accRepo.save(acc));
 			auto acc2 = std::make_unique<AccountInfo>();
 			accRepo.loadByID(1, acc2);
-			expect(eq(acc2->id, 1));
-			expect(eq(acc2->accountType, AccountType::ACCOUNT_TYPE_SENIORTUTOR));
-			expect(eq(acc2->premiumRemainingDays, 10));
-			expect(approx(acc2->premiumLastDay, acc->premiumLastDay, 60));
-			expect(eq(acc2->sessionExpires, 0));
-		});
+			EXPECT_EQ(1, acc2->id);
+			EXPECT_EQ(AccountType::ACCOUNT_TYPE_SENIORTUTOR, acc2->accountType);
+			EXPECT_EQ(10, acc2->premiumRemainingDays);
+			EXPECT_NEAR(static_cast<double>(acc2->premiumLastDay), static_cast<double>(acc->premiumLastDay), 60.0);
+			EXPECT_EQ(0, acc2->sessionExpires);
+		})();
 	}
-
-	inline suite<"AccountRepositoryDB"> suite_all = [] {
-		auto &db = g_database();
-		auto &logger = dynamic_cast<InMemoryLogger &>(g_logger());
-
-		register_loadByID(db);
-		register_loadByEmailOrName(db);
-		register_loadBySession(db);
-		register_premiumPurchasedSync(db);
-		register_getPassword(db);
-		register_getPassword_logs(db, logger);
-		register_save(db);
-	};
 
 } // namespace it_account_repo_db

--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -91,7 +91,7 @@ namespace it_account_repo_db {
 
 	TEST_F(AccountRepositoryDBTest, PremiumDaysPurchasedSync) {
 		auto &db = g_database();
-		databaseTest(db, [] {
+		databaseTest(db, [&db] {
 			AccountRepositoryDB accRepo {};
 			auto acc = std::make_unique<AccountInfo>();
 			ASSERT_TRUE(accRepo.loadByID(1, acc));

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -1,14 +1,14 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include "config/configmanager.hpp"
 #include "database/database.hpp"
 #include "lib/di/container.hpp"
 #include "lib/logging/in_memory_logger.hpp"
 #include "test_database.hpp"
 
-using namespace boost::ut;
+int main(int argc, char** argv) {
+	::testing::InitGoogleTest(&argc, argv);
 
-int main() {
-	di::extension::injector<> injector {};
+	static di::extension::injector<> injector {};
 	InMemoryLogger::install(injector);
 	DI::setTestContainer(&injector);
 
@@ -17,5 +17,5 @@ int main() {
 	(void)g_configManager();
 	(void)g_database();
 
-	return cfg<>.run();
+	return RUN_ALL_TESTS();
 }

--- a/tests/integration/player_storage/player_storage_repository_db_it.cpp
+++ b/tests/integration/player_storage/player_storage_repository_db_it.cpp
@@ -1,4 +1,4 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "io/player_storage_repository_db.hpp"
 #include "test_env.hpp"
@@ -8,8 +8,6 @@
 #include <vector>
 #include <fmt/format.h>
 
-using namespace boost::ut;
-
 namespace it_player_storage_repo_db {
 
 	constexpr uint32_t ACCOUNT_ID = 600000000;
@@ -17,22 +15,31 @@ namespace it_player_storage_repo_db {
 
 	inline void createPlayer(Database &db) {
 		db.executeQuery(fmt::format("INSERT INTO `accounts` (`id`,`name`,`password`) VALUES ({}, 'acc', '')", ACCOUNT_ID));
-		db.executeQuery(fmt::format("INSERT INTO `players` (`id`,`name`,`account_id`,`conditions`) VALUES ({}, 'player', {}, '')", PLAYER_ID, ACCOUNT_ID));
+		db.executeQuery(fmt::format(
+			"INSERT INTO `players` (`id`,`name`,`account_id`,`conditions`) VALUES ({}, 'player', {}, '')",
+			PLAYER_ID,
+			ACCOUNT_ID
+		));
 	}
 
 	inline bool hasRow(const std::vector<PlayerStorageRow> &rows, uint32_t key, int32_t value) {
-		return std::ranges::any_of(rows, [key, value](const auto &r) {
-			return r.key == key && r.value == value;
-		});
+		return std::ranges::any_of(rows, [key, value](const auto &r) { return r.key == key && r.value == value; });
 	}
 
-	inline void register_load(Database &db) {
-		test("DbPlayerStorageRepository::load") = databaseTest(db, [&db] {
+	class PlayerStorageRepositoryDBTest : public ::testing::Test { };
+
+	TEST_F(PlayerStorageRepositoryDBTest, Load) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
 			DbPlayerStorageRepository repo {};
 			createPlayer(db);
-			db.executeQuery(fmt::format("INSERT INTO `player_storage` (`player_id`,`key`,`value`) VALUES ({}, 100, 42), ({}, 200, 55)", PLAYER_ID, PLAYER_ID));
+			db.executeQuery(fmt::format(
+				"INSERT INTO `player_storage` (`player_id`,`key`,`value`) VALUES ({}, 100, 42), ({}, 200, 55)",
+				PLAYER_ID,
+				PLAYER_ID
+			));
 			auto rows = repo.load(PLAYER_ID);
-			expect(eq(rows.size(), 2_u));
+			EXPECT_EQ(2u, rows.size());
 			bool found100 = false;
 			bool found200 = false;
 			for (auto &r : rows) {
@@ -43,46 +50,45 @@ namespace it_player_storage_repo_db {
 					found200 = true;
 				}
 			}
-			expect(found100);
-			expect(found200);
-		});
+			EXPECT_TRUE(found100);
+			EXPECT_TRUE(found200);
+		})();
 	}
 
-	inline void register_deleteKeys(Database &db) {
-		test("DbPlayerStorageRepository::deleteKeys") = databaseTest(db, [&db] {
-			DbPlayerStorageRepository repo {};
-			createPlayer(db);
-			db.executeQuery(fmt::format("INSERT INTO `player_storage` (`player_id`,`key`,`value`) VALUES ({}, 1, 10), ({}, 2, 20), ({}, 3, 30)", PLAYER_ID, PLAYER_ID, PLAYER_ID));
-			expect(repo.deleteKeys(PLAYER_ID, { 1, 3 }));
-			auto rows = repo.load(PLAYER_ID);
-			expect(eq(rows.size(), 1_u));
-			expect(eq(rows[0].key, 2_u));
-			expect(eq(rows[0].value, 20));
-		});
-	}
-
-	inline void register_upsert(Database &db) {
-		test("DbPlayerStorageRepository::upsert") = databaseTest(db, [&db] {
-			DbPlayerStorageRepository repo {};
-			createPlayer(db);
-			expect(repo.upsert(PLAYER_ID, { { 1, 10 }, { 2, 20 } }));
-			auto rows = repo.load(PLAYER_ID);
-			expect(eq(rows.size(), 2_u));
-			expect(hasRow(rows, 1, 10));
-			expect(hasRow(rows, 2, 20));
-			expect(repo.upsert(PLAYER_ID, { { 1, 100 } }));
-			auto rows2 = repo.load(PLAYER_ID);
-			expect(hasRow(rows2, 1, 100));
-			expect(hasRow(rows2, 2, 20));
-		});
-	}
-
-	inline suite<"DbPlayerStorageRepository"> suite_all = [] {
+	TEST_F(PlayerStorageRepositoryDBTest, DeleteKeys) {
 		auto &db = g_database();
+		databaseTest(db, [&db] {
+			DbPlayerStorageRepository repo {};
+			createPlayer(db);
+			db.executeQuery(fmt::format(
+				"INSERT INTO `player_storage` (`player_id`,`key`,`value`) VALUES ({}, 1, 10), ({}, 2, 20), ({}, 3, 30)",
+				PLAYER_ID,
+				PLAYER_ID,
+				PLAYER_ID
+			));
+			EXPECT_TRUE(repo.deleteKeys(PLAYER_ID, { 1, 3 }));
+			auto rows = repo.load(PLAYER_ID);
+			ASSERT_EQ(1u, rows.size());
+			EXPECT_EQ(2u, rows[0].key);
+			EXPECT_EQ(20, rows[0].value);
+		})();
+	}
 
-		register_load(db);
-		register_deleteKeys(db);
-		register_upsert(db);
-	};
+	TEST_F(PlayerStorageRepositoryDBTest, Upsert) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
+			DbPlayerStorageRepository repo {};
+			createPlayer(db);
+			EXPECT_TRUE(repo.upsert(PLAYER_ID, { { 1, 10 }, { 2, 20 } }));
+			auto rows = repo.load(PLAYER_ID);
+			EXPECT_EQ(2u, rows.size());
+			EXPECT_TRUE(hasRow(rows, 1, 10));
+			EXPECT_TRUE(hasRow(rows, 2, 20));
+			EXPECT_TRUE(repo.upsert(PLAYER_ID, { { 1, 100 } }));
+			auto rows2 = repo.load(PLAYER_ID);
+			EXPECT_TRUE(hasRow(rows2, 1, 100));
+			EXPECT_TRUE(hasRow(rows2, 2, 20));
+		})();
+	}
 
 } // namespace it_player_storage_repo_db

--- a/tests/unit/account/account_test.cpp
+++ b/tests/unit/account/account_test.cpp
@@ -8,7 +8,7 @@
  */
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "account/account.hpp"
 #include "utils/tools.hpp"
@@ -18,7 +18,6 @@
 #include "enums/account_errors.hpp"
 #include "enums/account_group_type.hpp"
 
-using namespace boost::ut;
 using namespace std;
 
 template <typename T, typename U>
@@ -34,511 +33,583 @@ bool eqEnum(const T &lhs, const U &rhs) {
 	}
 }
 
-suite<"account"> accountTest = [] {
-	// DI setup once
-	di::extension::injector<> injector {};
-	InMemoryLogger::install(injector);
-	tests::InMemoryAccountRepository::install(injector);
-	DI::setTestContainer(&injector);
-
-	auto* accountRepository = &dynamic_cast<tests::InMemoryAccountRepository &>(DI::get<AccountRepository>());
-	auto* logger = &dynamic_cast<InMemoryLogger &>(DI::get<Logger>());
-
-	auto withFresh = [accountRepository, logger](const char* name, auto fn) {
-		test(name) = [fn, accountRepository, logger] {
-			accountRepository->reset();
-			logger->logs.clear();
-			fn();
-		};
-	};
-
-	test("Account::Account default constructors") = [] {
-		shared_ptr<Account> byId = make_shared<Account>(1);
-		shared_ptr<Account> byDescriptor = make_shared<Account>("canary@test.com");
-
-		expect(eq(byId->getID(), 1));
-		expect(eq(byDescriptor->getID(), 0));
-
-		expect(byId->getDescriptor().empty());
-		expect(eq(byDescriptor->getDescriptor(), string { "canary@test.com" }));
-
-		for (auto &account : { byId, byDescriptor }) {
-			expect(eq(account->getPremiumRemainingDays(), 0));
-			expect(eq(account->getPremiumLastDay(), 0));
-			expect(eqEnum(account->getAccountType(), AccountType::ACCOUNT_TYPE_NORMAL));
-		}
-	};
-
-	struct AccountLoadTestCase {
-		const char* description;
-		shared_ptr<Account> account;
-		AccountErrors_t expectedError;
-	};
-
-	static vector<AccountLoadTestCase> accountLoadTestCases {
-		{ "returns by id if exists", make_shared<Account>(1), AccountErrors_t::Ok },
-		{ "returns by descriptor if exists", make_shared<Account>("canary@test.com"), AccountErrors_t::Ok },
-		{ "returns error if id is not valid", make_shared<Account>(2), AccountErrors_t::LoadingAccount },
-		{ "returns error if descriptor is not valid", make_shared<Account>("not@valid.com"), AccountErrors_t::LoadingAccount }
-	};
-
-	for (const auto &testCase : accountLoadTestCases) {
-		withFresh(testCase.description, [testCase, accountRepository] {
-			accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-			expect(eqEnum(testCase.account->load(), testCase.expectedError)) << testCase.description;
-		});
+class AccountTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		InMemoryLogger::install(injector);
+		tests::InMemoryAccountRepository::install(injector);
+		DI::setTestContainer(&injector);
+		accountRepository = &dynamic_cast<tests::InMemoryAccountRepository &>(DI::get<AccountRepository>());
+		logger = &dynamic_cast<InMemoryLogger &>(DI::get<Logger>());
 	}
 
-	test("Account::reload returns error if not yet loaded") = [] {
-		expect(eqEnum(Account { 1 }.reload(), AccountErrors_t::NotInitialized));
-	};
-
-	withFresh("Account::reload reloads account info", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GOD));
-
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
-
-		expect(eqEnum(acc.reload(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
-	});
-
-	test("Account::save returns error if not yet loaded") = [] {
-		expect(eqEnum(Account { 1 }.save(), AccountErrors_t::NotInitialized));
-	};
-
-	withFresh("Account::save returns error if it fails", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failSave = true;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.save(), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::save saves account info", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failSave = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.save(), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::getCoins returns error if not yet loaded", [accountRepository] {
-		expect(eqEnum(std::get<1>(Account { 1 }.getCoins(CoinType::Normal)), AccountErrors_t::NotInitialized));
-	});
-
-	withFresh("Account::getCoins returns error if it fails", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::getCoins returns coins", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 100));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::getCoins returns coins for specified account only", [accountRepository] {
-		Account acc { 2 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		accountRepository->addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(2, CoinType::Normal, 33);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 33));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::getCoins returns coins for specified coin type only", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-		accountRepository->setCoins(1, CoinType::Tournament, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 100));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Tournament)), 100));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Tournament)), AccountErrors_t::Ok));
-	});
-
-	test("Account::addCoins returns error if not yet loaded") = [] {
-		expect(eqEnum(Account { 1 }.addCoins(CoinType::Normal, 100), AccountErrors_t::NotInitialized));
-	};
-
-	withFresh("Account::addCoins returns error if it fails", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = true;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::addCoins returns error if get coins fail", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.addCoins(CoinType::Tournament, 100), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::addCoins adds coins", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 200));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::addCoins adds coins for specified account only", [accountRepository] {
-		Account acc { 2 };
-		accountRepository->failAddCoins = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		accountRepository->addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(2, CoinType::Normal, 33);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 133));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::addCoins adds coins for specified coin type only", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-		accountRepository->setCoins(1, CoinType::Tournament, 57);
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 200));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Tournament)), 57));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Tournament)), AccountErrors_t::Ok));
-
-		expect(eq(accountRepository->coinsTransactions_.size(), 1) >> fatal);
-		expect(eq(accountRepository->coinsTransactions_[1].size(), 1) >> fatal);
-
-		auto [type, coins, coinType, description] = accountRepository->coinsTransactions_[1][0];
-		expect(eq(coins, 100));
-		expect(eqEnum(coinType, CoinType::Normal));
-		expect(eqEnum(type, CoinTransactionType::Add));
-		expect(eq(description, std::string { "ADD Coins" }));
-	});
-
-	test("Account::removeCoins returns error if not yet loaded") = [] {
-		expect(eqEnum(Account { 1 }.removeCoins(CoinType::Normal, 100), AccountErrors_t::NotInitialized));
-	};
-
-	withFresh("Account::removeCoins returns error if it fails", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = true;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::removeCoins returns error if get coins fail", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Tournament, 100), AccountErrors_t::Storage));
-	});
-
-	withFresh("Account::removeCoins removes coins", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 0));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::removeCoins removes coins for specified account only", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-
-		accountRepository->addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(2, CoinType::Normal, 33);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 0));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-	});
-
-	withFresh("Account::removeCoins removes coins for specified coin type only", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-		accountRepository->setCoins(1, CoinType::Tournament, 57);
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 0));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Tournament)), 57));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Tournament)), AccountErrors_t::Ok));
-
-		expect(eq(accountRepository->coinsTransactions_.size(), 1) >> fatal);
-		expect(eq(accountRepository->coinsTransactions_[1].size(), 1) >> fatal);
-
-		auto [type, coins, coinType, description] = accountRepository->coinsTransactions_[1][0];
-		expect(eq(coins, 100));
-		expect(eqEnum(coinType, CoinType::Normal));
-		expect(eqEnum(type, CoinTransactionType::Remove));
-		expect(eq(description, std::string { "REMOVE Coins" }));
-	});
-
-	withFresh("Account::removeCoins returns error if account doesn't have enough coins", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->failAddCoins = false;
-		accountRepository->setCoins(1, CoinType::Normal, 1);
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
-
-		accountRepository->setCoins(1, CoinType::Normal, 50);
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
-
-		accountRepository->setCoins(1, CoinType::Normal, 100);
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
-
-		expect(eq(accountRepository->coinsTransactions_.size(), 1) >> fatal);
-		expect(eq(accountRepository->coinsTransactions_[1].size(), 1) >> fatal);
-
-		auto [type, coins, coinType, description] = accountRepository->coinsTransactions_[1][0];
-		expect(eq(coins, 100));
-		expect(eqEnum(coinType, CoinType::Normal));
-		expect(eqEnum(type, CoinTransactionType::Remove));
-		expect(eq(description, std::string { "REMOVE Coins" }));
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
-
-		expect(eq(accountRepository->coinsTransactions_.size(), 1) >> fatal);
-		expect(eq(accountRepository->coinsTransactions_[1].size(), 1) >> fatal);
-	});
-
-	withFresh("Account::registerCoinTransaction does nothing if detail is empty", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		accountRepository->setCoins(1, CoinType::Normal, 1);
-
-		expect(eqEnum(acc.addCoins(CoinType::Normal, 100, ""), AccountErrors_t::Ok));
-		expect(eqEnum(acc.removeCoins(CoinType::Normal, 80, ""), AccountErrors_t::Ok));
-
-		expect(eqEnum(std::get<0>(acc.getCoins(CoinType::Normal)), 21));
-		expect(eqEnum(std::get<1>(acc.getCoins(CoinType::Normal)), AccountErrors_t::Ok));
-
-		acc.registerCoinTransaction(CoinTransactionType::Add, CoinType::Normal, 100, "");
-		acc.registerCoinTransaction(CoinTransactionType::Remove, CoinType::Normal, 100, "");
-
-		expect(eq(accountRepository->coinsTransactions_.size(), 0));
-	});
-
-	test("Account::getPassword returns empty string if not yet loaded") = [] {
-		expect(eqEnum(Account { 1 }.getPassword(), std::string { "" }));
-	};
-
-	withFresh("Account::getPassword returns password", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eq(acc.getPassword(), std::string { "123456" }));
-	});
-
-	withFresh("Account::getPassword returns logs error if it fails", [accountRepository, logger] {
-		Account acc { 1 };
-		accountRepository->failGetPassword = true;
-		accountRepository->addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
-
-		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
-		expect(eq(std::string {}, acc.getPassword()));
-		expect(eq(std::string { "error" }, logger->logs[0].level));
-		expect(eq(std::string { "Failed to get password for account[1]!" }, logger->logs[0].message));
-	});
-
-	test("Account::addPremiumDays sets premium remaining days") = [] {
-		Account acc { 1 };
-		acc.addPremiumDays(100);
-
-		expect(eq(acc.getPremiumRemainingDays(), 100));
-	};
-
-	test("Account::addPremiumDays can increase premium") = [] {
-		Account acc { 1 };
-
-		acc.setPremiumDays(50);
-		acc.addPremiumDays(50);
-
-		expect(approx(acc.getPremiumLastDay(), getTimeNow() + (100 * 86400), 60 * 60 * 1000));
-		expect(eq(acc.getPremiumRemainingDays(), 100));
-	};
-
-	test("Account::addPremiumDays can reduce premium") = [] {
-		Account acc { 1 };
-
-		acc.setPremiumDays(50);
-		acc.addPremiumDays(-30);
-
-		expect(approx(acc.getPremiumLastDay(), getTimeNow() - (20 * 86400), 60 * 60 * 1000));
-		expect(eq(acc.getPremiumRemainingDays(), 20));
-	};
-
-	test("Account::setPremiumDays sets to 0 if day is negative") = [] {
-		Account acc { 1 };
-		acc.setPremiumDays(10);
-		acc.setPremiumDays(-20);
-
-		expect(eq(acc.getPremiumLastDay(), 0));
-		expect(eq(acc.getPremiumLastDay(), 0));
-	};
-
-	test("Account::setAccountType sets account type") = [] {
-		Account acc { 1 };
-		expect(eqEnum(acc.setAccountType(AccountType::ACCOUNT_TYPE_GAMEMASTER), AccountErrors_t::Ok));
-		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
-	};
-
-	test("Account::updatePremiumTime sets premium remaining days to 0 if last day is in the past") = [] {
-		Account acc { 1 };
-		acc.setPremiumDays(-10);
-		acc.updatePremiumTime();
-		expect(eq(acc.getPremiumRemainingDays(), 0));
-		expect(eq(acc.getPremiumLastDay(), 0));
-	};
-
-	test("Account::updatePremiumTime sets premium remaining days to 0 if last day is 0") = [] {
-		Account acc { 1 };
-		acc.setPremiumDays(0);
-		acc.updatePremiumTime();
-		expect(eq(acc.getPremiumLastDay(), 0));
-		expect(eq(acc.getPremiumRemainingDays(), 0));
-	};
-
-	test("Account::updatePremiumTime sets premium remaining days to N if last day is in the future") = [] {
-		Account acc { 1 };
-		acc.setPremiumDays(8);
-		acc.updatePremiumTime();
-
-		auto remainingTime = (acc.getPremiumLastDay() - getTimeNow()) / 86400;
-		expect(approx(remainingTime, 8, 0.1));
-		expect(eq(acc.getPremiumRemainingDays(), 8));
-	};
-
-	test("Account::updatePremiumTime sets premium remaining days to 1 if last day is in less than a day from now") = [] {
-		Account acc { 1 };
-		acc.setPremiumDays(1);
-		acc.updatePremiumTime();
-
-		auto remainingTime = (acc.getPremiumLastDay() - getTimeNow()) / 86400;
-		expect(approx(remainingTime, 1, 0.1));
-		expect(eq(acc.getPremiumRemainingDays(), 1));
-	};
-
-	test("Account::getAccountPlayer returns error if not yet loaded") = [] {
-		expect(eqEnum(std::get<1>(Account { 1 }.getAccountPlayers()), AccountErrors_t::NotInitialized));
-	};
-
-	withFresh("Account::getAccountPlayer returns players", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount(
-			"canary@test.com",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } } }
-		);
-
-		expect(acc.load() == AccountErrors_t::Ok);
-		auto [players, error] = acc.getAccountPlayers();
-
-		expect(eqEnum(error, AccountErrors_t::Ok));
-		expect(eq(players.size(), 2));
-		expect(eq(players["Canary"], 1));
-		expect(eq(players["Canary2"], 2));
-	});
-
-	withFresh("Account::authenticate password using sha1", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount(
-			"canary@test.com",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } } }
-		);
-
-		expect(acc.load() == AccountErrors_t::Ok);
-		accountRepository->password_ = "7c4a8d09ca3762af61e59520943dc26494f8941b";
-		expect(acc.authenticate("123456"));
-	});
-
-	withFresh("Account::authenticate using sessions", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount(
-			"session-key",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } }, false, getTimeNow() + 24 * 60 * 60 * 1000 }
-		);
-
-		expect(acc.load() == AccountErrors_t::Ok);
-		expect(acc.authenticate());
-	});
-
-	withFresh("Account::getCharacterByAccountIdAndName using an account with the given character.", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount(
-			"session-key",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } }, false, getTimeNow() + 24 * 60 * 60 * 1000 }
-		);
-
-		const auto hasCharacter = accountRepository->getCharacterByAccountIdAndName(1, "Canary");
-
-		expect(hasCharacter);
-	});
-
-	withFresh("Account::getCharacterByAccountIdAndName using an account without the given character.", [accountRepository] {
-		Account acc { 1 };
-		accountRepository->addAccount(
-			"session-key",
-			AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } }, false, getTimeNow() + 24 * 60 * 60 * 1000 }
-		);
-
-		const auto hasCharacter = accountRepository->getCharacterByAccountIdAndName(1, "Invalid");
-
-		expect(!hasCharacter);
-	});
+	void SetUp() override {
+		ClearState();
+	}
+
+	void TearDown() override {
+		ClearState();
+	}
+
+	static tests::InMemoryAccountRepository &repository() {
+		return *accountRepository;
+	}
+
+	static InMemoryLogger &testLogger() {
+		return *logger;
+	}
+
+private:
+	static void ClearState() {
+		if (accountRepository != nullptr) {
+			accountRepository->reset();
+		}
+		if (logger != nullptr) {
+			logger->logs.clear();
+		}
+	}
+
+	inline static di::extension::injector<> injector {};
+	inline static tests::InMemoryAccountRepository* accountRepository { nullptr };
+	inline static InMemoryLogger* logger { nullptr };
 };
+
+TEST_F(AccountTest, DefaultConstructors) {
+	auto byId = make_shared<Account>(1);
+	auto byDescriptor = make_shared<Account>("canary@test.com");
+
+	EXPECT_EQ(1, byId->getID());
+	EXPECT_EQ(0, byDescriptor->getID());
+
+	EXPECT_TRUE(byId->getDescriptor().empty());
+	EXPECT_EQ(string { "canary@test.com" }, byDescriptor->getDescriptor());
+
+	for (const auto &account : { byId, byDescriptor }) {
+		EXPECT_EQ(0, account->getPremiumRemainingDays());
+		EXPECT_EQ(0, account->getPremiumLastDay());
+		EXPECT_TRUE(eqEnum(account->getAccountType(), AccountType::ACCOUNT_TYPE_NORMAL));
+	}
+}
+
+TEST_F(AccountTest, LoadReturnsByIdIfExists) {
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	auto account = make_shared<Account>(1);
+	EXPECT_TRUE(eqEnum(account->load(), AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, LoadReturnsByDescriptorIfExists) {
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	auto account = make_shared<Account>("canary@test.com");
+	EXPECT_TRUE(eqEnum(account->load(), AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, LoadReturnsErrorIfIdInvalid) {
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	auto account = make_shared<Account>(2);
+	EXPECT_TRUE(eqEnum(account->load(), AccountErrors_t::LoadingAccount));
+}
+
+TEST_F(AccountTest, LoadReturnsErrorIfDescriptorInvalid) {
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	auto account = make_shared<Account>("not@valid.com");
+	EXPECT_TRUE(eqEnum(account->load(), AccountErrors_t::LoadingAccount));
+}
+
+TEST_F(AccountTest, ReloadReturnsErrorIfNotYetLoaded) {
+	EXPECT_TRUE(eqEnum(Account { 1 }.reload(), AccountErrors_t::NotInitialized));
+}
+
+TEST_F(AccountTest, ReloadReloadsAccountInfo) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GOD));
+
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
+
+	EXPECT_TRUE(eqEnum(acc.reload(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
+}
+
+TEST_F(AccountTest, SaveReturnsErrorIfNotYetLoaded) {
+	EXPECT_TRUE(eqEnum(Account { 1 }.save(), AccountErrors_t::NotInitialized));
+}
+
+TEST_F(AccountTest, SaveReturnsErrorIfRepositoryFails) {
+	Account acc { 1 };
+	repository().failSave = true;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.save(), AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, SavePersistsAccountInfo) {
+	Account acc { 1 };
+	repository().failSave = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.save(), AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, GetCoinsReturnsErrorIfNotYetLoaded) {
+	auto [coins, error] = Account { 1 }.getCoins(CoinType::Normal);
+	(void)coins;
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::NotInitialized));
+}
+
+TEST_F(AccountTest, GetCoinsReturnsErrorIfRepositoryFails) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(0, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, GetCoinsReturnsCoins) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(100, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, GetCoinsReturnsCoinsForSpecifiedAccountOnly) {
+	Account acc { 2 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	repository().addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(2, CoinType::Normal, 33);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(33, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, GetCoinsReturnsCoinsForSpecifiedCoinTypeOnly) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+	repository().setCoins(1, CoinType::Tournament, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+
+	auto [normalCoins, normalError] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(100, normalCoins);
+	EXPECT_TRUE(eqEnum(normalError, AccountErrors_t::Ok));
+
+	auto [tournamentCoins, tournamentError] = acc.getCoins(CoinType::Tournament);
+	EXPECT_EQ(100, tournamentCoins);
+	EXPECT_TRUE(eqEnum(tournamentError, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, AddCoinsReturnsErrorIfNotYetLoaded) {
+	EXPECT_TRUE(eqEnum(Account { 1 }.addCoins(CoinType::Normal, 100), AccountErrors_t::NotInitialized));
+}
+
+TEST_F(AccountTest, AddCoinsReturnsErrorIfRepositoryFails) {
+	Account acc { 1 };
+	repository().failAddCoins = true;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, AddCoinsReturnsErrorIfGetCoinsFails) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Tournament, 100), AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, AddCoinsAddsCoins) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(200, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, AddCoinsAddsCoinsForSpecifiedAccountOnly) {
+	Account acc { 2 };
+	repository().failAddCoins = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	repository().addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(2, CoinType::Normal, 33);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(133, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, AddCoinsAddsCoinsForSpecifiedCoinTypeOnly) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().setCoins(1, CoinType::Normal, 100);
+	repository().setCoins(1, CoinType::Tournament, 57);
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [normalCoins, normalError] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(200, normalCoins);
+	EXPECT_TRUE(eqEnum(normalError, AccountErrors_t::Ok));
+
+	auto [tournamentCoins, tournamentError] = acc.getCoins(CoinType::Tournament);
+	EXPECT_EQ(57, tournamentCoins);
+	EXPECT_TRUE(eqEnum(tournamentError, AccountErrors_t::Ok));
+
+	ASSERT_EQ(1u, repository().coinsTransactions_.size());
+	ASSERT_EQ(1u, repository().coinsTransactions_[1].size());
+
+	const auto &[type, coins, coinType, description] = repository().coinsTransactions_[1][0];
+	EXPECT_EQ(100u, coins);
+	EXPECT_TRUE(eqEnum(coinType, CoinType::Normal));
+	EXPECT_TRUE(eqEnum(type, CoinTransactionType::Add));
+	EXPECT_EQ(string { "ADD Coins" }, description);
+}
+
+TEST_F(AccountTest, RemoveCoinsReturnsErrorIfNotYetLoaded) {
+	EXPECT_TRUE(eqEnum(Account { 1 }.removeCoins(CoinType::Normal, 100), AccountErrors_t::NotInitialized));
+}
+
+TEST_F(AccountTest, RemoveCoinsReturnsErrorIfRepositoryFails) {
+	Account acc { 1 };
+	repository().failAddCoins = true;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, RemoveCoinsReturnsErrorIfGetCoinsFails) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Tournament, 100), AccountErrors_t::Storage));
+}
+
+TEST_F(AccountTest, RemoveCoinsRemovesCoins) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(0, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, RemoveCoinsRemovesCoinsForSpecifiedAccountOnly) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+
+	repository().addAccount("canary2@test.com", AccountInfo { 2, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(2, CoinType::Normal, 33);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(0, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+}
+
+TEST_F(AccountTest, RemoveCoinsRemovesCoinsForSpecifiedCoinTypeOnly) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	repository().setCoins(1, CoinType::Normal, 100);
+	repository().setCoins(1, CoinType::Tournament, 57);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	auto [normalCoins, normalError] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(0, normalCoins);
+	EXPECT_TRUE(eqEnum(normalError, AccountErrors_t::Ok));
+
+	auto [tournamentCoins, tournamentError] = acc.getCoins(CoinType::Tournament);
+	EXPECT_EQ(57, tournamentCoins);
+	EXPECT_TRUE(eqEnum(tournamentError, AccountErrors_t::Ok));
+
+	ASSERT_EQ(1u, repository().coinsTransactions_.size());
+	ASSERT_EQ(1u, repository().coinsTransactions_[1].size());
+
+	const auto &[type, coins, coinType, description] = repository().coinsTransactions_[1][0];
+	EXPECT_EQ(100u, coins);
+	EXPECT_TRUE(eqEnum(coinType, CoinType::Normal));
+	EXPECT_TRUE(eqEnum(type, CoinTransactionType::Remove));
+	EXPECT_EQ(string { "REMOVE Coins" }, description);
+}
+
+TEST_F(AccountTest, RemoveCoinsReturnsErrorIfNotEnoughCoins) {
+	Account acc { 1 };
+	repository().failAddCoins = false;
+	repository().setCoins(1, CoinType::Normal, 1);
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
+
+	repository().setCoins(1, CoinType::Normal, 50);
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
+
+	repository().setCoins(1, CoinType::Normal, 100);
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::Ok));
+
+	ASSERT_EQ(1u, repository().coinsTransactions_.size());
+	ASSERT_EQ(1u, repository().coinsTransactions_[1].size());
+
+	const auto &[type, coins, coinType, description] = repository().coinsTransactions_[1][0];
+	EXPECT_EQ(100u, coins);
+	EXPECT_TRUE(eqEnum(coinType, CoinType::Normal));
+	EXPECT_TRUE(eqEnum(type, CoinTransactionType::Remove));
+	EXPECT_EQ(string { "REMOVE Coins" }, description);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 100), AccountErrors_t::RemoveCoins));
+
+	ASSERT_EQ(1u, repository().coinsTransactions_.size());
+	ASSERT_EQ(1u, repository().coinsTransactions_[1].size());
+}
+
+TEST_F(AccountTest, RegisterCoinTransactionDoesNothingIfDetailIsEmpty) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	repository().setCoins(1, CoinType::Normal, 1);
+
+	EXPECT_TRUE(eqEnum(acc.addCoins(CoinType::Normal, 100, string {}), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.removeCoins(CoinType::Normal, 80, string {}), AccountErrors_t::Ok));
+
+	auto [coins, error] = acc.getCoins(CoinType::Normal);
+	EXPECT_EQ(21, coins);
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+
+	acc.registerCoinTransaction(CoinTransactionType::Add, CoinType::Normal, 100, "");
+	acc.registerCoinTransaction(CoinTransactionType::Remove, CoinType::Normal, 100, "");
+
+	EXPECT_EQ(0u, repository().coinsTransactions_.size());
+}
+
+TEST_F(AccountTest, GetPasswordReturnsEmptyStringIfNotLoaded) {
+	EXPECT_EQ(string {}, Account { 1 }.getPassword());
+}
+
+TEST_F(AccountTest, GetPasswordReturnsPassword) {
+	Account acc { 1 };
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_EQ(string { "123456" }, acc.getPassword());
+}
+
+TEST_F(AccountTest, GetPasswordLogsErrorOnFailure) {
+	Account acc { 1 };
+	repository().failGetPassword = true;
+	repository().addAccount("canary@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_EQ(string {}, acc.getPassword());
+	ASSERT_FALSE(testLogger().logs.empty());
+	EXPECT_EQ(string { "error" }, testLogger().logs[0].level);
+	EXPECT_EQ(string { "Failed to get password for account[1]!" }, testLogger().logs[0].message);
+}
+
+TEST_F(AccountTest, AddPremiumDaysSetsPremiumRemainingDays) {
+	Account acc { 1 };
+	acc.addPremiumDays(100);
+
+	EXPECT_EQ(100, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, AddPremiumDaysCanIncreasePremium) {
+	Account acc { 1 };
+
+	acc.setPremiumDays(50);
+	acc.addPremiumDays(50);
+
+	EXPECT_NEAR(static_cast<double>(acc.getPremiumLastDay()), static_cast<double>(getTimeNow() + (100 * 86400)), 60.0 * 60.0 * 1000.0);
+	EXPECT_EQ(100, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, AddPremiumDaysCanReducePremium) {
+	Account acc { 1 };
+
+	acc.setPremiumDays(50);
+	acc.addPremiumDays(-30);
+
+	EXPECT_NEAR(static_cast<double>(acc.getPremiumLastDay()), static_cast<double>(getTimeNow() - (20 * 86400)), 60.0 * 60.0 * 1000.0);
+	EXPECT_EQ(20, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, SetPremiumDaysSetsToZeroIfNegative) {
+	Account acc { 1 };
+	acc.setPremiumDays(10);
+	acc.setPremiumDays(-20);
+
+	EXPECT_EQ(0, acc.getPremiumLastDay());
+	EXPECT_EQ(0, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, SetAccountTypeSetsAccountType) {
+	Account acc { 1 };
+	EXPECT_TRUE(eqEnum(acc.setAccountType(AccountType::ACCOUNT_TYPE_GAMEMASTER), AccountErrors_t::Ok));
+	EXPECT_TRUE(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
+}
+
+TEST_F(AccountTest, UpdatePremiumTimeSetsRemainingDaysToZeroWhenExpired) {
+	Account acc { 1 };
+	acc.setPremiumDays(-10);
+	acc.updatePremiumTime();
+	EXPECT_EQ(0, acc.getPremiumRemainingDays());
+	EXPECT_EQ(0, acc.getPremiumLastDay());
+}
+
+TEST_F(AccountTest, UpdatePremiumTimeSetsRemainingDaysToZeroWhenLastDayIsZero) {
+	Account acc { 1 };
+	acc.setPremiumDays(0);
+	acc.updatePremiumTime();
+	EXPECT_EQ(0, acc.getPremiumLastDay());
+	EXPECT_EQ(0, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, UpdatePremiumTimeKeepsFutureRemainingDays) {
+	Account acc { 1 };
+	acc.setPremiumDays(8);
+	acc.updatePremiumTime();
+
+	auto remainingTime = static_cast<double>(acc.getPremiumLastDay() - getTimeNow()) / 86400.0;
+	EXPECT_NEAR(8.0, remainingTime, 0.1);
+	EXPECT_EQ(8, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, UpdatePremiumTimeKeepsNearFutureRemainingDays) {
+	Account acc { 1 };
+	acc.setPremiumDays(1);
+	acc.updatePremiumTime();
+
+	auto remainingTime = static_cast<double>(acc.getPremiumLastDay() - getTimeNow()) / 86400.0;
+	EXPECT_NEAR(1.0, remainingTime, 0.1);
+	EXPECT_EQ(1, acc.getPremiumRemainingDays());
+}
+
+TEST_F(AccountTest, GetAccountPlayersReturnsErrorIfNotLoaded) {
+	auto [players, error] = Account { 1 }.getAccountPlayers();
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::NotInitialized));
+	EXPECT_TRUE(players.empty());
+}
+
+TEST_F(AccountTest, GetAccountPlayersReturnsPlayers) {
+	Account acc { 1 };
+	repository().addAccount(
+		"canary@test.com",
+		AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } } }
+	);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	auto [players, error] = acc.getAccountPlayers();
+
+	EXPECT_TRUE(eqEnum(error, AccountErrors_t::Ok));
+	ASSERT_EQ(2u, players.size());
+	EXPECT_EQ(1, players["Canary"]);
+	EXPECT_EQ(2, players["Canary2"]);
+}
+
+TEST_F(AccountTest, AuthenticatePasswordUsingSha1) {
+	Account acc { 1 };
+	repository().addAccount(
+		"canary@test.com",
+		AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD, { { "Canary", 1 }, { "Canary2", 2 } } }
+	);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	repository().password_ = "7c4a8d09ca3762af61e59520943dc26494f8941b";
+	EXPECT_TRUE(acc.authenticate("123456"));
+}
+
+TEST_F(AccountTest, AuthenticateUsingSessions) {
+	Account acc { 1 };
+	repository().addAccount(
+		"session-key",
+		AccountInfo {
+			1,
+			1,
+			1,
+			AccountType::ACCOUNT_TYPE_GOD,
+			{ { "Canary", 1 }, { "Canary2", 2 } },
+			false,
+			getTimeNow() + 24 * 60 * 60 * 1000 }
+	);
+
+	EXPECT_TRUE(eqEnum(acc.load(), AccountErrors_t::Ok));
+	EXPECT_TRUE(acc.authenticate());
+}
+
+TEST_F(AccountTest, GetCharacterByAccountIdAndNameFindsCharacter) {
+	repository().addAccount(
+		"session-key",
+		AccountInfo {
+			1,
+			1,
+			1,
+			AccountType::ACCOUNT_TYPE_GOD,
+			{ { "Canary", 1 }, { "Canary2", 2 } },
+			false,
+			getTimeNow() + 24 * 60 * 60 * 1000 }
+	);
+
+	EXPECT_TRUE(repository().getCharacterByAccountIdAndName(1, "Canary"));
+}
+
+TEST_F(AccountTest, GetCharacterByAccountIdAndNameReturnsFalseWhenMissing) {
+	repository().addAccount(
+		"session-key",
+		AccountInfo {
+			1,
+			1,
+			1,
+			AccountType::ACCOUNT_TYPE_GOD,
+			{ { "Canary", 1 }, { "Canary2", 2 } },
+			false,
+			getTimeNow() + 24 * 60 * 60 * 1000 }
+	);
+
+	EXPECT_FALSE(repository().getCharacterByAccountIdAndName(1, "Invalid"));
+}

--- a/tests/unit/items/containers/container_test.cpp
+++ b/tests/unit/items/containers/container_test.cpp
@@ -1,9 +1,7 @@
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "lib/logging/in_memory_logger.hpp"
 
 #include "items/containers/container.hpp"
-
-using namespace boost::ut;

--- a/tests/unit/kv/kv_test.cpp
+++ b/tests/unit/kv/kv_test.cpp
@@ -15,40 +15,45 @@
 #include "injection_fixture.hpp"
 
 class KVTest : public ::testing::Test {
-protected:
-	InjectionFixture fixture {};
+public:
+	InjectionFixture &fixture() {
+		return fixture_;
+	}
+
+private:
+	InjectionFixture fixture_ {};
 };
 
 TEST_F(KVTest, SetAndGetIntegerValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("keyInt", 42);
 	ASSERT_TRUE(kv.get("keyInt").has_value());
 	EXPECT_EQ(42, kv.get("keyInt")->get<int>());
 }
 
 TEST_F(KVTest, SetAndGetBooleanValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("keyBool", true);
 	ASSERT_TRUE(kv.get("keyBool").has_value());
 	EXPECT_TRUE(kv.get("keyBool")->get<bool>());
 }
 
 TEST_F(KVTest, SetAndGetStringValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("keyString", std::string("hello"));
 	ASSERT_TRUE(kv.get("keyString").has_value());
 	EXPECT_EQ(std::string("hello"), kv.get("keyString")->get<std::string>());
 }
 
 TEST_F(KVTest, SetAndGetDoubleValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("keyDouble", 3.14);
 	ASSERT_TRUE(kv.get("keyDouble").has_value());
 	EXPECT_DOUBLE_EQ(3.14, kv.get("keyDouble")->get<double>());
 }
 
 TEST_F(KVTest, OverwriteExistingKey) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("keyInt", 42);
 	kv.set("keyInt", 43);
 	ASSERT_TRUE(kv.get("keyInt").has_value());
@@ -56,7 +61,7 @@ TEST_F(KVTest, OverwriteExistingKey) {
 }
 
 TEST_F(KVTest, MultipleKeyValuePairs) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("key1", 1);
 	kv.set("key2", 2);
 	kv.set("key3", 3);
@@ -69,13 +74,13 @@ TEST_F(KVTest, MultipleKeyValuePairs) {
 }
 
 TEST_F(KVTest, NonExistantKey) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	EXPECT_FALSE(kv.get("non-existant").has_value());
 	EXPECT_FALSE(kv.get("non-existant2").has_value());
 }
 
 TEST_F(KVTest, SetAndGetMapTypeValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	ValueWrapper mapValue { { "key1", 1 }, { "key2", 2 } };
 	kv.set("keyMap", mapValue);
 	ASSERT_TRUE(kv.get("keyMap").has_value());
@@ -83,7 +88,7 @@ TEST_F(KVTest, SetAndGetMapTypeValue) {
 }
 
 TEST_F(KVTest, SetAndGetArrayTypeValue) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	ValueWrapper arrayValue(ArrayType({ 1, 2, 3 }));
 	kv.set("keyArray", arrayValue);
 	ASSERT_TRUE(kv.get("keyArray").has_value());
@@ -91,7 +96,7 @@ TEST_F(KVTest, SetAndGetArrayTypeValue) {
 }
 
 TEST_F(KVTest, MixedTypesInMapType) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	ValueWrapper mixedMap { { "keyInt", 1 }, { "keyString", std::string("hello") }, { "keyDouble", 3.14 } };
 	kv.set("keyMixedMap", mixedMap);
 	ASSERT_TRUE(kv.get("keyMixedMap").has_value());
@@ -99,7 +104,7 @@ TEST_F(KVTest, MixedTypesInMapType) {
 }
 
 TEST_F(KVTest, NestedMapTypeAndArrayType) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	ValueWrapper nestedMap { { "keyArray", ValueWrapper { 1, 2 } }, { "keyInnerMap", ValueWrapper { { "key3", 3 } } } };
 	kv.set("keyNested", nestedMap);
 	ASSERT_TRUE(kv.get("keyNested").has_value());
@@ -107,7 +112,7 @@ TEST_F(KVTest, NestedMapTypeAndArrayType) {
 }
 
 TEST_F(KVTest, ScopedKv) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	auto scoped = kv.scoped("scope-name");
 	scoped->set("key1", 1);
 	ASSERT_TRUE(scoped->get("key1").has_value());
@@ -117,7 +122,7 @@ TEST_F(KVTest, ScopedKv) {
 }
 
 TEST_F(KVTest, NestedScopedKv) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	auto scoped = kv.scoped("scope-name");
 	auto nestedScoped = scoped->scoped("nested-scope-name");
 	auto nestedScoped2 = nestedScoped->scoped("nested-scope-name2");
@@ -133,7 +138,7 @@ TEST_F(KVTest, NestedScopedKv) {
 }
 
 TEST_F(KVTest, RemovingAnElement) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("key1", 1);
 	kv.set("key2", 2);
 	ASSERT_TRUE(kv.get("key1").has_value());
@@ -147,7 +152,7 @@ TEST_F(KVTest, RemovingAnElement) {
 }
 
 TEST_F(KVTest, KeysSkipDeletedEntries) {
-	auto [kv] = fixture.get<KVStore>();
+	auto [kv] = fixture().get<KVStore>();
 	kv.set("key1", 1);
 	kv.set("key2", 2);
 	kv.remove("key1");

--- a/tests/unit/kv/kv_test.cpp
+++ b/tests/unit/kv/kv_test.cpp
@@ -8,132 +8,150 @@
  */
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "kv/kv.hpp"
 #include "utils/tools.hpp"
 #include "injection_fixture.hpp"
 
-suite<"kv"> kvTest = [] {
-	InjectionFixture injectionFixture {};
-
-	test("Set and get integer value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("keyInt", 42);
-		expect(eq(kv.get("keyInt")->get<int>(), 42));
-	};
-
-	test("Set and get boolean value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("keyBool", true);
-		expect(eq(kv.get("keyBool")->get<bool>(), true));
-	};
-
-	test("Set and get string value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("keyString", std::string("hello"));
-		expect(eq(kv.get("keyString")->get<std::string>(), std::string("hello")));
-	};
-
-	test("Set and get double value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("keyDouble", 3.14);
-		expect(eq(kv.get("keyDouble")->get<double>(), 3.14));
-	};
-
-	test("Overwrite existing key") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("keyInt", 42);
-		kv.set("keyInt", 43);
-		expect(eq(kv.get("keyInt")->get<int>(), 43));
-	};
-
-	test("Multiple key-value pairs") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		kv.set("key1", 1);
-		kv.set("key2", 2);
-		kv.set("key3", 3);
-		expect(eq(kv.get("key1")->get<int>(), 1));
-		expect(eq(kv.get("key2")->get<int>(), 2));
-		expect(eq(kv.get("key3")->get<int>(), 3));
-	};
-
-	test("non-existant key") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		expect(!kv.get("non-existant").has_value());
-		expect(!kv.get("non-existant2").has_value());
-	};
-
-	test("Set and get MapType value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		ValueWrapper mapValue { { "key1", 1 }, { "key2", 2 } };
-		kv.set("keyMap", mapValue);
-		expect(eq(kv.get("keyMap")->get<MapType>(), mapValue.getVariant()));
-	};
-
-	test("Set and get ArrayType value") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		ValueWrapper arrayValue(ArrayType({ 1, 2, 3 }));
-		kv.set("keyArray", arrayValue);
-		expect(eq(kv.get("keyArray")->get<ArrayType>(), arrayValue.getVariant()));
-	};
-
-	test("Mixed types in MapType") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		ValueWrapper mixedMap { { "keyInt", 1 }, { "keyString", std::string("hello") }, { "keyDouble", 3.14 } };
-		kv.set("keyMixedMap", mixedMap);
-		expect(eq(kv.get("keyMixedMap")->get<MapType>(), mixedMap.getVariant()));
-	};
-
-	test("Nested MapType and ArrayType") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		ValueWrapper nestedMap { { "keyArray", ValueWrapper { 1, 2 } }, { "keyInnerMap", ValueWrapper { { "key3", 3 } } } };
-		kv.set("keyNested", nestedMap);
-		expect(eq(kv.get("keyNested")->get<MapType>(), nestedMap.getVariant()));
-	};
-
-	test("Scoped KV") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		auto scoped = kv.scoped("scope-name");
-		scoped->set("key1", 1);
-		expect(eq(scoped->get("key1")->get<int>(), 1));
-		expect(eq(kv.get("scope-name.key1")->get<int>(), 1));
-	};
-
-	test("Nested Scoped KV") = [&injectionFixture] {
-		auto [kv] = injectionFixture.get<KVStore>();
-		auto scoped = kv.scoped("scope-name");
-		auto nestedScoped = scoped->scoped("nested-scope-name");
-		auto nestedScoped2 = nestedScoped->scoped("nested-scope-name2");
-		nestedScoped2->set("key1", 1);
-		expect(eq(nestedScoped2->get("key1")->get<int>(), 1));
-		expect(eq(nestedScoped->get("nested-scope-name2.key1")->get<int>(), 1));
-		expect(eq(scoped->get("nested-scope-name.nested-scope-name2.key1")->get<int>(), 1));
-		expect(eq(kv.get("scope-name.nested-scope-name.nested-scope-name2.key1")->get<int>(), 1));
-	};
-
-	test("Removing an element")
-		= [&injectionFixture] {
-			  auto [kv] = injectionFixture.get<KVStore>();
-			  kv.set("key1", 1);
-			  kv.set("key2", 2);
-			  expect(eq(kv.get("key1")->get<int>(), 1));
-			  expect(eq(kv.get("key2")->get<int>(), 2));
-			  kv.set("key1", ValueWrapper::deleted());
-			  expect(!kv.get("key1").has_value());
-			  expect(eq(kv.get("key2")->get<int>(), 2));
-			  kv.remove("key2");
-			  expect(!kv.get("key2").has_value());
-		  };
-
-	test("Keys skip deleted entries")
-		= [&injectionFixture] {
-			  auto [kv] = injectionFixture.get<KVStore>();
-			  kv.set("key1", 1);
-			  kv.set("key2", 2);
-			  kv.remove("key1");
-			  auto keys = kv.keys();
-			  expect(!keys.contains("key1"));
-			  expect(keys.contains("key2"));
-		  };
+class KVTest : public ::testing::Test {
+protected:
+	InjectionFixture fixture {};
 };
+
+TEST_F(KVTest, SetAndGetIntegerValue) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("keyInt", 42);
+	ASSERT_TRUE(kv.get("keyInt").has_value());
+	EXPECT_EQ(42, kv.get("keyInt")->get<int>());
+}
+
+TEST_F(KVTest, SetAndGetBooleanValue) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("keyBool", true);
+	ASSERT_TRUE(kv.get("keyBool").has_value());
+	EXPECT_TRUE(kv.get("keyBool")->get<bool>());
+}
+
+TEST_F(KVTest, SetAndGetStringValue) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("keyString", std::string("hello"));
+	ASSERT_TRUE(kv.get("keyString").has_value());
+	EXPECT_EQ(std::string("hello"), kv.get("keyString")->get<std::string>());
+}
+
+TEST_F(KVTest, SetAndGetDoubleValue) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("keyDouble", 3.14);
+	ASSERT_TRUE(kv.get("keyDouble").has_value());
+	EXPECT_DOUBLE_EQ(3.14, kv.get("keyDouble")->get<double>());
+}
+
+TEST_F(KVTest, OverwriteExistingKey) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("keyInt", 42);
+	kv.set("keyInt", 43);
+	ASSERT_TRUE(kv.get("keyInt").has_value());
+	EXPECT_EQ(43, kv.get("keyInt")->get<int>());
+}
+
+TEST_F(KVTest, MultipleKeyValuePairs) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("key1", 1);
+	kv.set("key2", 2);
+	kv.set("key3", 3);
+	ASSERT_TRUE(kv.get("key1").has_value());
+	ASSERT_TRUE(kv.get("key2").has_value());
+	ASSERT_TRUE(kv.get("key3").has_value());
+	EXPECT_EQ(1, kv.get("key1")->get<int>());
+	EXPECT_EQ(2, kv.get("key2")->get<int>());
+	EXPECT_EQ(3, kv.get("key3")->get<int>());
+}
+
+TEST_F(KVTest, NonExistantKey) {
+	auto [kv] = fixture.get<KVStore>();
+	EXPECT_FALSE(kv.get("non-existant").has_value());
+	EXPECT_FALSE(kv.get("non-existant2").has_value());
+}
+
+TEST_F(KVTest, SetAndGetMapTypeValue) {
+	auto [kv] = fixture.get<KVStore>();
+	ValueWrapper mapValue { { "key1", 1 }, { "key2", 2 } };
+	kv.set("keyMap", mapValue);
+	ASSERT_TRUE(kv.get("keyMap").has_value());
+	EXPECT_EQ(kv.get("keyMap")->get<MapType>(), mapValue.getVariant());
+}
+
+TEST_F(KVTest, SetAndGetArrayTypeValue) {
+	auto [kv] = fixture.get<KVStore>();
+	ValueWrapper arrayValue(ArrayType({ 1, 2, 3 }));
+	kv.set("keyArray", arrayValue);
+	ASSERT_TRUE(kv.get("keyArray").has_value());
+	EXPECT_EQ(kv.get("keyArray")->get<ArrayType>(), arrayValue.getVariant());
+}
+
+TEST_F(KVTest, MixedTypesInMapType) {
+	auto [kv] = fixture.get<KVStore>();
+	ValueWrapper mixedMap { { "keyInt", 1 }, { "keyString", std::string("hello") }, { "keyDouble", 3.14 } };
+	kv.set("keyMixedMap", mixedMap);
+	ASSERT_TRUE(kv.get("keyMixedMap").has_value());
+	EXPECT_EQ(kv.get("keyMixedMap")->get<MapType>(), mixedMap.getVariant());
+}
+
+TEST_F(KVTest, NestedMapTypeAndArrayType) {
+	auto [kv] = fixture.get<KVStore>();
+	ValueWrapper nestedMap { { "keyArray", ValueWrapper { 1, 2 } }, { "keyInnerMap", ValueWrapper { { "key3", 3 } } } };
+	kv.set("keyNested", nestedMap);
+	ASSERT_TRUE(kv.get("keyNested").has_value());
+	EXPECT_EQ(kv.get("keyNested")->get<MapType>(), nestedMap.getVariant());
+}
+
+TEST_F(KVTest, ScopedKv) {
+	auto [kv] = fixture.get<KVStore>();
+	auto scoped = kv.scoped("scope-name");
+	scoped->set("key1", 1);
+	ASSERT_TRUE(scoped->get("key1").has_value());
+	ASSERT_TRUE(kv.get("scope-name.key1").has_value());
+	EXPECT_EQ(1, scoped->get("key1")->get<int>());
+	EXPECT_EQ(1, kv.get("scope-name.key1")->get<int>());
+}
+
+TEST_F(KVTest, NestedScopedKv) {
+	auto [kv] = fixture.get<KVStore>();
+	auto scoped = kv.scoped("scope-name");
+	auto nestedScoped = scoped->scoped("nested-scope-name");
+	auto nestedScoped2 = nestedScoped->scoped("nested-scope-name2");
+	nestedScoped2->set("key1", 1);
+	ASSERT_TRUE(nestedScoped2->get("key1").has_value());
+	ASSERT_TRUE(nestedScoped->get("nested-scope-name2.key1").has_value());
+	ASSERT_TRUE(scoped->get("nested-scope-name.nested-scope-name2.key1").has_value());
+	ASSERT_TRUE(kv.get("scope-name.nested-scope-name.nested-scope-name2.key1").has_value());
+	EXPECT_EQ(1, nestedScoped2->get("key1")->get<int>());
+	EXPECT_EQ(1, nestedScoped->get("nested-scope-name2.key1")->get<int>());
+	EXPECT_EQ(1, scoped->get("nested-scope-name.nested-scope-name2.key1")->get<int>());
+	EXPECT_EQ(1, kv.get("scope-name.nested-scope-name.nested-scope-name2.key1")->get<int>());
+}
+
+TEST_F(KVTest, RemovingAnElement) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("key1", 1);
+	kv.set("key2", 2);
+	ASSERT_TRUE(kv.get("key1").has_value());
+	ASSERT_TRUE(kv.get("key2").has_value());
+	kv.set("key1", ValueWrapper::deleted());
+	EXPECT_FALSE(kv.get("key1").has_value());
+	ASSERT_TRUE(kv.get("key2").has_value());
+	EXPECT_EQ(2, kv.get("key2")->get<int>());
+	kv.remove("key2");
+	EXPECT_FALSE(kv.get("key2").has_value());
+}
+
+TEST_F(KVTest, KeysSkipDeletedEntries) {
+	auto [kv] = fixture.get<KVStore>();
+	kv.set("key1", 1);
+	kv.set("key2", 2);
+	kv.remove("key1");
+	auto keys = kv.keys();
+	EXPECT_FALSE(keys.contains("key1"));
+	EXPECT_TRUE(keys.contains("key2"));
+}

--- a/tests/unit/lib/di/soft_singleton_test.cpp
+++ b/tests/unit/lib/di/soft_singleton_test.cpp
@@ -8,52 +8,67 @@
  */
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "lib/di/container.hpp"
 #include "lib/di/soft_singleton.hpp"
 #include "lib/logging/in_memory_logger.hpp"
 
-using namespace boost::ut;
-
-suite<"lib"> softSingletonTest = [] {
-	test("SoftSingleton warns about multiple instances") = [] {
-		di::extension::injector<> injector {};
+class SoftSingletonTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		previousContainer = DI::getTestContainer();
 		DI::setTestContainer(&InMemoryLogger::install(injector));
+		logger = &dynamic_cast<InMemoryLogger &>(DI::get<Logger>());
+	}
 
-		SoftSingleton softSingleton { "Test" };
-		SoftSingletonGuard guard { softSingleton };
-		SoftSingletonGuard guard2 { softSingleton };
-		softSingleton.increment();
+	static void TearDownTestSuite() {
+		DI::setTestContainer(previousContainer);
+	}
 
-		auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
-		expect(eq(2, logger.logCount()) >> fatal);
-		expect(
-			eq(std::string { "warning" }, logger.logs[0].level) and eq(std::string { "2 instances created for Test. This is a soft singleton, you probably want to use g_test instead." }, logger.logs[0].message)
-		);
-		expect(
-			eq(std::string { "warning" }, logger.logs[1].level) and eq(std::string { "3 instances created for Test. This is a soft singleton, you probably want to use g_test instead." }, logger.logs[1].message)
-		);
-	};
+	void SetUp() override {
+		logger->reset();
+	}
 
-	test("SoftSingleton doesn't warn if instance was released") = [] {
-		di::extension::injector<> injector {};
-		DI::setTestContainer(&InMemoryLogger::install(injector));
-		SoftSingleton softSingleton { "Test" };
+	static InMemoryLogger &testLogger() {
+		return *logger;
+	}
 
-		[&softSingleton] { SoftSingletonGuard guard { softSingleton }; }();
-
-		// Lambda scope, guard was destructed.
-		[&softSingleton] { SoftSingletonGuard guard { softSingleton }; }();
-
-		// Lambda scope, guard2 was destructed.
-		softSingleton.increment();
-		softSingleton.decrement();
-
-		// Decrement resets the counter;
-		softSingleton.increment();
-
-		auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
-		expect(eq(0, logger.logCount()));
-	};
+private:
+	inline static di::extension::injector<> injector {};
+	inline static di::extension::injector<>* previousContainer { nullptr };
+	inline static InMemoryLogger* logger { nullptr };
 };
+
+TEST_F(SoftSingletonTest, WarnsAboutMultipleInstances) {
+	SoftSingleton softSingleton { "Test" };
+	SoftSingletonGuard guard { softSingleton };
+	SoftSingletonGuard guard2 { softSingleton };
+	softSingleton.increment();
+
+	auto &logger = testLogger();
+	ASSERT_EQ(2, logger.logCount());
+	EXPECT_EQ(std::string { "warning" }, logger.logs[0].level);
+	EXPECT_EQ(
+		std::string { "2 instances created for Test. This is a soft singleton, you probably want to use g_test instead." },
+		logger.logs[0].message
+	);
+	EXPECT_EQ(std::string { "warning" }, logger.logs[1].level);
+	EXPECT_EQ(
+		std::string { "3 instances created for Test. This is a soft singleton, you probably want to use g_test instead." },
+		logger.logs[1].message
+	);
+}
+
+TEST_F(SoftSingletonTest, DoesNotWarnIfInstanceReleased) {
+	SoftSingleton softSingleton { "Test" };
+
+	[&softSingleton] { SoftSingletonGuard guard { softSingleton }; }();
+	[&softSingleton] { SoftSingletonGuard guard { softSingleton }; }();
+
+	softSingleton.increment();
+	softSingleton.decrement();
+	softSingleton.increment();
+
+	EXPECT_EQ(0, testLogger().logCount());
+}

--- a/tests/unit/lib/di/soft_singleton_test.cpp
+++ b/tests/unit/lib/di/soft_singleton_test.cpp
@@ -27,7 +27,7 @@ protected:
 	}
 
 	void SetUp() override {
-		logger->reset();
+		logger = &logger->reset();
 	}
 
 	static InMemoryLogger &testLogger() {

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -1,13 +1,13 @@
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 #include "config/configmanager.hpp"
 #include "database/database.hpp"
 #include "lib/di/container.hpp"
 #include "lib/logging/in_memory_logger.hpp"
 
-using namespace boost::ut;
+int main(int argc, char** argv) {
+	::testing::InitGoogleTest(&argc, argv);
 
-int main() {
-	di::extension::injector<> injector {};
+	static di::extension::injector<> injector {};
 	InMemoryLogger::install(injector);
 	DI::setTestContainer(&injector);
 
@@ -15,5 +15,5 @@ int main() {
 	(void)g_configManager();
 	(void)g_database();
 
-	return cfg<>.run();
+	return RUN_ALL_TESTS();
 }

--- a/tests/unit/players/components/player_storage_test.cpp
+++ b/tests/unit/players/components/player_storage_test.cpp
@@ -9,7 +9,7 @@
 
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <array>
@@ -22,161 +22,139 @@
 #include "creatures/players/grouping/familiars.hpp"
 #include "utils/const.hpp"
 
-#include "injection_fixture.hpp"
+#include "lib/logging/in_memory_logger.hpp"
 
-using namespace boost::ut;
+class PlayerStorageTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		InMemoryLogger::install(injector);
+		DI::setTestContainer(&injector);
+	}
 
-static void reg_add_and_get_storage_value() {
-	test("add and get storage value") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-		const uint32_t key = 50000;
-
-		storage.ingest({});
-		storage.add(key, 42, /*shouldStorageUpdate=*/true);
-
-		expect(storage.has(key));
-		expect(eq(storage.get(key), 42));
-		expect(eq(storage.getStorageMap().size(), std::size_t { 1 }));
-		auto d = storage.delta();
-		expect(eq(d.upserts.size(), std::size_t { 1 }));
-		expect(eq(d.upserts.at(key), 42));
-		storage.clearDirty();
-	};
-}
-
-static void reg_remove_storage_value() {
-	test("remove storage value") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-		const uint32_t key = 50001;
-
-		storage.ingest({});
-		storage.add(key, 7, /*shouldStorageUpdate=*/true);
-		expect(storage.has(key));
-
-		expect(storage.remove(key));
-		expect(!storage.has(key));
-		auto d = storage.delta();
-		expect(eq(d.deletions.size(), std::size_t { 1 }));
-		expect(std::ranges::find(d.deletions, key) != d.deletions.end());
-		storage.clearDirty();
-	};
-}
-
-static void reg_passthrough_mounts() {
-	test("pass-through range is persisted (mounts)") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-		const uint32_t key = PSTRG_MOUNTS_RANGE_START + 1;
-
-		storage.ingest({});
-		storage.add(key, 123, /*shouldStorageUpdate=*/true);
-
-		expect(storage.has(key));
-		expect(eq(storage.get(key), 123));
-		expect(eq(storage.getModifiedKeys().count(key), std::size_t { 1 }));
-	};
-}
-
-static void reg_passthrough_wing_effect_aura_shader() {
-	test("pass-through range is persisted (wing/effect/aura/shader)") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-
-		storage.ingest({});
-		constexpr std::array<uint32_t, 4> keys {
-			PSTRG_WING_RANGE_START + 1,
-			PSTRG_EFFECT_RANGE_START + 1,
-			PSTRG_AURA_RANGE_START + 1,
-			PSTRG_SHADER_RANGE_START + 1,
-		};
-
-		int v = 10;
-		for (auto k : keys) {
-			storage.add(k, v, /*shouldStorageUpdate=*/true);
-			v++;
-			expect(storage.has(k));
-			expect(eq(storage.get(k), v - 1));
-			expect(eq(storage.getModifiedKeys().count(k), std::size_t { 1 }));
-		}
-	};
-}
-
-static void reg_outfits_side_effect() {
-	test("outfits side-effect only via public API") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-
-		storage.ingest({});
-		const auto beforeOutfits = player->getOutfits().size();
-		const uint32_t key = PSTRG_OUTFITS_RANGE_START + 1;
-		const uint32_t lookType = 50u;
-		const uint8_t addons = 3u;
-
-		storage.add(key, (lookType << 16) | addons, /*shouldStorageUpdate=*/true);
-		expect(eq(player->getOutfits().size(), beforeOutfits + 1));
-		const auto &os = player->getOutfits();
-		auto it = std::ranges::find_if(os, [&](const auto &e) { return e.lookType == lookType; });
-		expect(it != os.end());
-		expect((it->addons & addons) == addons);
-	};
-}
-
-static void reg_familiars_side_effect() {
-	test("familiars side-effect does not persist storage entry") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-
-		storage.ingest({});
-		const auto before = player->getFamiliars().size();
-		const uint32_t key = PSTRG_FAMILIARS_RANGE_START + 1;
-		const uint32_t lookType = 77u;
-
-		storage.add(key, (lookType << 16), /*shouldStorageUpdate=*/true);
-
-		expect(eq(player->getFamiliars().size(), before + 1));
-		expect(eq(storage.getStorageMap().size(), std::size_t { 0 }));
-	};
-}
-
-static void reg_unknown_reserved_key() {
-	test("unknown reserved key persists and does not block flow") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-
-		storage.ingest({});
-		const uint32_t key = PSTRG_RESERVED_RANGE_START + 900000u;
-
-		storage.add(key, 321, /*shouldStorageUpdate=*/true);
-
-		expect(storage.has(key));
-		expect(eq(storage.get(key), 321));
-	};
-}
-
-static void reg_get_missing_key() {
-	test("get returns -1 for missing key") = [] {
-		auto player = std::make_shared<Player>();
-		auto &storage = player->storage();
-
-		storage.ingest({});
-		expect(eq(storage.get(999999u), -1));
-		expect(!storage.has(999999u));
-	};
-}
-
-suite<"player_storage"> playerStorageTests = [] {
-	static di::extension::injector<> injector {};
-	InMemoryLogger::install(injector);
-	DI::setTestContainer(&injector);
-
-	reg_add_and_get_storage_value();
-	reg_remove_storage_value();
-	reg_passthrough_mounts();
-	reg_passthrough_wing_effect_aura_shader();
-	reg_outfits_side_effect();
-	reg_familiars_side_effect();
-	reg_unknown_reserved_key();
-	reg_get_missing_key();
+private:
+	inline static di::extension::injector<> injector {};
 };
+
+TEST_F(PlayerStorageTest, AddAndGetStorageValue) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+	const uint32_t key = 50000;
+
+	storage.ingest({});
+	storage.add(key, 42, true);
+
+	EXPECT_TRUE(storage.has(key));
+	EXPECT_EQ(42, storage.get(key));
+	EXPECT_EQ(std::size_t { 1 }, storage.getStorageMap().size());
+	auto delta = storage.delta();
+	EXPECT_EQ(std::size_t { 1 }, delta.upserts.size());
+	EXPECT_EQ(42, delta.upserts.at(key));
+	storage.clearDirty();
+}
+
+TEST_F(PlayerStorageTest, RemoveStorageValue) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+	const uint32_t key = 50001;
+
+	storage.ingest({});
+	storage.add(key, 7, true);
+	EXPECT_TRUE(storage.has(key));
+
+	EXPECT_TRUE(storage.remove(key));
+	EXPECT_FALSE(storage.has(key));
+	auto delta = storage.delta();
+	EXPECT_EQ(std::size_t { 1 }, delta.deletions.size());
+	EXPECT_NE(delta.deletions.end(), std::ranges::find(delta.deletions, key));
+	storage.clearDirty();
+}
+
+TEST_F(PlayerStorageTest, PassthroughRangeIsPersistedMounts) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+	const uint32_t key = PSTRG_MOUNTS_RANGE_START + 1;
+
+	storage.ingest({});
+	storage.add(key, 123, true);
+
+	EXPECT_TRUE(storage.has(key));
+	EXPECT_EQ(123, storage.get(key));
+	EXPECT_EQ(std::size_t { 1 }, storage.getModifiedKeys().count(key));
+}
+
+TEST_F(PlayerStorageTest, PassthroughRangeIsPersistedWingEffectAuraShader) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+
+	storage.ingest({});
+	constexpr std::array<uint32_t, 4> keys {
+		PSTRG_WING_RANGE_START + 1,
+		PSTRG_EFFECT_RANGE_START + 1,
+		PSTRG_AURA_RANGE_START + 1,
+		PSTRG_SHADER_RANGE_START + 1,
+	};
+
+	int value = 10;
+	for (auto k : keys) {
+		storage.add(k, value, true);
+		value++;
+		EXPECT_TRUE(storage.has(k));
+		EXPECT_EQ(value - 1, storage.get(k));
+		EXPECT_EQ(std::size_t { 1 }, storage.getModifiedKeys().count(k));
+	}
+}
+
+TEST_F(PlayerStorageTest, OutfitsSideEffectOnlyViaPublicApi) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+
+	storage.ingest({});
+	const auto beforeOutfits = player->getOutfits().size();
+	const uint32_t key = PSTRG_OUTFITS_RANGE_START + 1;
+	const uint32_t lookType = 50u;
+	const uint8_t addons = 3u;
+
+	storage.add(key, (lookType << 16) | addons, true);
+	EXPECT_EQ(beforeOutfits + 1, player->getOutfits().size());
+	const auto &outfits = player->getOutfits();
+	auto it = std::ranges::find_if(outfits, [&](const auto &entry) { return entry.lookType == lookType; });
+	ASSERT_NE(outfits.end(), it);
+	EXPECT_EQ(addons, it->addons & addons);
+}
+
+TEST_F(PlayerStorageTest, FamiliarsSideEffectDoesNotPersistEntry) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+
+	storage.ingest({});
+	const auto before = player->getFamiliars().size();
+	const uint32_t key = PSTRG_FAMILIARS_RANGE_START + 1;
+	const uint32_t lookType = 77u;
+
+	storage.add(key, (lookType << 16), true);
+
+	EXPECT_EQ(before + 1, player->getFamiliars().size());
+	EXPECT_EQ(std::size_t { 0 }, storage.getStorageMap().size());
+}
+
+TEST_F(PlayerStorageTest, UnknownReservedKeyPersists) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+
+	storage.ingest({});
+	const uint32_t key = PSTRG_RESERVED_RANGE_START + 900000u;
+
+	storage.add(key, 321, true);
+
+	EXPECT_TRUE(storage.has(key));
+	EXPECT_EQ(321, storage.get(key));
+}
+
+TEST_F(PlayerStorageTest, GetReturnsMinusOneForMissingKey) {
+	auto player = std::make_shared<Player>();
+	auto &storage = player->storage();
+
+	storage.ingest({});
+	EXPECT_EQ(-1, storage.get(999999u));
+	EXPECT_FALSE(storage.has(999999u));
+}

--- a/tests/unit/security/rsa_test.cpp
+++ b/tests/unit/security/rsa_test.cpp
@@ -26,7 +26,7 @@ protected:
 	}
 
 	void SetUp() override {
-		logger->reset();
+		logger = &logger->reset();
 	}
 
 	static InMemoryLogger &testLogger() {

--- a/tests/unit/security/rsa_test.cpp
+++ b/tests/unit/security/rsa_test.cpp
@@ -8,25 +8,46 @@
  */
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "lib/logging/in_memory_logger.hpp"
 #include "security/rsa.hpp"
 
-using namespace boost::ut;
-
-suite<"security"> rsaTest = [] {
-	test("RSA::start logs error for missing .pem file") = [] {
-		di::extension::injector<> injector {};
+class RSATest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		previousContainer = DI::getTestContainer();
 		DI::setTestContainer(&InMemoryLogger::install(injector));
+		logger = &dynamic_cast<InMemoryLogger &>(DI::get<Logger>());
+	}
 
-		DI::create<RSA &>().start();
+	static void TearDownTestSuite() {
+		DI::setTestContainer(previousContainer);
+	}
 
-		auto &logger = dynamic_cast<InMemoryLogger &>(injector.create<Logger &>());
+	void SetUp() override {
+		logger->reset();
+	}
 
-		expect(eq(1, logger.logs.size()) >> fatal);
-		expect(
-			eq(std::string { "error" }, logger.logs[0].level) and eq(std::string { "File key.pem not found or have problem on loading... Setting standard rsa key\n" }, logger.logs[0].message)
-		);
-	};
+	static InMemoryLogger &testLogger() {
+		return *logger;
+	}
+
+private:
+	inline static di::extension::injector<> injector {};
+	inline static di::extension::injector<>* previousContainer { nullptr };
+	inline static InMemoryLogger* logger { nullptr };
 };
+
+TEST_F(RSATest, StartLogsErrorForMissingPemFile) {
+	DI::create<RSA &>().start();
+
+	auto &logger = testLogger();
+
+	ASSERT_EQ(1u, logger.logs.size());
+	EXPECT_EQ(std::string { "error" }, logger.logs[0].level);
+	EXPECT_EQ(
+		std::string { "File key.pem not found or have problem on loading... Setting standard rsa key\n" },
+		logger.logs[0].message
+	);
+}

--- a/tests/unit/utils/position_functions_test.cpp
+++ b/tests/unit/utils/position_functions_test.cpp
@@ -1,59 +1,58 @@
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "game/movement/position.hpp"
 #include "utils/tools.hpp"
 
-using namespace boost::ut;
-
-suite<"utils"> getDirectionToTest = [] {
-	struct GetDirectionToTestCase {
-		Position from, to;
-		Direction expected, expectedForExactDiagonal;
-
-		[[nodiscard]] std::string toString() const {
-			return fmt::format("from {} to {}", from.toString(), to.toString());
-		}
-	};
-
-	std::vector getDirectionToTestCases {
-		GetDirectionToTestCase { Position {}, Position {}, DIRECTION_NONE, DIRECTION_NONE },
-		GetDirectionToTestCase { Position { 0, 0, 0 }, Position { 0, 0, 0 }, DIRECTION_NONE, DIRECTION_NONE },
-		GetDirectionToTestCase { Position { 100, 100, 100 }, Position { 100, 100, 100 }, DIRECTION_NONE, DIRECTION_NONE },
-		GetDirectionToTestCase { Position { 125, 1123, 5 }, Position { 125, 1153, 5 }, DIRECTION_SOUTH, DIRECTION_SOUTH },
-		GetDirectionToTestCase { Position { 5555, 3212, 15 }, Position { 5555, 3211, 15 }, DIRECTION_NORTH, DIRECTION_NORTH },
-		GetDirectionToTestCase { Position { 32132, 65000, 11 }, Position { 31512, 65000, 11 }, DIRECTION_WEST, DIRECTION_WEST },
-		GetDirectionToTestCase { Position { 5123, 6554, 7 }, Position { 40000, 6554, 7 }, DIRECTION_EAST, DIRECTION_EAST },
-		GetDirectionToTestCase { Position { 25200, 33173, 8 }, Position { 5200, 13173, 7 }, DIRECTION_NORTHWEST, DIRECTION_NORTHWEST },
-		GetDirectionToTestCase { Position { 22137, 6, 9 }, Position { 22141, 2, 15 }, DIRECTION_NORTHEAST, DIRECTION_NORTHEAST },
-		GetDirectionToTestCase { Position { 32011, 2197, 1 }, Position { 32135, 2321, 13 }, DIRECTION_SOUTHEAST, DIRECTION_SOUTHEAST },
-		GetDirectionToTestCase { Position { 13121, 5213, 5 }, Position { 5213, 13121, 5 }, DIRECTION_SOUTHWEST, DIRECTION_SOUTHWEST },
-
-		GetDirectionToTestCase { Position { 123, 122, 0 }, Position { 0, 0, 0 }, DIRECTION_NORTHWEST, DIRECTION_WEST },
-		GetDirectionToTestCase { Position { 122, 123, 0 }, Position { 0, 0, 0 }, DIRECTION_NORTHWEST, DIRECTION_NORTH },
-		GetDirectionToTestCase { Position { 0, 122, 0 }, Position { 123, 0, 0 }, DIRECTION_NORTHEAST, DIRECTION_EAST },
-		GetDirectionToTestCase { Position { 0, 123, 0 }, Position { 122, 0, 0 }, DIRECTION_NORTHEAST, DIRECTION_NORTH },
-		GetDirectionToTestCase { Position { 0, 0, 0 }, Position { 123, 122, 0 }, DIRECTION_SOUTHEAST, DIRECTION_EAST },
-		GetDirectionToTestCase { Position { 0, 0, 0 }, Position { 122, 123, 0 }, DIRECTION_SOUTHEAST, DIRECTION_SOUTH },
-		GetDirectionToTestCase { Position { 123, 0, 0 }, Position { 0, 122, 0 }, DIRECTION_SOUTHWEST, DIRECTION_WEST },
-		GetDirectionToTestCase { Position { 122, 0, 0 }, Position { 0, 123, 0 }, DIRECTION_SOUTHWEST, DIRECTION_SOUTH },
-	};
-
-	static std::vector<std::string> test_names;
-	test_names.reserve(getDirectionToTestCases.size());
-
-	for (auto getDirectionToTestCase : getDirectionToTestCases) {
-		test_names.push_back("getDirectionTo " + getDirectionToTestCase.toString());
-		auto &name = test_names.back();
-		test(std::string_view { name }) = [getDirectionToTestCase] {
-			auto [from, to, expected, expectedForExactDiagonal] = getDirectionToTestCase;
-
-			auto result = getDirectionTo(from, to);
-			expect(eq(expectedForExactDiagonal, result)) << fmt::format("[exact diagonal] {} != {}", static_cast<uint8_t>(expectedForExactDiagonal), static_cast<uint8_t>(result));
-
-			result = getDirectionTo(from, to, false);
-			expect(eq(expected, result)) << fmt::format("[non-exact diagonal] {} != {}", static_cast<uint8_t>(expected), static_cast<uint8_t>(result));
-		};
-	}
+struct GetDirectionToTestCase {
+	Position from;
+	Position to;
+	Direction expected;
+	Direction expectedForExactDiagonal;
+	std::string description;
 };
+
+class GetDirectionToTest : public ::testing::TestWithParam<GetDirectionToTestCase> { };
+
+TEST_P(GetDirectionToTest, ReturnsExpectedDirections) {
+	const auto &testCase = GetParam();
+	SCOPED_TRACE(testCase.description);
+
+	auto result = getDirectionTo(testCase.from, testCase.to);
+	EXPECT_EQ(testCase.expectedForExactDiagonal, result);
+
+	result = getDirectionTo(testCase.from, testCase.to, false);
+	EXPECT_EQ(testCase.expected, result);
+}
+
+static const std::vector<GetDirectionToTestCase> kGetDirectionToTestCases {
+	{ Position {}, Position {}, DIRECTION_NONE, DIRECTION_NONE, "origin" },
+	{ Position { 0, 0, 0 }, Position { 0, 0, 0 }, DIRECTION_NONE, DIRECTION_NONE, "zero" },
+	{ Position { 100, 100, 100 }, Position { 100, 100, 100 }, DIRECTION_NONE, DIRECTION_NONE, "same coords" },
+	{ Position { 125, 1123, 5 }, Position { 125, 1153, 5 }, DIRECTION_SOUTH, DIRECTION_SOUTH, "south" },
+	{ Position { 5555, 3212, 15 }, Position { 5555, 3211, 15 }, DIRECTION_NORTH, DIRECTION_NORTH, "north" },
+	{ Position { 32132, 65000, 11 }, Position { 31512, 65000, 11 }, DIRECTION_WEST, DIRECTION_WEST, "west" },
+	{ Position { 5123, 6554, 7 }, Position { 40000, 6554, 7 }, DIRECTION_EAST, DIRECTION_EAST, "east" },
+	{ Position { 25200, 33173, 8 }, Position { 5200, 13173, 7 }, DIRECTION_NORTHWEST, DIRECTION_NORTHWEST, "northwest far" },
+	{ Position { 22137, 6, 9 }, Position { 22141, 2, 15 }, DIRECTION_NORTHEAST, DIRECTION_NORTHEAST, "northeast far" },
+	{ Position { 32011, 2197, 1 }, Position { 32135, 2321, 13 }, DIRECTION_SOUTHEAST, DIRECTION_SOUTHEAST, "southeast far" },
+	{ Position { 13121, 5213, 5 }, Position { 5213, 13121, 5 }, DIRECTION_SOUTHWEST, DIRECTION_SOUTHWEST, "southwest far" },
+	{ Position { 123, 122, 0 }, Position { 0, 0, 0 }, DIRECTION_NORTHWEST, DIRECTION_WEST, "northwest bias west" },
+	{ Position { 122, 123, 0 }, Position { 0, 0, 0 }, DIRECTION_NORTHWEST, DIRECTION_NORTH, "northwest bias north" },
+	{ Position { 0, 122, 0 }, Position { 123, 0, 0 }, DIRECTION_NORTHEAST, DIRECTION_EAST, "northeast bias east" },
+	{ Position { 0, 123, 0 }, Position { 122, 0, 0 }, DIRECTION_NORTHEAST, DIRECTION_NORTH, "northeast bias north" },
+	{ Position { 0, 0, 0 }, Position { 123, 122, 0 }, DIRECTION_SOUTHEAST, DIRECTION_EAST, "southeast bias east" },
+	{ Position { 0, 0, 0 }, Position { 122, 123, 0 }, DIRECTION_SOUTHEAST, DIRECTION_SOUTH, "southeast bias south" },
+	{ Position { 123, 0, 0 }, Position { 0, 122, 0 }, DIRECTION_SOUTHWEST, DIRECTION_WEST, "southwest bias west" },
+	{ Position { 122, 0, 0 }, Position { 0, 123, 0 }, DIRECTION_SOUTHWEST, DIRECTION_SOUTH, "southwest bias south" },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+	GetDirectionTo,
+	GetDirectionToTest,
+	::testing::ValuesIn(kGetDirectionToTestCases),
+	[](const ::testing::TestParamInfo<GetDirectionToTest::ParamType> &info) {
+		return fmt::format("Case{}", info.index);
+	}
+);

--- a/tests/unit/utils/string_functions_test.cpp
+++ b/tests/unit/utils/string_functions_test.cpp
@@ -1,34 +1,40 @@
 #include "pch.hpp"
 
-#include <boost/ut.hpp>
+#include <gtest/gtest.h>
 
 #include "utils/tools.hpp"
 
-using namespace boost::ut;
-
-suite<"utils"> replaceStringTest = [] {
-	struct ReplaceStringTestCase {
-		std::string subject, search, replace, expected;
-
-		[[nodiscard]] std::string toString() const {
-			return fmt::format("replace '{}' in '{}' by '{}'", search, subject, replace);
-		}
-	};
-
-	static const std::vector<ReplaceStringTestCase> replaceStringTestCases {
-		{ "", "", "", "" },
-		{ "all together", " ", "_", "all_together" },
-		{ "beautiful", "u", "", "beatifl" },
-		{ "empty_empty_empty_", "empty_", "", "" },
-		{ "I am someone", "someone", "Lucas", "I am Lucas" },
-		{ "[[123[[[[[[124[[asf[[ccc[[[", "[[", "\\[[", "\\[[123\\[[\\[[\\[[124\\[[asf\\[[ccc\\[[[" },
-	};
-
-	for (const auto &replaceStringTestCase : replaceStringTestCases) {
-		test("replaceString") = [replaceStringTestCase] {
-			auto [subject, search, replace, expected] = replaceStringTestCase;
-			replaceString(subject, search, replace);
-			expect(eq(expected, subject)) << fmt::format("FAILED: {}", replaceStringTestCase.toString());
-		};
-	}
+struct ReplaceStringTestCase {
+	std::string subject;
+	std::string search;
+	std::string replace;
+	std::string expected;
+	std::string description;
 };
+
+class ReplaceStringTest : public ::testing::TestWithParam<ReplaceStringTestCase> { };
+
+TEST_P(ReplaceStringTest, ReplacesStrings) {
+	auto testCase = GetParam();
+	SCOPED_TRACE(testCase.description);
+	replaceString(testCase.subject, testCase.search, testCase.replace);
+	EXPECT_EQ(testCase.expected, testCase.subject);
+}
+
+static const std::vector<ReplaceStringTestCase> kReplaceStringTestCases {
+	{ "", "", "", "", "empty" },
+	{ "all together", " ", "_", "all_together", "spaces" },
+	{ "beautiful", "u", "", "beatifl", "remove char" },
+	{ "empty_empty_empty_", "empty_", "", "", "remove substr" },
+	{ "I am someone", "someone", "Lucas", "I am Lucas", "replace word" },
+	{ "[[123[[[[[[124[[asf[[ccc[[[", "[[", "\\[[", "\\[[123\\[[\\[[\\[[124\\[[asf\\[[ccc\\[[[", "escape" },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+	ReplaceString,
+	ReplaceStringTest,
+	::testing::ValuesIn(kReplaceStringTestCases),
+	[](const ::testing::TestParamInfo<ReplaceStringTest::ParamType> &info) {
+		return fmt::format("Case{}", info.index);
+	}
+);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "bext-ut",
     "curl",
     "eventpp",
+    "gtest",
     "libmariadb",
     "luajit",
     "magic-enum",


### PR DESCRIPTION
# Description

Replaces boost::ut with GoogleTest in all test sources and CMake configuration. Updates test code to use GoogleTest macros and fixtures, and refactors test registration and execution accordingly. This improves compatibility and leverages GoogleTest’s features for test discovery and reporting.

Replaces **Boost.UT** with **GoogleTest** across all tests.  
Key changes:
- Remove `suite<>` and `register_*` manual registration.
- Introduce fixtures (`::testing::Test`) and `TEST_F(...)` cases.
- Map assertions to `EXPECT_*`/`ASSERT_*`.
- CMake updates:
  - `find_package(GTest CONFIG REQUIRED)`
  - `target_link_libraries(... GTest::gtest GTest::gtest_main)` (and `GTest::gmock` when applicable)
  - Automatic discovery via `gtest_discover_tests(...)`
  - Remove Boost.UT dependencies and includes.
- Standardize execution via `ctest` and optional JUnit reports.

Motivation: better IDE/CI integration, improved discovery/filtering/reporting tooling, ability to use `gmock` and parameterized tests, and easier maintenance for a large codebase (MMORPG).

Dependencies:
- GoogleTest

## Behaviour
### **Actual**
Manual registration via `suite_all`/`register_*`; limited discovery; weak CI/report integration; no fixtures or `gmock`.

### **Expected**
Automatic discovery (`gtest_discover_tests`/`ctest`), filterable execution (`--gtest_filter`), standardized fixtures, optional `gmock`, and JUnit reports.

## Type of change
  - [x] New feature (non-breaking change which adds functionality)
  - [x] This change requires a documentation update

## Checklist

  - [x] My code follows the project’s style guidelines
  - [x] I have performed a self-review of my code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, especially in hard-to-understand areas
  - [x] I have updated documentation (README/CONTRIBUTING for tests)
  - [x] My changes introduce no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works (migration preserved existing coverage)
