### PR TITLE
fix: roshamuul quest resonance chamber action

### DIFF
--- a/data-otservbr-global/scripts/quests/roshamuul_quest/actions_resonance_chamber.lua
+++ b/data-otservbr-global/scripts/quests/roshamuul_quest/actions_resonance_chamber.lua
@@ -82,7 +82,7 @@ function lowerRoshamuulChamber.onUse(cid, item, fromPosition, itemEx, toPosition
 		end
 
 		local raid = config.raid
-		for y, x in pairs(raid) do
+		for y, x in ipairs(raid) do
 			local i = 1
 			while i <= #x do
 				time = time + config.timeBetweenraid


### PR DESCRIPTION
Currently waves of summons are being summoned in the wrong order.

Description from tibia fandom:
The silencer raid includes 4 waves of Silencers, culminating in a wave of 3-5 Sights of Surrender.


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Behaviour
### **Actual**

After triggering the raid, the waves of monsters appear in an incorrect order.
Sights of Surrender spawn before all 4 Silencer waves are completed.


### **Expected**

The raid should spawn 4 consecutive waves of Silencers,
followed only then by a final wave of 3–5 Sights of Surrender, as documented on Tibia Fandom.


### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raid event processing in quest resonance chamber to ensure consistent ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->