### PR TITLE
fix: koshei the deathless quest amulet

### DIFF
--- a/data-otservbr-global/npc/a_sweaty_cyclops.lua
+++ b/data-otservbr-global/npc/a_sweaty_cyclops.lua
@@ -60,6 +60,50 @@ local function creatureSayCallback(npc, creature, type, message)
 		return false
 	end
 
+-- Amulet quest // quick fix
+if MsgContains(message, "amulet") then
+	-- automatic exchange: crystal coin (ID 3043) -> platinum coins (ID 3035)
+	if player:getItemCount(3043) > 0 then
+		local count = player:getItemCount(3043)
+		player:removeItem(3043, count)
+		player:addItem(3035, count * 100)
+		npcHandler:say("Me break shiny crystal coin into platinum pieces for lil' one!", npc, creature)
+	end
+
+	-- 4 specific required items
+	local requiredItems = {7528, 7529, 7530, 7531}
+	local hasAllItems = true
+
+	-- checking 4 required items
+	for _, itemId in ipairs(requiredItems) do
+		if player:getItemCount(itemId) < 1 then
+			hasAllItems = false
+			break
+		end
+	end
+
+	-- checking for 50 platinum coins (ID 3035)
+	if player:getItemCount(3035) < 50 then
+		hasAllItems = false
+	end
+
+	if hasAllItems then
+		-- remove 4 required items
+		for _, itemId in ipairs(requiredItems) do
+			player:removeItem(itemId, 1)
+		end
+		-- remove 50 platinum coins
+		player:removeItem(3035, 50)
+
+		-- give reward: Koshei's Ancient Amulet (ID 7532)
+		player:addItem(7532, 1)
+
+		npcHandler:say("Cling clang! Lil' one bring shiny things, me give ancient amulet!", npc, creature)
+	else
+		npcHandler:say("Lil' one no have all shiny things. Need 4 more pieces of a broken amulet and 50 platinum coins!", npc, creature)
+	end
+end
+	
 	-- uth'lokr (Bast Skirts)
 	if MsgContains(message, "uth'lokr") and player:getStorageValue(Storage.Quest.U7_8.FriendsandTraders.TheSweatyCyclops) < 1 then
 		npcHandler:say("Firy steel it is. Need green ones' breath to melt. Or red even better. Me can make from shield. Lil' one want to trade?", npc, creature)


### PR DESCRIPTION
Koshei The Deathless Quest amulet fix


# Description

Added script to make "A Sweaty Cyclops" responds to "amulet" while doing "Koshei The Deathless Quest", only needing adding code to a_sweaty_cyclops.lua to make him give you the amulet for 4 broken pieces found on the map and 50 platinium coins. Only I didn't add the 24 hour cooldown for it, I think it is not needed that much.

## Behaviour
### **Actual**

If you talk with "A Sweaty Cyclops" Hi --> Amulet 
The NPC will not respond because of missing code.

### **Expected**

You should be able to talk with "A Sweaty Cyclops" about amulet to make quest completed.

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ Talk with "A Sweaty Cyclops" while having "Koshei The Deathless Quest" active and say "Hi --> amulet" ] Test A
  - [ None ] Test B

**Test Configuration**:

  - Server Version: Actual Latest 3.2.1 Canary
  - Client: 14.12
  - Operating System: Windows 10

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have commented my code
  - [ ] My changes generate no new warnings
