### PR TITLE
fix: vcxproj build problems

### DIFF
--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -591,11 +591,7 @@
   <Target Name="DisplayRunProtoCompileValue" BeforeTargets="ProtoCompile">
     <Message Text="RunProtoCompile value: $(RunProtoCompile)" Importance="high" />
   </Target>
-  <PropertyGroup Condition="'$(RunProtoCompile)'=='true'">
-    <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
-    <ProtoPath>$(SourcePath)\protobuf</ProtoPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(RunProtoCompile)'=='false'">
+  <PropertyGroup>
     <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
     <ProtoPath>$(SourcePath)\protobuf</ProtoPath>
   </PropertyGroup>

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -50,6 +50,7 @@
     <ClInclude Include="..\src\creatures\players\animus_mastery\animus_mastery.hpp" />
     <ClInclude Include="..\src\creatures\players\components\player_badge.hpp" />
     <ClInclude Include="..\src\creatures\players\components\player_cyclopedia.hpp" />
+    <ClInclude Include="..\src\creatures\players\components\player_forge_history.hpp" />
     <ClInclude Include="..\src\creatures\players\components\player_storage.hpp" />
     <ClInclude Include="..\src\creatures\players\components\player_title.hpp" />
     <ClInclude Include="..\src\creatures\players\components\player_vip.hpp" />
@@ -271,6 +272,7 @@
     <ClCompile Include="..\src\creatures\players\animus_mastery\animus_mastery.cpp" />
     <ClCompile Include="..\src\creatures\players\components\player_badge.cpp" />
     <ClCompile Include="..\src\creatures\players\components\player_cyclopedia.cpp" />
+    <ClCompile Include="..\src\creatures\players\components\player_forge_history.cpp" />
     <ClCompile Include="..\src\creatures\players\components\player_storage.cpp" />
     <ClCompile Include="..\src\creatures\players\components\player_title.cpp" />
     <ClCompile Include="..\src\creatures\players\components\player_vip.cpp" />
@@ -441,7 +443,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <OutDir>$(ProjectDir)../</OutDir>
-    <SourcePath>$(OutDirFullPath)src</SourcePath>
+    <SourcePath>$(OutDirFullPath)../src/</SourcePath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -514,7 +516,6 @@
       <Optimization>Disabled</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>
-      $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
       vcpkg_installed\$(VcpkgTriplet)\include\;
       generated
       </AdditionalIncludeDirectories>
@@ -535,7 +536,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>
-      $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\lib\;
       vcpkg_installed\$(VcpkgTriplet)\lib\
       </AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -551,7 +551,6 @@
       <Optimization>MaxSpeed</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>
-      $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\include\;
       vcpkg_installed\$(VcpkgTriplet)\include\;
       generated
       </AdditionalIncludeDirectories>
@@ -571,7 +570,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>
-      $(GITHUB_WORKSPACE)\vcpkg\installed\$(VcpkgTriplet)\lib\;
       vcpkg_installed\$(VcpkgTriplet)\lib\
       </AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -594,12 +592,12 @@
     <Message Text="RunProtoCompile value: $(RunProtoCompile)" Importance="high" />
   </Target>
   <PropertyGroup Condition="'$(RunProtoCompile)'=='true'">
-    <ProtocPath>$(ProjectDir)vcpkg_installed\$(VcpkgTriplet)\tools\protobuf\protoc</ProtocPath>
-    <ProtoPath>..\$(SourcePath)\protobuf</ProtoPath>
+    <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
+    <ProtoPath>$(SourcePath)\protobuf</ProtoPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RunProtoCompile)'=='false'">
-    <ProtocPath>$(ProjectDir)vcpkg_installed\$(VcpkgTriplet)\tools\protobuf\protoc</ProtocPath>
-    <ProtoPath>$(GITHUB_WORKSPACE)\src\protobuf</ProtoPath>
+    <ProtocPath>$(VcpkgInstalledDir)\$(VcpkgTriplet)\tools\protobuf\protoc.exe</ProtocPath>
+    <ProtoPath>$(SourcePath)\protobuf</ProtoPath>
   </PropertyGroup>
   <ItemGroup>
     <ProtoFiles Include="$(ProtoPath)\*.proto" />

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -443,7 +443,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <OutDir>$(ProjectDir)../</OutDir>
-    <SourcePath>$(OutDirFullPath)../src/</SourcePath>
+    <SourcePath>$(ProjectDir)..\src\</SourcePath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -516,8 +516,9 @@
       <Optimization>Disabled</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>
-      vcpkg_installed\$(VcpkgTriplet)\include\;
-      generated
+      $(VcpkgInstalledDir)\$(VcpkgTriplet)\include\;
+      generated;
+      %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <WarningLevel>Level1</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -536,7 +537,8 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>
-      vcpkg_installed\$(VcpkgTriplet)\lib\
+      $(VcpkgInstalledDir)\$(VcpkgTriplet)\lib\;
+      %(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <GenerateMapFile>false</GenerateMapFile>
@@ -551,8 +553,9 @@
       <Optimization>MaxSpeed</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>
-      vcpkg_installed\$(VcpkgTriplet)\include\;
-      generated
+      $(VcpkgInstalledDir)\$(VcpkgTriplet)\include\;
+      generated;
+      %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <WarningLevel>Level1</WarningLevel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -570,7 +573,8 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>
-      vcpkg_installed\$(VcpkgTriplet)\lib\
+      $(VcpkgInstalledDir)\$(VcpkgTriplet)\lib\;
+      %(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <GenerateMapFile>false</GenerateMapFile>
@@ -599,7 +603,7 @@
     <ProtoFiles Include="$(ProtoPath)\*.proto" />
   </ItemGroup>
   <Target Name="ProtoCompile" BeforeTargets="PrepareForBuild" DependsOnTargets="VcpkgInstallManifestDependencies">
-    <Exec Command="$(ProtocPath) --proto_path=$(ProtoPath) --cpp_out=generated %(ProtoFiles.Identity)" />
+    <Exec Command="&quot;$(ProtocPath)&quot; --proto_path=&quot;$(ProtoPath)&quot; --cpp_out=&quot;generated&quot; &quot;%(ProtoFiles.Identity)&quot;" />
     <ItemGroup>
       <ClCompile Include="generated\%(ProtoFiles.Filename).pb.cc">
         <IncludeInUnityFile>false</IncludeInUnityFile>


### PR DESCRIPTION
# Description

Fixes the following problems:
- protoc version conflict (was building from vcpkg_generated, but linking from c:/vcpkg)
- bad source path
- linker error: missing include for player forge

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

1. open vcxproj
2. build on release
3. build on debug

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized build and toolchain paths and adjusted proto generation invocation for consistent outputs.
  * Normalized dependency include/library paths to a single vcpkg-style layout.
* **New Features**
  * Included a new player-related component in build outputs so it’s packaged with releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->