### PR TITLE
ci: enable vcpkg binary caching (x-gha/nuget) and fix build caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # --- Fast Checks ---
 

--- a/.github/workflows/reusable-build-docker.yml
+++ b/.github/workflows/reusable-build-docker.yml
@@ -42,4 +42,4 @@ jobs:
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha
-          cache-to: type=gha, mode=max
+          cache-to: type=gha,mode=max

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       CC: gcc-13
       CXX: g++-13
+      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          nuget=$(vcpkg fetch nuget | tail -n 1)
-          $nuget sources add \
+          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | tail -n 1)
+          "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
+          unset VCPKG_FORCE_SYSTEM_BINARIES
           NUGET_PATH=$(vcpkg fetch nuget | tail -n 1)
           mono "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CC: gcc-13
       CXX: g++-13
-      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | tail -n 1)
+          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)
           "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          mono $(vcpkg fetch nuget) sources add \
+          nuget=$(vcpkg fetch nuget | tail -n 1)
+          $nuget sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CC: gcc-13
       CXX: g++-13
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,6 +48,15 @@ jobs:
           key: ccache-linux-${{ matrix.buildtype }}
           restore-keys: |
             ccache-linux
+
+      - name: Setup NuGet for vcpkg
+        run: |
+          mono $(vcpkg fetch nuget) sources add \
+            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            -storepasswordincleartext \
+            -name "GitHubPackages" \
+            -username "${{ github.repository_owner }}" \
+            -password "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -49,10 +49,13 @@ jobs:
           restore-keys: |
             ccache-linux
 
+      - name: Install mono for NuGet
+        run: sudo apt-get update && sudo apt-get install -y mono-complete
+
       - name: Setup NuGet for vcpkg
         run: |
-          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)
-          "$NUGET_PATH" sources add \
+          NUGET_PATH=$(vcpkg fetch nuget | tail -n 1)
+          mono "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
+          unset VCPKG_FORCE_SYSTEM_BINARIES
           NUGET_PATH=$(vcpkg fetch nuget | tail -n 1)
           mono "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          mono $(vcpkg fetch nuget) sources add \
+          nuget=$(vcpkg fetch nuget | tail -n 1)
+          $nuget sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -8,7 +8,7 @@ jobs:
     name: Compile (macOS)
     runs-on: macos-latest
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,6 +37,15 @@ jobs:
           key: ccache-macos-release
           restore-keys: |
             ccache-macos
+
+      - name: Setup NuGet for vcpkg
+        run: |
+          mono $(vcpkg fetch nuget) sources add \
+            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            -storepasswordincleartext \
+            -name "GitHubPackages" \
+            -username "${{ github.repository_owner }}" \
+            -password "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -38,10 +38,13 @@ jobs:
           restore-keys: |
             ccache-macos
 
+      - name: Install mono for NuGet
+        run: brew install mono
+
       - name: Setup NuGet for vcpkg
         run: |
-          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)
-          "$NUGET_PATH" sources add \
+          NUGET_PATH=$(vcpkg fetch nuget | tail -n 1)
+          mono "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -25,7 +25,6 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Get vcpkg baseline
-        id: vcpkg-baseline
         shell: bash
         run: |
           set -euo pipefail
@@ -38,6 +37,8 @@ jobs:
           set -euo pipefail
           brew update
           brew install ccache ninja pkg-config mono
+          which ninja
+          ninja --version
 
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.20
@@ -47,15 +48,21 @@ jobs:
           restore-keys: |
             ccache-macos
 
-      - name: Setup NuGet for vcpkg
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
+
+      - name: Setup NuGet source for vcpkg (GitHub Packages)
         shell: bash
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
           unset VCPKG_FORCE_SYSTEM_BINARIES
 
-          # vcpkg may print the path among other lines; select absolute path lines
           NUGET_PATH="$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)"
           if [[ -z "${NUGET_PATH}" || ! -f "${NUGET_PATH}" ]]; then
             echo "Failed to locate NuGet fetched by vcpkg."
