### PR TITLE
refactor: workflows to use concurrency for run cancellation

### DIFF
--- a/.github/workflows/analysis-reviewdog.yml
+++ b/.github/workflows/analysis-reviewdog.yml
@@ -4,17 +4,14 @@ name: Analysis - Review Dog
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   luac:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        if: github.ref != 'refs/heads/main'
-        uses: fkirc/skip-duplicate-actions@v5.3.1
-        with:
-          concurrent_skipping: "same_content"
-          cancel_others: true
-
       - name: Check out code.
         uses: actions/checkout@v6.0.1
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,16 +16,11 @@ on:
     branches:
       - main
 
-jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build_docker_x86:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -20,16 +20,11 @@ env:
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   MAKEFLAGS: "-j 4"
 
-jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     name: macos-${{ matrix.buildtype }}

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -17,20 +17,15 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 2
   MAKEFLAGS: "-j 2"
 
 jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     name: ${{ matrix.os }}-${{ matrix.buildtype }}

--- a/.github/workflows/build-windows-cmake.yml
+++ b/.github/workflows/build-windows-cmake.yml
@@ -18,16 +18,11 @@ on:
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 2
   MAKEFLAGS: "-j 2"
-jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   job:
     if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
     name: ${{ matrix.os }}-${{ matrix.buildtype }}

--- a/.github/workflows/clang-lint.yml
+++ b/.github/workflows/clang-lint.yml
@@ -10,16 +10,11 @@ on:
     paths:
       - "src/**"
       - "tests/**/*.cpp"
-jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cmake-lint.yml
+++ b/.github/workflows/cmake-lint.yml
@@ -13,16 +13,11 @@ on:
       - "**/*.cmake"
       - "cmake/**"
       - .github/workflows/cmake-lint.yml
-jobs:
-  cancel-runs:
-    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lua-format.yml
+++ b/.github/workflows/lua-format.yml
@@ -8,6 +8,10 @@ on:
   push:
     paths:
       - "data*/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lua-formatter:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-lua.yml
+++ b/.github/workflows/tests-lua.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   job:
     name: Run Lua Tests


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow files to improve how concurrent workflow runs are managed. Instead of using third-party actions or custom job steps to cancel previous runs, it now leverages the native `concurrency` feature provided by GitHub Actions. This change simplifies workflow configuration and ensures that only the latest run for a given pull request or branch is active, reducing unnecessary resource usage.

**Workflow concurrency management improvements:**

* Added the `concurrency` key to all major workflow files (including `.github/workflows/build-docker.yml`, `.github/workflows/build-ubuntu.yml`, `.github/workflows/build-macos.yml`, `.github/workflows/build-windows-cmake.yml`, `.github/workflows/clang-lint.yml`, `.github/workflows/cmake-lint.yml`, `.github/workflows/lua-format.yml`, `.github/workflows/tests-lua.yml`, and `.github/workflows/analysis-reviewdog.yml`) to ensure that only one run per workflow and pull request/branch is active at a time, with any in-progress runs automatically canceled. [[1]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL19-R23) [[2]](diffhunk://#diff-3dc91c5652448e68371fa6d23e2a83da91a66ad49d85a828dcaf8bcab84ded5fR20-L33) [[3]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L23-R27) [[4]](diffhunk://#diff-86fa76102ff1c926c342c3906db6296c412c41268dbbc5cbb4878e74903744dbL21-R25) [[5]](diffhunk://#diff-3527e163d43961edc37a6f6556d78770975f85a27b70eddd4b9cf55834246bf5L13-R17) [[6]](diffhunk://#diff-4a4bd293c205efe8028460cf431f880d99567f2855b1343f09f2e1d308500709L16-R20) [[7]](diffhunk://#diff-b9d2d549d0c7b12084fb1e1d507ba1c065b179b4a5c59bf66654905fa2921cecR11-R14) [[8]](diffhunk://#diff-4ff6ba69969e2720fb21d9061c51eff4ff8dc28940e6778f91a6827e16657bfdR11-R14) [[9]](diffhunk://#diff-143f363ff1ea8a09d65926cb387a4cc922e39c0d791156abe2e7785501ff12f4R7-L17)

* Removed previous custom steps and third-party actions (`fkirc/skip-duplicate-actions` and `styfle/cancel-workflow-action`) that were used to cancel duplicate or previous workflow runs, resulting in cleaner and more maintainable workflow files. [[1]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL19-R23) [[2]](diffhunk://#diff-3dc91c5652448e68371fa6d23e2a83da91a66ad49d85a828dcaf8bcab84ded5fR20-L33) [[3]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L23-R27) [[4]](diffhunk://#diff-86fa76102ff1c926c342c3906db6296c412c41268dbbc5cbb4878e74903744dbL21-R25) [[5]](diffhunk://#diff-3527e163d43961edc37a6f6556d78770975f85a27b70eddd4b9cf55834246bf5L13-R17) [[6]](diffhunk://#diff-4a4bd293c205efe8028460cf431f880d99567f2855b1343f09f2e1d308500709L16-R20) [[7]](diffhunk://#diff-143f363ff1ea8a09d65926cb387a4cc922e39c0d791156abe2e7785501ff12f4R7-L17)

These changes streamline workflow execution, reduce maintenance overhead, and make use of GitHub's built-in capabilities for managing concurrent runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline workflows to more efficiently manage concurrent builds. Updated workflow configurations to automatically cancel duplicate in-progress runs when new builds are triggered, reducing unnecessary resource consumption and pipeline clutter across multiple build and test workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->