### PR TITLE
fix: elemental spheres quest

### DIFF
--- a/data-otservbr-global/scripts/actions/other/enchanting.lua
+++ b/data-otservbr-global/scripts/actions/other/enchanting.lua
@@ -52,7 +52,7 @@ function enchanting.onUse(player, item, fromPosition, target, toPosition, isHotk
 	if table.contains({ 33268, 33269 }, toPosition.x) and toPosition.y == 31830 and toPosition.z == 10 and player:getStorageValue(Storage.Quest.U8_2.ElementalSpheres.QuestLine) > 0 then
 		if not table.contains(spheres[item.itemid], player:getVocation():getBaseId()) then
 			return false
-		elseif table.contains({ 842, 843 }, target.itemid) then
+		elseif table.contains({ 846, 847 }, target.itemid) then
 			player:say("Turn off the machine first.", TALKTYPE_MONSTER_SAY)
 			return true
 		else

--- a/data-otservbr-global/scripts/quests/elemental_spheres/actions_machine1.lua
+++ b/data-otservbr-global/scripts/quests/elemental_spheres/actions_machine1.lua
@@ -29,7 +29,7 @@ function elementalSpheresMachine1.onUse(player, item, fromPosition, target, toPo
 		toPosition.x = toPosition.x + (item.itemid == 846 and 1 or -1)
 		local tile = toPosition:getTile()
 		if tile then
-			local thing = tile:getItemById(item.itemid == 842 and 843 or 842)
+			local thing = tile:getItemById(item.itemid == 846 and 847 or 846)
 			if thing then
 				thing:transform(thing.itemid - 4)
 			end
@@ -39,5 +39,5 @@ function elementalSpheresMachine1.onUse(player, item, fromPosition, target, toPo
 	return true
 end
 
-elementalSpheresMachine1:id(842, 843)
+elementalSpheresMachine1:id(842, 843, 846, 847)
 elementalSpheresMachine1:register()

--- a/data-otservbr-global/scripts/quests/elemental_spheres/actions_machine2.lua
+++ b/data-otservbr-global/scripts/quests/elemental_spheres/actions_machine2.lua
@@ -14,7 +14,7 @@ function elementalSpheresMachine2.onUse(player, item, fromPosition, target, toPo
 		player:say("ON", TALKTYPE_MONSTER_SAY, false, player, toPosition)
 	else
 		toPosition.y = toPosition.y + (item.itemid == 848 and 1 or -1)
-		local machineItem = Tile(toPosition):getItemById(item.itemid == 848 and 845 or 849)
+		local machineItem = Tile(toPosition):getItemById(item.itemid == 848 and 849 or 848)
 		if machineItem then
 			machineItem:transform(machineItem.itemid - 4)
 		end

--- a/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
+++ b/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
@@ -14,7 +14,7 @@ local globalTable = {
 
 local elementalSpheresSoils2 = Action()
 function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not table.contains({ 842, 843, 844, 845 }, target.itemid) then
+	if not table.contains({ 842, 843, 844, 845, 846, 847, 848, 849 }, target.itemid) then
 		return false
 	end
 

--- a/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
+++ b/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
@@ -1,8 +1,8 @@
 local spheres = {
-	[8300] = VOCATION.BASE_ID.PALADIN,
-	[8304] = VOCATION.BASE_ID.SORCERER,
-	[8305] = VOCATION.BASE_ID.DRUID,
-	[8306] = VOCATION.BASE_ID.KNIGHT,
+	[942] = VOCATION.BASE_ID.PALADIN,
+	[946] = VOCATION.BASE_ID.SORCERER,
+	[947] = VOCATION.BASE_ID.DRUID,
+	[948] = VOCATION.BASE_ID.KNIGHT,
 }
 
 local globalTable = {
@@ -14,7 +14,7 @@ local globalTable = {
 
 local elementalSpheresSoils2 = Action()
 function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not table.contains({ 7917, 7918, 7913, 7914 }, target.itemid) then
+	if not table.contains({ 842, 843, 844, 845 }, target.itemid) then
 		return false
 	end
 
@@ -22,11 +22,11 @@ function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosi
 		return false
 	end
 
-	if not table.contains(spheres[item.itemid], player:getVocation():getBaseId()) then
+	if spheres[item.itemid] ~= player:getVocation():getBaseId() then
 		return false
 	end
 
-	if table.contains({ 7917, 7918 }, target.itemid) then
+	if table.contains({ 846, 847, 848, 849 }, target.itemid) then
 		player:say("Turn off the machine first.", TALKTYPE_MONSTER_SAY)
 		return true
 	end
@@ -37,5 +37,5 @@ function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosi
 	return true
 end
 
-elementalSpheresSoils2:id(8300, 8304, 8305, 8306)
+elementalSpheresSoils2:id(942, 946, 947, 948)
 elementalSpheresSoils2:register()

--- a/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
+++ b/data-otservbr-global/scripts/quests/elemental_spheres/actions_soils2.lua
@@ -32,7 +32,7 @@ function elementalSpheresSoils2.onUse(player, item, fromPosition, target, toPosi
 	end
 
 	toPosition:sendMagicEffect(CONST_ME_PURPLEENERGY)
-	Game.setStorageValue(globalTable[player:getVocation():getBase():getId()], 1)
+	Game.setStorageValue(globalTable[player:getVocation():getBaseId()], 1)
 	item:remove(1)
 	return true
 end


### PR DESCRIPTION
# Description

This PR corrects the item IDs for the elemental spheres quest, as the current IDs were from an older TFS.

## Behavior

After speaking with the NPC Arkulius, the player has to use 20 enchanted stones on the machine.

The emeralds should be used on the machine while it's off, and then the player turns it back on to be teleported. However, this isn't happening because, when the machine is off, the player can't turn it back on due to the incorrect ID.

The boss drops also had incorrect IDs, so in the second part of the quest, returning to the NPC and reporting didn't change anything.

Old machine IDs:
`7917, 7918, 7913, 7914`

New machine IDs:
`842, 843, 844, 845`

Drop from old boss: `8300, 8304, 8305, 8306`

Drop from new boss: `942, 946, 947, 948`

Connected machine IDs changed:
`elseif table.contains({ 842, 843 }, target.itemid) then`

to: `elseif table.contains({ 846, 847 }, target.itemid) then`

## Change Type

- [ ] Incompatible change (fix or feature that would cause existing functionality to not work as expected)

**Test configuration**:

- Server version: 14.12
- Client: Cip Client

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I performed a self-assessment of my code
- [ ] I checked the PR verification reports
- [ ] I commented my code, especially in areas that are difficult to understand
- [ ] I made the corresponding changes in the documentation
- [ ] My changes do not generate new warnings
- [ ] I added tests that prove the effectiveness of my correction or the functionality of my feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quest Updates**
  * Refined Elemental Spheres enchanting and machine interactions for clearer on/off behavior.
  * Broadened supported items for sphere and soil interactions, enabling more valid uses.
  * Adjusted neighboring-item transformation behavior for more consistent puzzle responses.
  * Tightened vocation and trigger checks and updated interaction messages shown to players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->