### PR TITLE
fix: add dwarven helmet to the horned fox loot table

### DIFF
--- a/data-otservbr-global/monster/raids/the_horned_fox.lua
+++ b/data-otservbr-global/monster/raids/the_horned_fox.lua
@@ -87,6 +87,7 @@ monster.loot = {
 	{ id = 3483, chance = 7410 }, -- fishing rod
 	{ id = 236, chance = 7410 }, -- strong health potion
 	{ id = 7401, chance = 900 }, -- minotaur trophy,
+	{ name = "dwarven helmet", chance = 10000 },
 	{ id = 21174, chance = 12000 }, -- mino lance
 	{ id = 21175, chance = 6000 }, -- mino shield
 }


### PR DESCRIPTION
Added dwarven helmet to the horned fox loot table, % based on tibia.fandom.com


# Description
Added Dwarven Helmet to The Horned Fox loot table, based on Tibia Fandom.

According to Tibia Fandom, The Horned Fox can drop a Dwarven Helmet, however it is currently missing from the loot table.


## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

The Horned Fox was killed multiple times before and after the change.
Loot table was verified to include Dwarven Helmet.


  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version:
  - Client:
  - Operating System:

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new loot item (dwarven helmet) to The Horned Fox raid encounter's loot table, expanding the rewards players can obtain from this boss.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->