### PR TITLE
fix: lion's rock quest - small topaz and searing fire field

### DIFF
--- a/data-otservbr-global/scripts/actions/other/gems.lua
+++ b/data-otservbr-global/scripts/actions/other/gems.lua
@@ -183,11 +183,9 @@ function gems.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	return false
 end
 
-gems:id(3029)
-gems:id(3030)
-gems:id(3032)
-gems:id(3033)
-gems:id(9057)
-
+for index, value in pairs(shrine) do
+	gems:id(index)
 end
+
+gems:id(9057)
 gems:register()

--- a/data-otservbr-global/scripts/actions/other/gems.lua
+++ b/data-otservbr-global/scripts/actions/other/gems.lua
@@ -59,7 +59,7 @@ local lionsRock = {
 		storage = Storage.Quest.U10_70.LionsRock.Questline,
 		value = 8,
 		item = 3033,
-		fieldId = 7465,
+		fieldId = 2137,
 		message = "You place the amethyst on the small socket. A violet flame begins to burn.",
 		effect = CONST_ME_PURPLESMOKE,
 	},

--- a/data-otservbr-global/scripts/actions/other/gems.lua
+++ b/data-otservbr-global/scripts/actions/other/gems.lua
@@ -183,7 +183,11 @@ function gems.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	return false
 end
 
-for index, value in pairs(shrine) do
-	gems:id(index)
+gems:id(3029)
+gems:id(3030)
+gems:id(3032)
+gems:id(3033)
+gems:id(9057)
+
 end
 gems:register()

--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -607,10 +607,6 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		target:transform(594)
 		target:decay()
 		toPosition:sendMagicEffect(CONST_ME_HITAREA)
-	elseif target.itemid == 6298 and target.actionid > 0 then
-		target:transform(615)
-		target:decay()
-		toPosition:sendMagicEffect(CONST_ME_HITAREA)
 	elseif target.itemid == 21341 then
 		target:transform(21342)
 		target:decay()


### PR DESCRIPTION
1) Fixed gem function id's.
Before it didnt use id 9057 at all - so small topaz couldnt be ever used on proper tile.


2)Replaced firefield ld
7465 -> 2137
Becouse previous field could be moved by hand. The one you make with amethyst.

Now Lion's Rock Quest can be completed.
I checked it ingame.


************NEW PART AFTER CODERABBIT CHECK**************
3) to be deleted unused "end" in gems.lua - done
4) deleted unintended transformation on item id 6298 on a way to the hidden city of beregar.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gem recognition and placement so only intended gems interact correctly with shrines.
  * Removed an unintended transformation that occurred when using a pick on a specific item, preventing unexpected item changes.

* **Improvements**
  * Added support for an additional gem to be included in the public gem registry, improving gem availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->