### PR TITLE
fix: add starting items for Monk vocation

### DIFF
--- a/data/scripts/creaturescripts/player/send_first_items.lua
+++ b/data/scripts/creaturescripts/player/send_first_items.lua
@@ -81,6 +81,24 @@ local config = {
 			{ 266, 10 }, -- health potion
 		},
 	},
+
+	[VOCATION.ID.MONK] = {
+		items = {
+			{ 50171, 1 }, -- jo staff
+			{ 3359, 1 }, -- brass armor
+			{ 3354, 1 }, -- brass helmet
+			{ 3372, 1 }, -- brass legs
+			{ 3552, 1 }, -- leather boots
+			{ 3572, 1 }, -- scarf
+		},
+
+		container = {
+			{ 3425, 1 }, -- dwarven shield
+			{ 3003, 1 }, -- rope
+			{ 5710, 1 }, -- light shovel
+			{ 266, 10 }, -- health potion
+		},
+	},
 }
 
 local sendFirstItems = CreatureEvent("SendFirstItems")


### PR DESCRIPTION
This pull request adds initial equipment and container items for the `MONK` vocation to the player item configuration. This update ensures that new players who select the `MONK` vocation receive appropriate starting gear similar to other vocations.

Vocation item configuration updates:

* Added a new entry for `VOCATION.ID.MONK` in the `config` table within `send_first_items.lua`, specifying both `items` and `container` contents for the vocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MONK vocation: Players can now create characters of the new MONK class with specialized starting equipment, including a jo staff, brass armor set, boots, scarf, and a starter container filled with essentials like a shield, rope, shovel, and health potions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->