### PR TITLE
feat: add skill trainer item for offline skill training

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -84500,6 +84500,9 @@ Granted by TibiaGoals.com"/>
 		<attribute key="charges" value="14400"/>
 		<attribute key="weight" value="1000"/>
 	</item>
+	<item id="50296" article="a" name="skill trainer">
+		<attribute key="description" value="Use this statue to train your fist fighting and shielding skill offline."/>
+	</item>
 	<item id="50308" article="a" name="monk pedestal">
 		<attribute key="primarytype" value="artificial tiles"/>
 	</item>

--- a/data/scripts/actions/objects/skill_trainer.lua
+++ b/data/scripts/actions/objects/skill_trainer.lua
@@ -4,6 +4,7 @@ local setting = {
 	[16200] = SKILL_CLUB,
 	[16201] = SKILL_DISTANCE,
 	[16202] = SKILL_MAGLEVEL,
+	[50296] = SKILL_FIST,
 }
 
 local skillTrainer = Action()

--- a/data/scripts/creaturescripts/player/offline_training.lua
+++ b/data/scripts/creaturescripts/player/offline_training.lua
@@ -57,7 +57,7 @@ function offlineTraining.onLogin(player)
 	local topVocation = not promotion and vocation or promotion
 
 	local tries = nil
-	if table.contains({ SKILL_CLUB, SKILL_SWORD, SKILL_AXE, SKILL_DISTANCE }, offlineTrainingSkill) then
+	if table.contains({ SKILL_CLUB, SKILL_SWORD, SKILL_AXE, SKILL_DISTANCE, SKILL_FIST }, offlineTrainingSkill) then
 		local modifier = topVocation:getBaseAttackSpeed() / 1000
 		tries = (trainingTime / modifier) / (offlineTrainingSkill == SKILL_DISTANCE and 4 or 2)
 	elseif offlineTrainingSkill == SKILL_MAGLEVEL then


### PR DESCRIPTION
This pull request introduces a new "skill trainer" item to the game, allowing players to train their fist fighting and shielding skills offline. The changes add the item definition and ensure it is recognized as a skill trainer in the relevant script.

New item definition:

* Added a new item with ID `50296` named `skill trainer` to `items.xml`, including a description for its use in offline skill training.

Script integration:

* Registered the new `skill trainer` item (`50296`) in `skill_trainer.lua` so that it is associated with the `SKILL_FIST` skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new skill trainer item that enables offline training for fist fighting and shielding skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->