### PR TITLE
feat: fiery horseshoe action to add mount to player

### DIFF
--- a/data/scripts/actions/items/fiery_horseshoe.lua
+++ b/data/scripts/actions/items/fiery_horseshoe.lua
@@ -1,0 +1,41 @@
+local config = {
+	requiredItems = {
+		[36938] = { key = "fiery-horseshoe", count = 4 },
+	},
+	mountId = 184,
+}
+
+local fieryHorseshoe = Action()
+
+function fieryHorseshoe.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	local itemInfo = config.requiredItems[item:getId()]
+	if not itemInfo then
+		return true
+	end
+
+	if player:hasMount(config.mountId) then
+		return true
+	end
+
+	local currentCount = (player:kv():get(itemInfo.key) or 0) + 1
+	player:kv():set(itemInfo.key, currentCount)
+	player:getPosition():sendMagicEffect(CONST_ME_FIREATTACK)
+	item:remove(1)
+
+	for _, info in pairs(config.requiredItems) do
+		if (player:kv():get(info.key) or 0) < info.count then
+			return true
+		end
+	end
+
+	player:addMount(config.mountId)
+	player:addAchievement("Hot on the Trail")
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Singeing Steed is now yours!")
+	return true
+end
+
+for itemId, _ in pairs(config.requiredItems) do
+	fieryHorseshoe:id(itemId)
+end
+
+fieryHorseshoe:register()


### PR DESCRIPTION
# Description

Using 4 fiery horseshoe gives you the mount Singeing Steed and the achievement Hot on the Trail

## Behaviour
### **Actual**

The item doesn't do anything.

### **Expected**

Using 4 adds Singeing Steed mount to player

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
