### PR TITLE
fix: XP boost display not returning to normal after boost expiry

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2969,6 +2969,10 @@ uint16_t Player::getXpBoostPercent() const {
 }
 
 uint16_t Player::getDisplayXpBoostPercent() const {
+	if (xpBoostTime == 0) {
+		return 0;
+	}
+
 	return std::clamp<uint16_t>(xpBoostPercent * (baseXpGain / 100), 0, std::numeric_limits<uint16_t>::max());
 }
 
@@ -2986,12 +2990,18 @@ void Player::setStaminaXpBoost(uint16_t value) {
 }
 
 void Player::setXpBoostTime(uint16_t timeLeft) {
+	const bool hadXpBoost = xpBoostTime > 0;
+
 	// only allow time boosts of 12 hours or less
 	if (timeLeft > 12 * 3600) {
 		xpBoostTime = 12 * 3600;
-		return;
+	} else {
+		xpBoostTime = timeLeft;
 	}
-	xpBoostTime = timeLeft;
+
+	if (hadXpBoost != (xpBoostTime > 0)) {
+		sendStats();
+	}
 }
 
 uint16_t Player::getXpBoostTime() const {


### PR DESCRIPTION
### Motivation
- Fix client-side XP rate display remaining boosted after the server-side XP boost expires (reported in Issue #3857).

### Description
- Make `Player::getDisplayXpBoostPercent()` return `0` when `xpBoostTime == 0`, and update `Player::setXpBoostTime()` to call `sendStats()` when the boost transitions between active/inactive while preserving the existing 12-hour clamp.

### Testing
- Verified the code change with `git diff` and `git status` and committed the patch, and attempted `cmake --build` which was skipped because the `build/` directory is not present in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XP boost indicator displaying when no active boost time is present.
  * Improved synchronization of XP boost state changes between client and server to ensure accurate status updates when boost status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->