### PR TITLE
refactor: player save logic for async tasks and fmt usage

### DIFF
--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1707,6 +1707,8 @@ private:
 	friend class PlayerWheel;
 	friend class IOLoginDataLoad;
 	friend class IOLoginDataSave;
+	friend class DbLoginDataLoadRepository;
+	friend class DbLoginDataSaveRepository;
 	friend class PlayerAchievement;
 	friend class PlayerBadge;
 	friend class PlayerCyclopedia;

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -185,6 +185,7 @@ public:
 	static uint8_t getU8FromString(const std::string &string, const std::string &function);
 	static int8_t getInt8FromString(const std::string &string, const std::string &function);
 
+	size_t getNumColumns() const;
 	size_t countResults() const;
 	bool hasNext() const;
 	bool next();
@@ -194,6 +195,7 @@ private:
 	MYSQL_ROW row;
 
 	std::map<std::string_view, size_t> listNames;
+	size_t m_numColumns { 0 };
 
 	friend class Database;
 };

--- a/src/game/scheduling/save_manager.hpp
+++ b/src/game/scheduling/save_manager.hpp
@@ -29,6 +29,8 @@ public:
 	void saveAll();
 	void scheduleAll();
 
+	void addTask(std::function<void()> task, std::string_view taskName);
+
 	bool savePlayer(std::shared_ptr<Player> player);
 	void saveGuild(std::shared_ptr<Guild> guild);
 

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
             io_bosstiary.cpp
             ioguild.cpp
             iologindata.cpp
+            account_vip_repository_db.cpp
             functions/iologindata_load_player.cpp
             functions/iologindata_save_player.cpp
             iomap.cpp

--- a/src/io/account_vip_repository.hpp
+++ b/src/io/account_vip_repository.hpp
@@ -1,0 +1,39 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#pragma once
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <cstdint>
+	#include <string>
+	#include <vector>
+#endif
+
+struct VIPEntry;
+struct VIPGroupEntry;
+
+class IAccountVipRepository {
+public:
+	virtual ~IAccountVipRepository() = default;
+
+	virtual std::vector<VIPEntry> getEntries(uint32_t accountId) = 0;
+	virtual bool addEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) = 0;
+	virtual bool editEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) = 0;
+	virtual bool removeEntry(uint32_t accountId, uint32_t guid) = 0;
+
+	virtual std::vector<VIPGroupEntry> getGroups(uint32_t accountId) = 0;
+	virtual bool addGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) = 0;
+	virtual bool editGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) = 0;
+	virtual bool removeGroup(uint8_t groupId, uint32_t accountId) = 0;
+
+	virtual bool addGuidToGroup(uint8_t groupId, uint32_t accountId, uint32_t guid) = 0;
+	virtual bool removeGuidFromGroup(uint32_t accountId, uint32_t guid) = 0;
+};
+
+IAccountVipRepository &g_accountVipRepository();

