### PR TITLE
fix: familiar time

### DIFF
--- a/data/scripts/creaturescripts/familiar/on_login.lua
+++ b/data/scripts/creaturescripts/familiar/on_login.lua
@@ -10,7 +10,7 @@ function familiarOnLogin.onLogin(player)
 
 	local familiarName
 	local familiarSummonTime = player:kv():get("familiar-summon-time") or 0
-	local familiarTimeLeft = familiarSummonTime - player:getLastLogout()
+	local familiarTimeLeft = math.max(0, familiarSummonTime - os.time())
 
 	if vocation then
 		if (not player:isPremium() and player:hasFamiliar(vocation.id)) or player:getLevel() < 200 then


### PR DESCRIPTION
This pull request makes a small but important fix to the familiar system on player login. It ensures that the remaining familiar summon time is never negative by clamping the value to zero. This prevents potential issues if the stored summon time is in the past.

* Clamp `familiarTimeLeft` to zero to prevent negative values by using `math.max(0, familiarSummonTime - os.time())` in `familiarOnLogin.onLogin` (`data/scripts/creaturescripts/familiar/on_login.lua`).

Fix: #3710