### PR TITLE
fix: active gem not clearing

### DIFF
--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1191,6 +1191,11 @@ void PlayerWheel::destroyGem(uint16_t index) {
 	}
 
 	m_destroyedGems.emplace_back(gem);
+	for (auto &activeGem : m_activeGems) {
+		if (activeGem && activeGem.uuid == gem.uuid) {
+			activeGem = emptyGem;
+		}
+	}
 	m_revealedGems.erase(m_revealedGems.begin() + index);
 
 	const auto totalLesserFragment = m_player.getItemTypeCount(ITEM_LESSER_FRAGMENT) + m_player.getStashItemCount(ITEM_LESSER_FRAGMENT);

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1191,10 +1191,19 @@ void PlayerWheel::destroyGem(uint16_t index) {
 	}
 
 	m_destroyedGems.emplace_back(gem);
+	gem.remove(gemsKV());
+
+	bool wasActive = false;
 	for (auto &activeGem : m_activeGems) {
 		if (activeGem && activeGem.uuid == gem.uuid) {
 			activeGem = emptyGem;
+			wasActive = true;
 		}
+	}
+
+	if (wasActive) {
+		const auto affinityKey = std::string(magic_enum::enum_name(gem.affinity));
+		gemsKV()->scoped("active")->remove(affinityKey);
 	}
 	m_revealedGems.erase(m_revealedGems.begin() + index);
 

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1250,7 +1250,8 @@ void PlayerWheel::setActiveGem(WheelGemAffinity_t affinity, uint16_t index) {
 	if (index >= m_revealedGems.size()) {
 		g_logger().error(
 			"[{}] Player {} tried to activate gem {} but only has {} revealed gems",
-			__FUNCTION__, m_player.getName(), index, m_revealedGems.size());
+			__FUNCTION__, m_player.getName(), index, m_revealedGems.size()
+		);
 		removeActiveGem(affinity);
 		return;
 	}
@@ -1261,11 +1262,11 @@ void PlayerWheel::setActiveGem(WheelGemAffinity_t affinity, uint16_t index) {
 		removeActiveGem(affinity);
 		return;
 	}
-        if (gem.affinity != affinity) {
-                g_logger().error("[{}] Gem with index {} has affinity {} but trying to set it to {}", __FUNCTION__, index, fmt::underlying(gem.affinity), fmt::underlying(affinity));
-                return;
-        }
-        m_activeGems[static_cast<uint8_t>(affinity)] = gem;
+	if (gem.affinity != affinity) {
+		g_logger().error("[{}] Gem with index {} has affinity {} but trying to set it to {}", __FUNCTION__, index, fmt::underlying(gem.affinity), fmt::underlying(affinity));
+		return;
+	}
+	m_activeGems[static_cast<uint8_t>(affinity)] = gem;
 }
 
 void PlayerWheel::removeActiveGem(WheelGemAffinity_t affinity) {

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1247,16 +1247,25 @@ void PlayerWheel::toggleGemLock(uint16_t index) {
 }
 
 void PlayerWheel::setActiveGem(WheelGemAffinity_t affinity, uint16_t index) {
-	auto &gem = getGem(index);
+	if (index >= m_revealedGems.size()) {
+		g_logger().error(
+			"[{}] Player {} tried to activate gem {} but only has {} revealed gems",
+			__FUNCTION__, m_player.getName(), index, m_revealedGems.size());
+		removeActiveGem(affinity);
+		return;
+	}
+
+	auto &gem = m_revealedGems[index];
 	if (!gem) {
 		g_logger().error("[{}] Failed to load gem with index {}", __FUNCTION__, index);
+		removeActiveGem(affinity);
 		return;
 	}
-	if (gem.affinity != affinity) {
-		g_logger().error("[{}] Gem with index {} has affinity {} but trying to set it to {}", __FUNCTION__, index, fmt::underlying(gem.affinity), fmt::underlying(affinity));
-		return;
-	}
-	m_activeGems[static_cast<uint8_t>(affinity)] = gem;
+        if (gem.affinity != affinity) {
+                g_logger().error("[{}] Gem with index {} has affinity {} but trying to set it to {}", __FUNCTION__, index, fmt::underlying(gem.affinity), fmt::underlying(affinity));
+                return;
+        }
+        m_activeGems[static_cast<uint8_t>(affinity)] = gem;
 }
 
 void PlayerWheel::removeActiveGem(WheelGemAffinity_t affinity) {


### PR DESCRIPTION
Now it clears the active gem slot when the equipped gem gets dismantled, this prevents it from showing up again after relogging.

#3724