### PR TITLE
feat: add accounts indexes (email + password)

### DIFF
--- a/data-otservbr-global/migrations/56.lua
+++ b/data-otservbr-global/migrations/56.lua
@@ -1,6 +1,7 @@
 function onUpdateDatabase()
 	logger.info("Updating database to version 56 (feat: accounts email + password indexes)")
 
+	db.query("ALTER TABLE `accounts` MODIFY `password` VARCHAR(255) NOT NULL;")
 	db.query("CREATE INDEX `accounts_email` ON `accounts` (`email`);")
 	db.query("CREATE INDEX `accounts_password` ON `accounts` (`password`);")
 end

--- a/data-otservbr-global/migrations/56.lua
+++ b/data-otservbr-global/migrations/56.lua
@@ -10,6 +10,6 @@ function onUpdateDatabase()
 	end
 
 	if not db.query("CREATE INDEX `accounts_password` ON `accounts` (`password`);") then
-		logger.error("Failed to create accounts password index."
+		logger.error("Failed to create accounts password index.")
 	end
 end

--- a/data-otservbr-global/migrations/56.lua
+++ b/data-otservbr-global/migrations/56.lua
@@ -1,0 +1,6 @@
+function onUpdateDatabase()
+	logger.info("Updating database to version 56 (feat: accounts email + password indexes)")
+
+	db.query("CREATE INDEX `accounts_email` ON `accounts` (`email`);")
+	db.query("CREATE INDEX `accounts_password` ON `accounts` (`password`);")
+end

--- a/data-otservbr-global/migrations/56.lua
+++ b/data-otservbr-global/migrations/56.lua
@@ -1,7 +1,15 @@
 function onUpdateDatabase()
 	logger.info("Updating database to version 56 (feat: accounts email + password indexes)")
 
-	db.query("ALTER TABLE `accounts` MODIFY `password` VARCHAR(255) NOT NULL;")
-	db.query("CREATE INDEX `accounts_email` ON `accounts` (`email`);")
-	db.query("CREATE INDEX `accounts_password` ON `accounts` (`password`);")
+	if not db.query("ALTER TABLE `accounts` MODIFY `password` VARCHAR(255) NOT NULL;") then
+		logger.error("Failed to modify password field.")
+	end
+
+	if not db.query("CREATE INDEX `accounts_email` ON `accounts` (`email`);") then
+		logger.error("Failed to create accounts email index.")
+	end
+
+	if not db.query("CREATE INDEX `accounts_password` ON `accounts` (`password`);") then
+		logger.error("Failed to create accounts password index."
+	end
 end

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS `server_config` (
     CONSTRAINT `server_config_pk` PRIMARY KEY (`config`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '54'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '56'), ('motd_hash', ''), ('motd_num', '0'), ('players_record', '0');
 
 -- Table structure `accounts`
 CREATE TABLE IF NOT EXISTS `accounts` (

--- a/schema.sql
+++ b/schema.sql
@@ -26,7 +26,9 @@ CREATE TABLE IF NOT EXISTS `accounts` (
     `recruiter` INT(6) DEFAULT 0,
     `house_bid_id` int(11) NOT NULL DEFAULT '0',
     CONSTRAINT `accounts_pk` PRIMARY KEY (`id`),
-    CONSTRAINT `accounts_unique` UNIQUE (`name`)
+    CONSTRAINT `accounts_unique` UNIQUE (`name`),
+    INDEX `accounts_email` (`email`),
+    INDEX `accounts_password` (`password`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Table structure `coins_transactions`

--- a/schema.sql
+++ b/schema.sql
@@ -13,7 +13,7 @@ INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '56'), ('m
 CREATE TABLE IF NOT EXISTS `accounts` (
     `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
     `name` varchar(32) NOT NULL,
-    `password` TEXT NOT NULL,
+    `password` VARCHAR(255) NOT NULL,
     `email` varchar(255) NOT NULL DEFAULT '',
     `premdays` int(11) NOT NULL DEFAULT '0',
     `premdays_purchased` int(11) NOT NULL DEFAULT '0',


### PR DESCRIPTION
# Description

Added indexes into accounts table - for email and password. This gives 10x performance boost when searching for those columns. I tested on db with 3k accounts.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Tested execution of migration + schema.sql in the phpmyadmin

**Test Configuration**:

  - MySQL Version: 11.2.0-MariaDB
  - Server Version: Canary latest
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database upgraded to version 56 (server config updated).
  * Account password field now required and limited to 255 characters.
  * New indexes on account email and password to improve lookup and authentication performance.
  * Migration runs with guarded logging to report and surface any upgrade failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->