### PR TITLE
fix: cap god setmaxspeed walk bug

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6790,7 +6790,7 @@ void Player::updateBaseSpeed() {
 	if (!hasFlag(PlayerFlags_t::SetMaxSpeed)) {
 		baseSpeed = static_cast<uint16_t>(vocation->getBaseSpeed() + (level - 1));
 	} else {
-		baseSpeed = PLAYER_MAX_SPEED;
+		baseSpeed = PLAYER_MAX_STAFF_SPEED;
 	}
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6785,7 +6785,7 @@ void Player::checkSkullTicks(int64_t ticks) {
 void Player::updateBaseSpeed() {
 	const uint16_t maxSpeed = hasFlag(PlayerFlags_t::SetMaxSpeed) ? PLAYER_MAX_STAFF_SPEED : PLAYER_MAX_SPEED;
 	if (!hasFlag(PlayerFlags_t::SetMaxSpeed)) {
-		const uint32_t computedSpeed = static_cast<uint32_t>(vocation->getBaseSpeed()) + (level - 1);
+		const uint32_t computedSpeed = vocation->getBaseSpeed() + (level - 1);
 		baseSpeed = static_cast<uint16_t>(std::min<uint32_t>(computedSpeed, maxSpeed));
 	} else {
 		baseSpeed = maxSpeed;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6783,14 +6783,16 @@ void Player::checkSkullTicks(int64_t ticks) {
 }
 
 void Player::updateBaseSpeed() {
-	if (baseSpeed >= PLAYER_MAX_SPEED) {
+	const uint16_t maxSpeed = hasFlag(PlayerFlags_t::SetMaxSpeed) ? PLAYER_MAX_STAFF_SPEED : PLAYER_MAX_SPEED;
+	if (baseSpeed >= maxSpeed) {
+		baseSpeed = maxSpeed;
 		return;
 	}
 
 	if (!hasFlag(PlayerFlags_t::SetMaxSpeed)) {
 		baseSpeed = static_cast<uint16_t>(vocation->getBaseSpeed() + (level - 1));
 	} else {
-		baseSpeed = PLAYER_MAX_STAFF_SPEED;
+		baseSpeed = maxSpeed;
 	}
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6785,12 +6785,9 @@ void Player::checkSkullTicks(int64_t ticks) {
 void Player::updateBaseSpeed() {
 	const uint16_t maxSpeed = hasFlag(PlayerFlags_t::SetMaxSpeed) ? PLAYER_MAX_STAFF_SPEED : PLAYER_MAX_SPEED;
 	if (!hasFlag(PlayerFlags_t::SetMaxSpeed)) {
-		baseSpeed = static_cast<uint16_t>(vocation->getBaseSpeed() + (level - 1));
+		const uint32_t computedSpeed = static_cast<uint32_t>(vocation->getBaseSpeed()) + (level - 1);
+		baseSpeed = static_cast<uint16_t>(std::min<uint32_t>(computedSpeed, maxSpeed));
 	} else {
-		baseSpeed = maxSpeed;
-	}
-
-	if (baseSpeed >= maxSpeed) {
 		baseSpeed = maxSpeed;
 	}
 }

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6784,14 +6784,13 @@ void Player::checkSkullTicks(int64_t ticks) {
 
 void Player::updateBaseSpeed() {
 	const uint16_t maxSpeed = hasFlag(PlayerFlags_t::SetMaxSpeed) ? PLAYER_MAX_STAFF_SPEED : PLAYER_MAX_SPEED;
-	if (baseSpeed >= maxSpeed) {
-		baseSpeed = maxSpeed;
-		return;
-	}
-
 	if (!hasFlag(PlayerFlags_t::SetMaxSpeed)) {
 		baseSpeed = static_cast<uint16_t>(vocation->getBaseSpeed() + (level - 1));
 	} else {
+		baseSpeed = maxSpeed;
+	}
+
+	if (baseSpeed >= maxSpeed) {
 		baseSpeed = maxSpeed;
 	}
 }

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -106,6 +106,7 @@ struct OpenContainer {
 using MuteCountMap = std::map<uint32_t, uint32_t>;
 
 static constexpr uint16_t PLAYER_MAX_SPEED = std::numeric_limits<uint16_t>::max();
+static constexpr uint16_t PLAYER_MAX_STAFF_SPEED = 1500;
 static constexpr uint16_t PLAYER_MIN_SPEED = 10;
 static constexpr uint8_t PLAYER_SOUND_HEALTH_CHANGE = 10;
 
@@ -1661,7 +1662,8 @@ private:
 
 	void updateItemsLight(bool internal = false);
 	uint16_t getStepSpeed() const override {
-		return std::max<uint16_t>(PLAYER_MIN_SPEED, std::min<uint16_t>(PLAYER_MAX_SPEED, getSpeed()));
+		const uint16_t maxStepSpeed = hasFlag(PlayerFlags_t::SetMaxSpeed) ? PLAYER_MAX_STAFF_SPEED : PLAYER_MAX_SPEED;
+		return std::max<uint16_t>(PLAYER_MIN_SPEED, std::min<uint16_t>(maxStepSpeed, getSpeed()));
 	}
 	void updateBaseSpeed();
 


### PR DESCRIPTION
Cap player step speed when SetMaxSpeed is enabled (GOD group uses setmaxspeed), preventing excessive walk speed that makes the client appear to “float” while moving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Movement speed now uses a conditional maximum: players with a special status may use a higher speed cap while others use the standard cap.
  * Base speed and per-step speed are clamped to the appropriate maximum, producing consistent and differentiated movement behavior across player types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->