### PR TITLE
fix: ignore removed creatures or creatures with no HP when assembling tile descriptions

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1488,6 +1488,9 @@ void ProtocolGame::GetTileDescription(const std::shared_ptr<Tile> &tile, Network
 	if (creatures) {
 		bool playerAdded = false;
 		for (auto creature : std::ranges::reverse_view(*creatures)) {
+			if (!creature || creature->isRemoved() || !creature->isAlive()) {
+				continue;
+			}
 			if (!player->canSeeCreature(creature)) {
 				continue;
 			}


### PR DESCRIPTION
This pull request introduces a small but significant improvement to the creature visibility logic in the `ProtocolGame::GetTileDescription` method. The change ensures that only valid, alive, and non-removed creatures are processed when generating a tile description.

* Added a check to skip creatures that are null, removed, or not alive in the loop iterating over `creatures` in `protocolgame.cpp`, improving robustness and preventing potential errors.

# Description

Avoid call "AddCreature" with `known = true` when creature is already dead.

## Behaviour
### **Actual**
```txt
[2025-10-11 22:13:27.205] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275940) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.207] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275941) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.208] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275942) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.210] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275943) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.211] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275944) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.211] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275945) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.212] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275946) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.213] [info] [ProtocolGame::AddCreature] Sent unknown creature: Rootthing Nutshell (ID: 1342275947) to player: DEV Gabp, remove 0 (0x0)
[2025-10-11 22:13:27.232] [info] spectator send tile DEV Gabp
[2025-10-11 22:13:27.232] [info] [SendUpdateTile] row 7441
[2025-10-11 22:13:27.233] [info] [ProtocolGame::GetTileDescription] row 1577
[2025-10-11 22:13:27.234] [info] [ProtocolGame::AddCreature] name=Rootthing Nutshell, id=1342275940, known=true, hp=0/13500, isRemoved=false, hasTile=true
[2025-10-11 22:13:27.235] [info] spectator send tile DEV Gabp
[2025-10-11 22:13:27.235] [info] [SendUpdateTile] row 7441
```

## After
```txt
// /m rat, 8
[2025-13-11 14:07:45.100] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260606 health: 13500
[2025-13-11 14:07:45.100] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260607 health: 13500
[2025-13-11 14:07:45.101] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260608 health: 13500
[2025-13-11 14:07:45.102] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260609 health: 13500
[2025-13-11 14:07:45.102] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260610 health: 13500
[2025-13-11 14:07:45.102] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260611 health: 13500
[2025-13-11 14:07:45.103] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260612 health: 13500
[2025-13-11 14:07:45.103] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260613 health: 13500
[2025-13-11 14:07:45.126] [info] BYTE RECEIVED: 0x83 // kill with rune id 3191
// /m rat, 8
[2025-13-11 14:08:23.124] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260614 health: 13500
[2025-13-11 14:08:23.125] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260615 health: 13500
[2025-13-11 14:08:23.125] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260616 health: 13500
[2025-13-11 14:08:23.126] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260617 health: 13500
[2025-13-11 14:08:23.126] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260618 health: 13500
[2025-13-11 14:08:23.127] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260619 health: 13500
[2025-13-11 14:08:23.127] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260620 health: 13500
[2025-13-11 14:08:23.128] [info] [ProtocolGame::AddCreature] unknown creature id: 1342260621 health: 13500
```


## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Kill a lot of monsters in same tile, and after 8 corpses, it will call "AddCreature" to a creature as known with 0 hp


## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  
  thanks to @dudantas help with debug and fix
