### PR TITLE
feat: add open PvP situations and improve skull duration logic

### DIFF
--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -333,6 +333,15 @@ public:
 	void clearPartyInvitations();
 
 	void sendUnjustifiedPoints() const;
+	void sendOpenPvpSituations();
+	void refreshSkullTicksFromLastKill();
+	void updateLastKillTimeCache(time_t killTime);
+	struct SkullTimeInfo {
+		int64_t remainingSeconds { 0 };
+		uint8_t remainingDays { 0 };
+	};
+
+	SkullTimeInfo computeSkullTimeFromLastKill() const;
 
 	GuildEmblems_t getGuildEmblem(const std::shared_ptr<Player> &player) const;
 
@@ -1487,6 +1496,8 @@ private:
 	uint64_t forgeDustLevel = 0;
 	int64_t lastFailedFollow = 0;
 	int64_t skullTicks = 0;
+	mutable int64_t m_lastKillTimeCache = 0;
+	mutable bool m_lastKillTimeCached = false;
 	int64_t lastWalkthroughAttempt = 0;
 	int64_t lastToggleMount = 0;
 	int64_t lastUIInteraction = 0;

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -376,11 +376,12 @@ void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBR
 	query << "SELECT `player_id`, `time`, `target`, `unavenged` FROM `player_kills` WHERE `player_id` = " << player->getGUID();
 	if ((result = db.storeQuery(query.str()))) {
 		int64_t lastKillTime = 0;
+		const int64_t fragTime = g_configManager().getNumber(FRAG_TIME);
 		do {
 			auto killTime = result->getNumber<time_t>("time");
-			lastKillTime = std::max<int64_t>(lastKillTime, killTime);
-			if ((time(nullptr) - killTime) <= g_configManager().getNumber(FRAG_TIME)) {
+			if ((time(nullptr) - killTime) <= fragTime) {
 				player->unjustifiedKills.emplace_back(result->getNumber<uint32_t>("target"), killTime, result->getNumber<bool>("unavenged"));
+				lastKillTime = std::max<int64_t>(lastKillTime, killTime);
 			}
 		} while (result->next());
 		player->updateLastKillTimeCache(lastKillTime);

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -375,12 +375,15 @@ void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBR
 	std::ostringstream query;
 	query << "SELECT `player_id`, `time`, `target`, `unavenged` FROM `player_kills` WHERE `player_id` = " << player->getGUID();
 	if ((result = db.storeQuery(query.str()))) {
+		int64_t lastKillTime = 0;
 		do {
 			auto killTime = result->getNumber<time_t>("time");
+			lastKillTime = std::max<int64_t>(lastKillTime, killTime);
 			if ((time(nullptr) - killTime) <= g_configManager().getNumber(FRAG_TIME)) {
 				player->unjustifiedKills.emplace_back(result->getNumber<uint32_t>("target"), killTime, result->getNumber<bool>("unavenged"));
 			}
 		} while (result->next());
+		player->updateLastKillTimeCache(lastKillTime);
 	}
 }
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4921,6 +4921,13 @@ void ProtocolGame::sendUnjustifiedPoints(const uint8_t &dayProgress, const uint8
 	writeToOutputBuffer(msg);
 }
 
+void ProtocolGame::sendOpenPvpSituations(const uint8_t &openPvpSituations) {
+	NetworkMessage msg;
+	msg.addByte(0xB8);
+	msg.addByte(openPvpSituations);
+	writeToOutputBuffer(msg);
+}
+
 void ProtocolGame::sendContainer(uint8_t cid, const std::shared_ptr<Container> &container, bool hasParent, uint16_t firstIndex) {
 	if (!player || !container) {
 		return;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4921,7 +4921,7 @@ void ProtocolGame::sendUnjustifiedPoints(const uint8_t &dayProgress, const uint8
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendOpenPvpSituations(const uint8_t &openPvpSituations) {
+void ProtocolGame::sendOpenPvpSituations(uint8_t openPvpSituations) {
 	NetworkMessage msg;
 	msg.addByte(0xB8);
 	msg.addByte(openPvpSituations);

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -330,7 +330,7 @@ private:
 
 	// Unjust Panel
 	void sendUnjustifiedPoints(const uint8_t &dayProgress, const uint8_t &dayLeft, const uint8_t &weekProgress, const uint8_t &weekLeft, const uint8_t &monthProgress, const uint8_t &monthLeft, const uint8_t &skullDuration);
-	void sendOpenPvpSituations(const uint8_t &openPvpSituations);
+	void sendOpenPvpSituations(uint8_t openPvpSituations);
 
 	void sendCancelWalk();
 	void sendChangeSpeed(const std::shared_ptr<Creature> &creature, uint16_t speed);

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -330,6 +330,7 @@ private:
 
 	// Unjust Panel
 	void sendUnjustifiedPoints(const uint8_t &dayProgress, const uint8_t &dayLeft, const uint8_t &weekProgress, const uint8_t &weekLeft, const uint8_t &monthProgress, const uint8_t &monthLeft, const uint8_t &skullDuration);
+	void sendOpenPvpSituations(const uint8_t &openPvpSituations);
 
 	void sendCancelWalk();
 	void sendChangeSpeed(const std::shared_ptr<Creature> &creature, uint16_t speed);


### PR DESCRIPTION
Introduces tracking and sending of open PvP situations to clients. Refactors skull duration calculation to use the last kill time, caches kill times for efficiency, and updates related logic in player and protocol classes. Also ensures correct skull duration and PvP situation data is sent on relevant player events.

Closes #3660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients now receive explicit notifications of current open PvP situations after combat and key player events.

* **Improvements**
  * More accurate skull/penalty timing and day-left displays using cached last-kill data.
  * Better tracking of last-kill time to improve unjustified-death records and UI accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Thanks and credits to @libergod