### PR TITLE
fix: update GitHub Actions to use versioned actions

### DIFF
--- a/.github/workflows/analysis-reviewdog-cppcheck.yml
+++ b/.github/workflows/analysis-reviewdog-cppcheck.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         if: github.ref != 'refs/heads/main'
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
           concurrent_skipping: "same_content"
           cancel_others: true
 
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1.0.3

--- a/.github/workflows/analysis-reviewdog.yml
+++ b/.github/workflows/analysis-reviewdog.yml
@@ -10,13 +10,13 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         if: github.ref != 'refs/heads/main'
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
           concurrent_skipping: "same_content"
           cancel_others: true
 
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1.0.3
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1.0.3
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1.15.0
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1.0.3
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Run yamllint
         uses: reviewdog/action-yamllint@v1.6.1
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: hadolint
         uses: reviewdog/action-hadolint@v1.33.0
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: actionlint
         uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Setup Latest Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -65,7 +65,7 @@ jobs:
           echo "Architecture: $(uname -m)"
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           max-size: "1G"
           key: ccache-macos-${{ matrix.buildtype }}
@@ -83,23 +83,23 @@ jobs:
           echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" >> "$GITHUB_ENV"
 
       - name: Get vcpkg commit id from vcpkg.json
-        uses: lukka/run-vcpkg@main
+        uses: lukka/run-vcpkg@v11.5
         with:
           vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
           vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@main
+        uses: lukka/get-cmake@v4.2.1
 
       - name: Run CMake
-        uses: lukka/run-cmake@main
+        uses: lukka/run-cmake@v10.8
         with:
           configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 
       - name: Create and Upload Artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: canary-macos-${{ matrix.buildtype }}-${{ github.sha }}
           path: |

--- a/.github/workflows/build-ubuntu-dummy.yml
+++ b/.github/workflows/build-ubuntu-dummy.yml
@@ -26,4 +26,4 @@ jobs:
     steps:
       - run: echo "This is a dummy job to satisfy branch protection checks"
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Install Linux Dependencies
         run: >
@@ -73,7 +73,7 @@ jobs:
           sudo update-alternatives --set gcc /usr/bin/gcc-14
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           max-size: "1G"
           key: ccache-${{ matrix.os }}-${{ matrix.buildtype }}
@@ -88,23 +88,23 @@ jobs:
           echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" >> "$GITHUB_ENV"
 
       - name: Get vcpkg commit id from vcpkg.json
-        uses: lukka/run-vcpkg@main
+        uses: lukka/run-vcpkg@v11.5
         with:
           vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
           vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@main
+        uses: lukka/get-cmake@v4.2.1
 
       - name: Run CMake
-        uses: lukka/run-cmake@main
+        uses: lukka/run-cmake@v10.8
         with:
           configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 
       - name: Create and Upload Artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: canary-${{ matrix.os }}-${{ matrix.buildtype }}-${{ github.sha }}
           path: |

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -42,10 +42,10 @@ jobs:
               sccache
     steps:
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           max-size: "1G"
           variant: "sccache"
@@ -59,6 +59,7 @@ jobs:
 
       - name: Restore artifacts and install vcpkg
         id: vcpkg-step
+        shell: pwsh
         run: |
           $json=Get-Content vcpkg.json -Raw | ConvertFrom-Json
           $vcpkgCommitId=$json.'builtin-baseline'
@@ -66,23 +67,23 @@ jobs:
           echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Get vcpkg commit id from vcpkg.json
-        uses: lukka/run-vcpkg@main
+        uses: lukka/run-vcpkg@v11.5
         with:
           vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
           vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
 
       - name: Get latest CMake and ninja
-        uses: lukka/get-cmake@main
+        uses: lukka/get-cmake@v4.2.1
 
       - name: Run CMake
-        uses: lukka/run-cmake@main
+        uses: lukka/run-cmake@v10.8
         with:
           configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON']"
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}
 
       - name: Create and Upload Artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: canary-${{ matrix.buildtype }}-${{ github.sha }}
           path: |

--- a/.github/workflows/build-windows-solution.yml
+++ b/.github/workflows/build-windows-solution.yml
@@ -51,9 +51,10 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
 
       - name: Install vcpkg
+        shell: pwsh
         run: |
           $vcpkgJson = Get-Content .\vcpkg.json -Raw | ConvertFrom-Json
           $vcpkgCommitId = $vcpkgJson.'builtin-baseline'.Trim()
@@ -76,7 +77,7 @@ jobs:
         run: msbuild.exe /p:VcpkgEnableManifest=true /p:Configuration=Debug /p:Platform=x64 /p:GITHUB_WORKSPACE="$env:GITHUB_WORKSPACE" vcproj/canary.sln
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: ${{ matrix.os }}-${{ matrix.buildtype }}
           path: |

--- a/.github/workflows/mysql-schema-check.yml
+++ b/.github/workflows/mysql-schema-check.yml
@@ -32,7 +32,7 @@ jobs:
     name: Check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1
       - name: 📌 MySQL Start & init & show db
         run: |
           sudo /etc/init.d/mysql start

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,6 +7,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/tests-lua.yml
+++ b/.github/workflows/tests-lua.yml
@@ -21,4 +21,4 @@ jobs:
         run: sudo apt-get install -y libluajit-5.1-dev
 
       - name: Check out code.
-        uses: actions/checkout@main
+        uses: actions/checkout@v6.0.1


### PR DESCRIPTION
Replaced usage of ```@main``` and ```@master``` with specific version tags for all GitHub Actions in workflow files. This improves build stability and security by ensuring consistent action versions are used across CI workflows.
