### PR TITLE
fix: add dawnfire pantaloons item to timira loot table

### DIFF
--- a/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
+++ b/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
@@ -75,7 +75,7 @@ monster.loot = {
 	{ name = "giant sapphire", chance = 2041 },
 	{ name = "giant topaz", chance = 2041 },
 	{ name = "dawnfire sherwani", chance = 200 },
-	{ id = 39166, chance = 200 }, -- dawnfire pantaloons
+	{ name = "dawnfire pantaloons", chance = 200 },
 	{ name = "frostflower boots", chance = 200 },
 	{ name = "feverbloom boots", chance = 200 },
 	{ id = 39233, chance = 200 }, -- enchanted turtle amulet

--- a/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
+++ b/data-otservbr-global/monster/quests/marapur/timira_the_many-headed.lua
@@ -75,6 +75,7 @@ monster.loot = {
 	{ name = "giant sapphire", chance = 2041 },
 	{ name = "giant topaz", chance = 2041 },
 	{ name = "dawnfire sherwani", chance = 200 },
+	{ id = 39166, chance = 200 }, -- dawnfire pantaloons
 	{ name = "frostflower boots", chance = 200 },
 	{ name = "feverbloom boots", chance = 200 },
 	{ id = 39233, chance = 200 }, -- enchanted turtle amulet


### PR DESCRIPTION
Add Dawnfire Pantaloons (ID 39166) to Timira loot table

This item was missing from the boss loot and is now added with proper item ID.


# Description

The item "Dawnfire Pantaloons", together with "Dawnfire Sherwani", is part of the naga set for sorcerers and should normally drop from Timira.
Similar to the naga set for druids, which includes "Midnight Tunic" and "Midnight Sarong", already added to the loot.
Additionally, both items can also be obtained from chests located in the rooms before Timira's fight during the "Within the Tides" quest, which is already configured.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
