### PR TITLE
fix: quiver usage conditions

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -40,6 +40,7 @@
 #include "io/ioprey.hpp"
 #include "items/items_classification.hpp"
 #include "items/weapons/weapons.hpp"
+#include "items/containers/container.hpp"
 #include "lua/creature/creatureevent.hpp"
 #include "lua/modules/modules.hpp"
 #include "server/network/message/outputmessage.hpp"


### PR DESCRIPTION
- Lets you swap quivers whether they have arrows or not.
- Lets you quickly equip a shield in a pinch.

1. fix: #3745