### PR TITLE
perf: replace std::ranges::copy with std::memcpy for buffer ops

### DIFF
--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -163,7 +163,10 @@ void NetworkMessage::addString(const std::string &value, const std::source_locat
 	auto len = static_cast<uint16_t>(stringLen);
 	add<uint16_t>(len);
 	// Using to copy the string into the buffer
-	std::ranges::copy(value, buffer.begin() + info.position);
+	if (std::memcpy(buffer.data() + info.position, value.data(), stringLen) == nullptr) {
+		g_logger().error("[{}] memcpy failed while adding string", __FUNCTION__);
+		return;
+	}
 	info.position += stringLen;
 	info.length += stringLen;
 }
@@ -213,7 +216,10 @@ void NetworkMessage::addBytes(const char* bytes, size_t size) {
 		return;
 	}
 
-	std::ranges::copy(std::span(bytes, size), buffer.begin() + info.position);
+	if (std::memcpy(buffer.data() + info.position, bytes, size) == nullptr) {
+		g_logger().error("[NetworkMessage::addBytes] - memcpy failed while adding bytes");
+		return;
+	}
 	info.position += size;
 	info.length += size;
 }
@@ -294,10 +300,10 @@ void NetworkMessage::append(const NetworkMessage &other) {
 		return;
 	}
 
-	std::ranges::copy(
-		std::span<const unsigned char>(other.getBuffer() + otherStartPos, otherLength),
-		buffer.data() + info.position
-	);
+	if (std::memcpy(buffer.data() + info.position, other.getBuffer() + otherStartPos, otherLength) == nullptr) {
+		g_logger().error("[{}] memcpy failed while appending message", __FUNCTION__);
+		return;
+	}
 
 	// Update the buffer information
 	info.length += otherLength;

--- a/src/server/network/message/networkmessage.hpp
+++ b/src/server/network/message/networkmessage.hpp
@@ -51,8 +51,10 @@ public:
 		// Create a temporary byte array to store the value read from the buffer.
 		std::array<unsigned char, sizeof(T)> tempBuffer;
 		// Copy data from the buffer to the temporary array
-		std::span<const unsigned char> sourceSpan(buffer.data() + info.position, sizeof(T));
-		std::ranges::copy(sourceSpan, tempBuffer.begin());
+		if (std::memcpy(tempBuffer.data(), buffer.data() + info.position, sizeof(T)) == nullptr) {
+			g_logger().error("[{}] memcpy failed while reading message buffer", __FUNCTION__);
+			return T();
+		}
 		// Update the read position in the buffer
 		info.position += sizeof(T);
 		// Convert the byte array to type T using std::bit_cast and return the result
@@ -87,17 +89,18 @@ public:
 		auto byteArray = std::bit_cast<std::array<unsigned char, sizeof(T)>>(value);
 
 		// Create a span from the byte array