@@ -63,7 +70,6 @@ jobs:
             exit 1
           fi
 
-          # idempotent
           mono "${NUGET_PATH}" sources remove -name "GitHubPackages" >/dev/null 2>&1 || true
           mono "${NUGET_PATH}" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
@@ -72,14 +78,16 @@ jobs:
             -username "${{ github.repository_owner }}" \
             -password "${NUGET_AUTH_TOKEN}"
 
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
-          vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
+      - name: Configure (CMake preset)
+        shell: bash
+        run: |
+          set -euo pipefail
+          unset VCPKG_FORCE_SYSTEM_BINARIES
+          cmake --preset macos-release
 
-      - name: Run CMake
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: macos-release
-          buildPreset: macos-release
+      - name: Build (CMake preset)
+        shell: bash
+        run: |
+          set -euo pipefail
+          unset VCPKG_FORCE_SYSTEM_BINARIES
+          cmake --build --preset macos-release

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | tail -n 1)
+          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)
           "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -3,6 +3,10 @@ name: Reusable macOS Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     name: Compile (macOS)
@@ -17,18 +21,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-              core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-              core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Get vcpkg baseline
         id: vcpkg-baseline
         shell: bash
         run: |
+          set -euo pipefail
           vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')
           echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" >> "$GITHUB_ENV"
 
-      - name: Install macOS Dependencies
-        run: brew install ccache ninja pkg-config
+      - name: Install macOS dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew update
+          brew install ccache ninja pkg-config mono
 
       - name: CCache
         uses: hendrikmuhs/ccache-action@v1.2.20
@@ -38,19 +47,30 @@ jobs:
           restore-keys: |
             ccache-macos
 
-      - name: Install mono for NuGet
-        run: brew install mono
-
       - name: Setup NuGet for vcpkg
+        shell: bash
+        env:
+          NUGET_AUTH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           unset VCPKG_FORCE_SYSTEM_BINARIES
-          NUGET_PATH=$(vcpkg fetch nuget | tail -n 1)
-          mono "$NUGET_PATH" sources add \
+
+          # vcpkg may print the path among other lines; select absolute path lines
+          NUGET_PATH="$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)"
+          if [[ -z "${NUGET_PATH}" || ! -f "${NUGET_PATH}" ]]; then
+            echo "Failed to locate NuGet fetched by vcpkg."
+            vcpkg fetch nuget 2>&1 || true
+            exit 1
+          fi
+
+          # idempotent
+          mono "${NUGET_PATH}" sources remove -name "GitHubPackages" >/dev/null 2>&1 || true
+          mono "${NUGET_PATH}" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \
             -username "${{ github.repository_owner }}" \
-            -password "${{ secrets.GITHUB_TOKEN }}"
+            -password "${NUGET_AUTH_TOKEN}"
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Compile (macOS)
     runs-on: macos-latest
+    env:
+      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -8,7 +8,7 @@ jobs:
     name: Compile (macOS)
     runs-on: macos-latest
     env:
-      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Setup NuGet for vcpkg
         run: |
-          nuget=$(vcpkg fetch nuget | tail -n 1)
-          $nuget sources add \
+          NUGET_PATH=$(vcpkg fetch nuget 2>&1 | tail -n 1)
+          "$NUGET_PATH" sources add \
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             -storepasswordincleartext \
             -name "GitHubPackages" \

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Setup NuGet for vcpkg
         shell: pwsh
         run: |
-          & $(vcpkg fetch nuget) sources add `
+          $nuget = (vcpkg fetch nuget | Select-Object -Last 1)
+          & $nuget sources add `
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
             -storepasswordincleartext `
             -name "GitHubPackages" `

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         type: [CMake, Solution]
     runs-on: windows-2025
