### PR TITLE
fix: use curl instead of wget on docker/start.sh

### DIFF
--- a/docker/data/start.sh
+++ b/docker/data/start.sh
@@ -42,7 +42,7 @@ if [ "$OT_SERVER_DATA" = "data-otservbr-global" ] && [ ! -f data-otservbr-global
 	echo "YES"
 
 	echo "Downloading OTBR Map..."
-	wget --no-check-certificate "$OT_SERVER_MAP" -O data-otservbr-global/world/otservbr.otbm
+	curl -L "$OT_SERVER_MAP" -o data-otservbr-global/world/otservbr.otbm
 
 	echo "Done"
 

--- a/docker/data/start.sh
+++ b/docker/data/start.sh
@@ -42,7 +42,7 @@ if [ "$OT_SERVER_DATA" = "data-otservbr-global" ] && [ ! -f data-otservbr-global
 	echo "YES"
 
 	echo "Downloading OTBR Map..."
-	curl -L "$OT_SERVER_MAP" -o data-otservbr-global/world/otservbr.otbm
+	curl -Lk "$OT_SERVER_MAP" -o data-otservbr-global/world/otservbr.otbm
 
 	echo "Done"
 

--- a/docker/data/start.sh
+++ b/docker/data/start.sh
@@ -42,6 +42,10 @@ if [ "$OT_SERVER_DATA" = "data-otservbr-global" ] && [ ! -f data-otservbr-global
 	echo "YES"
 
 	echo "Downloading OTBR Map..."
+# -L = follow redirects, needed for GitHub URLs
+# -k = ignore failed TLS trust issues
+# -f = fail fast with no output on HTTP errors
+# -o = write output to file
 	curl -Lk "$OT_SERVER_MAP" -o data-otservbr-global/world/otservbr.otbm
 
 	echo "Done"


### PR DESCRIPTION
# Description

This PR makes `/canary/start.sh` call `curl` instead of `wget`, because `wget` is not present in the image, but `curl` is.

Motivation: I wanted to run my own OTS from a ready Docker image. But it's not working.

## Behaviour
### **Actual**

```
===== OTBR Global Data Pack =====

YES
Downloading OTBR Map...
/canary/start.sh: line 45: wget: command not found
```

### **Expected**

The image should download the OTBM successfully.

### Fixes #3881 

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

The effective command:
```
curl -Lk https://github.com/opentibiabr/canary/releases/download/v3.1.0/otservbr.otbm -o data-otservbr-global/world/otservbr.otbm
```
has been run on the container when it's docile, as run with `--rm -it --entrypoint '' ... bash`

And it succeeded.
```
root@d2e8180f91d3:/canary# curl -Lk https://github.com/opentibiabr/canary/releases/download/v3.1.0/otservbr.otbm -o data-otservbr-global/world/otservbr.otbm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  174M  100  174M    0     0  1229k      0  0:02:25  0:02:25 --:--:-- 17.5M
```

## Checklist

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved map data download reliability by switching the downloader to better handle redirects and SSL certificate options, reducing download failures when fetching map files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->