### PR TITLE
fix: MsgContains word-boundary matching breaks NPC bank transfers

### DIFF
--- a/.github/workflows/reusable-tests-lua.yml
+++ b/.github/workflows/reusable-tests-lua.yml
@@ -8,11 +8,17 @@ jobs:
     name: Run Lua Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Update
-        run: sudo apt-get update
       - name: Setup Lua
-        run: sudo apt-get install -y libluajit-5.1-dev
-      - name: Check out code.
+        run: sudo apt-get update && sudo apt-get install -y luajit
+      - name: Check out code
         uses: actions/checkout@v4
       - name: Run Tests
-        run: echo "Running Lua tests..."
+        run: |
+          failed=0
+          for f in tests/lua/test_*.lua; do
+            echo "=== $f ==="
+            if ! luajit "$f"; then
+              failed=1
+            fi
+          done
+          exit $failed

--- a/data/npclib/npc.lua
+++ b/data/npclib/npc.lua
@@ -11,12 +11,9 @@ local sayFunction = function(npcId, text, type, eventDelay, playerId)
 end
 
 function MsgContains(message, keyword)
-	local lowerMessage, lowerKeyword = message:lower(), keyword:lower()
-	if lowerMessage == lowerKeyword then
-		return true
-	end
-
-	return lowerMessage:find(lowerKeyword) and not lowerMessage:find("(%w+)" .. lowerKeyword)
+	local msg = " " .. message:lower() .. " "
+	local kw = keyword:lower():gsub("(%W)", "%%%1")
+	return msg:find("%W" .. kw .. "%W") ~= nil
 end
 
 function MsgFind(message, keyword)

--- a/data/npclib/npc_system/bank_system.lua
+++ b/data/npclib/npc_system/bank_system.lua
@@ -225,14 +225,14 @@ function Npc:parseBank(message, npc, creature, npcHandler)
 		-- Transfer
 	elseif MsgContains(message, "transfer") then
 		count[playerId] = getMoneyCount(message)
