### PR TITLE
ci: avoid detached HEAD when auto-committing formatting in reusable fast checks

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
 
       - name: Set up Git
         run: |
@@ -43,10 +44,6 @@ jobs:
         run: |
           pip install cmakelang PyYAML
           find . -name "CMakeLists.txt" -o -name "*.cmake" | grep -v build/ | grep -v vcpkg_installed/ | xargs cmake-format -i
-
-      - name: Commit formatting changes
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        run: git checkout "${{ github.head_ref }}"
 
       - name: Commit formatting changes
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |
@@ -41,6 +43,10 @@ jobs:
         run: |
           pip install cmakelang PyYAML
           find . -name "CMakeLists.txt" -o -name "*.cmake" | grep -v build/ | grep -v vcpkg_installed/ | xargs cmake-format -i
+
+      - name: Commit formatting changes
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: git checkout "${{ github.head_ref }}"
 
       - name: Commit formatting changes
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -7,11 +7,18 @@ jobs:
   run-checks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (PR head branch for same-repo PRs)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
+          ref: ${{ github.head_ref }}
+
+      - name: Checkout repository (default ref)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Git
         run: |

--- a/tests/lua/test_npc_messaging.lua
+++ b/tests/lua/test_npc_messaging.lua
@@ -28,15 +28,28 @@ end
 
 -- Stub globals required by npc.lua
 logger = { error = function() end }
-Npc = setmetatable({}, { __call = function() return nil end })
+Npc = setmetatable({}, {
+	__call = function()
+		return nil
+	end,
+})
 TALKTYPE_PRIVATE_NP = 0
 addEvent = function() end
 TAG_PLAYERNAME = 1
 TAG_TIME = 2
 TAG_BLESSCOST = 3
 TAG_PVPBLESSCOST = 4
-Blessings = { getBlessingCost = function() return 0 end, getPvpBlessingCost = function() return 0 end }
-function getFormattedWorldTime() return "" end
+Blessings = {
+	getBlessingCost = function()
+		return 0
+	end,
+	getPvpBlessingCost = function()
+		return 0
+	end,
+}
+function getFormattedWorldTime()
+	return ""
+end
 
 -- Load MsgContains from the real source
 dofile("data/npclib/npc.lua")


### PR DESCRIPTION
This pull request includes improvements to the GitHub Actions workflow for handling pull request checkouts and refactors some Lua test stubs for readability and maintainability. The most important changes are grouped below:

**GitHub Actions workflow improvements:**

* Updated the `run-checks` job in `.github/workflows/reusable-checks.yml` to use two separate checkout steps: one that checks out the PR head branch for same-repo pull requests, and another that checks out the default ref for all other cases. Both steps now use `fetch-depth: 0` to ensure the full git history is available.

**Lua test stub refactoring:**

* Reformatted the stubbed global objects and functions in `tests/lua/test_npc_messaging.lua` (such as `Npc`, `Blessings`, and `getFormattedWorldTime`) to use multi-line, more readable definitions, improving code clarity and maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline to retrieve full repository history and ensure the correct branch/ref is checked out for pull requests and other runs
  * Adjusted workflow control to better handle PR vs non-PR scenarios during automated checks

* **Tests**
  * Reformatted and cleaned up a test file for improved readability and maintainability; no functional changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->