### PR TITLE
fix: add new item "ramp" with floor change attribute

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -82642,6 +82642,9 @@ Granted by TibiaGoals.com"/>
 		<attribute key="decayTo" value="0"/>
 		<attribute key="duration" value="5"/>
 	</item>
+	<item id="49937" article="a" name="ramp">
+		<attribute key="floorchange" value="north"/>
+	</item>
 	<item id="49995" article="a" name="dead brinebrute inferniarch">
 		<attribute key="decayTo" value="0"/>
 		<attribute key="duration" value="60"/>


### PR DESCRIPTION
### Summary

This pull request introduces a new item definition to the `items.xml` file. The main change is the addition of a new item called "ramp" with a specific attribute.

### New item addition:

* Added a new item with `id="49937"` and name `"ramp"`, including the attribute `floorchange` set to `"north"` in `items.xml`.

### Objective
The goal of this change is to fix the staircase leading to the upper area in Blue Valley, ensuring the ramp functions correctly for players.

### Visual Reference
![Monk Temple](https://github.com/user-attachments/assets/886ca5d2-dc8b-4a38-b1cc-1883d66e7e3e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "ramp" item (article "a") that enables northward floor transitions when placed in the world.
  * The item is available alongside existing items and can be used to create multi-level navigation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->