### PR TITLE
fix: house checks to monster movement logic

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1422,6 +1422,10 @@ bool Monster::pushItem(const std::shared_ptr<Item> &item, const Direction &dir) 
 		return false;
 	}
 
+	if (fromTile->getHouse()) {
+		return false;
+	}	
+
 	const Position &fromPos = fromTile->getPosition();
 	std::shared_ptr<Cylinder> fromCyl = fromTile;
 
@@ -1443,6 +1447,10 @@ void Monster::pushItems(const std::shared_ptr<Tile> &tile, const Direction &next
 
 	const auto* items = tile->getItemList();
 	if (!items || items->empty()) {
+		return;
+	}
+
+	if (tile->getHouse()) {
 		return;
 	}
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1424,7 +1424,7 @@ bool Monster::pushItem(const std::shared_ptr<Item> &item, const Direction &dir) 
 
 	if (fromTile->getHouse()) {
 		return false;
-	}	
+	}
 
 	const Position &fromPos = fromTile->getPosition();
 	std::shared_ptr<Cylinder> fromCyl = fromTile;


### PR DESCRIPTION
This pull request introduces a safeguard to prevent monsters from pushing items that are located inside houses. The changes ensure that both single-item and multi-item push actions by monsters are blocked if the target tile is part of a house.

Item pushing restrictions:

* Updated `Monster::pushItem` to immediately return `false` if the source tile is inside a house, preventing monsters from pushing items out of houses.
* Updated `Monster::pushItems` to return early if the tile is inside a house, stopping monsters from pushing multiple items within or out of houses.

# Description

Skip monster item push logic when the target tile belongs to a house to avoid accidental moves/removals.

-- When canPushItems = true, on custom servers.



https://github.com/user-attachments/assets/5fcffd2b-8858-48cb-991a-807bc218ab6d


https://github.com/user-attachments/assets/814c6808-e943-47d0-8750-7449bacca817


