### PR TITLE
fix: market enter item count overflow and enforce entry limit

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5311,16 +5311,34 @@ void ProtocolGame::sendMarketEnter(uint32_t depotId) {
 
 	// Only use here locker items, itemVector is for use of Game::createMarketOffer
 	auto [itemVector, lockerItems] = player->requestLockerItems(depotLocker, true);
-	msg.add<uint16_t>(lockerItems.size());
+	auto totalItemsCountPosition = msg.getBufferPosition();
+	msg.skipBytes(2); // Total items count
+
+	const uint16_t entriesLimit = std::numeric_limits<uint16_t>::max();
+	uint16_t entriesSent = 0;
+	bool limitReached = false;
 	for (const auto &[itemId, tierAndCountMap] : lockerItems) {
 		for (const auto &[tier, count] : tierAndCountMap) {
+			if (entriesSent >= entriesLimit) {
+				limitReached = true;
+				break;
+			}
 			msg.add<uint16_t>(itemId);
 			if (!oldProtocol && Item::items[itemId].upgradeClassification > 0) {
 				msg.addByte(tier);
 			}
 			msg.add<uint16_t>(static_cast<uint16_t>(count));
+			++entriesSent;
+		}
+		if (limitReached) {
+			break;
 		}
 	}
+
+	auto endPosition = msg.getBufferPosition();
+	msg.setBufferPosition(totalItemsCountPosition);
+	msg.add<uint16_t>(entriesSent);
+	msg.setBufferPosition(endPosition);
 
 	writeToOutputBuffer(msg);
 


### PR DESCRIPTION
This change fixes a potential overflow and protocol inconsistency when sending market depot items. Instead of directly writing the locker item count, the total number of entries is now calculated dynamically while serializing the data.

Key points:

Reserves space for the total item count and fills it after serialization.

Enforces a hard limit of uint16_t entries to prevent overflow.

Stops serialization gracefully once the limit is reached.

Ensures the item count sent to the client always matches the actual number of entries written.

This improves protocol safety and avoids client-side desynchronization or crashes when a depot contains a large number of marketable items.

Resolves #3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed market locker item count reporting to accurately reflect the total number of items sent to players. The server now employs an improved encoding mechanism to ensure that reported item counts precisely match the actual payload delivered, preventing potential count mismatches, overflow, or truncation issues in the market locker interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->