### PR TITLE
fix: disable target changing for spectres and arachnophobica

### DIFF
--- a/data-otservbr-global/monster/magicals/arachnophobica.lua
+++ b/data-otservbr-global/monster/magicals/arachnophobica.lua
@@ -35,7 +35,7 @@ monster.manaCost = 0
 
 monster.changeTarget = {
 	interval = 4000,
-	chance = 10,
+	chance = 0,
 }
 
 monster.strategiesTarget = {

--- a/data-otservbr-global/monster/undeads/burster_spectre.lua
+++ b/data-otservbr-global/monster/undeads/burster_spectre.lua
@@ -35,7 +35,7 @@ monster.manaCost = 0
 
 monster.changeTarget = {
 	interval = 4000,
-	chance = 10,
+	chance = 0,
 }
 
 monster.strategiesTarget = {

--- a/data-otservbr-global/monster/undeads/gazer_spectre.lua
+++ b/data-otservbr-global/monster/undeads/gazer_spectre.lua
@@ -35,7 +35,7 @@ monster.manaCost = 0
 
 monster.changeTarget = {
 	interval = 4000,
-	chance = 10,
+	chance = 0,
 }
 
 monster.strategiesTarget = {

--- a/data-otservbr-global/monster/undeads/ripper_spectre.lua
+++ b/data-otservbr-global/monster/undeads/ripper_spectre.lua
@@ -35,7 +35,7 @@ monster.manaCost = 0
 
 monster.changeTarget = {
 	interval = 4000,
-	chance = 10,
+	chance = 0,
 }
 
 monster.strategiesTarget = {


### PR DESCRIPTION

# Description

Spectres (ripper, gazer, burster) and arachnophobica are not supposed to switch targets once they have engaged one. Currently they have `changeTarget.chance = 10`, giving them a 10% chance every 4 seconds to switch to a different target. This sets it to 0 to disable target switching entirely.

## Behaviour
### **Actual**

Spectres and arachnophobica randomly switch between available targets every few seconds.

### **Expected**

Spectres and arachnophobica stay locked on their current target and do not switch.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

  - [x] Spawned burster spectre with multiple players nearby, verified it stays on initial target
  - [x] Verified ripper and gazer spectres behave the same
  - [x] Verified arachnophobica stays on target

**Test Configuration**:

  - Client: 14
  - Server: v3.3.0 + this

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Gameplay Adjustments**
  * Disabled automatic target switching for Arachnophobica, Burster Spectre, Gazer Spectre, and Ripper Spectre. These monsters will now maintain focus on their current target instead of randomly switching during combat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->