### PR TITLE
fix: packets error hireling (0xC8 lua) in OTCR

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -52,6 +52,10 @@ function Player.isUsingOtClient(self)
 	return self:getClient().os >= CLIENTOS_OTCLIENT_LINUX
 end
 
+function Player.isUsingOTCR(self)
+	return self:getClient().os >= CLIENTOS_OTCLIENT_LINUX and self:getClient().os < CLIENTOS_OTCLIENT_MAC
+end
+
 function Player.sendExtendedOpcode(self, opcode, buffer)
 	if not self:isUsingOtClient() then
 		return false

--- a/data/libs/systems/hireling.lua
+++ b/data/libs/systems/hireling.lua
@@ -617,7 +617,6 @@ function Player:sendHirelingOutfitWindow(hireling)
 	end
 	msg:addU16(outfit.lookMount)
 
-    end
 	if self:isUsingOTCR() then
 		msg:addU16(0) -- lookWing
 		msg:addU16(0) -- lookAura

--- a/data/libs/systems/hireling.lua
+++ b/data/libs/systems/hireling.lua
@@ -617,6 +617,13 @@ function Player:sendHirelingOutfitWindow(hireling)
 	end
 	msg:addU16(outfit.lookMount)
 
+    if self:isUsingOTCR() then
+        msg:addU16(0) -- lookWing
+        msg:addU16(0) -- lookAura
+        msg:addU16(0) -- lookEffect
+        msg:addU16(0) -- lookShader
+    end
+
 	msg:addByte(0x00) -- Mount head
 	msg:addByte(0x00) -- Mount body
 	msg:addByte(0x00) -- Mount legs
@@ -638,6 +645,12 @@ function Player:sendHirelingOutfitWindow(hireling)
 	msg:addByte(0x00) -- Is mounted bool
 	msg:addByte(0x00) -- Random outfit bool
 
+    if self:isUsingOTCR() then
+        msg:addByte(0) -- Wings
+        msg:addByte(0) -- Auras
+        msg:addByte(0) -- Effects
+        msg:addByte(0) -- Shaders
+    end
 	msg:sendToPlayer(self)
 end
 

--- a/data/libs/systems/hireling.lua
+++ b/data/libs/systems/hireling.lua
@@ -617,12 +617,13 @@ function Player:sendHirelingOutfitWindow(hireling)
 	end
 	msg:addU16(outfit.lookMount)
 
-    if self:isUsingOTCR() then
-        msg:addU16(0) -- lookWing
-        msg:addU16(0) -- lookAura
-        msg:addU16(0) -- lookEffect
-        msg:addU16(0) -- lookShader
     end
+	if self:isUsingOTCR() then
+		msg:addU16(0) -- lookWing
+		msg:addU16(0) -- lookAura
+		msg:addU16(0) -- lookEffect
+		msg:addU16(0) -- lookShader
+	end
 
 	msg:addByte(0x00) -- Mount head
 	msg:addByte(0x00) -- Mount body
@@ -645,12 +646,12 @@ function Player:sendHirelingOutfitWindow(hireling)
 	msg:addByte(0x00) -- Is mounted bool
 	msg:addByte(0x00) -- Random outfit bool
 
-    if self:isUsingOTCR() then
-        msg:addByte(0) -- Wings
-        msg:addByte(0) -- Auras
-        msg:addByte(0) -- Effects
-        msg:addByte(0) -- Shaders
-    end
+	if self:isUsingOTCR() then
+		msg:addByte(0) -- Wings
+		msg:addByte(0) -- Auras
+		msg:addByte(0) -- Effects
+		msg:addByte(0) -- Shaders
+	end
 	msg:sendToPlayer(self)
 end
 


### PR DESCRIPTION



# Description


<img width="832" height="111" alt="image" src="https://github.com/user-attachments/assets/8113fdb1-5cc5-4b4e-8e33-7686c518855e" />
<img width="758" height="501" alt="image" src="https://github.com/user-attachments/assets/85b95aeb-a8b2-4be2-82ae-eb06c68c76af" />

## Behaviour
### **Actual**

```log
ERROR: ProtocolGame parse message exception (83 bytes, 56 unread at pos 27, last opcode: 0xC8 (200), prev opcode: 0x-1 (-1), protocol: 1511): InputMessage eof reached
Next unread bytes: 07 00 43 69 74 69 7A 65 6E 00 00 00 00 00 00 00 00 00 C8 80 00 61 22 03 74 00 00 00 00 00 00 00 00 00 01 00 54 04 07 00 43 69 74 69 7A 65 6E 00 00 00 00 00 00 00 00 00
```

### **Expected**

<img width="758" height="501" alt="image" src="https://github.com/user-attachments/assets/901af92b-dcc0-4583-999d-3b6315754f14" />


### Fixes

## Type of change


  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

```
1) /i 29432
2) use item 29342
3) say hi -> services-> outfit

```
- test in cipsoft and otcr


**Test Configuration**:

  - Server Version: 15.00
  - Client: OTCR
  - Operating System: windows

## Checklist

  - [x] My code follows the style guidelines of this project


### This change does not affect Cipsoft client .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OTCR client detection for more accurate compatibility checks on affected clients.
  * Expanded hireling outfit display for OTCR-compatible clients, adding support for wings, auras, effects, and shaders in outgoing outfit messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->