### PR TITLE
fix: bounac entrance teleport

### DIFF
--- a/data-otservbr-global/scripts/quests/the_order_of_lion/action-bounac_entrance.lua
+++ b/data-otservbr-global/scripts/quests/the_order_of_lion/action-bounac_entrance.lua
@@ -21,5 +21,5 @@ bounacEntrance:aid(59602)
 bounacEntrance:aid(59603)
 bounacEntrance:register()
 
-SimpleTeleport(Position(32475, 32497, 7), Position(32475, 32496, 6), nil, true)
-SimpleTeleport(Position(32475, 32497, 6), Position(32475, 32498, 7), nil, true)
+SimpleTeleport(Position(32475, 32498, 7), Position(32475, 32496, 6), nil, true) -- sobe
+SimpleTeleport(Position(32475, 32497, 6), Position(32475, 32499, 7), nil, true) -- desce

--- a/data-otservbr-global/scripts/quests/the_order_of_lion/action-bounac_entrance.lua
+++ b/data-otservbr-global/scripts/quests/the_order_of_lion/action-bounac_entrance.lua
@@ -21,5 +21,5 @@ bounacEntrance:aid(59602)
 bounacEntrance:aid(59603)
 bounacEntrance:register()
 
-SimpleTeleport(Position(32475, 32498, 7), Position(32475, 32496, 6), nil, true) -- sobe
-SimpleTeleport(Position(32475, 32497, 6), Position(32475, 32499, 7), nil, true) -- desce
+SimpleTeleport(Position(32475, 32498, 7), Position(32475, 32496, 6), nil, true) -- up
+SimpleTeleport(Position(32475, 32497, 6), Position(32475, 32499, 7), nil, true) -- down


### PR DESCRIPTION
# Description

The player gets stuck when boarding the boat; the teleport to disembark is in the same square as the teleport to ascend, throwing the player backward.

The coordinates were repositioned when the changes occurred.

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: canary main
  - Client:
  - Operating System: 

## Checklist

  - [x ] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teleport alignment in the Order of Lion quest to prevent mis-positioning when entering the Bounac area.
  * Corrected up/down transition points to ensure smoother, more reliable movement during the quest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->