### PR TITLE
fix: prevent teleport usage with invalid destination

### DIFF
--- a/src/game/movement/teleport.cpp
+++ b/src/game/movement/teleport.cpp
@@ -72,6 +72,13 @@ void Teleport::addThing(int32_t, const std::shared_ptr<Thing> &thing) {
 		return;
 	}
 
+	if (destPos.x == 0 && destPos.y == 0 && destPos.z == 0) {
+		const auto &thingCreature = thing->getCreature();
+		const auto thingCreatureName = thingCreature ? thingCreature->getName() : "Unknown";
+		g_logger().warn("[Teleport:addThing] Skipping teleport with invalid destPos (0, 0, 0) at tile {}, for creature: {}", getPosition().toString(), thingCreatureName);
+		return;
+	}
+
 	const std::shared_ptr<Tile> &destTile = g_game().map.getTile(destPos);
 	if (!destTile) {
 		return;

--- a/src/game/movement/teleport.cpp
+++ b/src/game/movement/teleport.cpp
@@ -75,7 +75,7 @@ void Teleport::addThing(int32_t, const std::shared_ptr<Thing> &thing) {
 	if (destPos.x == 0 && destPos.y == 0 && destPos.z == 0) {
 		const auto &thingCreature = thing->getCreature();
 		const auto thingCreatureName = thingCreature ? thingCreature->getName() : "Unknown";
-		g_logger().warn("[Teleport:addThing] Skipping teleport with invalid destPos (0, 0, 0) at tile {}, for creature: {}", getPosition().toString(), thingCreatureName);
+		g_logger().debug("[Teleport:addThing] Skipping teleport with invalid destPos (0, 0, 0) at tile {}, for creature: {}", getPosition().toString(), thingCreatureName);
 		return;
 	}
 


### PR DESCRIPTION
Add a safety check to skip teleports with an invalid destination position (0,0,0). When detected, the teleport is ignored and a warning is logged with the teleport position and creature name (if available).

This prevents unintended behavior and potential crashes caused by misconfigured teleports, while improving diagnostics through clearer logging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid teleportation attempts with zeroed destination coordinates could cause errors. The system now properly validates destination positions and safely skips invalid teleports while logging diagnostic details, improving gameplay stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->