### PR TITLE
fix: Ice Islands Quest and Buddel after Barbarian test

### DIFF
--- a/data-otservbr-global/npc/buddel.lua
+++ b/data-otservbr-global/npc/buddel.lua
@@ -82,7 +82,7 @@ addTravelKeyword("okolnir", "It's nice there. Except of the ice dragons which ar
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -93,7 +93,7 @@ addTravelKeyword("helheim", "T'at is a small island to the east.", Position(3246
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -106,7 +106,7 @@ addTravelKeyword("tyrsung", "*HICKS* Big, big island east of here. Venorian hunt
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -117,7 +117,7 @@ addTravelKeyword("camp", "Both of you look like you could defend yourself! If yo
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)

--- a/data-otservbr-global/npc/buddel_helheim.lua
+++ b/data-otservbr-global/npc/buddel_helheim.lua
@@ -79,7 +79,7 @@ addTravelKeyword("svargrond", "You know a town nicer than this? NICER DICER! Apr
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -90,7 +90,7 @@ addTravelKeyword("okolnir", "It's nice there. Except of the ice dragons which ar
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -101,7 +101,7 @@ addTravelKeyword("tyrsung", "*HICKS* Big, big island east of here. Venorian hunt
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -112,7 +112,7 @@ addTravelKeyword("camp", "Both of you look like you could defend yourself! If yo
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)

--- a/data-otservbr-global/npc/buddel_okolnir.lua
+++ b/data-otservbr-global/npc/buddel_okolnir.lua
@@ -82,7 +82,7 @@ addTravelKeyword("svargrond", "You know a town nicer than this? NICER DICER! Apr
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -93,7 +93,7 @@ addTravelKeyword("camp", "Both of you look like you could defend yourself! If yo
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -104,7 +104,7 @@ addTravelKeyword("helheim", "T'at is a small island to the east.", Position(3246
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -117,7 +117,7 @@ addTravelKeyword("tyrsung", "*HICKS* Big, big island east of here. Venorian hunt
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)

--- a/data-otservbr-global/npc/buddel_raider_camp.lua
+++ b/data-otservbr-global/npc/buddel_raider_camp.lua
@@ -82,7 +82,7 @@ addTravelKeyword("svargrond", "You know a town nicer than this? NICER DICER! Apr
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -93,7 +93,7 @@ addTravelKeyword("okolnir", "It's nice there. Except of the ice dragons which ar
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -104,7 +104,7 @@ addTravelKeyword("helheim", "T'at is a small island to the east.", Position(3246
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -117,7 +117,7 @@ addTravelKeyword("tyrsung", "*HICKS* Big, big island east of here. Venorian hunt
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)

--- a/data-otservbr-global/npc/buddel_tyrsung.lua
+++ b/data-otservbr-global/npc/buddel_tyrsung.lua
@@ -82,7 +82,7 @@ addTravelKeyword("svargrond", "You know a town nicer than this? NICER DICER! Apr
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -93,7 +93,7 @@ addTravelKeyword("okolnir", "It's nice there. Except of the ice dragons which ar
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -104,7 +104,7 @@ addTravelKeyword("helheim", "T'at is a small island to the east.", Position(3246
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)
@@ -117,7 +117,7 @@ addTravelKeyword("camp", "Both of you look like you could defend yourself! If yo
 end, function()
 	return math.random(5) > 1
 end, function(player)
-	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8
+	return player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) ~= 8
 end, function(player)
 	return player:getItemCount(3097) > 0
 end, function(player)

--- a/data-otservbr-global/npc/lurik.lua
+++ b/data-otservbr-global/npc/lurik.lua
@@ -95,7 +95,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceMusic, 62)
 			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 62)
 			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.IceMusicDoor, 1)
-		elseif player:getStorageValue(Storage.TheIceIslands.Questline) == 32 then
+		elseif player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline) == 32 then
 			npcHandler:say({
 				"You are the one who became an honorary barbarian! The one who made friends with the grim local musher and helped the shamans of Nibelor! The one they call old bearhugg ... erm ... I mean indeed I might have a mission for someone like you ...",
 				"We are trying to find out what is happening in the raider camps. Through our connection to the shamans we could get a covered contact in their majorcamp far to the south. We equipped our contact with a memory crystal so he could report all he knew ...",


### PR DESCRIPTION
Hi !

Only files related to npcs were changed.

Buddel needed fix becouse after we got value 8 at 41174 of BarbarianTest (After completing with Sven)
Buddel would say that we are not barbarians and we cannot travel.
Now he wont travel anyone whose questline status is other than 8.
Edited all Buddels.

Lurik similar problem, even though we had proper TheIceIslands.Questline number 32 he didnt respond to "mission".
Its becouse there was a mistake in storage path.
				

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [X] Done quests till i needed to speak with npcs. Couldnt move forward. Tested after changes. All good.
  - [ ] Test B

**Test Configuration**:

  - Server Version:14.12
  - Client:14.12.95
  - Operating System: w11 / ubuntu server

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

Imo easy changes but efficient.
BTW. My first pull request ever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Corrected NPC travel availability conditions across multiple locations to properly gate routes based on BarbarianTest questline progression. Travel options now accurately reflect quest status requirements.
- Updated a quest condition reference in NPC dialogue to use the correct quest data structure for consistent interaction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->