### PR TITLE
fix: create NPCs after using "/reload npc(s)" command

### DIFF
--- a/src/creatures/npcs/npcs.cpp
+++ b/src/creatures/npcs/npcs.cpp
@@ -117,20 +117,20 @@ bool Npcs::load(bool loadLibs /* = true*/, bool loadNpcs /* = true*/, bool reloa
 	return false;
 }
 
-bool Npcs::reload() {
-	// Load the "npclib" folder
-	if (load(true, false, true)) {
-		// Load the npcs scripts folder
-		if (!load(false, true, true)) {
-			return false;
-		}
-
-		npcs.clear();
-		scriptInterface.reset();
-		g_game().resetNpcs();
-		return true;
-	}
-	return false;
+bool Npcs::reload() {   
+    npcs.clear();          
+    scriptInterface.reset();  
+    g_game().resetNpcs();  
+      
+	// Load the "npclib" folder  
+    if (load(true, false, true)) {  
+		// Load the npcs scripts folder  
+        if (!load(false, true, true)) {  
+            return false;  
+        }  
+        return true;  
+    }  
+    return false;  
 }
 
 Npcs &Npcs::getInstance() {


### PR DESCRIPTION
# Description

This PR fixes NPC creation after using "/reload npc(s)" command.

## Behaviour
### **Actual**

NPCs cannot be created after using the "/reload npc(s)" command.

### **Expected**

Allow NPC creation after using the "/reload npc(s)" command.


## Type of change

Please delete options that are not relevant.

  - [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested

**Test Configuration**:

  - Server Version: 14.12 (main branch).
  - Client: OTClient Redemption (main branch).
  - Operating System: Windows 10.

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
