### PR TITLE
Improve player and invitee handling in Party class

### DIFF
--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -90,15 +90,10 @@ size_t Party::getInvitationCount() const {
 	});
 }
 
+//Sorcerer, Druid, Knight, Paladin, Monk.
 uint8_t Party::getUniqueVocationsCount() const {
 	std::unordered_set<uint8_t> uniqueVocations;
-
 	for (const auto &player : getPlayers()) {
-		if (!player) {
-			continue;
-		}
-
-		//Sorcerer, Druid, Knight, Paladin, Monk
 		if (uniqueVocations.size() >= 5) {
 			break;
 		}

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -535,7 +535,7 @@ void Party::broadcastPartyMessage(MessageClasses msgClass, const std::string &ms
 }
 
 bool Party::empty() const {
-	return memberList.empty() && inviteList.empty();
+	return getMemberCount() == 0 && getInvitationCount() == 0;
 }
 
 void Party::updateSharedExperience() {

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -98,7 +98,8 @@ uint8_t Party::getUniqueVocationsCount() const {
 			continue;
 		}
 
-		if (uniqueVocations.size() >= 4) {
+		//Sorcerer, Druid, Knight, Paladin, Monk
+		if (uniqueVocations.size() >= 5) {
 			break;
 		}
 

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -46,33 +46,58 @@ std::shared_ptr<Player> Party::getMantraHolder() const {
 
 std::vector<std::shared_ptr<Player>> Party::getPlayers() const {
 	std::vector<std::shared_ptr<Player>> players;
+	players.reserve(memberList.size() + 1);
 	for (auto &member : memberList) {
+		if (!member) {
+			continue;
+		}
 		players.push_back(member);
 	}
-	players.push_back(getLeader());
+
+	if (const auto &leader = getLeader()) {
+		players.push_back(leader);
+	}
 	return players;
 }
 
 std::vector<std::shared_ptr<Player>> Party::getMembers() {
-	return memberList;
+	std::vector<std::shared_ptr<Player>> members;
+	members.reserve(memberList.size());
+	std::ranges::copy_if(memberList, std::back_inserter(members), [](const auto &member) {
+		return member != nullptr;
+	});
+	return members;
 }
 
 std::vector<std::shared_ptr<Player>> Party::getInvitees() {
-	return inviteList;
+	std::vector<std::shared_ptr<Player>> invitees;
+	invitees.reserve(inviteList.size());
+	std::ranges::copy_if(inviteList, std::back_inserter(invitees), [](const auto &invitee) {
+		return invitee != nullptr;
+	});
+	return invitees;
 }
 
 size_t Party::getMemberCount() const {
-	return memberList.size();
+	return std::ranges::count_if(memberList, [](const auto &member) {
+		return member != nullptr;
+	});
 }
 
 size_t Party::getInvitationCount() const {
-	return inviteList.size();
+	return std::ranges::count_if(inviteList, [](const auto &invitee) {
+		return invitee != nullptr;
+	});
 }
 
 uint8_t Party::getUniqueVocationsCount() const {
 	std::unordered_set<uint8_t> uniqueVocations;
 
 	for (const auto &player : getPlayers()) {
+		if (!player) {
+			continue;
+		}
+
 		if (uniqueVocations.size() >= 4) {
 			break;
 		}


### PR DESCRIPTION
Reserve space for players and check for null members before adding to the list. Clean up member and invitee lists by removing null pointers.

Changes:
a)
getPlayers(): explicitly filters out null members and only appends the leader if it exists, preventing propagation of invalid entries to callers iterating over the returned vector.

b)
getMembers() / getInvitees(): sanitize internal containers by removing nullptr entries before returning them, reducing the risk of intermittent crashes during party/invite updates.

c)
getUniqueVocationsCount(): adds a defensive null check before accessing player data.

Extra info:
Performance impact is minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Member and invitee lists now exclude invalid/empty entries so counts reflect actual participants.
  * Party leader is displayed only when present.
  * Unique vocation count correctly reports up to five distinct vocations among current members.
  * Party "empty" state detection improved to accurately report when no valid members or invitees remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->