### PR TITLE
fix: allow summoned creatures to self-heal in combat healing logic

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1522,7 +1522,7 @@ void Combat::doCombatHealth(const std::shared_ptr<Creature> &caster, const std::
 			return;
 		}
 
-		if (target->isSummon() && caster && caster->getMonster()) {
+		if (target->isSummon() && caster && caster->getMonster() && caster != target) {
 			const auto &targetMaster = target->getMaster();
 			if (targetMaster && targetMaster->getPlayer()) {
 				return;


### PR DESCRIPTION
### Motivation
- Fix a logic bug in `doCombatHealth` that prevented a summoned creature from being healed when it was both the caster and the target due to the monster-origin early-return.

### Description
- Add `caster != target` to the summon/monster early-return check in `doCombatHealth` so the return only triggers when a different monster tries to heal a summon, permitting self-healing by summons.

### Testing
- Rebuilt the project and ran the automated unit test suite including combat tests (`make && ctest`), and the tests completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected healing interaction behavior for summoned creatures when cast by monsters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->