### PR TITLE
feat: prevent idle kick when KICK_AFTER_MINUTES is zero

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7925,7 +7925,7 @@ void Player::onThink(uint32_t interval) {
 	idleTime += interval;
 	if (playerTile && !playerTile->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer() && !isExerciseTraining() && !vipStaysOnline) {
 		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
-		if (idleTime > (kickAfterMinutes * 60000) + 60000) {
+		if (kickAfterMinutes > 0 && idleTime > (kickAfterMinutes * 60000) + 60000) {
 			removePlayer(true);
 		} else if (client && idleTime == 60000 * kickAfterMinutes) {
 			std::ostringstream ss;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7923,9 +7923,9 @@ void Player::onThink(uint32_t interval) {
 	const auto &playerTile = getTile();
 	const bool vipStaysOnline = isVip() && g_configManager().getBoolean(VIP_STAY_ONLINE);
 	idleTime += interval;
-	if (playerTile && !playerTile->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer() && !isExerciseTraining() && !vipStaysOnline) {
-		const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
-		if (kickAfterMinutes > 0 && idleTime > (kickAfterMinutes * 60000) + 60000) {
+	const int32_t kickAfterMinutes = g_configManager().getNumber(KICK_AFTER_MINUTES);
+	if (kickAfterMinutes > 0 && playerTile && !playerTile->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer() && !isExerciseTraining() && !vipStaysOnline) {
+		if (idleTime > (kickAfterMinutes * 60000) + 60000) {
 			removePlayer(true);
 		} else if (client && idleTime == 60000 * kickAfterMinutes) {
 			std::ostringstream ss;


### PR DESCRIPTION
This pull request introduces a small improvement to the player idle timeout logic. The change ensures that the idle kick check only applies if the `KICK_AFTER_MINUTES` configuration value is greater than zero, preventing unintended behavior when the setting is disabled.

- Player idle timeout logic: Added a check to ensure `kickAfterMinutes` is greater than zero before applying the idle kick, preventing players from being kicked if the configuration is set to zero. (`src/creatures/players/player.cpp`)