### PR TITLE
fix: update lastLogout to current time on player actions

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3903,6 +3903,7 @@ void Player::death(const std::shared_ptr<Creature> &lastHitCreature) {
 		sendSkills();
 		sendReLoginWindow(unfairFightReduction);
 		sendBlessStatus();
+		lastLogout = time(nullptr);
 		if (getSkull() == SKULL_BLACK) {
 			health = 40;
 			mana = 0;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3903,7 +3903,7 @@ void Player::death(const std::shared_ptr<Creature> &lastHitCreature) {
 		sendSkills();
 		sendReLoginWindow(unfairFightReduction);
 		sendBlessStatus();
-		lastLogout = time(nullptr);
+		lastLogout = getTimeNow();
 		if (getSkull() == SKULL_BLACK) {
 			health = 40;
 			mana = 0;


### PR DESCRIPTION
This pull request makes a small but important change to the `Player::death` method in `player.cpp`. Now, when a player dies, the `lastLogout` timestamp is updated to the current time. This ensures that the player's last logout time is accurately recorded upon death.

* Update player logout timestamp on death by setting `lastLogout` to the current time in `Player::death` (`player.cpp`).