### PR TITLE
fix: ravenous lava lurker

### DIFF
--- a/data-otservbr-global/monster/elementals/ravenous_lava_lurker.lua
+++ b/data-otservbr-global/monster/elementals/ravenous_lava_lurker.lua
@@ -29,7 +29,7 @@ monster.Bestiary = {
 monster.health = 5000
 monster.maxHealth = 5000
 monster.race = "fire"
-monster.corpse = 0
+monster.corpse = 11317
 monster.speed = 58
 monster.manaCost = 0
 
@@ -76,14 +76,12 @@ monster.voices = {
 	chance = 10,
 }
 
-monster.loot = {
-	{ name = "small enchanted ruby", chance = 14620 },
-}
+monster.loot = {}
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -150 },
-	{ name = "ravennouslavalurkerwave", interval = 2000, chance = 15, minDamage = 0, maxDamage = -400, target = false },
-	{ name = "ravennouslavalurkertarget", interval = 2000, chance = 40, minDamage = 0, maxDamage = -400, target = true },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -215 },
+	{ name = "ravennouslavalurkerwave", interval = 2000, chance = 25, minDamage = -90, maxDamage = -120, target = false },
+	{ name = "ravennouslavalurkertarget", interval = 2000, chance = 20, minDamage = -82, maxDamage = -95, target = true },
 }
 
 monster.defenses = {


### PR DESCRIPTION
# Description

set death sprite to the same as death blob
modifies damage to align with real world ones, doing more physical than fire damange. Values and ranges used taken from tibiawiki.com.br, and corroborated by taking a look at Kusnier's lava lurker video (fire damage never goes upwards from 130 at any point. Most common attack is the wave on itself (target = false) (exori mas, but flam style), not the gfb style one.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Replicated Kusnier's character in [this video](https://www.youtube.com/watch?v=caQBlOhC5vY) but left it with 200k hp and mana, played around with 6 monsters with occasional utito tempo's until the average damage ratio matched what was shown there (53-58% phys, 47-42% fire), max DPS was around 1150, in the video it was 960, but in the video he was actually killing them, not just playing at tanking them indefinitely.



**Test Configuration**:

  - Server Version: v3.3.0
  - Client: 14.x
  - Operating System: macOS 26.2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Game Balance**
  * Ravenous Lava Lurker: Corpse value increased to 11317
  * Loot table updated; enchanted ruby drop removed
  * Attack patterns and damage values rebalanced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->