### PR TITLE
fix: map download url

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -396,7 +396,7 @@ pushWhenAttacking = false
 -- Note: If toggleDownloadMap is set to false, the mapDownloadUrl will not be used.
 -- Note: If a map with the same name already exists in the world folder, the map will not be downloaded, even if toggleDownloadMap is set to true.
 toggleDownloadMap = true
-mapDownloadUrl = "https://github.com/opentibiabr/canary/releases/download/v3.2.0/otservbr.otbm"
+mapDownloadUrl = "https://github.com/opentibiabr/canary/releases/download/v3.4.0/otservbr.otbm"
 mapName = "otservbr"
 mapAuthor = "OpenTibiaBR"
 


### PR DESCRIPTION
# Description

Change the map download link in config.lua.dis from 3.2.0 to 3.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default map download to version v3.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->