-		std::span<const unsigned char> byteSpan(byteArray);
-
-		// Check if the size of byteSpan can fit into the buffer
-		if (byteSpan.size() > (buffer.size() - info.position)) {
-			g_logger().error("Buffer overflow during span copy. Source span size: {}, buffer available space: {}", byteSpan.size(), buffer.size() - info.position);
+		// Check if the size of byteArray can fit into the buffer
+		if (byteArray.size() > (buffer.size() - info.position)) {
+			g_logger().error("Buffer overflow during span copy. Source span size: {}, buffer available space: {}", byteArray.size(), buffer.size() - info.position);
 			return;
 		}
 
 		g_logger().trace("[{}] called at line '{}:{}' in '{}'", __FUNCTION__, location.line(), location.column(), location.function_name());
 
-		std::ranges::copy(byteSpan, buffer.begin() + info.position);
+		if (std::memcpy(buffer.data() + info.position, byteArray.data(), byteArray.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while writing message buffer", __FUNCTION__);
+			return;
+		}
 
 		info.position += sizeof(T);
 		info.length += sizeof(T);

--- a/src/server/network/message/outputmessage.hpp
+++ b/src/server/network/message/outputmessage.hpp
@@ -47,18 +47,20 @@ public:
 
 	void append(const NetworkMessage &msg) {
 		auto msgLen = msg.getLength();
-		std::span<const unsigned char> sourceSpan(msg.getBuffer() + INITIAL_BUFFER_POSITION, msgLen);
-		std::span<unsigned char> destSpan(buffer.data() + info.position, msgLen);
-		std::ranges::copy(sourceSpan, destSpan.begin());
+		if (std::memcpy(buffer.data() + info.position, msg.getBuffer() + INITIAL_BUFFER_POSITION, msgLen) == nullptr) {
+			g_logger().error("[{}] memcpy failed while appending message", __FUNCTION__);
+			return;
+		}
 		info.length += msgLen;
 		info.position += msgLen;
 	}
 
 	void append(const OutputMessage_ptr &msg) {
 		auto msgLen = msg->getLength();
-		std::span<const unsigned char> sourceSpan(msg->getBuffer() + INITIAL_BUFFER_POSITION, msgLen);
-		std::span<unsigned char> destSpan(buffer.data() + info.position, msgLen);
-		std::ranges::copy(sourceSpan, destSpan.begin());
+		if (std::memcpy(buffer.data() + info.position, msg->getBuffer() + INITIAL_BUFFER_POSITION, msgLen) == nullptr) {
+			g_logger().error("[{}] memcpy failed while appending output message", __FUNCTION__);
+			return;
+		}
 		info.length += msgLen;
 		info.position += msgLen;
 	}
@@ -81,9 +83,11 @@ private:
 		// Convert the header to an array of unsigned char using std::bit_cast
 		auto byteArray = std::bit_cast<std::array<unsigned char, sizeof(T)>>(addHeader);
 
-		std::span<const unsigned char> byteSpan(byteArray);
 		// Copy the bytes into the buffer
-		std::ranges::copy(byteSpan, buffer.begin() + outputBufferStart);
+		if (std::memcpy(buffer.data() + outputBufferStart, byteArray.data(), byteArray.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while adding header", __FUNCTION__);
+			return;
+		}
 		// Update the message size
 		info.length += sizeof(T);
 	}

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -151,7 +151,10 @@ void Protocol::XTEA_transform(uint8_t* buffer, size_t messageLength, bool encryp
 
 	while (readPos < messageLength) {
 		std::array<uint8_t, 8> tempBuffer;
-		std::ranges::copy_n(buffer + readPos, 8, tempBuffer.begin());
+		if (std::memcpy(tempBuffer.data(), buffer + readPos, tempBuffer.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while preparing XTEA block", __FUNCTION__);
+			return;
+		}
 
 		// Convert bytes to uint32_t considering little-endian order
 		std::array<uint8_t, 4> bytes0;

--- a/src/server/network/protocol/protocol.hpp
+++ b/src/server/network/protocol/protocol.hpp
@@ -59,7 +59,10 @@ protected:
 		encryptionEnabled = true;
 	}
 	void setXTEAKey(const uint32_t* newKey) {
-		std::ranges::copy(newKey, newKey + 4, this->key.begin());
+		if (std::memcpy(key.data(), newKey, sizeof(uint32_t) * key.size()) == nullptr) {
+			g_logger().error("[{}] memcpy failed while setting XTEA key", __FUNCTION__);
+			return;
+		}
 	}
 
 	void setChecksumMethod(ChecksumMethods_t method) {


### PR DESCRIPTION
This pull request refactors several buffer copying operations throughout the networking codebase to use `std::memcpy` instead of `std::ranges::copy` and related span-based copying. The changes add error checking after each `memcpy` call, logging an error and returning early if the copy fails. This improves robustness and consistency in handling buffer operations, especially for network message serialization and cryptographic routines.

**Buffer Copying Refactor and Error Handling**

* Replaced all usages of `std::ranges::copy` and related span-based copying in `NetworkMessage` methods (`addString`, `addBytes`, `append`, serialization/deserialization) with `std::memcpy`, adding error checks and logging for failed copies in `networkmessage.cpp` and `networkmessage.hpp`. [[1]](diffhunk://#diff-e5fc3bee294fe149d73c65098b0041a71f89e1c200050e918076aa9819bd20d4L166-R169) [[2]](diffhunk://#diff-e5fc3bee294fe149d73c65098b0041a71f89e1c200050e918076aa9819bd20d4L216-R222) [[3]](diffhunk://#diff-e5fc3bee294fe149d73c65098b0041a71f89e1c200050e918076aa9819bd20d4L297-R306) [[4]](diffhunk://#diff-fff76ab6a89f9b2010b7bc39819fc7cd1e6027f95864a53ccc4b2039d3b9f738L54-R57) [[5]](diffhunk://#diff-fff76ab6a89f9b2010b7bc39819fc7cd1e6027f95864a53ccc4b2039d3b9f738L90-R103)
* Updated `OutputMessage` append and header methods to use `std::memcpy` with error logging, ensuring safe copying of message buffers in `outputmessage.hpp`. [[1]](diffhunk://#diff-32d35b4472a42a1b0050dcdb9dcf0d94e8cb74b2fffb76498a4a64e503b679e3L50-R63) [[2]](diffhunk://#diff-32d35b4472a42a1b0050dcdb9dcf0d94e8cb74b2fffb76498a4a64e503b679e3L84-R90)

**Cryptographic Operations**

* Refactored XTEA block preparation in `Protocol::XTEA_transform` to use `std::memcpy` with error handling for copying 8-byte blocks, improving reliability in `protocol.cpp`.
* Changed XTEA key assignment in `Protocol::setXTEAKey` to use `std::memcpy` with error checking, ensuring proper key initialization in `protocol.hpp`.