### PR TITLE
fix: enforce max item tier in market operations

### DIFF
--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -189,7 +189,7 @@ void IOMarket::processExpiredOffers(const DBResult_ptr &result, bool) {
 					}
 
 					if (tier != 0) {
-						item->setAttribute(ItemAttribute_t::TIER, tier);
+						item->setTier(tier);
 					}
 
 					tmpAmount -= stackCount;
@@ -209,7 +209,7 @@ void IOMarket::processExpiredOffers(const DBResult_ptr &result, bool) {
 					}
 
 					if (tier != 0) {
-						item->setAttribute(ItemAttribute_t::TIER, tier);
+						item->setTier(tier);
 					}
 				}
 			}


### PR DESCRIPTION
Adds validation to ensure item tier does not exceed the configured maximum in market offer creation, cancellation, and acceptance. Also updates item tier assignment to use setTier instead of setAttribute. This improves consistency and prevents invalid item upgrades in market transactions.

