### PR TITLE
fix: sendUpdateTileCreature log client debug

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6982,9 +6982,9 @@ void ProtocolGame::sendUpdateTileCreature(const Position &pos, uint32_t stackpos
 	msg.addByte(static_cast<uint8_t>(stackpos));
 
 	bool known;
-	uint32_t removedKnown;
+	uint32_t removedKnown = 0;
 	checkCreatureAsKnown(creature->getID(), known, removedKnown);
-	AddCreature(msg, creature, false, removedKnown);
+	AddCreature(msg, creature, known, removedKnown);
 	writeToOutputBuffer(msg);
 }
 


### PR DESCRIPTION
Fix: #3741 

This pull request makes a targeted improvement to the `sendUpdateTileCreature` function in `protocolgame.cpp`. The main change ensures that the `known` status of a creature is correctly passed to the `AddCreature` function, which likely affects how creature updates are handled in the game protocol.

- Networking and game protocol:
  * In `ProtocolGame::sendUpdateTileCreature`, initialized `removedKnown` to 0 and updated the call to `AddCreature` to pass the `known` variable, ensuring accurate handling of whether a creature is already known to the client.