--- a/src/io/account_vip_repository_db.cpp
+++ b/src/io/account_vip_repository_db.cpp
@@ -1,0 +1,151 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "io/account_vip_repository_db.hpp"
+
+#include "database/database.hpp"
+#include "lib/di/container.hpp"
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <fmt/format.h>
+#endif
+
+std::vector<VIPEntry> DbAccountVipRepository::getEntries(uint32_t accountId) {
+	std::vector<VIPEntry> entries;
+
+	const auto query = fmt::format(
+		"SELECT `player_id`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `name`, `description`, `icon`, `notify` "
+		"FROM `account_viplist` WHERE `account_id` = {}",
+		accountId
+	);
+
+	if (const auto &result = g_database().storeQuery(query)) {
+		entries.reserve(result->countResults());
+		do {
+			entries.emplace_back(
+				result->getNumber<uint32_t>("player_id"),
+				result->getString("name"),
+				result->getString("description"),
+				result->getNumber<uint32_t>("icon"),
+				result->getNumber<uint16_t>("notify") != 0
+			);
+		} while (result->next());
+	}
+
+	return entries;
+}
+
+bool DbAccountVipRepository::addEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) {
+	const auto query = fmt::format(
+		"INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES ({}, {}, {}, {}, {})",
+		accountId,
+		guid,
+		g_database().escapeString(description),
+		icon,
+		notify
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::editEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) {
+	const auto query = fmt::format(
+		"UPDATE `account_viplist` SET `description` = {}, `icon` = {}, `notify` = {} WHERE `account_id` = {} AND `player_id` = {}",
+		g_database().escapeString(description),
+		icon,
+		notify,
+		accountId,
+		guid
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::removeEntry(uint32_t accountId, uint32_t guid) {
+	const auto query = fmt::format(
+		"DELETE FROM `account_viplist` WHERE `account_id` = {} AND `player_id` = {}",
+		accountId,
+		guid
+	);
+	return g_database().executeQuery(query);
+}
+
+std::vector<VIPGroupEntry> DbAccountVipRepository::getGroups(uint32_t accountId) {
+	std::vector<VIPGroupEntry> entries;
+
+	const auto query = fmt::format(
+		"SELECT `id`, `name`, `customizable` FROM `account_vipgroups` WHERE `account_id` = {}",
+		accountId
+	);
+
+	if (const auto &result = g_database().storeQuery(query)) {
+		entries.reserve(result->countResults());
+		do {
+			entries.emplace_back(
+				result->getNumber<uint8_t>("id"),
+				result->getString("name"),
+				result->getNumber<uint8_t>("customizable") != 0
+			);
+		} while (result->next());
+	}
+
+	return entries;
+}
+
+bool DbAccountVipRepository::addGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) {
+	const auto query = fmt::format(
+		"INSERT INTO `account_vipgroups` (`id`, `account_id`, `name`, `customizable`) VALUES ({}, {}, {}, {})",
+		groupId,
+		accountId,
+		g_database().escapeString(groupName),
+		customizable
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::editGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) {
+	const auto query = fmt::format(
+		"UPDATE `account_vipgroups` SET `name` = {}, `customizable` = {} WHERE `id` = {} AND `account_id` = {}",
+		g_database().escapeString(groupName),
+		customizable,
+		groupId,
+		accountId
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::removeGroup(uint8_t groupId, uint32_t accountId) {
+	const auto query = fmt::format(
+		"DELETE FROM `account_vipgroups` WHERE `id` = {} AND `account_id` = {}",
+		groupId,
+		accountId
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::addGuidToGroup(uint8_t groupId, uint32_t accountId, uint32_t guid) {
+	const auto query = fmt::format(
+		"INSERT INTO `account_vipgrouplist` (`account_id`, `player_id`, `vipgroup_id`) VALUES ({}, {}, {})",
+		accountId,
+		guid,
+		groupId
+	);
+	return g_database().executeQuery(query);
+}
+
+bool DbAccountVipRepository::removeGuidFromGroup(uint32_t accountId, uint32_t guid) {
+	const auto query = fmt::format(
+		"DELETE FROM `account_vipgrouplist` WHERE `account_id` = {} AND `player_id` = {}",
+		accountId,
+		guid
+	);
+	return g_database().executeQuery(query);
+}
+
+IAccountVipRepository &g_accountVipRepository() {
+	return inject<DbAccountVipRepository>();
+}

--- a/src/io/account_vip_repository_db.hpp
+++ b/src/io/account_vip_repository_db.hpp
@@ -1,0 +1,28 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#pragma once
+
+#include "io/account_vip_repository.hpp"
+
+class DbAccountVipRepository final : public IAccountVipRepository {
+public:
+	std::vector<VIPEntry> getEntries(uint32_t accountId) override;
+	bool addEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) override;
+	bool editEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) override;
+	bool removeEntry(uint32_t accountId, uint32_t guid) override;
+
+	std::vector<VIPGroupEntry> getGroups(uint32_t accountId) override;
+	bool addGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) override;
+	bool editGroup(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) override;
+	bool removeGroup(uint8_t groupId, uint32_t accountId) override;
+
+	bool addGuidToGroup(uint8_t groupId, uint32_t accountId, uint32_t guid) override;
+	bool removeGuidFromGroup(uint32_t accountId, uint32_t guid) override;
+};

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -31,7 +31,7 @@
 #include "lib/di/container.hpp"
 
 namespace {
-	ILoginDataLoadRepository *g_testLoginDataLoadRepository = nullptr;
+	ILoginDataLoadRepository* g_testLoginDataLoadRepository = nullptr;
 }
 
 class DbLoginDataLoadRepository final : public ILoginDataLoadRepository {
@@ -1062,7 +1062,7 @@ ILoginDataLoadRepository &g_loginDataLoadRepository() {
 	return inject<DbLoginDataLoadRepository>();
 }
 
-void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository *repository) {
+void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository* repository) {
 	g_testLoginDataLoadRepository = repository;
 }
 

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -28,8 +28,47 @@
 #include "creatures/players/player.hpp"
 #include "utils/tools.hpp"
 #include "io/player_storage_repository.hpp"
+#include "lib/di/container.hpp"
 
-void IOLoginDataLoad::loadItems(ItemsMap &itemsMap, const DBResult_ptr &result, const std::shared_ptr<Player> &player) {
+class DbLoginDataLoadRepository final : public ILoginDataLoadRepository {
+public:
+	bool preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) override;
+	bool loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerAnimusMastery(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerDefaultOutfit(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override;
+	void loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerInventoryItems(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerStoreInbox(const std::shared_ptr<Player> &player) override;
+	void loadPlayerDepotItems(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadRewardItems(const std::shared_ptr<Player> &player) override;
+	void loadPlayerInboxItems(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerStorageMap(const std::shared_ptr<Player> &player) override;
+	void loadPlayerVip(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerPreyClass(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerForgeHistory(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result) override;
+	void loadPlayerInitializeSystem(const std::shared_ptr<Player> &player) override;
+	void loadPlayerUpdateSystem(const std::shared_ptr<Player> &player) override;
+
+private:
+	using ItemsMap = std::map<uint32_t, std::pair<std::shared_ptr<Item>, uint32_t>>;
+
+	void loadItems(ItemsMap &itemsMap, const DBResult_ptr &result, const std::shared_ptr<Player> &player);
+	void bindRewardBag(const std::shared_ptr<Player> &player, ItemsMap &rewardItemsMap);
+	void insertItemsIntoRewardBag(const ItemsMap &rewardItemsMap);
+};
+
+void DbLoginDataLoadRepository::loadItems(ItemsMap &itemsMap, const DBResult_ptr &result, const std::shared_ptr<Player> &player) {
 	try {
 		do {
 			auto sid = result->getNumber<uint32_t>("sid");
@@ -62,7 +101,7 @@ void IOLoginDataLoad::loadItems(ItemsMap &itemsMap, const DBResult_ptr &result, 
 	}
 }
 
-bool IOLoginDataLoad::preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) {
+bool DbLoginDataLoadRepository::preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) {
 	Database &db = Database::getInstance();
 
 	std::ostringstream query;
@@ -116,7 +155,7 @@ bool IOLoginDataLoad::preLoadPlayer(const std::shared_ptr<Player> &player, const
 	return true;
 }
 
-bool IOLoginDataLoad::loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+bool DbLoginDataLoadRepository::loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return false;
@@ -217,7 +256,7 @@ bool IOLoginDataLoad::loadPlayerBasicInfo(const std::shared_ptr<Player> &player,
 	return true;
 }
 
-void IOLoginDataLoad::loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -240,7 +279,7 @@ void IOLoginDataLoad::loadPlayerExperience(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -251,7 +290,7 @@ void IOLoginDataLoad::loadPlayerBlessings(const std::shared_ptr<Player> &player,
 	}
 }
 
-void IOLoginDataLoad::loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -271,7 +310,7 @@ void IOLoginDataLoad::loadPlayerConditions(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadPlayerAnimusMastery(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerAnimusMastery(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -285,7 +324,7 @@ void IOLoginDataLoad::loadPlayerAnimusMastery(const std::shared_ptr<Player> &pla
 	player->animusMastery().unserialize(propStream);
 }
 
-void IOLoginDataLoad::loadPlayerDefaultOutfit(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerDefaultOutfit(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -316,7 +355,7 @@ void IOLoginDataLoad::loadPlayerDefaultOutfit(const std::shared_ptr<Player> &pla
 	player->currentOutfit = player->defaultOutfit;
 }
 
-void IOLoginDataLoad::loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -338,7 +377,7 @@ void IOLoginDataLoad::loadPlayerSkullSystem(const std::shared_ptr<Player> &playe
 	}
 }
 
-void IOLoginDataLoad::loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void DbLoginDataLoadRepository::loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -365,7 +404,7 @@ void IOLoginDataLoad::loadPlayerSkill(const std::shared_ptr<Player> &player, con
 	}
 }
 
-void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -384,7 +423,7 @@ void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBR
 	}
 }
 
-void IOLoginDataLoad::loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -434,7 +473,7 @@ void IOLoginDataLoad::loadPlayerGuild(const std::shared_ptr<Player> &player, DBR
 	}
 }
 
-void IOLoginDataLoad::loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -462,7 +501,7 @@ void IOLoginDataLoad::loadPlayerStashItems(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -517,7 +556,7 @@ void IOLoginDataLoad::loadPlayerBestiaryCharms(const std::shared_ptr<Player> &pl
 	}
 }
 
-void IOLoginDataLoad::loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -533,7 +572,7 @@ void IOLoginDataLoad::loadPlayerInstantSpellList(const std::shared_ptr<Player> &
 	}
 }
 
-void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerInventoryItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -597,11 +636,11 @@ void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &pl
 		}
 
 	} catch (const std::exception &e) {
-		g_logger().error("[IOLoginDataLoad::loadPlayerInventoryItems] - Exception during inventory loading: {}", e.what());
+		g_logger().error("[DbLoginDataLoadRepository::loadPlayerInventoryItems] - Exception during inventory loading: {}", e.what());
 	}
 }
 
-void IOLoginDataLoad::loadPlayerStoreInbox(const std::shared_ptr<Player> &player) {
+void DbLoginDataLoadRepository::loadPlayerStoreInbox(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -612,7 +651,7 @@ void IOLoginDataLoad::loadPlayerStoreInbox(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadRewardItems(const std::shared_ptr<Player> &player) {
+void DbLoginDataLoadRepository::loadRewardItems(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -630,7 +669,7 @@ void IOLoginDataLoad::loadRewardItems(const std::shared_ptr<Player> &player) {
 	}
 }
 
-void IOLoginDataLoad::loadPlayerDepotItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerDepotItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -677,7 +716,7 @@ void IOLoginDataLoad::loadPlayerDepotItems(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadPlayerInboxItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerInboxItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -727,7 +766,7 @@ void IOLoginDataLoad::loadPlayerInboxItems(const std::shared_ptr<Player> &player
 	}
 }
 
-void IOLoginDataLoad::loadPlayerStorageMap(const std::shared_ptr<Player> &player) {
+void DbLoginDataLoadRepository::loadPlayerStorageMap(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -737,7 +776,7 @@ void IOLoginDataLoad::loadPlayerStorageMap(const std::shared_ptr<Player> &player
 	player->storage().ingest(rows);
 }
 
-void IOLoginDataLoad::loadPlayerVip(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerVip(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -775,7 +814,7 @@ void IOLoginDataLoad::loadPlayerVip(const std::shared_ptr<Player> &player, DBRes
 	}
 }
 
-void IOLoginDataLoad::loadPlayerPreyClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerPreyClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -822,7 +861,7 @@ void IOLoginDataLoad::loadPlayerPreyClass(const std::shared_ptr<Player> &player,
 	}
 }
 
-void IOLoginDataLoad::loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result || !player) {
 		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
 		return;
@@ -872,7 +911,7 @@ void IOLoginDataLoad::loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &
 	}
 }
 
-void IOLoginDataLoad::loadPlayerForgeHistory(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerForgeHistory(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -897,7 +936,7 @@ void IOLoginDataLoad::loadPlayerForgeHistory(const std::shared_ptr<Player> &play
 	}
 }
 
-void IOLoginDataLoad::loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+void DbLoginDataLoadRepository::loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result) {
 	if (!result) {
 		g_logger().warn("[{}] - Result nullptr", __FUNCTION__);
 		return;
@@ -934,7 +973,7 @@ void IOLoginDataLoad::loadPlayerBosstiary(const std::shared_ptr<Player> &player,
 	}
 }
 
-void IOLoginDataLoad::bindRewardBag(const std::shared_ptr<Player> &player, ItemsMap &rewardItemsMap) {
+void DbLoginDataLoadRepository::bindRewardBag(const std::shared_ptr<Player> &player, ItemsMap &rewardItemsMap) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -953,7 +992,7 @@ void IOLoginDataLoad::bindRewardBag(const std::shared_ptr<Player> &player, Items
 	}
 }
 
-void IOLoginDataLoad::insertItemsIntoRewardBag(const ItemsMap &rewardItemsMap) {
+void DbLoginDataLoadRepository::insertItemsIntoRewardBag(const ItemsMap &rewardItemsMap) {
 	for (const auto &it : std::views::reverse(rewardItemsMap)) {
 		const std::pair<std::shared_ptr<Item>, int32_t> &pair = it.second;
 		const auto &item = pair.first;
@@ -978,7 +1017,7 @@ void IOLoginDataLoad::insertItemsIntoRewardBag(const ItemsMap &rewardItemsMap) {
 	}
 }
 
-void IOLoginDataLoad::loadPlayerInitializeSystem(const std::shared_ptr<Player> &player) {
+void DbLoginDataLoadRepository::loadPlayerInitializeSystem(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -1001,7 +1040,7 @@ void IOLoginDataLoad::loadPlayerInitializeSystem(const std::shared_ptr<Player> &
 	player->initializeTaskHunting();
 }
 
-void IOLoginDataLoad::loadPlayerUpdateSystem(const std::shared_ptr<Player> &player) {
+void DbLoginDataLoadRepository::loadPlayerUpdateSystem(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
@@ -1010,4 +1049,116 @@ void IOLoginDataLoad::loadPlayerUpdateSystem(const std::shared_ptr<Player> &play
 	player->updateBaseSpeed();
 	player->updateInventoryWeight();
 	player->updateItemsLight(true);
+}
+
+ILoginDataLoadRepository &g_loginDataLoadRepository() {
+	return inject<DbLoginDataLoadRepository>();
+}
+
+bool IOLoginDataLoad::preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) {
+	return g_loginDataLoadRepository().preLoadPlayer(player, name);
+}
+
+bool IOLoginDataLoad::loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	return g_loginDataLoadRepository().loadPlayerBasicInfo(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerExperience(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerBlessings(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerConditions(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerAnimusMastery(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerAnimusMastery(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerDefaultOutfit(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerDefaultOutfit(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerSkullSystem(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+	g_loginDataLoadRepository().loadPlayerSkill(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerKills(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerGuild(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerStashItems(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerBestiaryCharms(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerInstantSpellList(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerInventoryItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerInventoryItems(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerStoreInbox(const std::shared_ptr<Player> &player) {
+	g_loginDataLoadRepository().loadPlayerStoreInbox(player);
+}
+
+void IOLoginDataLoad::loadRewardItems(const std::shared_ptr<Player> &player) {
+	g_loginDataLoadRepository().loadRewardItems(player);
+}
+
+void IOLoginDataLoad::loadPlayerDepotItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerDepotItems(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerInboxItems(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerInboxItems(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerStorageMap(const std::shared_ptr<Player> &player) {
+	g_loginDataLoadRepository().loadPlayerStorageMap(player);
+}
+
+void IOLoginDataLoad::loadPlayerVip(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerVip(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerPreyClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerPreyClass(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerTaskHuntingClass(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerForgeHistory(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerForgeHistory(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result) {
+	g_loginDataLoadRepository().loadPlayerBosstiary(player, result);
+}
+
+void IOLoginDataLoad::loadPlayerInitializeSystem(const std::shared_ptr<Player> &player) {
+	g_loginDataLoadRepository().loadPlayerInitializeSystem(player);
+}
+
+void IOLoginDataLoad::loadPlayerUpdateSystem(const std::shared_ptr<Player> &player) {
+	g_loginDataLoadRepository().loadPlayerUpdateSystem(player);
 }

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -30,6 +30,10 @@
 #include "io/player_storage_repository.hpp"
 #include "lib/di/container.hpp"
 
+namespace {
+	ILoginDataLoadRepository *g_testLoginDataLoadRepository = nullptr;
+}
+
 class DbLoginDataLoadRepository final : public ILoginDataLoadRepository {
 public:
 	bool preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) override;
@@ -1052,7 +1056,18 @@ void DbLoginDataLoadRepository::loadPlayerUpdateSystem(const std::shared_ptr<Pla
 }
 
 ILoginDataLoadRepository &g_loginDataLoadRepository() {
+	if (g_testLoginDataLoadRepository) {
+		return *g_testLoginDataLoadRepository;
+	}
 	return inject<DbLoginDataLoadRepository>();
+}
+
+void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository *repository) {
+	g_testLoginDataLoadRepository = repository;
+}
+
+void resetLoginDataLoadRepositoryForTest() {
+	g_testLoginDataLoadRepository = nullptr;
 }
 
 bool IOLoginDataLoad::preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) {

--- a/src/io/functions/iologindata_load_player.hpp
+++ b/src/io/functions/iologindata_load_player.hpp
@@ -49,7 +49,7 @@ public:
 };
 
 ILoginDataLoadRepository &g_loginDataLoadRepository();
-void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository *repository);
+void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository* repository);
 void resetLoginDataLoadRepositoryForTest();
 
 class IOLoginDataLoad : public IOLoginData {

--- a/src/io/functions/iologindata_load_player.hpp
+++ b/src/io/functions/iologindata_load_player.hpp
@@ -15,10 +15,45 @@ class Player;
 class DBResult;
 using DBResult_ptr = std::shared_ptr<DBResult>;
 
+class ILoginDataLoadRepository {
+public:
+	virtual ~ILoginDataLoadRepository() = default;
+
+	virtual bool preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) = 0;
+	virtual bool loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerAnimusMastery(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerDefaultOutfit(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result) = 0;
+	virtual void loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerInventoryItems(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerStoreInbox(const std::shared_ptr<Player> &player) = 0;
+	virtual void loadPlayerDepotItems(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadRewardItems(const std::shared_ptr<Player> &player) = 0;
+	virtual void loadPlayerInboxItems(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerStorageMap(const std::shared_ptr<Player> &player) = 0;
+	virtual void loadPlayerVip(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerPreyClass(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerForgeHistory(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result) = 0;
+	virtual void loadPlayerInitializeSystem(const std::shared_ptr<Player> &player) = 0;
+	virtual void loadPlayerUpdateSystem(const std::shared_ptr<Player> &player) = 0;
+};
+
+ILoginDataLoadRepository &g_loginDataLoadRepository();
+
 class IOLoginDataLoad : public IOLoginData {
 public:
-	static bool loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static bool preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name);
+	static bool loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static void loadPlayerExperience(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static void loadPlayerBlessings(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static void loadPlayerConditions(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
@@ -44,12 +79,4 @@ public:
 	static void loadPlayerBosstiary(const std::shared_ptr<Player> &player, DBResult_ptr result);
 	static void loadPlayerInitializeSystem(const std::shared_ptr<Player> &player);
 	static void loadPlayerUpdateSystem(const std::shared_ptr<Player> &player);
-
-private:
-	using ItemsMap = std::map<uint32_t, std::pair<std::shared_ptr<Item>, uint32_t>>;
-
-	static void bindRewardBag(const std::shared_ptr<Player> &player, ItemsMap &rewardItemsMap);
-	static void insertItemsIntoRewardBag(const ItemsMap &rewardItemsMap);
-
-	static void loadItems(ItemsMap &itemsMap, const DBResult_ptr &result, const std::shared_ptr<Player> &player);
 };

--- a/src/io/functions/iologindata_load_player.hpp
+++ b/src/io/functions/iologindata_load_player.hpp
@@ -49,6 +49,8 @@ public:
 };
 
 ILoginDataLoadRepository &g_loginDataLoadRepository();
+void setLoginDataLoadRepositoryForTest(ILoginDataLoadRepository *repository);
+void resetLoginDataLoadRepositoryForTest();
 
 class IOLoginDataLoad : public IOLoginData {
 public:

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -25,7 +25,7 @@
 #include "lib/di/container.hpp"
 
 namespace {
-	ILoginDataSaveRepository *g_testLoginDataSaveRepository = nullptr;
+	ILoginDataSaveRepository* g_testLoginDataSaveRepository = nullptr;
 }
 
 class DbLoginDataSaveRepository final : public ILoginDataSaveRepository {
@@ -944,7 +944,7 @@ ILoginDataSaveRepository &g_loginDataSaveRepository() {
 	return inject<DbLoginDataSaveRepository>();
 }
 
-void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository *repository) {
+void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository* repository) {
 	g_testLoginDataSaveRepository = repository;
 }
 

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -24,6 +24,10 @@
 #include "game/scheduling/save_manager.hpp"
 #include "lib/di/container.hpp"
 
+namespace {
+	ILoginDataSaveRepository *g_testLoginDataSaveRepository = nullptr;
+}
+
 class DbLoginDataSaveRepository final : public ILoginDataSaveRepository {
 public:
 	bool savePlayerFirst(const std::shared_ptr<Player> &player) override;
@@ -934,7 +938,18 @@ bool DbLoginDataSaveRepository::savePlayerStorage(const std::shared_ptr<Player> 
 }
 
 ILoginDataSaveRepository &g_loginDataSaveRepository() {
+	if (g_testLoginDataSaveRepository) {
+		return *g_testLoginDataSaveRepository;
+	}
 	return inject<DbLoginDataSaveRepository>();
+}
+
+void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository *repository) {
+	g_testLoginDataSaveRepository = repository;
+}
+
+void resetLoginDataSaveRepositoryForTest() {
+	g_testLoginDataSaveRepository = nullptr;
 }
 
 bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -21,22 +21,50 @@
 #include "items/containers/rewards/reward.hpp"
 #include "creatures/players/player.hpp"
 #include "io/player_storage_repository.hpp"
+#include "game/scheduling/save_manager.hpp"
+#include "lib/di/container.hpp"
 
-bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
+class DbLoginDataSaveRepository final : public ILoginDataSaveRepository {
+public:
+	bool savePlayerFirst(const std::shared_ptr<Player> &player) override;
+	bool savePlayerStash(const std::shared_ptr<Player> &player) override;
+	bool savePlayerSpells(const std::shared_ptr<Player> &player) override;
+	bool savePlayerKills(const std::shared_ptr<Player> &player) override;
+	bool savePlayerBestiarySystem(const std::shared_ptr<Player> &player) override;
+	bool savePlayerItem(const std::shared_ptr<Player> &player) override;
+	bool savePlayerDepotItems(const std::shared_ptr<Player> &player) override;
+	bool saveRewardItems(const std::shared_ptr<Player> &player) override;
+	bool savePlayerInbox(const std::shared_ptr<Player> &player) override;
+	bool savePlayerPreyClass(const std::shared_ptr<Player> &player) override;
+	bool savePlayerTaskHuntingClass(const std::shared_ptr<Player> &player) override;
+	bool savePlayerForgeHistory(const std::shared_ptr<Player> &player) override;
+	bool savePlayerBosstiary(const std::shared_ptr<Player> &player) override;
+	bool savePlayerStorage(const std::shared_ptr<Player> &player) override;
+
+private:
+	using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
+	using ItemDepotList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
+	using ItemRewardList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
+	using ItemInboxList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
+
+	bool saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &stream);
+};
+
+bool DbLoginDataSaveRepository::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	const Database &db = Database::getInstance();
-	std::ostringstream ss;
+	const auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(256);
 
-	// Initialize variables
 	using ContainerBlock = std::pair<std::shared_ptr<Container>, int32_t>;
 	std::list<ContainerBlock> queue;
 	int32_t runningId = 100;
 
-	// Loop through each item in itemList
 	const auto &openContainers = player->getOpenContainers();
 	for (const auto &it : itemList) {
 		const auto &item = it.second;
@@ -44,11 +72,10 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 			continue;
 		}
 
-		int32_t pid = it.first;
+		const int32_t pid = it.first;
 
 		++runningId;
 
-		// Update container attributes if necessary
 		if (const std::shared_ptr<Container> &container = item->getContainer()) {
 			if (!container) {
 				continue;
@@ -70,26 +97,33 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 				}
 			}
 
-			// Add container to queue
 			queue.emplace_back(container, runningId);
 		}
 
-		// Serialize item attributes
 		propWriteStream.clear();
 		item->serializeAttr(propWriteStream);
 
 		size_t attributesSize;
 		const char* attributes = propWriteStream.getStream(attributesSize);
 
-		// Build query string and add row
-		ss << player->getGUID() << ',' << pid << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize));
-		if (!query_insert.addRow(ss)) {
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{},{},{},{},{}",
+			playerGuid,
+			pid,
+			runningId,
+			item->getID(),
+			item->getSubType(),
+			db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))
+		);
+
+		if (!query_insert.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			g_logger().error("Error adding row to query.");
 			return false;
 		}
 	}
 
-	// Loop through containers in queue
 	while (!queue.empty()) {
 		const ContainerBlock &cb = queue.front();
 		const std::shared_ptr<Container> &container = cb.first;
@@ -97,9 +131,8 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 			continue;
 		}
 
-		int32_t parentId = cb.second;
+		const int32_t parentId = cb.second;
 
-		// Loop through items in container
 		for (auto &item : container->getItemList()) {
 			if (!item) {
 				continue;
@@ -107,7 +140,6 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 
 			++runningId;
 
-			// Update sub-container attributes if necessary
 			const auto &subContainer = item->getContainer();
 			if (subContainer) {
 				queue.emplace_back(subContainer, runningId);
@@ -128,36 +160,39 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 				}
 			}
 
-			// Serialize item attributes
 			propWriteStream.clear();
 			item->serializeAttr(propWriteStream);
 
 			size_t attributesSize;
 			const char* attributes = propWriteStream.getStream(attributesSize);
 
-			// Build query string and add row
-			ss << player->getGUID() << ',' << parentId << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize));
-			if (!query_insert.addRow(ss)) {
+			rowBuffer.clear();
+			fmt::format_to(
+				std::back_inserter(rowBuffer),
+				"{},{},{},{},{},{}",
+				playerGuid,
+				parentId,
+				runningId,
+				item->getID(),
+				item->getSubType(),
+				db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))
+			);
+
+			if (!query_insert.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 				g_logger().error("Error adding row to query for container item.");
 				return false;
 			}
 		}
 
-		// Removes the object after processing everything, avoiding memory usage after freeing
 		queue.pop_front();
 	}
 
-	// Execute query
-	if (!query_insert.execute()) {
-		g_logger().error("Error executing query.");
-		return false;
-	}
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	if (!player) {
-		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
+		g_logger().warn("[DbLoginDataSaveRepository::savePlayerFirst] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
@@ -165,77 +200,84 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 		player->changeHealth(1);
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
 
-	std::ostringstream query;
-	query << "SELECT `save` FROM `players` WHERE `id` = " << player->getGUID();
-	DBResult_ptr result = db.storeQuery(query.str());
+	auto result = db.storeQuery(fmt::format("SELECT `save` FROM `players` WHERE `id` = {}", playerGuid));
 	if (!result) {
-		g_logger().warn("[IOLoginData::savePlayer] - Error for select result query from player: {}", player->getName());
+		g_logger().warn("[DbLoginDataSaveRepository::savePlayerFirst] - Error retrieving save flag for player: {}", player->getName());
 		return false;
 	}
 
 	if (result->getNumber<uint16_t>("save") == 0) {
-		query.str("");
-		query << "UPDATE `players` SET `lastlogin` = " << player->lastLoginSaved << ", `lastip` = " << player->lastIP << " WHERE `id` = " << player->getGUID();
-		return db.executeQuery(query.str());
+		auto quickUpdateTask = [queryStr = fmt::format(
+									"UPDATE `players` SET `lastlogin` = {}, `lastip` = {} WHERE `id` = {}",
+									player->lastLoginSaved, player->lastIP, playerGuid
+								)]() {
+			if (!g_database().executeQuery(queryStr)) {
+				g_logger().warn("[SaveManager::quickUpdateTask] - Failed to execute quick update for player.");
+			}
+		};
+
+		g_saveManager().addTask(std::move(quickUpdateTask), "DbLoginDataSaveRepository::savePlayerFirst - quickUpdateTask");
+		return true;
 	}
 
-	// First, an UPDATE query to write the player itself
-	query.str("");
-	query << "UPDATE `players` SET ";
-	query << "`name` = " << db.escapeString(player->name) << ",";
-	query << "`level` = " << player->level << ",";
-	query << "`group_id` = " << player->group->id << ",";
-	query << "`vocation` = " << player->getVocationId() << ",";
-	query << "`health` = " << player->health << ",";
-	query << "`healthmax` = " << player->healthMax << ",";
-	query << "`experience` = " << player->experience << ",";
-	query << "`lookbody` = " << static_cast<uint32_t>(player->defaultOutfit.lookBody) << ",";
-	query << "`lookfeet` = " << static_cast<uint32_t>(player->defaultOutfit.lookFeet) << ",";
-	query << "`lookhead` = " << static_cast<uint32_t>(player->defaultOutfit.lookHead) << ",";
-	query << "`looklegs` = " << static_cast<uint32_t>(player->defaultOutfit.lookLegs) << ",";
-	query << "`looktype` = " << player->defaultOutfit.lookType << ",";
-	query << "`lookaddons` = " << static_cast<uint32_t>(player->defaultOutfit.lookAddons) << ",";
-	query << "`lookmountbody` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountBody) << ",";
-	query << "`lookmountfeet` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountFeet) << ",";
-	query << "`lookmounthead` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountHead) << ",";
-	query << "`lookmountlegs` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountLegs) << ",";
-	query << "`lookfamiliarstype` = " << player->defaultOutfit.lookFamiliarsType << ",";
-	query << "`isreward` = " << static_cast<uint16_t>(player->isDailyReward) << ",";
-	query << "`maglevel` = " << player->magLevel << ",";
-	query << "`mana` = " << player->mana << ",";
-	query << "`manamax` = " << player->manaMax << ",";
-	query << "`manaspent` = " << player->manaSpent << ",";
-	query << "`soul` = " << static_cast<uint16_t>(player->soul) << ",";
+	std::vector<std::string> columns;
+	static constexpr size_t kMinReserve = 96;
+	columns.reserve(std::max<size_t>(result->getNumColumns(), kMinReserve));
+
+	columns.emplace_back(fmt::format("`name` = {}", db.escapeString(player->name)));
+	columns.emplace_back(fmt::format("`level` = {}", player->level));
+	columns.emplace_back(fmt::format("`group_id` = {}", player->group->id));
+	columns.emplace_back(fmt::format("`vocation` = {}", player->getVocationId()));
+	columns.emplace_back(fmt::format("`health` = {}", player->health));
+	columns.emplace_back(fmt::format("`healthmax` = {}", player->healthMax));
+	columns.emplace_back(fmt::format("`experience` = {}", player->experience));
+	columns.emplace_back(fmt::format("`lookbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookBody)));
+	columns.emplace_back(fmt::format("`lookfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookFeet)));
+	columns.emplace_back(fmt::format("`lookhead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookHead)));
+	columns.emplace_back(fmt::format("`looklegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookLegs)));
+	columns.emplace_back(fmt::format("`looktype` = {}", player->defaultOutfit.lookType));
+	columns.emplace_back(fmt::format("`lookaddons` = {}", static_cast<uint32_t>(player->defaultOutfit.lookAddons)));
+	columns.emplace_back(fmt::format("`lookmountbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountBody)));
+	columns.emplace_back(fmt::format("`lookmountfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountFeet)));
+	columns.emplace_back(fmt::format("`lookmounthead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountHead)));
+	columns.emplace_back(fmt::format("`lookmountlegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountLegs)));
+	columns.emplace_back(fmt::format("`lookfamiliarstype` = {}", player->defaultOutfit.lookFamiliarsType));
+	columns.emplace_back(fmt::format("`isreward` = {}", static_cast<uint16_t>(player->isDailyReward)));
+	columns.emplace_back(fmt::format("`maglevel` = {}", player->magLevel));
+	columns.emplace_back(fmt::format("`mana` = {}", player->mana));
+	columns.emplace_back(fmt::format("`manamax` = {}", player->manaMax));
+	columns.emplace_back(fmt::format("`manaspent` = {}", player->manaSpent));
+	columns.emplace_back(fmt::format("`soul` = {}", static_cast<uint16_t>(player->soul)));
+
 	if (player->town) {
-		query << "`town_id` = " << player->town->getID() << ",";
+		columns.emplace_back(fmt::format("`town_id` = {}", player->town->getID()));
 	}
 
 	const Position &loginPosition = player->getLoginPosition();
-	query << "`posx` = " << loginPosition.getX() << ",";
-	query << "`posy` = " << loginPosition.getY() << ",";
-	query << "`posz` = " << loginPosition.getZ() << ",";
+	columns.emplace_back(fmt::format("`posx` = {}", loginPosition.getX()));
+	columns.emplace_back(fmt::format("`posy` = {}", loginPosition.getY()));
+	columns.emplace_back(fmt::format("`posz` = {}", loginPosition.getZ()));
 
-	query << "`prey_wildcard` = " << player->getPreyCards() << ",";
-	query << "`task_points` = " << player->getTaskHuntingPoints() << ",";
-	query << "`boss_points` = " << player->getBossPoints() << ",";
-	query << "`forge_dusts` = " << player->getForgeDusts() << ",";
-	query << "`forge_dust_level` = " << player->getForgeDustLevel() << ",";
-	query << "`randomize_mount` = " << static_cast<uint16_t>(player->isRandomMounted()) << ",";
-
-	query << "`cap` = " << (player->capacity / 100) << ",";
-	query << "`sex` = " << static_cast<uint16_t>(player->sex) << ",";
+	columns.emplace_back(fmt::format("`prey_wildcard` = {}", player->getPreyCards()));
+	columns.emplace_back(fmt::format("`task_points` = {}", player->getTaskHuntingPoints()));
+	columns.emplace_back(fmt::format("`boss_points` = {}", player->getBossPoints()));
+	columns.emplace_back(fmt::format("`forge_dusts` = {}", player->getForgeDusts()));
+	columns.emplace_back(fmt::format("`forge_dust_level` = {}", player->getForgeDustLevel()));
+	columns.emplace_back(fmt::format("`randomize_mount` = {}", static_cast<uint16_t>(player->isRandomMounted())));
+	columns.emplace_back(fmt::format("`cap` = {}", (player->capacity / 100)));
+	columns.emplace_back(fmt::format("`sex` = {}", static_cast<uint16_t>(player->sex)));
 
 	if (player->lastLoginSaved != 0) {
-		query << "`lastlogin` = " << player->lastLoginSaved << ",";
+		columns.emplace_back(fmt::format("`lastlogin` = {}", player->lastLoginSaved));
 	}
 
 	if (player->lastIP != 0) {
-		query << "`lastip` = " << player->lastIP << ",";
+		columns.emplace_back(fmt::format("`lastip` = {}", player->lastIP));
 	}
 
-	// serialize conditions
 	PropWriteStream propWriteStream;
 	for (const auto &condition : player->conditions) {
 		if (condition->isPersistent()) {
@@ -246,26 +288,23 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 
 	size_t attributesSize;
 	const char* attributes = propWriteStream.getStream(attributesSize);
+	columns.emplace_back(fmt::format("`conditions` = {}", db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))));
 
-	query << "`conditions` = " << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize)) << ",";
-
-	// serialize animus mastery
 	PropWriteStream propAnimusMasteryStream;
 	player->animusMastery().serialize(propAnimusMasteryStream);
 	size_t animusMasterySize;
 	const char* animusMastery = propAnimusMasteryStream.getStream(animusMasterySize);
-
-	query << "`animus_mastery` = " << db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize)) << ",";
+	columns.emplace_back(fmt::format("`animus_mastery` = {}", db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize))));
 
 	if (g_game().getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
 		int64_t skullTime = 0;
 
 		if (player->skullTicks > 0) {
-			auto now = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-			skullTime = now + player->skullTicks;
+			auto now = std::chrono::system_clock::now();
+			skullTime = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count() + player->skullTicks;
 		}
 
-		query << "`skulltime` = " << skullTime << ",";
+		columns.emplace_back(fmt::format("`skulltime` = {}", skullTime));
 
 		Skulls_t skull = SKULL_NONE;
 		if (player->skull == SKULL_RED) {
@@ -273,80 +312,96 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 		} else if (player->skull == SKULL_BLACK) {
 			skull = SKULL_BLACK;
 		}
-		query << "`skull` = " << static_cast<int64_t>(skull) << ",";
+		columns.emplace_back(fmt::format("`skull` = {}", static_cast<int64_t>(skull)));
 	}
 
-	query << "`lastlogout` = " << player->getLastLogout() << ",";
-	query << "`balance` = " << player->bankBalance << ",";
-	query << "`offlinetraining_time` = " << player->getOfflineTrainingTime() / 1000 << ",";
-	query << "`offlinetraining_skill` = " << std::to_string(player->getOfflineTrainingSkill()) << ",";
-	query << "`stamina` = " << player->getStaminaMinutes() << ",";
-	query << "`skill_fist` = " << player->skills[SKILL_FIST].level << ",";
-	query << "`skill_fist_tries` = " << player->skills[SKILL_FIST].tries << ",";
-	query << "`skill_club` = " << player->skills[SKILL_CLUB].level << ",";
-	query << "`skill_club_tries` = " << player->skills[SKILL_CLUB].tries << ",";
-	query << "`skill_sword` = " << player->skills[SKILL_SWORD].level << ",";
-	query << "`skill_sword_tries` = " << player->skills[SKILL_SWORD].tries << ",";
-	query << "`skill_axe` = " << player->skills[SKILL_AXE].level << ",";
-	query << "`skill_axe_tries` = " << player->skills[SKILL_AXE].tries << ",";
-	query << "`skill_dist` = " << player->skills[SKILL_DISTANCE].level << ",";
-	query << "`skill_dist_tries` = " << player->skills[SKILL_DISTANCE].tries << ",";
-	query << "`skill_shielding` = " << player->skills[SKILL_SHIELD].level << ",";
-	query << "`skill_shielding_tries` = " << player->skills[SKILL_SHIELD].tries << ",";
-	query << "`skill_fishing` = " << player->skills[SKILL_FISHING].level << ",";
-	query << "`skill_fishing_tries` = " << player->skills[SKILL_FISHING].tries << ",";
-	query << "`skill_critical_hit_chance` = " << player->skills[SKILL_CRITICAL_HIT_CHANCE].level << ",";
-	query << "`skill_critical_hit_chance_tries` = " << player->skills[SKILL_CRITICAL_HIT_CHANCE].tries << ",";
-	query << "`skill_critical_hit_damage` = " << player->skills[SKILL_CRITICAL_HIT_DAMAGE].level << ",";
-	query << "`skill_critical_hit_damage_tries` = " << player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries << ",";
-	query << "`skill_life_leech_chance` = " << player->skills[SKILL_LIFE_LEECH_CHANCE].level << ",";
-	query << "`skill_life_leech_chance_tries` = " << player->skills[SKILL_LIFE_LEECH_CHANCE].tries << ",";
-	query << "`skill_life_leech_amount` = " << player->skills[SKILL_LIFE_LEECH_AMOUNT].level << ",";
-	query << "`skill_life_leech_amount_tries` = " << player->skills[SKILL_LIFE_LEECH_AMOUNT].tries << ",";
-	query << "`skill_mana_leech_chance` = " << player->skills[SKILL_MANA_LEECH_CHANCE].level << ",";
-	query << "`skill_mana_leech_chance_tries` = " << player->skills[SKILL_MANA_LEECH_CHANCE].tries << ",";
-	query << "`skill_mana_leech_amount` = " << player->skills[SKILL_MANA_LEECH_AMOUNT].level << ",";
-	query << "`skill_mana_leech_amount_tries` = " << player->skills[SKILL_MANA_LEECH_AMOUNT].tries << ",";
-	query << "`manashield` = " << player->getManaShield() << ",";
-	query << "`max_manashield` = " << player->getMaxManaShield() << ",";
-	query << "`xpboost_value` = " << player->getXpBoostPercent() << ",";
-	query << "`xpboost_stamina` = " << player->getXpBoostTime() << ",";
-	query << "`quickloot_fallback` = " << (player->quickLootFallbackToMainContainer ? 1 : 0) << ",";
+	columns.emplace_back(fmt::format("`lastlogout` = {}", player->getLastLogout()));
+	columns.emplace_back(fmt::format("`balance` = {}", player->bankBalance));
+	columns.emplace_back(fmt::format("`offlinetraining_time` = {}", player->getOfflineTrainingTime() / 1000));
+	columns.emplace_back(fmt::format("`offlinetraining_skill` = {}", player->getOfflineTrainingSkill()));
+	columns.emplace_back(fmt::format("`stamina` = {}", player->getStaminaMinutes()));
+	columns.emplace_back(fmt::format("`skill_fist` = {}", player->skills[SKILL_FIST].level));
+	columns.emplace_back(fmt::format("`skill_fist_tries` = {}", player->skills[SKILL_FIST].tries));
+	columns.emplace_back(fmt::format("`skill_club` = {}", player->skills[SKILL_CLUB].level));
+	columns.emplace_back(fmt::format("`skill_club_tries` = {}", player->skills[SKILL_CLUB].tries));
+	columns.emplace_back(fmt::format("`skill_sword` = {}", player->skills[SKILL_SWORD].level));
+	columns.emplace_back(fmt::format("`skill_sword_tries` = {}", player->skills[SKILL_SWORD].tries));
+	columns.emplace_back(fmt::format("`skill_axe` = {}", player->skills[SKILL_AXE].level));
+	columns.emplace_back(fmt::format("`skill_axe_tries` = {}", player->skills[SKILL_AXE].tries));
+	columns.emplace_back(fmt::format("`skill_dist` = {}", player->skills[SKILL_DISTANCE].level));
+	columns.emplace_back(fmt::format("`skill_dist_tries` = {}", player->skills[SKILL_DISTANCE].tries));
+	columns.emplace_back(fmt::format("`skill_shielding` = {}", player->skills[SKILL_SHIELD].level));
+	columns.emplace_back(fmt::format("`skill_shielding_tries` = {}", player->skills[SKILL_SHIELD].tries));
+	columns.emplace_back(fmt::format("`skill_fishing` = {}", player->skills[SKILL_FISHING].level));
+	columns.emplace_back(fmt::format("`skill_fishing_tries` = {}", player->skills[SKILL_FISHING].tries));
+	columns.emplace_back(fmt::format("`skill_critical_hit_chance` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_critical_hit_chance_tries` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_critical_hit_damage` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].level));
+	columns.emplace_back(fmt::format("`skill_critical_hit_damage_tries` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries));
+	columns.emplace_back(fmt::format("`skill_life_leech_chance` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_life_leech_chance_tries` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_life_leech_amount` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].level));
+	columns.emplace_back(fmt::format("`skill_life_leech_amount_tries` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].tries));
+	columns.emplace_back(fmt::format("`skill_mana_leech_chance` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_mana_leech_chance_tries` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_mana_leech_amount` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].level));
+	columns.emplace_back(fmt::format("`skill_mana_leech_amount_tries` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].tries));
+	columns.emplace_back(fmt::format("`manashield` = {}", player->getManaShield()));
+	columns.emplace_back(fmt::format("`max_manashield` = {}", player->getMaxManaShield()));
+	columns.emplace_back(fmt::format("`xpboost_value` = {}", player->getXpBoostPercent()));
+	columns.emplace_back(fmt::format("`xpboost_stamina` = {}", player->getXpBoostTime()));
+	columns.emplace_back(fmt::format("`quickloot_fallback` = {}", player->quickLootFallbackToMainContainer ? 1 : 0));
 
 	if (!player->isOffline()) {
 		auto now = std::chrono::system_clock::now();
 		auto lastLoginSaved = std::chrono::system_clock::from_time_t(player->lastLoginSaved);
-		query << "`onlinetime` = `onlinetime` + " << std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count() << ",";
+		columns.emplace_back(fmt::format("`onlinetime` = `onlinetime` + {}", std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count()));
 	}
 
 	for (int i = 1; i <= 8; i++) {
-		query << "`blessings" << i << "`"
-			  << " = " << static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i))) << ((i == 8) ? " " : ",");
+		columns.emplace_back(fmt::format("`blessings{}` = {}", i, static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i)))));
 	}
-	query << " WHERE `id` = " << player->getGUID();
 
-	if (!db.executeQuery(query.str())) {
-		return false;
+	size_t estimatedSize = 0;
+	for (const auto &column : columns) {
+		estimatedSize += column.size() + 2;
 	}
+
+	std::string setClause;
+	setClause.reserve(estimatedSize);
+	for (size_t i = 0; i < columns.size(); ++i) {
+		setClause.append(columns[i]);
+		if (i + 1 < columns.size()) {
+			setClause.append(", ");
+		}
+	}
+
+	auto savePlayerTask = [queryStr = fmt::format("UPDATE `players` SET {} WHERE `id` = {}", setClause, playerGuid), playerName = player->getName()]() {
+		if (!g_database().executeQuery(queryStr)) {
+			g_logger().warn("[SaveManager::savePlayerTask] - Error executing player first save for player: {}", playerName);
+		}
+	};
+
+	g_saveManager().addTask(std::move(savePlayerTask), "IOLoginData::savePlayerFirst - savePlayerTask");
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerStash(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_stash` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_stash` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert stashQuery("INSERT INTO `player_stash` (`player_id`,`item_id`,`item_count`) VALUES ");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(48);
 	for (const auto &[itemId, itemCount] : player->getStashItems()) {
 		const ItemType &itemType = Item::items[itemId];
 		if (itemType.decayTo >= 0 && itemType.decayTime > 0) {
@@ -359,8 +414,16 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 			continue;
 		}
 
-		query << player->getGUID() << ',' << itemId << ',' << itemCount;
-		if (!stashQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{},{}",
+			playerGuid,
+			itemId,
+			itemCount
+		);
+
+		if (!stashQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -371,25 +434,32 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerSpells(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerSpells(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_spells` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_spells` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert spellsQuery("INSERT INTO `player_spells` (`player_id`, `name` ) VALUES ");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(64);
 	for (const std::string &spellName : player->learnedInstantSpellList) {
-		query << player->getGUID() << ',' << db.escapeString(spellName);
-		if (!spellsQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{}",
+			playerGuid,
+			db.escapeString(spellName)
+		);
+
+		if (!spellsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -400,25 +470,34 @@ bool IOLoginDataSave::savePlayerSpells(const std::shared_ptr<Player> &player) {
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerKills(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerKills(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_kills` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_kills` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert killsQuery("INSERT INTO `player_kills` (`player_id`, `target`, `time`, `unavenged`) VALUES");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(80);
 	for (const auto &kill : player->unjustifiedKills) {
-		query << player->getGUID() << ',' << kill.target << ',' << kill.time << ',' << kill.unavenged;
-		if (!killsQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{},{},{}",
+			playerGuid,
+			kill.target,
+			kill.time,
+			kill.unavenged
+		);
+
+		if (!killsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -429,23 +508,22 @@ bool IOLoginDataSave::savePlayerKills(const std::shared_ptr<Player> &player) {
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerBestiarySystem(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
-
-	std::ostringstream query;
-	query << "UPDATE `player_charms` SET ";
-	query << "`charm_points` = " << player->charmPoints << ",";
-	query << "`minor_charm_echoes` = " << player->minorCharmEchoes << ",";
-	query << "`max_charm_points` = " << player->maxCharmPoints << ",";
-	query << "`max_minor_charm_echoes` = " << player->maxMinorCharmEchoes << ",";
-	query << "`charm_expansion` = " << (player->charmExpansion ? 1 : 0) << ",";
-	query << "`UsedRunesBit` = " << player->UsedRunesBit << ",";
-	query << "`UnlockedRunesBit` = " << player->UnlockedRunesBit << ",";
+	auto &db = g_database();
+	std::vector<std::string> columns;
+	columns.reserve(10);
+	columns.emplace_back(fmt::format("`charm_points` = {}", player->charmPoints));
+	columns.emplace_back(fmt::format("`minor_charm_echoes` = {}", player->minorCharmEchoes));
+	columns.emplace_back(fmt::format("`max_charm_points` = {}", player->maxCharmPoints));
+	columns.emplace_back(fmt::format("`max_minor_charm_echoes` = {}", player->maxMinorCharmEchoes));
+	columns.emplace_back(fmt::format("`charm_expansion` = {}", player->charmExpansion ? 1 : 0));
+	columns.emplace_back(fmt::format("`UsedRunesBit` = {}", player->UsedRunesBit));
+	columns.emplace_back(fmt::format("`UnlockedRunesBit` = {}", player->UnlockedRunesBit));
 
 	PropWriteStream charmsStream;
 	for (uint8_t id = magic_enum::enum_value<charmRune_t>(1); id <= magic_enum::enum_count<charmRune_t>(); id++) {
@@ -456,7 +534,7 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 	size_t size;
 	const char* charmsList = charmsStream.getStream(size);
-	query << " `charms` = " << db.escapeBlob(charmsList, static_cast<uint32_t>(size)) << ",";
+	columns.emplace_back(fmt::format("`charms` = {}", db.escapeBlob(charmsList, static_cast<uint32_t>(size))));
 
 	PropWriteStream propBestiaryStream;
 	for (const auto &trackedType : player->getCyclopediaMonsterTrackerSet(false)) {
@@ -464,27 +542,43 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 	size_t trackerSize;
 	const char* trackerList = propBestiaryStream.getStream(trackerSize);
-	query << " `tracker list` = " << db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize));
-	query << " WHERE `player_id` = " << player->getGUID();
+	columns.emplace_back(fmt::format("`tracker list` = {}", db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize))));
 
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	size_t estimatedSize = 0;
+	for (const auto &column : columns) {
+		estimatedSize += column.size() + 2;
+	}
+
+	std::string setClause;
+	setClause.reserve(estimatedSize);
+	for (size_t i = 0; i < columns.size(); ++i) {
+		setClause.append(columns[i]);
+		if (i + 1 < columns.size()) {
+			setClause.append(", ");
+		}
+	}
+
+	const std::string query = fmt::format("UPDATE `player_charms` SET {} WHERE `player_id` = {}", setClause, playerGuid);
+
+	if (!db.executeQuery(query)) {
 		g_logger().warn("[IOLoginData::savePlayer] - Error saving bestiary data from player: {}", player->getName());
 		return false;
 	}
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerItem(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerItem(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
 	PropWriteStream propWriteStream;
-	std::ostringstream query;
-	query << "DELETE FROM `player_items` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_items` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		g_logger().warn("[IOLoginData::savePlayer] - Error delete query 'player_items' from player: {}", player->getName());
 		return false;
 	}
@@ -503,27 +597,29 @@ bool IOLoginDataSave::savePlayerItem(const std::shared_ptr<Player> &player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Failed for save items from player: {}", player->getName());
 		return false;
 	}
+	if (!itemsQuery.execute()) {
+		g_logger().warn("[IOLoginData::savePlayer] - Error executing insert query 'player_items' for player: {}", player->getName());
+		return false;
+	}
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerDepotItems(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerDepotItems(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
 	PropWriteStream propWriteStream;
 	ItemDepotList depotList;
+	const uint32_t playerGuid = player->getGUID();
 	if (player->lastDepotId != -1) {
-		std::ostringstream query;
-		query << "DELETE FROM `player_depotitems` WHERE `player_id` = " << player->getGUID();
+		const std::string deleteQuery = fmt::format("DELETE FROM `player_depotitems` WHERE `player_id` = {}", playerGuid);
 
-		if (!db.executeQuery(query.str())) {
+		if (!db.executeQuery(deleteQuery)) {
 			return false;
 		}
-
-		query.str("");
 
 		DBInsert depotQuery("INSERT INTO `player_depotitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 
@@ -536,21 +632,26 @@ bool IOLoginDataSave::savePlayerDepotItems(const std::shared_ptr<Player> &player
 		if (!saveItems(player, depotList, depotQuery, propWriteStream)) {
 			return false;
 		}
+		if (!depotQuery.execute()) {
+			g_logger().warn("[IOLoginData::savePlayer] - Error executing insert query 'player_depotitems' for player: {}", player->getName());
+			return false;
+		}
 		return true;
 	}
 	return true;
 }
 
-bool IOLoginDataSave::saveRewardItems(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::saveRewardItems(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	std::ostringstream query;
-	query << "DELETE FROM `player_rewards` WHERE `player_id` = " << player->getGUID();
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_rewards` WHERE `player_id` = {}", playerGuid);
 
-	if (!Database::getInstance().executeQuery(query.str())) {
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
@@ -571,26 +672,28 @@ bool IOLoginDataSave::saveRewardItems(const std::shared_ptr<Player> &player) {
 		if (!saveItems(player, rewardListItems, rewardQuery, propWriteStream)) {
 			return false;
 		}
+		if (!rewardQuery.execute()) {
+			g_logger().warn("[IOLoginData::savePlayer] - Error executing insert query 'player_rewards' for player: {}", player->getName());
+			return false;
+		}
 	}
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerInbox(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerInbox(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
 	PropWriteStream propWriteStream;
 	ItemInboxList inboxList;
-	std::ostringstream query;
-	query << "DELETE FROM `player_inboxitems` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_inboxitems` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
-
-	query.str("");
 	DBInsert inboxQuery("INSERT INTO `player_inboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 
 	for (const auto &item : player->getInbox()->getItemList()) {
@@ -600,33 +703,24 @@ bool IOLoginDataSave::savePlayerInbox(const std::shared_ptr<Player> &player) {
 	if (!saveItems(player, inboxList, inboxQuery, propWriteStream)) {
 		return false;
 	}
+	if (!inboxQuery.execute()) {
+		g_logger().warn("[IOLoginData::savePlayer] - Error executing insert query 'player_inboxitems' for player: {}", player->getName());
+		return false;
+	}
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerPreyClass(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
 	if (g_configManager().getBoolean(PREY_ENABLED)) {
-		std::ostringstream query;
+		const uint32_t playerGuid = player->getGUID();
 		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
 			if (const auto &slot = player->getPreySlotById(static_cast<PreySlot_t>(slotId))) {
-				query.str(std::string());
-				query << "INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
-					  << "VALUES (" << player->getGUID() << ", "
-					  << static_cast<uint16_t>(slot->id) << ", "
-					  << static_cast<uint16_t>(slot->state) << ", "
-					  << slot->selectedRaceId << ", "
-					  << static_cast<uint16_t>(slot->option) << ", "
-					  << static_cast<uint16_t>(slot->bonus) << ", "
-					  << static_cast<uint16_t>(slot->bonusRarity) << ", "
-					  << slot->bonusPercentage << ", "
-					  << slot->bonusTimeLeft << ", "
-					  << slot->freeRerollTimeStamp << ", ";
-
 				PropWriteStream propPreyStream;
 				std::ranges::for_each(slot->raceIdList, [&propPreyStream](uint16_t raceId) {
 					propPreyStream.write<uint16_t>(raceId);
@@ -634,20 +728,35 @@ bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player)
 
 				size_t preySize;
 				const char* preyList = propPreyStream.getStream(preySize);
-				query << db.escapeBlob(preyList, static_cast<uint32_t>(preySize)) << ")";
+				const std::string monsterList = db.escapeBlob(preyList, static_cast<uint32_t>(preySize));
 
-				query << " ON DUPLICATE KEY UPDATE "
-					  << "`state` = VALUES(`state`), "
-					  << "`raceid` = VALUES(`raceid`), "
-					  << "`option` = VALUES(`option`), "
-					  << "`bonus_type` = VALUES(`bonus_type`), "
-					  << "`bonus_rarity` = VALUES(`bonus_rarity`), "
-					  << "`bonus_percentage` = VALUES(`bonus_percentage`), "
-					  << "`bonus_time` = VALUES(`bonus_time`), "
-					  << "`free_reroll` = VALUES(`free_reroll`), "
-					  << "`monster_list` = VALUES(`monster_list`)";
+				const std::string query = fmt::format(
+					"INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
+					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+					"ON DUPLICATE KEY UPDATE "
+					"`state` = VALUES(`state`), "
+					"`raceid` = VALUES(`raceid`), "
+					"`option` = VALUES(`option`), "
+					"`bonus_type` = VALUES(`bonus_type`), "
+					"`bonus_rarity` = VALUES(`bonus_rarity`), "
+					"`bonus_percentage` = VALUES(`bonus_percentage`), "
+					"`bonus_time` = VALUES(`bonus_time`), "
+					"`free_reroll` = VALUES(`free_reroll`), "
+					"`monster_list` = VALUES(`monster_list`)",
+					playerGuid,
+					static_cast<uint16_t>(slot->id),
+					static_cast<uint16_t>(slot->state),
+					slot->selectedRaceId,
+					static_cast<uint16_t>(slot->option),
+					static_cast<uint16_t>(slot->bonus),
+					static_cast<uint16_t>(slot->bonusRarity),
+					slot->bonusPercentage,
+					slot->bonusTimeLeft,
+					slot->freeRerollTimeStamp,
+					monsterList
+				);
 
-				if (!db.executeQuery(query.str())) {
+				if (!db.executeQuery(query)) {
 					g_logger().warn("[IOLoginData::savePlayer] - Error saving prey slot data from player: {}", player->getName());
 					return false;
 				}
@@ -657,29 +766,17 @@ bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player)
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	Database &db = Database::getInstance();
+	auto &db = g_database();
 	if (g_configManager().getBoolean(TASK_HUNTING_ENABLED)) {
-		std::ostringstream query;
+		const uint32_t playerGuid = player->getGUID();
 		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
 			if (const auto &slot = player->getTaskHuntingSlotById(static_cast<PreySlot_t>(slotId))) {
-				query.str("");
-				query << "INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) VALUES (";
-				query << player->getGUID() << ", ";
-				query << static_cast<uint16_t>(slot->id) << ", ";
-				query << static_cast<uint16_t>(slot->state) << ", ";
-				query << slot->selectedRaceId << ", ";
-				query << (slot->upgrade ? 1 : 0) << ", ";
-				query << static_cast<uint16_t>(slot->rarity) << ", ";
-				query << slot->currentKills << ", ";
-				query << slot->disabledUntilTimeStamp << ", ";
-				query << slot->freeRerollTimeStamp << ", ";
-
 				PropWriteStream propTaskHuntingStream;
 				std::ranges::for_each(slot->raceIdList, [&propTaskHuntingStream](uint16_t raceId) {
 					propTaskHuntingStream.write<uint16_t>(raceId);
@@ -687,19 +784,33 @@ bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &
 
 				size_t taskHuntingSize;
 				const char* taskHuntingList = propTaskHuntingStream.getStream(taskHuntingSize);
-				query << db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize)) << ")";
+				const std::string monsterList = db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize));
 
-				query << " ON DUPLICATE KEY UPDATE "
-					  << "`state` = VALUES(`state`), "
-					  << "`raceid` = VALUES(`raceid`), "
-					  << "`upgrade` = VALUES(`upgrade`), "
-					  << "`rarity` = VALUES(`rarity`), "
-					  << "`kills` = VALUES(`kills`), "
-					  << "`disabled_time` = VALUES(`disabled_time`), "
-					  << "`free_reroll` = VALUES(`free_reroll`), "
-					  << "`monster_list` = VALUES(`monster_list`)";
+				const std::string query = fmt::format(
+					"INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) "
+					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+					"ON DUPLICATE KEY UPDATE "
+					"`state` = VALUES(`state`), "
+					"`raceid` = VALUES(`raceid`), "
+					"`upgrade` = VALUES(`upgrade`), "
+					"`rarity` = VALUES(`rarity`), "
+					"`kills` = VALUES(`kills`), "
+					"`disabled_time` = VALUES(`disabled_time`), "
+					"`free_reroll` = VALUES(`free_reroll`), "
+					"`monster_list` = VALUES(`monster_list`)",
+					playerGuid,
+					static_cast<uint16_t>(slot->id),
+					static_cast<uint16_t>(slot->state),
+					slot->selectedRaceId,
+					slot->upgrade ? 1 : 0,
+					static_cast<uint16_t>(slot->rarity),
+					slot->currentKills,
+					slot->disabledUntilTimeStamp,
+					slot->freeRerollTimeStamp,
+					monsterList
+				);
 
-				if (!db.executeQuery(query.str())) {
+				if (!db.executeQuery(query)) {
 					g_logger().warn("[IOLoginData::savePlayer] - Error saving task hunting slot data from player: {}", player->getName());
 					return false;
 				}
@@ -709,31 +820,37 @@ bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerForgeHistory(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerForgeHistory(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	std::ostringstream query;
-	query << "DELETE FROM `forge_history` WHERE `player_id` = " << player->getGUID();
-	if (!Database::getInstance().executeQuery(query.str())) {
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `forge_history` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
 	DBInsert insertQuery("INSERT INTO `forge_history` (`player_id`, `action_type`, `description`, `done_at`, `is_success`) VALUES");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(128);
 	for (const auto &history : player->getForgeHistory()) {
-		const auto stringDescription = Database::getInstance().escapeString(history.description);
-		auto actionString = magic_enum::enum_integer(history.actionType);
-		// Append query informations
-		query << player->getGUID() << ','
-			  << std::to_string(actionString) << ','
-			  << stringDescription << ','
-			  << history.createdAt << ','
-			  << history.success;
+		const auto stringDescription = db.escapeString(history.description);
+		const auto actionString = magic_enum::enum_integer(history.actionType);
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{},{},{},{}",
+			playerGuid,
+			actionString,
+			stringDescription,
+			history.createdAt,
+			history.success
+		);
 
-		if (!insertQuery.addRow(query)) {
+		if (!insertQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -743,19 +860,19 @@ bool IOLoginDataSave::savePlayerForgeHistory(const std::shared_ptr<Player> &play
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerBosstiary(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
 		return false;
 	}
 
-	std::ostringstream query;
-	query << "DELETE FROM `player_bosstiary` WHERE `player_id` = " << player->getGUID();
-	if (!Database::getInstance().executeQuery(query.str())) {
+	auto &db = g_database();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_bosstiary` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
 	DBInsert insertQuery("INSERT INTO `player_bosstiary` (`player_id`, `bossIdSlotOne`, `bossIdSlotTwo`, `removeTimes`, `tracker`) VALUES");
 
 	// Bosstiary tracker
@@ -769,14 +886,19 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 	}
 	size_t size;
 	const char* chars = stream.getStream(size);
-	// Append query informations
-	query << player->getGUID() << ','
-		  << player->getSlotBossId(1) << ','
-		  << player->getSlotBossId(2) << ','
-		  << std::to_string(player->getRemoveTimes()) << ','
-		  << Database::getInstance().escapeBlob(chars, static_cast<uint32_t>(size));
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(96);
+	fmt::format_to(
+		std::back_inserter(rowBuffer),
+		"{},{},{},{},{}",
+		playerGuid,
+		player->getSlotBossId(1),
+		player->getSlotBossId(2),
+		player->getRemoveTimes(),
+		db.escapeBlob(chars, static_cast<uint32_t>(size))
+	);
 
-	if (!insertQuery.addRow(query)) {
+	if (!insertQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 		return false;
 	}
 
@@ -787,7 +909,7 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 	return true;
 }
 
-bool IOLoginDataSave::savePlayerStorage(const std::shared_ptr<Player> &player) {
+bool DbLoginDataSaveRepository::savePlayerStorage(const std::shared_ptr<Player> &player) {
 	if (!player) {
 		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return false;
@@ -809,4 +931,64 @@ bool IOLoginDataSave::savePlayerStorage(const std::shared_ptr<Player> &player) {
 
 	storage.clearDirty();
 	return true;
+}
+
+ILoginDataSaveRepository &g_loginDataSaveRepository() {
+	return inject<DbLoginDataSaveRepository>();
+}
+
+bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerFirst(player);
+}
+
+bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerStash(player);
+}
+
+bool IOLoginDataSave::savePlayerSpells(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerSpells(player);
+}
+
+bool IOLoginDataSave::savePlayerKills(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerKills(player);
+}
+
+bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerBestiarySystem(player);
+}
+
+bool IOLoginDataSave::savePlayerItem(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerItem(player);
+}
+
+bool IOLoginDataSave::savePlayerDepotItems(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerDepotItems(player);
+}
+
+bool IOLoginDataSave::saveRewardItems(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().saveRewardItems(player);
+}
+
+bool IOLoginDataSave::savePlayerInbox(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerInbox(player);
+}
+
+bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerPreyClass(player);
+}
+
+bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerTaskHuntingClass(player);
+}
+
+bool IOLoginDataSave::savePlayerForgeHistory(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerForgeHistory(player);
+}
+
+bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerBosstiary(player);
+}
+
+bool IOLoginDataSave::savePlayerStorage(const std::shared_ptr<Player> &player) {
+	return g_loginDataSaveRepository().savePlayerStorage(player);
 }

--- a/src/io/functions/iologindata_save_player.hpp
+++ b/src/io/functions/iologindata_save_player.hpp
@@ -35,7 +35,7 @@ public:
 };
 
 ILoginDataSaveRepository &g_loginDataSaveRepository();
-void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository *repository);
+void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository* repository);
 void resetLoginDataSaveRepositoryForTest();
 
 class IOLoginDataSave : public IOLoginData {

--- a/src/io/functions/iologindata_save_player.hpp
+++ b/src/io/functions/iologindata_save_player.hpp
@@ -14,6 +14,28 @@
 class PropWriteStream;
 class DBInsert;
 
+class ILoginDataSaveRepository {
+public:
+	virtual ~ILoginDataSaveRepository() = default;
+
+	virtual bool savePlayerFirst(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerStash(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerSpells(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerKills(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerBestiarySystem(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerItem(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerDepotItems(const std::shared_ptr<Player> &player) = 0;
+	virtual bool saveRewardItems(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerInbox(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerPreyClass(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerTaskHuntingClass(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerForgeHistory(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerBosstiary(const std::shared_ptr<Player> &player) = 0;
+	virtual bool savePlayerStorage(const std::shared_ptr<Player> &player) = 0;
+};
+
+ILoginDataSaveRepository &g_loginDataSaveRepository();
+
 class IOLoginDataSave : public IOLoginData {
 public:
 	static bool savePlayerFirst(const std::shared_ptr<Player> &player);
@@ -30,12 +52,4 @@ public:
 	static bool savePlayerForgeHistory(const std::shared_ptr<Player> &player);
 	static bool savePlayerBosstiary(const std::shared_ptr<Player> &player);
 	static bool savePlayerStorage(const std::shared_ptr<Player> &player);
-
-protected:
-	using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
-	using ItemDepotList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
-	using ItemRewardList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
-	using ItemInboxList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
-
-	static bool saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &stream);
 };

--- a/src/io/functions/iologindata_save_player.hpp
+++ b/src/io/functions/iologindata_save_player.hpp
@@ -35,6 +35,8 @@ public:
 };
 
 ILoginDataSaveRepository &g_loginDataSaveRepository();
+void setLoginDataSaveRepositoryForTest(ILoginDataSaveRepository *repository);
+void resetLoginDataSaveRepositoryForTest();
 
 class IOLoginDataSave : public IOLoginData {
 public:

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@ setup_test(canary_ut unit)
 
 add_subdirectory(account)
 add_subdirectory(items)
+add_subdirectory(io)
 add_subdirectory(kv)
 add_subdirectory(lib)
 add_subdirectory(players)

--- a/tests/unit/io/CMakeLists.txt
+++ b/tests/unit/io/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(
+    canary_ut
+    PRIVATE login_data_repository_test.cpp
+)

--- a/tests/unit/io/login_data_repository_test.cpp
+++ b/tests/unit/io/login_data_repository_test.cpp
@@ -1,0 +1,384 @@
+/**
+* Canary - A free and open-source MMORPG server emulator
+* Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+* Repository: https://github.com/opentibiabr/canary
+* License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+* Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+* Website: https://docs.opentibiabr.com/
+*/
+#include "pch.hpp"
+
+#include <boost/ut.hpp>
+
+#include <string>
+#include <unordered_map>
+
+#include "io/functions/iologindata_load_player.hpp"
+#include "io/functions/iologindata_save_player.hpp"
+
+using namespace boost::ut;
+
+namespace {
+	struct StubLoginDataLoadRepository final : ILoginDataLoadRepository {
+		bool preLoadResult = true;
+		bool basicInfoResult = true;
+		std::string lastPreLoadName;
+		std::shared_ptr<Player> lastPreLoadPlayer;
+		DBResult_ptr lastBasicInfoResult;
+		std::unordered_map<std::string, uint32_t> callCount;
+
+		bool preLoadPlayer(const std::shared_ptr<Player> &player, const std::string &name) override {
+			++callCount["preLoadPlayer"];
+			lastPreLoadPlayer = player;
+			lastPreLoadName = name;
+			return preLoadResult;
+		}
+
+		bool loadPlayerBasicInfo(const std::shared_ptr<Player> &player, const DBResult_ptr &result) override {
+			++callCount["loadPlayerBasicInfo"];
+			lastPreLoadPlayer = player;
+			lastBasicInfoResult = result;
+			return basicInfoResult;
+		}
+
+		void loadPlayerExperience(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerExperience"];
+		}
+
+		void loadPlayerBlessings(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerBlessings"];
+		}
+
+		void loadPlayerConditions(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerConditions"];
+		}
+
+		void loadPlayerAnimusMastery(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerAnimusMastery"];
+		}
+
+		void loadPlayerDefaultOutfit(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerDefaultOutfit"];
+		}
+
+		void loadPlayerSkullSystem(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerSkullSystem"];
+		}
+
+		void loadPlayerSkill(const std::shared_ptr<Player> &, const DBResult_ptr &) override {
+			++callCount["loadPlayerSkill"];
+		}
+
+		void loadPlayerKills(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerKills"];
+		}
+
+		void loadPlayerGuild(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerGuild"];
+		}
+
+		void loadPlayerStashItems(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerStashItems"];
+		}
+
+		void loadPlayerBestiaryCharms(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerBestiaryCharms"];
+		}
+
+		void loadPlayerInstantSpellList(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerInstantSpellList"];
+		}
+
+		void loadPlayerInventoryItems(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerInventoryItems"];
+		}
+
+		void loadPlayerStoreInbox(const std::shared_ptr<Player> &) override {
+			++callCount["loadPlayerStoreInbox"];
+		}
+
+		void loadPlayerDepotItems(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerDepotItems"];
+		}
+
+		void loadRewardItems(const std::shared_ptr<Player> &) override {
+			++callCount["loadRewardItems"];
+		}
+
+		void loadPlayerInboxItems(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerInboxItems"];
+		}
+
+		void loadPlayerStorageMap(const std::shared_ptr<Player> &) override {
+			++callCount["loadPlayerStorageMap"];
+		}
+
+		void loadPlayerVip(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerVip"];
+		}
+
+		void loadPlayerPreyClass(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerPreyClass"];
+		}
+
+		void loadPlayerTaskHuntingClass(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerTaskHuntingClass"];
+		}
+
+		void loadPlayerForgeHistory(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerForgeHistory"];
+		}
+
+		void loadPlayerBosstiary(const std::shared_ptr<Player> &, DBResult_ptr) override {
+			++callCount["loadPlayerBosstiary"];
+		}
+
+		void loadPlayerInitializeSystem(const std::shared_ptr<Player> &) override {
+			++callCount["loadPlayerInitializeSystem"];
+		}
+
+		void loadPlayerUpdateSystem(const std::shared_ptr<Player> &) override {
+			++callCount["loadPlayerUpdateSystem"];
+		}
+	};
+
+	struct StubLoginDataSaveRepository final : ILoginDataSaveRepository {
+		std::unordered_map<std::string, uint32_t> callCount;
+		std::unordered_map<std::string, bool> returnValues;
+
+		bool call(const std::string &name) {
+			++callCount[name];
+			if (const auto it = returnValues.find(name); it != returnValues.end()) {
+				return it->second;
+			}
+			return true;
+		}
+
+		bool savePlayerFirst(const std::shared_ptr<Player> &) override {
+			return call("savePlayerFirst");
+		}
+
+		bool savePlayerStash(const std::shared_ptr<Player> &) override {
+			return call("savePlayerStash");
+		}
+
+		bool savePlayerSpells(const std::shared_ptr<Player> &) override {
+			return call("savePlayerSpells");
+		}
+
+		bool savePlayerKills(const std::shared_ptr<Player> &) override {
+			return call("savePlayerKills");
+		}
+
+		bool savePlayerBestiarySystem(const std::shared_ptr<Player> &) override {
+			return call("savePlayerBestiarySystem");
+		}
+
+		bool savePlayerItem(const std::shared_ptr<Player> &) override {
+			return call("savePlayerItem");
+		}
+
+		bool savePlayerDepotItems(const std::shared_ptr<Player> &) override {
+			return call("savePlayerDepotItems");
+		}
+
+		bool saveRewardItems(const std::shared_ptr<Player> &) override {
+			return call("saveRewardItems");
+		}
+
+		bool savePlayerInbox(const std::shared_ptr<Player> &) override {
+			return call("savePlayerInbox");
+		}
+
+		bool savePlayerPreyClass(const std::shared_ptr<Player> &) override {
+			return call("savePlayerPreyClass");
+		}
+
+		bool savePlayerTaskHuntingClass(const std::shared_ptr<Player> &) override {
+			return call("savePlayerTaskHuntingClass");
+		}
+
+		bool savePlayerForgeHistory(const std::shared_ptr<Player> &) override {
+			return call("savePlayerForgeHistory");
+		}
+
+		bool savePlayerBosstiary(const std::shared_ptr<Player> &) override {
+			return call("savePlayerBosstiary");
+		}
+
+		bool savePlayerStorage(const std::shared_ptr<Player> &) override {
+			return call("savePlayerStorage");
+		}
+	};
+
+	class RepositoryOverrideGuard final {
+		public:
+		RepositoryOverrideGuard(ILoginDataLoadRepository *loadRepo, ILoginDataSaveRepository *saveRepo) {
+			if (loadRepo) {
+				setLoginDataLoadRepositoryForTest(loadRepo);
+				loadConfigured = true;
+			}
+			if (saveRepo) {
+				setLoginDataSaveRepositoryForTest(saveRepo);
+				saveConfigured = true;
+			}
+		}
+
+		~RepositoryOverrideGuard() {
+			if (loadConfigured) {
+				resetLoginDataLoadRepositoryForTest();
+			}
+			if (saveConfigured) {
+				resetLoginDataSaveRepositoryForTest();
+			}
+		}
+
+		private:
+		bool loadConfigured = false;
+		bool saveConfigured = false;
+	};
+}
+
+suite<"login_data_repository"> loginDataRepositorySuite = [] {
+	test("IOLoginDataLoad forwards to repository") = [] {
+		StubLoginDataLoadRepository loadRepository;
+		loadRepository.preLoadResult = false;
+		loadRepository.basicInfoResult = true;
+		RepositoryOverrideGuard guard { &loadRepository, nullptr };
+
+		std::shared_ptr<Player> player;
+		DBResult_ptr result;
+
+		expect(!IOLoginDataLoad::preLoadPlayer(player, "test-player"));
+		expect(eq(loadRepository.callCount["preLoadPlayer"], 1_u));
+		expect(eq(loadRepository.lastPreLoadName, std::string { "test-player" }));
+
+		expect(IOLoginDataLoad::loadPlayerBasicInfo(player, result));
+		expect(eq(loadRepository.callCount["loadPlayerBasicInfo"], 1_u));
+
+		IOLoginDataLoad::loadPlayerExperience(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerExperience"], 1_u));
+
+		IOLoginDataLoad::loadPlayerBlessings(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerBlessings"], 1_u));
+
+		IOLoginDataLoad::loadPlayerConditions(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerConditions"], 1_u));
+
+		IOLoginDataLoad::loadPlayerAnimusMastery(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerAnimusMastery"], 1_u));
+
+		IOLoginDataLoad::loadPlayerDefaultOutfit(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerDefaultOutfit"], 1_u));
+
+		IOLoginDataLoad::loadPlayerSkullSystem(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerSkullSystem"], 1_u));
+
+		IOLoginDataLoad::loadPlayerSkill(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerSkill"], 1_u));
+
+		IOLoginDataLoad::loadPlayerKills(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerKills"], 1_u));
+
+		IOLoginDataLoad::loadPlayerGuild(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerGuild"], 1_u));
+
+		IOLoginDataLoad::loadPlayerStashItems(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerStashItems"], 1_u));
+
+		IOLoginDataLoad::loadPlayerBestiaryCharms(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerBestiaryCharms"], 1_u));
+
+		IOLoginDataLoad::loadPlayerInstantSpellList(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerInstantSpellList"], 1_u));
+
+		IOLoginDataLoad::loadPlayerInventoryItems(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerInventoryItems"], 1_u));
+
+		IOLoginDataLoad::loadPlayerStoreInbox(player);
+		expect(eq(loadRepository.callCount["loadPlayerStoreInbox"], 1_u));
+
+		IOLoginDataLoad::loadPlayerDepotItems(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerDepotItems"], 1_u));
+
+		IOLoginDataLoad::loadRewardItems(player);
+		expect(eq(loadRepository.callCount["loadRewardItems"], 1_u));
+
+		IOLoginDataLoad::loadPlayerInboxItems(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerInboxItems"], 1_u));
+
+		IOLoginDataLoad::loadPlayerStorageMap(player);
+		expect(eq(loadRepository.callCount["loadPlayerStorageMap"], 1_u));
+
+		IOLoginDataLoad::loadPlayerVip(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerVip"], 1_u));
+
+		IOLoginDataLoad::loadPlayerPreyClass(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerPreyClass"], 1_u));
+
+		IOLoginDataLoad::loadPlayerTaskHuntingClass(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerTaskHuntingClass"], 1_u));
+
+		IOLoginDataLoad::loadPlayerForgeHistory(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerForgeHistory"], 1_u));
+
+		IOLoginDataLoad::loadPlayerBosstiary(player, result);
+		expect(eq(loadRepository.callCount["loadPlayerBosstiary"], 1_u));
+
+		IOLoginDataLoad::loadPlayerInitializeSystem(player);
+		expect(eq(loadRepository.callCount["loadPlayerInitializeSystem"], 1_u));
+
+		IOLoginDataLoad::loadPlayerUpdateSystem(player);
+		expect(eq(loadRepository.callCount["loadPlayerUpdateSystem"], 1_u));
+	};
+
+	test("IOLoginDataSave forwards to repository") = [] {
+		StubLoginDataSaveRepository saveRepository;
+		saveRepository.returnValues["savePlayerFirst"] = false;
+		RepositoryOverrideGuard guard { nullptr, &saveRepository };
+
+		std::shared_ptr<Player> player;
+
+		expect(!IOLoginDataSave::savePlayerFirst(player));
+		expect(eq(saveRepository.callCount["savePlayerFirst"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerStash(player));
+		expect(eq(saveRepository.callCount["savePlayerStash"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerSpells(player));
+		expect(eq(saveRepository.callCount["savePlayerSpells"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerKills(player));
+		expect(eq(saveRepository.callCount["savePlayerKills"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerBestiarySystem(player));
+		expect(eq(saveRepository.callCount["savePlayerBestiarySystem"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerItem(player));
+		expect(eq(saveRepository.callCount["savePlayerItem"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerDepotItems(player));
+		expect(eq(saveRepository.callCount["savePlayerDepotItems"], 1_u));
+
+		expect(IOLoginDataSave::saveRewardItems(player));
+		expect(eq(saveRepository.callCount["saveRewardItems"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerInbox(player));
+		expect(eq(saveRepository.callCount["savePlayerInbox"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerPreyClass(player));
+		expect(eq(saveRepository.callCount["savePlayerPreyClass"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerTaskHuntingClass(player));
+		expect(eq(saveRepository.callCount["savePlayerTaskHuntingClass"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerForgeHistory(player));
+		expect(eq(saveRepository.callCount["savePlayerForgeHistory"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerBosstiary(player));
+		expect(eq(saveRepository.callCount["savePlayerBosstiary"], 1_u));
+
+		expect(IOLoginDataSave::savePlayerStorage(player));
+		expect(eq(saveRepository.callCount["savePlayerStorage"], 1_u));
+	};
+};

--- a/tests/unit/io/login_data_repository_test.cpp
+++ b/tests/unit/io/login_data_repository_test.cpp
@@ -1,11 +1,11 @@
 /**
-* Canary - A free and open-source MMORPG server emulator
-* Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
-* Repository: https://github.com/opentibiabr/canary
-* License: https://github.com/opentibiabr/canary/blob/main/LICENSE
-* Contributors: https://github.com/opentibiabr/canary/graphs/contributors
-* Website: https://docs.opentibiabr.com/
-*/
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
 #include "pch.hpp"
 
 #include <boost/ut.hpp>
@@ -212,8 +212,8 @@ namespace {
 	};
 
 	class RepositoryOverrideGuard final {
-		public:
-		RepositoryOverrideGuard(ILoginDataLoadRepository *loadRepo, ILoginDataSaveRepository *saveRepo) {
+	public:
+		RepositoryOverrideGuard(ILoginDataLoadRepository* loadRepo, ILoginDataSaveRepository* saveRepo) {
 			if (loadRepo) {
 				setLoginDataLoadRepositoryForTest(loadRepo);
 				loadConfigured = true;
@@ -233,7 +233,7 @@ namespace {
 			}
 		}
 
-		private:
+	private:
 		bool loadConfigured = false;
 		bool saveConfigured = false;
 	};

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -80,6 +80,7 @@
     <ClInclude Include="..\src\io\iobestiary.hpp" />
     <ClInclude Include="..\src\io\ioguild.hpp" />
     <ClInclude Include="..\src\io\iologindata.hpp" />
+    <ClInclude Include="..\src\io\account_vip_repository_db.hpp" />
     <ClInclude Include="..\src\io\iomap.hpp" />
     <ClInclude Include="..\src\io\iomapserialize.hpp" />
     <ClInclude Include="..\src\io\iomarket.hpp" />
@@ -296,6 +297,7 @@
     <ClCompile Include="..\src\io\iobestiary.cpp" />
     <ClCompile Include="..\src\io\ioguild.cpp" />
     <ClCompile Include="..\src\io\iologindata.cpp" />
+    <ClCompile Include="..\src\io\account_vip_repository_db.cpp" />
     <ClCompile Include="..\src\io\iomap.cpp" />
     <ClCompile Include="..\src\io\iomapserialize.cpp" />
     <ClCompile Include="..\src\io\iomarket.cpp" />


### PR DESCRIPTION
# Description

Refactor player save logic to enable async scheduling and adopt fmt-based SQL construction. Replace stringstream with fmt::format and fmt::memory_buffer across save paths for lower allocations and clearer code. Add SaveManager::addTask to dispatch DB writes asynchronously when TOGGLE_SAVE_ASYNC is true, with a synchronous fallback. Update IOLoginDataSave methods to use the new task path and to build UPDATE SET clauses via pre-sized vectors. Harden DBInsert::execute to trim trailing commas, reserve buffers, clear state after runs, and use g_database(). Add DBResult::getNumColumns with m_numColumns initialized in the constructor for safer column handling. No schema or protocol changes.

This change modernizes SQL construction and introduces optional asynchronous save scheduling.

- Motivation: Reduce main-thread blocking on player saves and cut stringstream overhead while keeping behavior and data formats stable.
- Scope:
  - src/database/database.cpp/.hpp
    - DBResult: add getNumColumns(), store m_numColumns from mysql_num_fields().
    - DBInsert::execute(): safe concatenation, trailing-comma handling, buffer reserves, clear internal values, call g_database().
  - src/game/scheduling/save_manager.cpp/.hpp
    - SaveManager::addTask(std::function<void()>, std::string_view): wrap try/catch, log errors, run inline if TOGGLE_SAVE_ASYNC=false, use threadPool.detach_task otherwise.
  - src/io/functions/iologindata_save_player.cpp
    - Replace stringstream with fmt for INSERT rows and UPDATE SET joins.
    - Use g_database(), g_saveManager().addTask where applicable.
    - Ensure DBInsert::execute() is called after addRow loops for items/depot/inbox/rewards, etc.

Dependencies: fmt (already in tree), magic_enum (already in tree). No new external deps.

## Behaviour
### **Actual**
- Player save paths build SQL with stringstream, causing extra allocations and risk of separator bugs.
- Saves may block the main thread during DB I/O.

### **Expected**
- SQL built with fmt::format/memory_buffer with pre-reserved capacity.
- Saves scheduled via SaveManager::addTask when TOGGLE_SAVE_ASYNC=true; synchronous fallback when disabled.
- DBInsert batches free of trailing commas and cleared after execution.

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Steps:
1. Unit: DBResult.getNumColumns returns mysql_num_fields result; constructor sets m_numColumns.
2. Unit: DBInsert::execute splits batches, trims trailing comma, clears internal buffers; verify queries sent to g_database().
3. Integration (TOGGLE_SAVE_ASYNC=false): trigger full player save; verify rows in:
   - player_items, player_depotitems, player_rewards, player_inboxitems
   - player_spells, player_kills, forge_history, player_bosstiary
   - player_charms, player_prey, player_taskhunt
   - players (first-phase fields, skills, blessings, timers)
4. Integration (TOGGLE_SAVE_ASYNC=true): same as above; assert main loop remains responsive; confirm tasks executed and errors logged on simulated DB failure.
5. Performance: compare save latency and allocations vs baseline on large inventory+depot profile; target <= +5% CPU, equal or lower P95 latency.

  - [x] Test A: Async enabled and disabled parity test on seeded character set
  - [x] Test B: DB failure injection inside addTask path logs error and process remains stable

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
