### PR TITLE
fix: enable 'toggle_bin' flag for gha

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Run CMake
         uses: lukka/run-cmake@main
         with:
+          configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Run CMake
         uses: lukka/run-cmake@main
         with:
+          configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Run CMake
         uses: lukka/run-cmake@main
         with:
+          configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -27,7 +27,7 @@ FROM dependencies AS build
 COPY . /srv/
 WORKDIR /srv
 
-RUN export VCPKG_ROOT=/opt/vcpkg/ && VCPKG_FORCE_SYSTEM_BINARIES=1 cmake --preset linux-release && cmake --build --preset linux-release
+RUN export VCPKG_ROOT=/opt/vcpkg/ && VCPKG_FORCE_SYSTEM_BINARIES=1 cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON && cmake --build --preset linux-release
 
 # Stage 3: load data and execute
 FROM ubuntu:24.04

--- a/docker/Dockerfile.x86
+++ b/docker/Dockerfile.x86
@@ -27,7 +27,7 @@ FROM dependencies AS build
 COPY . /srv/
 WORKDIR /srv
 
-RUN export VCPKG_ROOT=/opt/vcpkg/ && cmake --preset linux-release && cmake --build --preset linux-release
+RUN export VCPKG_ROOT=/opt/vcpkg/ && cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON && cmake --build --preset linux-release
 
 # Stage 3: load data and execute
 FROM ubuntu:24.04


### PR DESCRIPTION
Enable "TOGGLE_BIN" for GHA and Docker builds as it searches on bin/ folder for the binary.