### PR TITLE
Add Monk vocation rewards to daily rewards

### DIFF
--- a/data/modules/scripts/daily_reward/daily_reward.lua
+++ b/data/modules/scripts/daily_reward/daily_reward.lua
@@ -71,6 +71,7 @@ local DailyRewardItems = {
 	[VOCATION.BASE_ID.DRUID] = { 266, 268, 237, 238, 23373, 3203, 3161, 3178, 3153, 3197, 3149, 3164, 3200, 3192, 3188, 3190, 3189, 3156, 3191, 3158, 3152, 3180, 3173, 3176, 3195, 3175, 3155, 3202 },
 	[VOCATION.BASE_ID.SORCERER] = { 266, 268, 237, 238, 23373, 3203, 3161, 3178, 3153, 3197, 3149, 3164, 3200, 3192, 3188, 3190, 3189, 3191, 3158, 3152, 3180, 3173, 3176, 3195, 3175, 3155, 3202 },
 	[VOCATION.BASE_ID.KNIGHT] = { 266, 236, 239, 7643, 23375, 268, 3203, 3161, 3178, 3153, 3197, 3149, 3164, 3200, 3192, 3188, 3190, 3189, 3191, 3158, 3152, 3180, 3173, 3176, 3195, 3175, 3155, 3202 },
+	[VOCATION.BASE_ID.MONK] = { 266, 236, 268, 237, 7642, 23374, 3203, 3161, 3178, 3153, 3197, 3149, 3164, 3200, 3192, 3188, 3190, 3189, 3191, 3158, 3152, 3180, 3173, 3176, 3195, 3175, 3155, 3202 },
 }
 
 DailyReward = {
@@ -554,7 +555,7 @@ function Player.readDailyReward(self, msg, currentDay, state)
 	end
 
 	if systemType == DAILY_REWARD_SYSTEM_TYPE_ONE then
-		rewards = DailyRewardItems[self:getVocation():getBaseId()]
+		rewards = DailyRewardItems[self:getVocation():getBaseId()] or DailyRewardItems[0]
 		if dailyTable.items then
 			rewards = dailyTable.items
 		end


### PR DESCRIPTION
This pull request updates the daily reward system to better support the new Monk vocation and improve reward fallback behavior. The main changes are:

**Monk vocation support:**
* Added a new entry for `MONK` in the `DailyRewardItems` table, providing a specific list of reward item IDs for Monk players.

**Reward fallback logic:**
* Updated the reward selection logic in `Player.readDailyReward` to default to the base vocation (ID 0) rewards if the player's vocation is not explicitly listed in `DailyRewardItems`.