### PR TITLE
ci/cd: make reviewdog reporter dynamic and fail on errors

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -63,11 +63,12 @@ jobs:
       - name: Run Analysis (Reviewdog)
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_REPORTER: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-check' }}
         run: |
-          reviewdog -reporter=github-pr-check -runners=luac
-          reviewdog -reporter=github-pr-check -runners=luacheck
-          reviewdog -reporter=github-pr-check -runners=xmllint
-          reviewdog -reporter=github-pr-check -runners=cppcheck
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luac -fail-level=error
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luacheck -fail-level=error
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=xmllint -fail-level=error
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=cppcheck -fail-level=error
 
       - name: Run yamllint
         uses: reviewdog/action-yamllint@v1.6.1

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -2,10 +2,9 @@
 runner:
 
   cppcheck:
-    cmd: cppcheck --enable=warning,style,performance,portability --suppress=missingIncludeSystem --template="{file}:{line}:{message}" -i src/protobuf -i vcpkg -i vcpkg_installed -i build -i .git -i cmake-build-debug -i cmake-build-release --max-configs=1 -j 2 src/
+    cmd: cppcheck --enable=warning,style,performance,portability --suppress=missingIncludeSystem --template="{file}:{line}:{severity}:{message}" -i src/protobuf -i vcpkg -i vcpkg_installed -i build -i .git -i cmake-build-debug -i cmake-build-release --max-configs=1 -j 2 src/ | sed 's/:error:/:E:/;s/:warning:/:W:/;s/:style:/:I:/;s/:performance:/:I:/;s/:portability:/:I:/'
     errorformat:
-      - "%f:%l:%m"
-    level: warning
+      - "%f:%l:%t:%m"
 
   luacheck:
     cmd: luacheck --formatter=plain --no-color --no-config --no-global \
@@ -20,10 +19,10 @@ runner:
     cmd: find data/ -name '*.lua' -exec sh -c 'luajit -b "$1" /dev/null' _ {} \;
     errorformat:
       - "%r: %f:%l: %m"
-    level: warning
+    level: error
 
   xmllint:
     cmd: find data/ -name '*.xml' -exec xmllint --noout {} \;
     errorformat:
       - "%f:%l: %m"
-    level: warning
+    level: error

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -11,7 +11,7 @@ runner:
     cmd: luacheck --formatter=plain --no-color --no-config --no-global \
       --no-unused --no-unused-args --no-cache --no-max-line-length \
       --no-max-code-line-length --no-max-string-line-length \
-      --no-max-comment-line-length -d ./data/ || true
+      --no-max-comment-line-length --ignore 4 -d ./data/ || true
     errorformat:
       - "%f:%l:%c: %m"
     level: warning

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -2,7 +2,7 @@
 runner:
 
   cppcheck:
-    cmd: cppcheck --enable=warning,style,performance,portability --suppress=missingIncludeSystem --template="{file}:{line}:{severity}:{message}" -i src/protobuf -i vcpkg -i vcpkg_installed -i build -i .git -i cmake-build-debug -i cmake-build-release --max-configs=1 -j 2 src/ | sed 's/:error:/:E:/;s/:warning:/:W:/;s/:style:/:I:/;s/:performance:/:I:/;s/:portability:/:I:/'
+    cmd: cppcheck --enable=warning,style,performance,portability --suppress=missingIncludeSystem --template="{file}:{line}:{severity}:{message}" -i src/protobuf -i vcpkg -i vcpkg_installed -i build -i .git -i cmake-build-debug -i cmake-build-release --max-configs=1 -j 2 src/ 2>&1 | sed 's/:error:/:E:/;s/:warning:/:W:/;s/:style:/:I:/;s/:performance:/:I:/;s/:portability:/:I:/'
     errorformat:
       - "%f:%l:%t:%m"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/opentibiabr/canary/actions/workflows/ci.yml/badge.svg)](https://github.com/opentibiabr/canary/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=opentibiabr_canary&metric=alert_status)](https://sonarcloud.io/dashboard?id=opentibiabr_canary)
 ![GitHub repo size](https://img.shields.io/github/repo-size/opentibiabr/canary)
-[![GitHub](https://img.shields.io/github/license/opentibiabr/canary)](https://github.com/opentibiabr/canary/blob/main/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/opentibiabr/canary.svg)](https://github.com/opentibiabr/canary/blob/main/LICENSE)
 
 OpenTibiaBR - Canary is a free and open-source MMORPG server emulator written in C++. It is a fork of the [OTServBR-Global](https://github.com/opentibiabr/otservbr-global) project. To connect to the server and to take a stable experience, you can use [mehah's otclient](https://github.com/mehah/otclient)
 or [tibia client](https://github.com/dudantas/tibia-client/releases/latest) and if you want to edit something, check


### PR DESCRIPTION
Set REVIEWDOG_REPORTER based on the event (github-pr-check for pull_request, github-check otherwise) and use it for all reviewdog runners. Add -fail-level=error to luac, luacheck, xmllint and cppcheck invocations so errors cause failing checks. Update .reviewdog.yml luacheck command to include --ignore 4 for the ./data/ run. These changes ensure the appropriate reporter is used per event and that error-level findings fail the workflow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: Dynamic review reporting and stricter failure behavior; linting steps updated to surface severities consistently, map tool severities to standard levels, and suppress extra diagnostics for the data folder. Some tool warnings were elevated to errors.
* **Documentation**
  * Updated license badge and expanded project intro with references to related tools and editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->