### PR TITLE
feat: implement player food tracking & Lua binding

### DIFF
--- a/data/scripts/actions/items/carrot_cake.lua
+++ b/data/scripts/actions/items/carrot_cake.lua
@@ -13,6 +13,7 @@ function carrotCake.onUse(player, item, fromPosition, target, toPosition, isHotk
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(distanceCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel more focused.")
 	player:say("Mmmm.", TALKTYPE_MONSTER_SAY)

--- a/data/scripts/actions/items/coconut_shrimp_bake.lua
+++ b/data/scripts/actions/items/coconut_shrimp_bake.lua
@@ -18,6 +18,7 @@ function coconutShrimpBake.onUse(player, item, fromPosition, target, toPosition,
 		return true
 	end
 
+	player:updateFood(item:getId(), 86400)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your underwater walking speed while wearing a " .. headItem:getName() .. " has increased for twenty-four hours.")
 	player:say("Yum.", TALKTYPE_MONSTER_SAY)
 	player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)

--- a/data/scripts/actions/items/demonic_candy_ball.lua
+++ b/data/scripts/actions/items/demonic_candy_ball.lua
@@ -47,12 +47,15 @@ function demonicCandyBall.onUse(player, item, fromPosition, target, toPosition, 
 	local randomConditionIndex = math.random(1, 4)
 
 	if randomConditionIndex == 1 then
+		player:updateFood(item:getId(), 3600)
 		player:addCondition(availableConditions[math.random(1, #availableConditions)])
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel stronger, but you have no idea what was increased.")
 	elseif randomConditionIndex == 2 then
+		player:updateFood(item:getId(), 3600)
 		player:addCondition(lightCondition)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel enlightened.")
 	elseif randomConditionIndex == 3 then
+		player:updateFood(item:getId(), 3600)
 		player:addCondition(condition_i)
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You became invisible.")
 	elseif randomConditionIndex == 4 then

--- a/data/scripts/actions/items/filled_jalapeno_peppers.lua
+++ b/data/scripts/actions/items/filled_jalapeno_peppers.lua
@@ -10,6 +10,7 @@ function filledJalapenoPeppers.onUse(player, item, fromPosition, target, toPosit
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(speedCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your speed has been increased.")
 	player:say("Munch.", TALKTYPE_MONSTER_SAY)

--- a/data/scripts/actions/items/foods.lua
+++ b/data/scripts/actions/items/foods.lua
@@ -148,6 +148,7 @@ function food.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	end
 
+	player:updateFood(item:getId(), itemFood[1] * 12)
 	player:feed(itemFood[1] * 12)
 	player:say(itemFood[2], TALKTYPE_MONSTER_SAY)
 	player:updateSupplyTracker(item)

--- a/data/scripts/actions/items/hireling_foods.lua
+++ b/data/scripts/actions/items/hireling_foods.lua
@@ -48,6 +48,7 @@ function hirelingFoods.onUse(player, item, fromPosition, target, toPosition, isH
 	end
 
 	if dish.condition then
+		player:updateFood(item:getId(), 3600)
 		player:addCondition(dish.condition)
 	elseif dish.healing then
 		player:addHealth(player:getMaxHealth() * 0.3)

--- a/data/scripts/actions/items/northern_fishburger.lua
+++ b/data/scripts/actions/items/northern_fishburger.lua
@@ -13,6 +13,7 @@ function northernFishburger.onUse(player, item, fromPosition, target, toPosition
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(fishingCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You felt fishing inspiration.")
 	player:say("Smack.", TALKTYPE_MONSTER_SAY)

--- a/data/scripts/actions/items/roasted_dragon_wings.lua
+++ b/data/scripts/actions/items/roasted_dragon_wings.lua
@@ -13,6 +13,7 @@ function roastedDragonWings.onUse(player, item, fromPosition, target, toPosition
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(defenseCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel less vulnerable.")
 	player:say("Chomp.", TALKTYPE_MONSTER_SAY)

--- a/data/scripts/actions/items/tropical_fried_terrorbird.lua
+++ b/data/scripts/actions/items/tropical_fried_terrorbird.lua
@@ -13,6 +13,7 @@ function tropicalFriedTerrorbird.onUse(player, item, fromPosition, target, toPos
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(magicLevelCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel smarter.")
 	player:say("Chomp.", TALKTYPE_MONSTER_SAY)

--- a/data/scripts/actions/items/veggie_casserole.lua
+++ b/data/scripts/actions/items/veggie_casserole.lua
@@ -13,6 +13,7 @@ function veggieCasserole.onUse(player, item, fromPosition, target, toPosition, i
 		return true
 	end
 
+	player:updateFood(item:getId(), 3600)
 	player:addCondition(meleeCondition)
 	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You feel stronger.")
 	player:say("Yum.", TALKTYPE_MONSTER_SAY)

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5333,24 +5333,23 @@ bool Player::isConcoctionActive(Concoction_t concotion) const {
 }
 
 // Food system
-void Player::updateFood(uint16_t itemId, uint16_t timeLeft) {
+void Player::updateFood(uint16_t itemId, uint32_t timeLeft) {
 	if (timeLeft == 0) {
-		m_activeFoods.erase(itemId);
+		[[maybe_unused]] auto erased = m_activeFoods.erase(itemId);
 	} else {
 		m_activeFoods[itemId] = timeLeft;
 	}
 }
 
-const std::map<uint16_t, uint16_t> &Player::getActiveFoods() const {
+const std::map<uint16_t, uint32_t> &Player::getActiveFoods() const {
 	return m_activeFoods;
 }
 
 bool Player::isFoodActive(uint16_t itemId) const {
-	if (!m_activeFoods.contains(itemId)) {
-		return false;
+	if (auto it = m_activeFoods.find(itemId); it != m_activeFoods.end()) {
+		return it->second > 0;
 	}
-	const auto timeLeft = m_activeFoods.at(itemId);
-	return timeLeft > 0;
+	return false;
 }
 
 bool Player::checkAutoLoot(bool isBoss) const {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5341,7 +5341,7 @@ void Player::updateFood(uint16_t itemId, uint16_t timeLeft) {
 	}
 }
 
-std::map<uint16_t, uint16_t> Player::getActiveFoods() const {
+const std::map<uint16_t, uint16_t> &Player::getActiveFoods() const {
 	return m_activeFoods;
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5332,6 +5332,27 @@ bool Player::isConcoctionActive(Concoction_t concotion) const {
 	return timeLeft > 0;
 }
 
+// Food system
+void Player::updateFood(uint16_t itemId, uint16_t timeLeft) {
+	if (timeLeft == 0) {
+		m_activeFoods.erase(itemId);
+	} else {
+		m_activeFoods[itemId] = timeLeft;
+	}
+}
+
+std::map<uint16_t, uint16_t> Player::getActiveFoods() const {
+	return m_activeFoods;
+}
+
+bool Player::isFoodActive(uint16_t itemId) const {
+	if (!m_activeFoods.contains(itemId)) {
+		return false;
+	}
+	const auto timeLeft = m_activeFoods.at(itemId);
+	return timeLeft > 0;
+}
+
 bool Player::checkAutoLoot(bool isBoss) const {
 	if (!g_configManager().getBoolean(AUTOLOOT)) {
 		return false;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1478,8 +1478,8 @@ public:
 
 	void sendSpellCooldowns();
 
-	void updateFood(uint16_t itemId, uint16_t timeLeft);
-	const std::map<uint16_t, uint16_t> &getActiveFoods() const;
+	void updateFood(uint16_t itemId, uint32_t timeLeft);
+	const std::map<uint16_t, uint32_t> &getActiveFoods() const;
 	bool isFoodActive(uint16_t itemId) const;
 
 private:
@@ -1572,7 +1572,7 @@ private:
 	std::map<uint8_t, int64_t> moduleDelayMap;
 	std::map<uint16_t, uint64_t> itemPriceMap;
 
-	std::map<uint16_t, uint16_t> m_activeFoods;
+	std::map<uint16_t, uint32_t> m_activeFoods;
 
 	std::map<uint64_t, std::shared_ptr<Reward>> rewardMap;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1478,6 +1478,10 @@ public:
 
 	void sendSpellCooldowns();
 
+	void updateFood(uint16_t itemId, uint16_t timeLeft);
+	std::map<uint16_t, uint16_t> getActiveFoods() const;
+	bool isFoodActive(uint16_t itemId) const;
+
 private:
 	friend class PlayerLock;
 	std::mutex mutex;
@@ -1567,6 +1571,8 @@ private:
 	std::map<uint32_t, std::shared_ptr<DepotChest>> depotChests;
 	std::map<uint8_t, int64_t> moduleDelayMap;
 	std::map<uint16_t, uint64_t> itemPriceMap;
+
+	std::map<uint16_t, uint16_t> m_activeFoods;
 
 	std::map<uint64_t, std::shared_ptr<Reward>> rewardMap;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1479,7 +1479,7 @@ public:
 	void sendSpellCooldowns();
 
 	void updateFood(uint16_t itemId, uint16_t timeLeft);
-	std::map<uint16_t, uint16_t> getActiveFoods() const;
+	const std::map<uint16_t, uint16_t> &getActiveFoods() const;
 	bool isFoodActive(uint16_t itemId) const;
 
 private:

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -4629,7 +4629,7 @@ int PlayerFunctions::luaPlayerUpdateFood(lua_State* L) {
 		lua_pushnil(L);
 		return 1;
 	}
-	player->updateFood(Lua::getNumber<uint16_t>(L, 2), Lua::getNumber<uint16_t>(L, 3));
+	player->updateFood(Lua::getNumber<uint16_t>(L, 2), Lua::getNumber<uint32_t>(L, 3));
 	Lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -373,6 +373,7 @@ void PlayerFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Player", "setLoyaltyTitle", PlayerFunctions::luaPlayerSetLoyaltyTitle);
 
 	Lua::registerMethod(L, "Player", "updateConcoction", PlayerFunctions::luaPlayerUpdateConcoction);
+	Lua::registerMethod(L, "Player", "updateFood", PlayerFunctions::luaPlayerUpdateFood);
 	Lua::registerMethod(L, "Player", "clearSpellCooldowns", PlayerFunctions::luaPlayerClearSpellCooldowns);
 
 	Lua::registerMethod(L, "Player", "isVip", PlayerFunctions::luaPlayerIsVip);
@@ -4617,6 +4618,18 @@ int PlayerFunctions::luaPlayerUpdateConcoction(lua_State* L) {
 		return 1;
 	}
 	player->updateConcoction(Lua::getNumber<uint16_t>(L, 2), Lua::getNumber<uint16_t>(L, 3));
+	Lua::pushBoolean(L, true);
+	return 1;
+}
+
+int PlayerFunctions::luaPlayerUpdateFood(lua_State* L) {
+	// player:updateFood(itemId, timeLeft)
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+	player->updateFood(Lua::getNumber<uint16_t>(L, 2), Lua::getNumber<uint16_t>(L, 3));
 	Lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -361,7 +361,10 @@ class PlayerFunctions {
 
 	// Concoction system
 	static int luaPlayerUpdateConcoction(lua_State* L);
+
+	// Food system
 	static int luaPlayerUpdateFood(lua_State* L);
+
 	static int luaPlayerClearSpellCooldowns(lua_State* L);
 
 	static int luaPlayerIsVip(lua_State* L);

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -361,6 +361,7 @@ class PlayerFunctions {
 
 	// Concoction system
 	static int luaPlayerUpdateConcoction(lua_State* L);
+	static int luaPlayerUpdateFood(lua_State* L);
 	static int luaPlayerClearSpellCooldowns(lua_State* L);
 
 	static int luaPlayerIsVip(lua_State* L);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -4465,7 +4465,14 @@ void ProtocolGame::sendCyclopediaCharacterMiscStats() {
 		msg.add<uint32_t>(duration);
 	}
 
-	msg.addByte(0x00);
+	const auto &activeFoods = player->getActiveFoods();
+	msg.addByte(activeFoods.size());
+	for (const auto &[foodId, duration] : activeFoods) {
+		msg.add<uint16_t>(foodId);
+		msg.addByte(0x00);
+		msg.addByte(0x00);
+		msg.add<uint32_t>(duration);
+	}
 
 	writeToOutputBuffer(msg);
 }


### PR DESCRIPTION
This pull request introduces a new food effect tracking system for players. It adds the ability to track active food buffs by item and duration, exposes this functionality to Lua scripts, and updates existing food-related scripts to register food effects when consumed. Additionally, the player's active food effects are now sent to the client as part of their character stats.

Food effect system implementation:

* Added new methods and data members to the `Player` class to track active food effects (`updateFood`, `getActiveFoods`, `isFoodActive`, and the `m_activeFoods` map) in `player.cpp` and `player.hpp`. [[1]](diffhunk://#diff-446c95b161e562fe80eee30b6f967d7bfaa0a69d6c2ed46e2c5ba7a4ba8d9f9aR5335-R5355) [[2]](diffhunk://#diff-2112fca2e94520635fae6a0bfea02c3356ae99350a42dc8bf7da039f9a653cb9R1481-R1484) [[3]](diffhunk://#diff-2112fca2e94520635fae6a0bfea02c3356ae99350a42dc8bf7da039f9a653cb9R1575-R1576)
* Exposed the `updateFood` method to Lua by registering it in `player_functions.cpp` and `player_functions.hpp`, and implemented the corresponding Lua binding. [[1]](diffhunk://#diff-2b16a5ca17f2799203c4df2fdf8c16dbeceb88bb4aaf60513f647e704fbf4ddeR376) [[2]](diffhunk://#diff-2b16a5ca17f2799203c4df2fdf8c16dbeceb88bb4aaf60513f647e704fbf4ddeR4625-R4636) [[3]](diffhunk://#diff-f592ac5ed6e51c90ea5f702fed3a8235408abe3bba009ab6434c92766904ae58R364)

Integration with food item scripts:

* Updated all relevant food item scripts (e.g., `carrot_cake.lua`, `coconut_shrimp_bake.lua`, `demonic_candy_ball.lua`, etc.) to call `player:updateFood` with the appropriate item ID and duration when consumed. [[1]](diffhunk://#diff-296d7b6fe819d1cccf5562f869c05e0025aa0295e610ec72d1b7b8b23d0a1a6dR16) [[2]](diffhunk://#diff-078ef983ceae3f9c83f1783eaf4a6268088f0fb14b2f9584d79e951b7666bd41R21) [[3]](diffhunk://#diff-0fe30f5f827b2a622fff25b3ec950930d7b3c0eb8caf9e8ae827400332612daaR50-R58) [[4]](diffhunk://#diff-8b46030aaacf0f5c67eb90746c13f60940c73bd3ae81c0541ae2dbe498368c74R13) [[5]](diffhunk://#diff-e4a9087e2ec1180a7c625b8b423bfcf4344ed9f2d9eb37d9be632a306a9a495aR151) [[6]](diffhunk://#diff-80d66f3823d777a1c365df970b702af698f5427f5b4e8d91187be77b11a83664R51) [[7]](diffhunk://#diff-1e3ed9254d4aa013c2d4a4abde9e06cf4c090eb4c5d0f49094e7ef10e2df664fR16) [[8]](diffhunk://#diff-6f30c4236379b0699e24fa379ea038b7a8889bec566c9780da46fdce2df77c9aR16) [[9]](diffhunk://#diff-5d5da443b54b43011d0a6a43b9e3dbb6e2cfed62bbd0774547bdb729e52d67deR16) [[10]](diffhunk://#diff-f71b020b9ee069838403891f7e330d1e2bf8db3beaba5916a13397bd0eddf457R16)

Client/server communication:

* Modified `ProtocolGame::sendCyclopediaCharacterMiscStats` to include the player's active food effects and their remaining durations in the network message sent to the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Food effect duration tracking added — consumable foods now create visible active food buffs with remaining time.
  * Many consumables now grant timed food effects (commonly 1 hour; select items extend up to 24 hours).
  * Character summary now lists active foods and remaining durations for easier management.
  * Various dishes updated to set or refresh their food timers when consumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->