### PR TITLE
fix: loot highlight effect

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2999,6 +2999,26 @@ void Game::playerQuickLootCorpse(const std::shared_ptr<Player> &player, const st
 		}
 	}
 
+	bool hasLootavaible = false;
+	for (ContainerIterator it = corpse->iterator(); it.hasNext(); it.advance()) {
+		const auto &corpseItem = *it;
+		if (!corpseItem) {
+			continue;
+		}
+
+		const bool listed = player->isQuickLootListedItem(corpseItem);
+		if ((listed && ignoreListItems) || (!listed && !ignoreListItems)) {
+			continue;
+		}
+
+		hasLootavaible = true;
+		break;
+	}
+
+	if (!hasLootavaible) {
+		corpse->clearLootHighlight(player);
+	}
+
 	std::stringstream ss;
 	if (totalLootedGold != 0 || missedAnyGold || totalLootedItems != 0 || missedAnyItem) {
 		bool lootedAllGold = totalLootedGold != 0 && !missedAnyGold;


### PR DESCRIPTION
Fix #3751 

This pull request introduces a check to ensure that loot highlights are only shown on corpses when there are actually lootable items available for the player, improving the user experience and preventing misleading UI indications.

Loot highlight logic improvements:

* Added a loop to check if there are any lootable items available for the player in the corpse container, taking into account the player's quick loot list and the `ignoreListItems` flag.
* If no lootable items are found, the corpse's loot highlight is cleared for the player to prevent unnecessary UI cues.
