### PR TITLE
fix: single target damage application in CombatFunc

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1290,6 +1290,9 @@ void Combat::CombatFunc(const std::shared_ptr<Creature> &caster, const Position 
 	// The apply extensions can't modifify the damage value, so we need to create a copy of the damage value
 	auto extensionsDamage = tmpDamage;
 	applyExtensions(caster, affectedTargets, extensionsDamage, params);
+	if (affectedTargets.size() == 1) {
+		tmpDamage = extensionsDamage;
+	}
 	for (const auto &tile : tileList) {
 		if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
 			continue;
@@ -2404,9 +2407,9 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 			// If is single target, apply the damage directly
 			if (isSingleCombat) {
 				damage = targetDamage;
+			} else {
+				targetCreature->setCombatDamage(targetDamage);
 			}
-
-			targetCreature->setCombatDamage(targetDamage);
 		}
 	} else if (monster) {
 		baseChance = monster->getCriticalChance() * 100;


### PR DESCRIPTION
This pull request makes targeted adjustments to the combat damage application logic, specifically refining how damage is handled for single-target scenarios. The changes ensure that damage modifications from extensions are correctly applied when only one target is affected, and clarify the assignment of damage values in the `applyExtensions` method.

Combat damage handling improvements:

* In `Combat::CombatFunc`, the code now updates the main `tmpDamage` variable with the potentially modified damage from extensions when there is only a single target. This ensures that single-target spells or attacks receive the correct, modified damage value.
* In `Combat::applyExtensions`, the logic for setting damage values has been clarified: for single-target combat, the modified damage is applied directly to the main variable; for multi-target scenarios, the damage is set on the individual target creature.

Resolves #3600

Closes #3606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combat damage calculation consistency for single and multi-target scenarios. Damage is now properly aligned with effects and accurately applied to each affected target.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->