### PR TITLE
fix: add missing include

### DIFF
--- a/src/creatures/players/components/wheel/player_wheel.hpp
+++ b/src/creatures/players/components/wheel/player_wheel.hpp
@@ -11,6 +11,7 @@
 
 #include "creatures/creatures_definitions.hpp"
 #include "creatures/players/components/wheel/wheel_definitions.hpp"
+#include "creatures/players/components/wheel/wheel_spells.hpp"
 
 class Creature;
 class IOWheel;


### PR DESCRIPTION
Resolves #3456

This change fixes a compilation error caused by a missing direct include.

player_wheel.hpp uses declarations from wheel_spells.hpp but relied on
transitive includes, which fails depending on include order and compiler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency update with no impact to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->