### PR TITLE
ci/cd: filter reviewdog to added lines; update ignores

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -65,10 +65,10 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEWDOG_REPORTER: ${{ github.event_name == 'pull_request' && 'github-pr-check' || 'github-check' }}
         run: |
-          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luac -fail-level=error
-          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luacheck -fail-level=error
-          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=xmllint -fail-level=error
-          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=cppcheck -fail-level=error
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luac -fail-level=error -filter-mode=added
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=luacheck -fail-level=error -filter-mode=added
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=xmllint -fail-level=error -filter-mode=added
+          reviewdog -reporter="${REVIEWDOG_REPORTER}" -runners=cppcheck -fail-level=error -filter-mode=added
 
       - name: Run yamllint
         uses: reviewdog/action-yamllint@v1.6.1

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -10,7 +10,7 @@ runner:
     cmd: luacheck --formatter=plain --no-color --no-config --no-global \
       --no-unused --no-unused-args --no-cache --no-max-line-length \
       --no-max-code-line-length --no-max-string-line-length \
-      --no-max-comment-line-length --ignore 4 -d ./data/ || true
+      --no-max-comment-line-length --ignore 4 211 212 213 311 542 -d ./data/ || true
     errorformat:
       - "%f:%l:%c: %m"
     level: warning


### PR DESCRIPTION
This pull request introduces improvements to the static analysis workflow and configuration, focusing on reducing noise from irrelevant warnings and ensuring that review comments are limited to newly added code. The most important changes are grouped below:

**Workflow improvements:**

* [`.github/workflows/reusable-checks.yml`](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L68-R71): Updated all `reviewdog` runners to use the `-filter-mode=added` flag, so review comments are only generated for lines added in the pull request, reducing unnecessary feedback on unchanged code.

**Configuration enhancements:**

* [`.reviewdog.yml`](diffhunk://#diff-1f2dcdcd6a3efbb45dcf0dc62b5c72b093007f0586221f983e8549c2daf1a719L13-R13): Expanded the list of ignored warning codes for the `luacheck` runner to include `211`, `212`, `213`, `311`, and `542`, further minimizing irrelevant warnings during linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis configuration to focus on newly added issues and expanded linting exclusions for improved development workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->