### PR TITLE
fix: avoid infinite loop in replaceString with empty sought parameter

### DIFF
--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -247,7 +247,7 @@ std::string generateToken(const std::string &key, uint32_t ticks) {
 }
 
 void replaceString(std::string &str, const std::string &sought, const std::string &replacement) {
-	if (str.empty()) {
+	if (str.empty() || sought.empty()) {
 		return;
 	}
 

--- a/tests/unit/utils/string_functions_test.cpp
+++ b/tests/unit/utils/string_functions_test.cpp
@@ -23,6 +23,7 @@ TEST_P(ReplaceStringTest, ReplacesStrings) {
 
 static const std::vector<ReplaceStringTestCase> kReplaceStringTestCases {
 	{ "", "", "", "", "empty" },
+	{ "subject", "", "x", "subject" },
 	{ "all together", " ", "_", "all_together", "spaces" },
 	{ "beautiful", "u", "", "beatifl", "remove char" },
 	{ "empty_empty_empty_", "empty_", "", "", "remove substr" },


### PR DESCRIPTION
Implement safeguards in the replaceString function to prevent the occurrence of an infinite loop when the function is invoked with an empty search term. This change can be achieved by validating the input parameters before processing, ensuring that the search term is neither empty nor null, thus allowing the function to exit gracefully without causing any unintended repetitive behavior.