### PR TITLE
fix: memory safety for metrics initialization

### DIFF
--- a/src/lib/metrics/metrics.cpp
+++ b/src/lib/metrics/metrics.cpp
@@ -39,7 +39,7 @@ void Metrics::init(Options opts) {
 		p->AddMetricReader(std::move(prometheusExporter));
 	}
 
-	metrics_api::Provider::SetMeterProvider(std::move(provider));
+	metrics_api::Provider::SetMeterProvider(std::shared_ptr<metrics_api::MeterProvider>(std::move(provider)));
 	initHistograms();
 }
 


### PR DESCRIPTION
## Description

This PR addresses a potential ownership issue during the initialization of the metrics system. By wrapping the provider in a `std:: shared_ptr` before passing to `metrics_api::Provider::SetMeterProvider`, ensure that the meter provider's lifecycle is correctly managed by the OpenTelemetry API.

This prevents undefined behavior (memory leaks or segmentation faults) if the local scope provider is destroyed prematurely.

## Changes

**Location:** `Metrics::init`

**Logic:** Enhanced provider handling by utilizing `std::shared_ptr` to ensure shared ownership

semantics.

## How to Test To verify this implementation, use the following build commands:

1. Configure with metrics enabled:

```shell
cmake --preset linux-release -DFEATURE_METRICS=ON -DVCPKG_MANIFEST_FEATURES=metrics
```

2. Build the binary:

```shell
cmake --build build/linux-release
```

Note: Make sure you have the OpenTelemetry dependencies correctly installed via VCPKG as specified in the manifest features.