### PR TITLE
fix: architecture info message in recompile.sh

### DIFF
--- a/recompile.sh
+++ b/recompile.sh
@@ -27,7 +27,7 @@ check_architecture() {
 		info "its architecture is ARM"
 		ARCHITECTUREVALUE=1
 	else
-		info "its architecture is ARM $ARCHITECTURE"
+		info "its architecture is $ARCHITECTURE"
 	fi
 }
 

--- a/recompile.sh
+++ b/recompile.sh
@@ -24,7 +24,7 @@ check_command() {
 
 check_architecture() {
 	if [[ $ARCHITECTURE == "aarch64"* ]]; then
-		info "its architecture is ARM"
+		info "its architecture is $ARCHITECTURE (ARM)"
 		ARCHITECTUREVALUE=1
 	else
 		info "its architecture is $ARCHITECTURE"


### PR DESCRIPTION
Remove hardcoded ARM

This pull request makes a minor improvement to the log message in the `check_architecture()` function in `recompile.sh`. The message now correctly displays the detected architecture value instead of redundantly stating "ARM".

* Updated log message to accurately report the detected architecture in `check_architecture()` within `recompile.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved architecture log wording: ARM architectures are now shown as "<ARCHITECTURE> (ARM)" and non-ARM architectures as "<ARCHITECTURE>", removing redundant "ARM" prefix for clearer, more accurate output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->