### PR TITLE
fix: party hunt loot values (market data)

### DIFF
--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -19,6 +19,7 @@
 	#include <cstdint>
 	#include <memory>
 	#include <cmath>
+	#include <compare>
 #endif
 
 // Enum

--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -1810,6 +1810,23 @@ struct voiceBlock_t {
 	bool yellText;
 };
 
+struct AnalyzerItemKey {
+	uint16_t itemId = 0;
+	uint8_t tier = 0;
+
+	AnalyzerItemKey() = default;
+	AnalyzerItemKey(uint16_t id, uint8_t tierIndex) :
+		itemId(id),
+		tier(tierIndex) { }
+
+	bool operator<(const AnalyzerItemKey &other) const {
+		if (itemId != other.itemId) {
+			return itemId < other.itemId;
+		}
+		return tier < other.tier;
+	}
+};
+
 struct PartyAnalyzer {
 	PartyAnalyzer(uint32_t playerId, std::string playerName) :
 		id(playerId),
@@ -1824,6 +1841,6 @@ struct PartyAnalyzer {
 	uint64_t lootPrice = 0;
 	uint64_t supplyPrice = 0;
 
-	std::map<uint16_t, uint64_t> lootMap; // [itemID] = amount
-	std::map<uint16_t, uint64_t> supplyMap; // [itemID] = amount
+	std::map<AnalyzerItemKey, uint64_t> lootMap; // [itemID, tier] = amount
+	std::map<AnalyzerItemKey, uint64_t> supplyMap; // [itemID, tier] = amount
 };

--- a/src/creatures/creatures_definitions.hpp
+++ b/src/creatures/creatures_definitions.hpp
@@ -1819,12 +1819,7 @@ struct AnalyzerItemKey {
 		itemId(id),
 		tier(tierIndex) { }
 
-	bool operator<(const AnalyzerItemKey &other) const {
-		if (itemId != other.itemId) {
-			return itemId < other.itemId;
-		}
-		return tier < other.tier;
-	}
+	auto operator<=>(const AnalyzerItemKey &other) const = default;
 };
 
 struct PartyAnalyzer {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3394,11 +3394,7 @@ uint64_t Game::getItemMarketPrice(const std::map<uint16_t, uint64_t> &itemMap, b
 		const auto marketIt = itemsPriceMap.find(itemId);
 		if (marketIt != itemsPriceMap.end()) {
 			const auto &tierMap = marketIt->second;
-			auto tierIt = tierMap.find(0);
-			if (tierIt == tierMap.end() && !tierMap.empty()) {
-				tierIt = tierMap.begin();
-			}
-
+			const auto tierIt = tierMap.find(0);
 			if (tierIt != tierMap.end()) {
 				const uint64_t price = tierIt->second;
 				itemValue = price * count;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3427,32 +3427,21 @@ uint64_t Game::getItemMarketAveragePrice(uint16_t itemId, uint8_t tier) const {
 	}
 
 	const auto &market = IOMarket::getInstance();
-	const auto purchaseStats = market.getPurchaseStatistics();
-	const auto saleStats = market.getSaleStatistics();
+	const auto snapshot = market.getStatistics(itemId, tier);
 
 	uint64_t purchaseAverage = 0;
 	uint64_t saleAverage = 0;
 	bool hasPurchaseData = false;
 	bool hasSaleData = false;
 
-	if (const auto purchaseIt = purchaseStats.find(itemId); purchaseIt != purchaseStats.end()) {
-		if (const auto tierIt = purchaseIt->second.find(tier); tierIt != purchaseIt->second.end()) {
-			const auto &s = tierIt->second;
-			if (s.numTransactions > 0) {
-				purchaseAverage = s.totalPrice / s.numTransactions;
-				hasPurchaseData = true;
-			}
-		}
+	if (snapshot.purchase && snapshot.purchase->numTransactions > 0) {
+		purchaseAverage = snapshot.purchase->totalPrice / snapshot.purchase->numTransactions;
+		hasPurchaseData = true;
 	}
 
-	if (const auto saleIt = saleStats.find(itemId); saleIt != saleStats.end()) {
-		if (const auto tierIt = saleIt->second.find(tier); tierIt != saleIt->second.end()) {
-			const auto &s = tierIt->second;
-			if (s.numTransactions > 0) {
-				saleAverage = s.totalPrice / s.numTransactions;
-				hasSaleData = true;
-			}
-		}
+	if (snapshot.sale && snapshot.sale->numTransactions > 0) {
+		saleAverage = snapshot.sale->totalPrice / snapshot.sale->numTransactions;
+		hasSaleData = true;
 	}
 
 	if (hasPurchaseData && hasSaleData) {

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -235,6 +235,7 @@ public:
 	ObjectCategory_t getObjectCategory(const ItemType &it);
 
 	uint64_t getItemMarketPrice(const std::map<uint16_t, uint64_t> &itemMap, bool buyPrice) const;
+	uint64_t getItemMarketAveragePrice(uint16_t itemId, uint8_t tier) const;
 
 	void loadPlayersRecord();
 	void checkPlayersRecord();

--- a/src/io/iomarket.cpp
+++ b/src/io/iomarket.cpp
@@ -388,3 +388,22 @@ IOMarket::StatisticsMap IOMarket::getSaleStatistics() const {
 	std::scoped_lock lock(statisticsMutex);
 	return saleStatistics;
 }
+
+IOMarket::StatisticsSnapshot IOMarket::getStatistics(uint16_t itemId, uint8_t tier) const {
+	StatisticsSnapshot snapshot;
+	std::scoped_lock lock(statisticsMutex);
+
+	if (const auto purchaseIt = purchaseStatistics.find(itemId); purchaseIt != purchaseStatistics.end()) {
+		if (const auto tierIt = purchaseIt->second.find(tier); tierIt != purchaseIt->second.end()) {
+			snapshot.purchase = tierIt->second;
+		}
+	}
+
+	if (const auto saleIt = saleStatistics.find(itemId); saleIt != saleStatistics.end()) {
+		if (const auto tierIt = saleIt->second.find(tier); tierIt != saleIt->second.end()) {
+			snapshot.sale = tierIt->second;
+		}
+	}
+
+	return snapshot;
+}

--- a/src/io/iomarket.hpp
+++ b/src/io/iomarket.hpp
@@ -44,6 +44,11 @@ public:
 	using StatisticsMap = std::map<uint16_t, std::map<uint8_t, MarketStatistics>>;
 	StatisticsMap getPurchaseStatistics() const;
 	StatisticsMap getSaleStatistics() const;
+	struct StatisticsSnapshot {
+		std::optional<MarketStatistics> purchase;
+		std::optional<MarketStatistics> sale;
+	};
+	StatisticsSnapshot getStatistics(uint16_t itemId, uint8_t tier) const;
 
 	static uint8_t getTierFromDatabaseTable(const std::string &string);
 

--- a/src/io/iomarket.hpp
+++ b/src/io/iomarket.hpp
@@ -42,12 +42,8 @@ public:
 	void updateStatistics();
 
 	using StatisticsMap = std::map<uint16_t, std::map<uint8_t, MarketStatistics>>;
-	const StatisticsMap &getPurchaseStatistics() const {
-		return purchaseStatistics;
-	}
-	const StatisticsMap &getSaleStatistics() const {
-		return saleStatistics;
-	}
+	StatisticsMap getPurchaseStatistics() const;
+	StatisticsMap getSaleStatistics() const;
 
 	static uint8_t getTierFromDatabaseTable(const std::string &string);
 
@@ -55,4 +51,5 @@ private:
 	// [uint16_t = item id, [uint8_t = item tier, MarketStatistics = structure of the statistics]]
 	StatisticsMap purchaseStatistics;
 	StatisticsMap saleStatistics;
+	mutable std::mutex statisticsMutex;
 };

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -48,6 +48,7 @@
 #include <stack>
 #include <source_location>
 #include <span>
+#include <compare>
 
 // --------------------
 // System Includes


### PR DESCRIPTION
# Description

Currently, Party Hunt loot values (specifically for market data) don't behave like Global values.

## **_### OBSERVATION_**
Small differences still occur due to missing NPCs in the canary folders. For example, Meat has the highest price value from an NPC called 'Fral the Butcher' (15GP), but due to its being missing, the canary server will send NPC Arito/Jezzara (10GP). Creating differences between Supply Analyzer and Party Hunt Analyzer.

<img width="400" height="347" alt="image" src="https://github.com/user-attachments/assets/a948f430-7617-4251-8760-935932138909" /><img width="400" height="513" alt="image" src="https://github.com/user-attachments/assets/0d060324-cf21-433c-847d-bda702599c21" />



## Behaviour
### **Actual**

When selecting Market from Party Hunt analyzer, the values never use market historical data to generate an average of value.

### **Expected**

Expects to get the item's average historical data from the market (Buy Average + Sell Average) / 2. If no historical data in the server, then fall back to buy data value (NPCs).

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Tested Party Hunt x Loot Analyser x Hunting Analyser
CIP Client
<img width="446" height="1026" alt="image" src="https://github.com/user-attachments/assets/f7c2ae00-db1f-423e-a5d9-f815676ff4d4" />

OTC Redemption + Party Member
<img width="1556" height="1309" alt="image" src="https://github.com/user-attachments/assets/4a8becec-b128-4fc6-a84a-80687b9e6762" />

  - [X] Confirms data with the Cyclopedia information
<img width="1394" height="1027" alt="image" src="https://github.com/user-attachments/assets/e4f74278-2bc8-49e5-9812-c89b99affc89" />
<img width="1779" height="1099" alt="image" src="https://github.com/user-attachments/assets/fab08a55-31cb-4aac-9d8e-9cf45cd73fbb" />
<img width="1772" height="1095" alt="image" src="https://github.com/user-attachments/assets/28cdd611-be84-48d5-932d-a6ba747a7d73" />

  - [X] CIPSoft Tibia 1412
<img width="2223" height="1314" alt="image" src="https://github.com/user-attachments/assets/9544ca53-0725-42b8-8479-d3093bfa92e5" />

  - [X] OTClient Mehah (Needs https://github.com/mehah/otclient/pull/1310)

**Test Configuration**:

  - Server Version: 1412
  - Client: OTC and CipSoft 1412
  - Operating System: W11, SERVER UBUNTU 2204

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items are tracked with tier-aware keys for per-player loot and supply.
  * Tiered market-average price lookup for more accurate valuation.
  * Thread-safe market statistics accessors returning snapshot maps.

* **Bug Fixes**
  * Pricing now prefers tier-aware market averages with reliable fallbacks.
  * Improved market price calculation with correct coin-value handling and safer statistics updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->