### PR TITLE
fix: throttle imbuement tracker updates to 1s interval

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3081,9 +3081,17 @@ void Player::removeItemImbuementStats(const Imbuement* imbuement) {
 }
 
 void Player::updateImbuementTrackerStats() const {
-	if (imbuementTrackerWindowOpen) {
-		g_game().playerRequestInventoryImbuements(getID(), true);
+	if (!imbuementTrackerWindowOpen) {
+		return;
 	}
+
+	const int64_t currentTime = OTSYS_TIME();
+	if (currentTime - m_lastImbuementTrackerUpdate < 1000) {
+		return;
+	}
+
+	m_lastImbuementTrackerUpdate = currentTime;
+	g_game().playerRequestInventoryImbuements(getID(), true);
 }
 
 // User Interface action exhaustion

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1650,6 +1650,7 @@ private:
 	bool moved = false;
 	bool m_isDead = false;
 	bool imbuementTrackerWindowOpen = false;
+	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1651,6 +1651,8 @@ private:
 	bool m_isDead = false;
 	bool imbuementTrackerWindowOpen = false;
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
+	mutable bool m_hasPendingImbuementTrackerUpdate = false;
+	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
This pull request introduces a rate-limiting mechanism for updating imbuement tracker stats in the `Player` class to prevent excessive updates within short time intervals. The update logic now checks if the tracker window is open and ensures updates occur at most once per second.

Imbuement tracker update improvements:

* Added a new member variable `m_lastImbuementTrackerUpdate` to the `Player` class to track the last update time for imbuement stats.
* Modified `Player::updateImbuementTrackerStats()` to return early if the tracker window is closed or if less than one second has passed since the last update, thereby rate-limiting the update calls.