### PR TITLE
fix: refine down-item snapshot for monster push

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1462,7 +1462,7 @@ void Monster::pushItems(const std::shared_ptr<Tile> &tile, const Direction &next
 		downItems.push_back(items->at(i));
 	}
 
-	for (int32_t i = static_cast<int32_t>(downItems.size()); --i >= 0;) {
+	for (auto i = static_cast<int32_t>(downItems.size()); --i >= 0;) {
 		const auto &item = downItems.at(i);
 		if (!item || !item->hasProperty(CONST_PROP_MOVABLE) || !item->canBeMoved()) {
 			continue;

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -1456,10 +1456,18 @@ void Monster::pushItems(const std::shared_ptr<Tile> &tile, const Direction &next
 	uint32_t moveCount = 0;
 	uint32_t removeCount = 0;
 	int32_t downItemSize = tile->getDownItemCount();
+	std::vector<std::shared_ptr<Item>> downItems;
+	downItems.reserve(downItemSize);
+	for (int32_t i = 0; i < downItemSize; ++i) {
+		downItems.push_back(items->at(i));
+	}
 
-	for (int32_t i = downItemSize; --i >= 0;) {
-		const auto &item = items->at(i);
+	for (int32_t i = static_cast<int32_t>(downItems.size()); --i >= 0;) {
+		const auto &item = downItems.at(i);
 		if (!item || !item->hasProperty(CONST_PROP_MOVABLE) || !item->canBeMoved()) {
+			continue;
+		}
+		if (item->getTile() != tile) {
 			continue;
 		}
 		if (!item->hasProperty(CONST_PROP_BLOCKPATH) && !item->hasProperty(CONST_PROP_BLOCKSOLID)) {

--- a/src/creatures/monsters/monster.hpp
+++ b/src/creatures/monsters/monster.hpp
@@ -347,6 +347,21 @@ private:
 	bool canWalkTo(Position pos, Direction direction);
 
 	static bool pushItem(const std::shared_ptr<Item> &item, const Direction &nextDirection);
+	/**
+	 * @brief Attempts to push or remove movable blocking items stacked on a tile in a given direction.
+	 *
+	 * Processes the tile's "down" items (bottom-to-top) and, for each movable item that blocks pathing or is solid,
+	 * attempts to push it into the adjacent tile in nextDirection or, failing that, removes the item.
+	 * Will not operate on house tiles or when the tile has no items. When one or more items are removed, a puff
+	 * visual effect is produced at the tile position.
+	 *
+	 * Behavior specifics:
+	 * - Only items that are movable, can be moved, and currently reside on the provided tile are considered.
+	 * - Stops after successfully pushing up to 20 items and removing up to 10 items (these counters are independent).
+	 *
+	 * @param tile Shared pointer to the tile whose items should be processed.
+	 * @param nextDirection Direction in which items should be pushed.
+	 */
 	static void pushItems(const std::shared_ptr<Tile> &tile, const Direction &nextDirection);
 	static bool pushCreature(const std::shared_ptr<Creature> &creature);
 	static void pushCreatures(const std::shared_ptr<Tile> &tile);


### PR DESCRIPTION
This pull request refactors the `pushItems` method in `monster.cpp` to improve how down items are handled before processing. The main change is the creation of a separate vector to store down items, which helps avoid issues with modifying the original collection during iteration and adds an extra check to ensure items belong to the correct tile.

**Refactoring and Safety Improvements:**

* Created a `downItems` vector to copy items before iteration, preventing potential issues with modifying the original `items` collection during the loop.
* Added a check to ensure each item's tile matches the target `tile` before processing, increasing the robustness of the method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tile item interaction: when creatures push items, removals now produce a small puff visual and pushing is constrained by safety limits.

* **Bug Fixes**
  * More robust handling when moving items on a tile to prevent instability or incorrect item processing during creature interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->