### PR TITLE
fix: set default value for taskName in Dispatcher

### DIFF
--- a/src/game/scheduling/dispatcher.hpp
+++ b/src/game/scheduling/dispatcher.hpp
@@ -64,7 +64,7 @@ private:
 
 	DispatcherType type = DispatcherType::None;
 	TaskGroup group = TaskGroup::ThreadPool;
-	std::string_view taskName;
+	std::string_view taskName = "ThreadPool::call";
 
 	friend class Dispatcher;
 };

--- a/src/game/scheduling/dispatcher.hpp
+++ b/src/game/scheduling/dispatcher.hpp
@@ -56,15 +56,17 @@ struct DispatcherContext {
 	}
 
 private:
+	inline static constexpr std::string_view defaultTaskName { "ThreadPool::call" };
+
 	void reset() {
 		group = TaskGroup::ThreadPool;
 		type = DispatcherType::None;
-		taskName = "ThreadPool::call";
+		taskName = defaultTaskName;
 	}
 
 	DispatcherType type = DispatcherType::None;
 	TaskGroup group = TaskGroup::ThreadPool;
-	std::string_view taskName = "ThreadPool::call";
+	std::string_view taskName = defaultTaskName;
 
 	friend class Dispatcher;
 };


### PR DESCRIPTION
Initialized the taskName member to "ThreadPool::call" in the Dispatcher class to ensure a default value is set, improving clarity and preventing potential uninitialized usage.