### PR TITLE
fix: hotkey unequip swaps item instead of unequipping when duplicates exist

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3548,7 +3548,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t itemId, bool hasTier /* =
 	}
 	ReturnValue ret = RETURNVALUE_NOERROR;
 
-	if (slotItem && slotItem->getID() == it.id && (!hasTier || slotItem->getTier() == tier) && !equipItem) {
+	if (slotItem && slotItem->getID() == it.id && (!hasTier || slotItem->getTier() == tier)) {
 		ret = internalCollectManagedItems(player, slotItem, getObjectCategory(slotItem), false);
 	} else if (equipItem) {
 		// Shield slot item


### PR DESCRIPTION
## Summary

- Fixes hotkey unequip behavior when the player has duplicate items in their backpack. Previously, pressing the unequip hotkey would swap the equipped item with the backpack copy instead of unequipping. For example, with a 5-charge stone skin amulet equipped and a 3-charge one in the backpack, the hotkey would cycle between the two instead of unequipping.
- Root cause: PR #3436 (23d079183) refactored the unequip condition and accidentally pulled `!equipItem` out of an OR chain (where it only applied to stackable items) into a standalone AND condition (where it blocked unequip for all item types whenever a backpack copy existed).
- Fix: remove the `!equipItem` guard so the unequip branch always triggers when the equipped item matches the hotkey.

### Side effects

| Scenario | Before | After |
|---|---|---|
| Item equipped, no copy in backpack | Unequips | Unequips |
| Item equipped, copy in backpack | **Swaps (bug)** | **Unequips (fix)** |
| Nothing/different equipped, copy in bp | Equips | Equips |
| Same type equipped, different tier in bp | Equips | Equips |
| Nothing equipped, nothing in backpack | No-op | No-op |

### Fixes #3856 

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Equip a stone skin amulet, put a duplicate in backpack, press hotkey — should unequip
- [x] Equip an amulet with no duplicate in backpack, press hotkey — should unequip
- [x] Have no amulet equipped, one in backpack, press hotkey — should equip
- [x] Repeat above scenarios with rings, weapons, and tiered items

**Test Configuration**:

  - Server Version: v3.3.0
  - Client: 14.X
  - Operating System: macOS 26.2

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item equipping logic to properly handle scenarios when equipment slots contain items, ensuring correct item transfer behavior during equip actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->