+    env:
+      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
     steps:
       - name: Install VS 2026 Build Tools (v145 toolset)
         if: matrix.type == 'Solution'

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -12,7 +12,7 @@ jobs:
         type: [CMake, Solution]
     runs-on: windows-2025
     env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
     steps:
       - name: Install VS 2026 Build Tools (v145 toolset)
         if: matrix.type == 'Solution'
@@ -59,6 +59,16 @@ jobs:
           key: ccache-windows-release
           restore-keys: |
             ccache-windows
+
+      - name: Setup NuGet for vcpkg
+        shell: pwsh
+        run: |
+          & $(vcpkg fetch nuget) sources add `
+            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
+            -storepasswordincleartext `
+            -name "GitHubPackages" `
+            -username "${{ github.repository_owner }}" `
+            -password "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -12,7 +12,7 @@ jobs:
         type: [CMake, Solution]
     runs-on: windows-2025
     env:
-      VCPKG_BINARY_SOURCES: "clear;gha,readwrite"
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
       - name: Install VS 2026 Build Tools (v145 toolset)
         if: matrix.type == 'Solution'

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -3,6 +3,10 @@ name: Reusable Windows Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Compile (${{ matrix.type }})
@@ -19,7 +23,6 @@ jobs:
         shell: pwsh
         run: |
           choco install visualstudio2026-workload-vctools --yes --ignore-package-exit-codes=3010
-          # The tools are usually available immediately after installation without reboot
 
       - name: Setup MSBuild.exe
         if: matrix.type == 'Solution'
@@ -35,20 +38,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-              core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-              core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Get vcpkg baseline
-        id: vcpkg-baseline
         shell: pwsh
         run: |
           $json = Get-Content vcpkg.json -Raw | ConvertFrom-Json
           $vcpkgCommitId = $json.'builtin-baseline'
-          echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Remove Windows pre-installed MySQL
         if: matrix.type == 'CMake'
-        run: rm -r -fo C:/mysql*
+        shell: pwsh
+        run: Remove-Item -Recurse -Force C:\mysql* -ErrorAction SilentlyContinue
 
       - name: CCache
         if: matrix.type == 'CMake'
@@ -60,20 +63,31 @@ jobs:
           restore-keys: |
             ccache-windows
 
-      - name: Setup NuGet for vcpkg
+      # IMPORTANT: configure the nuget.exe that MSBuild/vcpkg.targets actually uses (Chocolatey)
+      - name: Setup NuGet source for GitHub Packages (for MSBuild/vcpkg.targets)
         shell: pwsh
+        env:
+          NUGET_AUTH_TOKEN: ${{ github.token }}
         run: |
-          $nuget = (vcpkg fetch nuget | Select-Object -Last 1)
+          $feed = "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+          $nuget = (Get-Command nuget.exe -ErrorAction SilentlyContinue).Source
+          if (-not $nuget) { throw "nuget.exe not found in PATH" }
+
+          & $nuget sources remove -Name "GitHubPackages" | Out-Null 2>$null
           & $nuget sources add `
-            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
-            -storepasswordincleartext `
-            -name "GitHubPackages" `
-            -username "${{ github.repository_owner }}" `
-            -password "${{ secrets.GITHUB_TOKEN }}"
+            -Name "GitHubPackages" `
+            -Source $feed `
+            -UserName "${{ github.repository_owner }}" `
+            -Password "$env:NUGET_AUTH_TOKEN" `
+            -StorePasswordInClearText
+
+          & $nuget sources list
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
         with:
+          # For Solution builds, keep vcpkg inside repo to match your msbuild /p:VcpkgRoot
           vcpkgDirectory: ${{ matrix.type == 'Solution' && format('{0}/vcpkg', github.workspace) || '' }}
           vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
           vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
@@ -91,14 +105,16 @@ jobs:
         run: |
           $vcpkgRoot = Join-Path (Get-Location) "vcpkg"
           $outDir = Join-Path (Get-Location) "artifacts"
