### PR TITLE
fix: burst arrow attributes

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -43997,6 +43997,10 @@ Awarded by TibiaMagazine.com.ve"/>
 	</item>
 	<item id="22119" article="a" name="burst arrow">
 		<attribute key="primarytype" value="ammunition"/>
+		<attribute key="weaponType" value="ammunition"/>
+		<attribute key="ammotype" value="arrow"/>
+		<attribute key="shootType" value="burstarrow"/>
+		<attribute key="maxhitchance" value="100"/>
 		<attribute key="attack" value="27"/>
 		<attribute key="weight" value="90"/>
 	</item>


### PR DESCRIPTION
# Description  
  
Fixes burst arrow (ID 22119) not being accepted into quivers.  
  
## Behaviour  
### **Actual**  
  
Burst arrows cannot be moved into quivers. When attempting to place a burst arrow in a quiver slot, the action is rejected.  
  
### **Expected**  
  
Burst arrows should be accepted into quivers like other arrow types, allowing players to store and use them from the quiver equipment slot.  
  
### Fixes #issuenumber  
  
## Type of change  
  
  - [x] Bug fix (non-breaking change which fixes an issue)  
  
## How Has This Been Tested  
  
  - [ ] Manually tested burst arrow placement in quiver  
  - [ ] Verified burst arrows can be equipped and used from quiver  
  - [x] Confirmed other arrow types still work correctly  
  
**Test Configuration**:  
  
  - Server Version: Canary (latest main branch)  
  - Client: 14.12
  - Operating System: Windows 10
  
## Checklist  
  
  - [x] My code follows the style guidelines of this project  
  - [x] I have performed a self-review of my own code  
  - [ ] I checked the PR checks reports  
  - [ ] I have commented my code, particularly in hard-to-understand areas  
  - [ ] I have made corresponding changes to the documentation  
  - [x] My changes generate no new warnings  
  - [ ] I have added tests that prove my fix is effective or that my feature works