### PR TITLE
fix: use format string for spdlog calls

### DIFF
--- a/src/lib/logging/log_with_spd_log.cpp
+++ b/src/lib/logging/log_with_spd_log.cpp
@@ -35,27 +35,27 @@ std::string LogWithSpdLog::getLevel() const {
 }
 
 void LogWithSpdLog::info(const std::string &msg) const {
-	SPDLOG_INFO(msg);
+	SPDLOG_INFO("{}", msg);
 }
 
 void LogWithSpdLog::warn(const std::string &msg) const {
-	SPDLOG_WARN(msg);
+	SPDLOG_WARN("{}", msg);
 }
 
 void LogWithSpdLog::error(const std::string &msg) const {
-	SPDLOG_ERROR(msg);
+	SPDLOG_ERROR("{}", msg);
 }
 
 void LogWithSpdLog::critical(const std::string &msg) const {
-	SPDLOG_CRITICAL(msg);
+	SPDLOG_CRITICAL("{}", msg);
 }
 
 #if defined(DEBUG_LOG)
 void LogWithSpdLog::debug(const std::string &msg) const {
-	SPDLOG_DEBUG(msg);
+	SPDLOG_DEBUG("{}", msg);
 }
 
 void LogWithSpdLog::trace(const std::string &msg) const {
-	SPDLOG_TRACE(msg);
+	SPDLOG_TRACE("{}", msg);
 }
 #endif


### PR DESCRIPTION
This pull request makes a small but important update to how log messages are passed to the `spdlog` logging macros in `log_with_spd_log.cpp`. The change ensures that log messages are consistently formatted using spdlog's formatting syntax, which improves safety and flexibility.

- Updated all logging macro calls (`SPDLOG_INFO`, `SPDLOG_WARN`, `SPDLOG_ERROR`, `SPDLOG_CRITICAL`, `SPDLOG_DEBUG`, and `SPDLOG_TRACE`) to use the format string `"{}"` with the message as an argument, instead of passing the message directly. This prevents potential formatting issues and aligns with spdlog best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging implementation with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->