### PR TITLE
fix: god account type 5->6 in schema.sql and add migration

### DIFF
--- a/data-otservbr-global/migrations/54.lua
+++ b/data-otservbr-global/migrations/54.lua
@@ -1,0 +1,13 @@
+function onUpdateDatabase()
+    logger.info("Updating database to version 54 (set community manager and god to type/group 6)")
+
+    local updateAccounts = db.query([[UPDATE accounts SET type = 6 WHERE type = 5;]])
+    local updatePlayers = db.query([[UPDATE players SET group_id = 6 WHERE group_id = 5;]])
+
+    if not updateAccounts or not updatePlayers then
+        logger.error("Failed to migrate god group values to 6.")
+        return false
+    end
+
+    return true
+end

--- a/data-otservbr-global/migrations/54.lua
+++ b/data-otservbr-global/migrations/54.lua
@@ -1,13 +1,12 @@
 function onUpdateDatabase()
-    logger.info("Updating database to version 54 (set community manager and god to type/group 6)")
+	logger.info("Updating database to version 54 (set god to account type 6)")
 
-    local updateAccounts = db.query([[UPDATE accounts SET type = 6 WHERE type = 5;]])
-    local updatePlayers = db.query([[UPDATE players SET group_id = 6 WHERE group_id = 5;]])
+	local updateAccounts = db.query([[UPDATE accounts SET type = 6 WHERE type = 5;]])
 
-    if not updateAccounts or not updatePlayers then
-        logger.error("Failed to migrate god group values to 6.")
-        return false
-    end
+	if not updateAccounts then
+		logger.error("Failed to migrate god type values to 6.")
+		return false
+	end
 
-    return true
+	return true
 end

--- a/schema.sql
+++ b/schema.sql
@@ -854,7 +854,7 @@ CREATE TABLE IF NOT EXISTS `kv_store` (
 -- Create Account god/god
 INSERT INTO `accounts`
 (`id`, `name`, `email`, `password`, `type`) VALUES
-(1, 'god', '@god', '21298df8a3277357ee55b01df9530b535cf08ec1', 5);
+(1, 'god', '@god', '21298df8a3277357ee55b01df9530b535cf08ec1', 6);
 
 -- Create player on GOD account
 -- Create sample characters

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
     CONSTRAINT `server_config_pk` PRIMARY KEY (`config`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '52'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '54'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 -- Table structure `accounts`
 CREATE TABLE IF NOT EXISTS `accounts` (


### PR DESCRIPTION
# Description

god account has wrong account type in schema, this PR fixes that

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

-

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped database schema version and added a migration to apply the update.
  * Adjusted the default GOD account type from 5 to 6 to align with the updated schema.

---

Note: No user-facing changes in this release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->