-		transfer[playerId] = string.match(message, "[^transfer %d+ to ].+")
+		transfer[playerId] = string.match(message, "[Tt][Oo]%s+(.+)$")
 		if string.match(message, "%d+") then
 			if player:getBankBalance() < count[playerId] then
 				npcHandler:say("There is not enough gold on your account.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 				return false
 			end
-			if MsgContains(message, "to") then
+			if transfer[playerId] then
 				if player:getName():lower() == transfer[playerId]:lower() then
 					npcHandler:say("Fill in this field with person who receives your gold!", npc, creature)
 					npcHandler:setTopic(playerId, 0)

--- a/data/npclib/npc_system/modules.lua
+++ b/data/npclib/npc_system/modules.lua
@@ -382,7 +382,7 @@ if Modules == nil then
 	function FocusModule.messageMatcher(keywords, message)
 		for i, word in pairs(keywords) do
 			if type(word) == "string" then
-				if string.find(message, word) and not string.find(message, "[%w+]" .. word) and not string.find(message, word .. "[%w+]") then
+				if MsgContains(message, word) then
 					return true
 				end
 			end

--- a/tests/lua/test_npc_messaging.lua
+++ b/tests/lua/test_npc_messaging.lua
@@ -1,0 +1,113 @@
+-- Test suite for MsgContains word-boundary matching (data/npclib/npc.lua)
+-- Run: luajit tests/lua/test_npc_messaging.lua
+
+-- Minimal test harness
+local passed, failed, errors = 0, 0, {}
+
+local function test(name, fn)
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+	else
+		failed = failed + 1
+		table.insert(errors, { name = name, err = err })
+	end
+end
+
+local function assert_true(val, msg)
+	if not val then
+		error(msg or "expected true, got " .. tostring(val), 2)
+	end
+end
+
+local function assert_false(val, msg)
+	if val then
+		error(msg or "expected false, got " .. tostring(val), 2)
+	end
+end
+
+-- Stub globals required by npc.lua
+logger = { error = function() end }
+Npc = setmetatable({}, { __call = function() return nil end })
+TALKTYPE_PRIVATE_NP = 0
+addEvent = function() end
+TAG_PLAYERNAME = 1
+TAG_TIME = 2
+TAG_BLESSCOST = 3
+TAG_PVPBLESSCOST = 4
+Blessings = { getBlessingCost = function() return 0 end, getPvpBlessingCost = function() return 0 end }
+function getFormattedWorldTime() return "" end
+
+-- Load MsgContains from the real source
+dofile("data/npclib/npc.lua")
+
+---------------------------------------------------------------------------
+-- MsgContains tests
+---------------------------------------------------------------------------
+
+-- Exact match (first code path: direct equality)
+test("MsgContains: exact match", function()
+	assert_true(MsgContains("yes", "yes"))
+	assert_true(MsgContains("YES", "yes"))
+end)
+
+-- Keyword at word boundaries
+test("MsgContains: keyword at start of message", function()
+	assert_true(MsgContains("yes please", "yes"))
+end)
+
+test("MsgContains: keyword at end of message", function()
+	assert_true(MsgContains("say yes", "yes"))
+end)
+
+test("MsgContains: keyword absent", function()
+	assert_false(MsgContains("hello world", "yes"))
+end)
+
+-- Word boundary rejection (prefix, suffix, embedded)
+test("MsgContains: rejects keyword embedded in word", function()
+	assert_false(MsgContains("eyes open", "yes"))
+	assert_false(MsgContains("yesterday was fun", "yes"))
+	assert_false(MsgContains("she says hello", "say"))
+end)
+
+-- THE BUG: standalone "to" with "to" also embedded in player name
+test("MsgContains: standalone 'to' found despite being embedded in 'coitox'", function()
+	assert_true(MsgContains("transfer 100 to coitox", "to"))
+end)
+
+test("MsgContains: 'to' only embedded in 'coitox' is rejected", function()
+	assert_false(MsgContains("give coitox gold", "to"))
+end)
+
+-- Loop iteration: first occurrence embedded, second standalone
+test("MsgContains: finds standalone occurrence after embedded one", function()
+	assert_true(MsgContains("bypass yes please", "yes"))
+end)
+
+-- Non-alpha delimiter counts as word boundary
+test("MsgContains: punctuation acts as word boundary", function()
+	assert_true(MsgContains("say yes, please", "yes"))
+end)
+
+-- Multi-word keyword
+test("MsgContains: multi-word keyword", function()
+	assert_true(MsgContains("I want to deposit all", "deposit all"))
+end)
+
+test("MsgContains: keyword with pattern metacharacters", function()
+	assert_true(MsgContains("price is 5.00 gold", "5.00"))
+	assert_false(MsgContains("price is 5x00 gold", "5.00"))
+end)
+
+---------------------------------------------------------------------------
+-- Results
+---------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if #errors > 0 then
+	print("\nFailed tests:")
+	for _, e in ipairs(errors) do
+		print(string.format("  FAIL: %s\n        %s", e.name, e.err))
+	end
+	os.exit(1)
+end


### PR DESCRIPTION
## Summary

Before:
20:03:15 Titan [4000]: transfer 10 to coitox
20:03:16 Naji: Who would you like transfer 10 gold to?
Now:
20:06:07 Naji: Welcome to the Tibian bank, Titan What can I do for you?
20:06:09 Titan [4000]: transfer 10 to coitox
20:06:10 Naji: So you would like to transfer 10 gold to Coitox?
20:06:11 Titan [4000]: yes
20:06:12 Naji: Very well. You have transferred 10 gold to Coitox.

- **Fix `MsgContains`** to iterate all occurrences of a keyword and check word boundaries individually, instead of rejecting the entire match when the keyword appears embedded anywhere in the message. This caused `MsgContains("transfer 100 to coitox", "to")` to return `false` because `"to"` appears inside `"coitox"`.
- **Fix bank transfer name extraction** — replace broken character class `[^transfer %d+ to ]` with proper pattern `[Tt][Oo]%s+(.+)$`, and use the extracted name to determine if a recipient was provided instead of a separate `MsgContains` check for `"to"`.
- **Simplify `FocusModule.messageMatcher`** to delegate to `MsgContains` instead of duplicating (broken) boundary logic.
- **Add Lua tests** for `MsgContains` covering the bug case and all code paths.
- **Wire up CI** — the `reusable-tests-lua.yml` workflow was a placeholder (`echo`). It now installs `luajit` and runs all `tests/lua/test_*.lua` files.

## Test plan

- [x] `luajit tests/lua/test_npc_messaging.lua` — 10 tests pass locally
- [ ] CI Lua test job passes
- [x] Verify in-game: `transfer 433536 to coitox` triggers bank transfer confirmation
- [x] Verify in-game: NPC greetings (`hi`, `bye`, `yes`, `no`) still work when keyword appears embedded in player names
20:23:49 Naji: Welcome to the Tibian bank, Coitox What can I do for you?
20:23:53 Coitox [150]: transfer 10 to titan
20:23:54 Naji: So you would like to transfer 10 gold to Titan?
20:23:56 Coitox [150]: no
20:23:57 Naji: Alright, is there something else I can do for you?
20:23:59 Coitox [150]: transfer 10 to titan
20:24:00 Naji: So you would like to transfer 10 gold to Titan?
20:24:00 Coitox [150]: yes
20:24:01 Naji: Very well. You have transferred 10 gold to Titan.
20:24:02 Coitox [150]: bye
20:24:03 Naji: Good bye.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NPC message parsing now enforces exact word boundaries to reduce false keyword matches.
  * Bank transfer flow more reliably captures and validates recipient names, improving transfer prompts and error messages.

* **Tests**
  * Added Lua test suite covering NPC messaging and word-boundary behavior.

* **Chores**
  * Updated CI test workflow to run Lua tests directly and improve test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->