-          New-Item -ItemType Directory -Force -Path $outDir
-          msbuild.exe /p:VcpkgEnableManifest=true `
-                      /p:Configuration=Debug `
-                      /p:Platform=x64 `
-                      /p:VcpkgRoot="$vcpkgRoot" `
-                      /p:OutDir="$outDir\\" `
-                      /p:GITHUB_WORKSPACE="${{ github.workspace }}" `
-                      vcproj/canary.sln
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          msbuild.exe vcproj/canary.sln `
+            /m `
+            /p:Configuration=Debug `
+            /p:Platform=x64 `
+            /p:VcpkgEnableManifest=true `
+            /p:VcpkgRoot="$vcpkgRoot" `
+            /p:OutDir="$outDir\\" `
+            /p:GITHUB_WORKSPACE="${{ github.workspace }}"
 
       - name: Upload artifacts
         if: matrix.type == 'Solution'


### PR DESCRIPTION
This pull request updates the CI/CD workflows for Linux, macOS, and Windows to improve integration with GitHub Packages via NuGet, enhance security with explicit permissions, and streamline the vcpkg setup process. The changes ensure that builds can pull and push packages to GitHub Packages across all platforms, and update dependency installation steps for better reliability and maintainability.

**GitHub Packages and NuGet Integration:**

* Added or updated configuration in all workflows (`reusable-build-linux.yml`, `reusable-build-macos.yml`, `reusable-build-windows.yml`) to set up NuGet sources for vcpkg, enabling seamless use of GitHub Packages as a binary cache for dependencies. This includes installing `mono` where needed, configuring NuGet credentials, and ensuring the correct NuGet executable is used on each platform. [[1]](diffhunk://#diff-8ec705cdab68163f020f695fbe58c1f013b415457be33ebfc2bed446002290a5R17) [[2]](diffhunk://#diff-8ec705cdab68163f020f695fbe58c1f013b415457be33ebfc2bed446002290a5R52-R65) [[3]](diffhunk://#diff-2870fee641f4df5c19b12fa919c9e53b57339238b8e17934551a6902304ba202R6-R15) [[4]](diffhunk://#diff-2870fee641f4df5c19b12fa919c9e53b57339238b8e17934551a6902304ba202L45-R93) [[5]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225R6-R9) [[6]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225R66-R90)

**Security and Permissions:**

* Explicitly set `permissions` blocks in all workflows to restrict GitHub Actions token scopes to only what is needed for reading contents and interacting with packages. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR31-R34) [[2]](diffhunk://#diff-2870fee641f4df5c19b12fa919c9e53b57339238b8e17934551a6902304ba202R6-R15) [[3]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225R6-R9)

**Dependency Installation and Environment Setup:**

* Updated dependency installation steps for Linux and macOS to ensure required tools (like `mono`, `ccache`, `ninja`, and `pkg-config`) are installed and available. Improved reliability by using `set -euo pipefail` in shell scripts.
* Set the `VCPKG_BINARY_SOURCES` environment variable in all workflows to use the GitHub Packages NuGet feed for binary caching. [[1]](diffhunk://#diff-8ec705cdab68163f020f695fbe58c1f013b415457be33ebfc2bed446002290a5R17) [[2]](diffhunk://#diff-2870fee641f4df5c19b12fa919c9e53b57339238b8e17934551a6902304ba202R6-R15) [[3]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225R18-L20)

**Workflow Improvements and Consistency:**

* Refined baseline extraction and artifact upload steps for better cross-platform compatibility and error handling. Updated some steps to use consistent shell environments and commands. [[1]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225L40-R54) [[2]](diffhunk://#diff-efe3f1fdc38a3743d97dda7428fe846b66d91cb741a4b94eba650f21e6e3b225L81-R117) [[3]](diffhunk://#diff-2870fee641f4df5c19b12fa919c9e53b57339238b8e17934551a6902304ba202L22-R41)

**Build Step Refactoring (macOS):**

* Refactored CMake build steps on macOS to separate configure and build phases, and replaced the previous composite `run-cmake` action with explicit shell commands for better control and debugging.