### PR TITLE
fix: Fix mount speed exploit in PZ

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4543,8 +4543,7 @@ void Game::playerSetShowOffSocket(uint32_t playerId, Outfit_t &outfit, const Pos
 		item->setCustomAttribute("LookLegs", static_cast<int64_t>(outfit.lookLegs));
 		item->setCustomAttribute("LookFeet", static_cast<int64_t>(outfit.lookFeet));
 		item->setCustomAttribute("LookAddons", static_cast<int64_t>(outfit.lookAddons));
-	} else if (auto pastLookType = item->getCustomAttribute("PastLookType");
-	           pastLookType && pastLookType->getInteger() > 0) {
+	} else if (auto pastLookType = item->getCustomAttribute("PastLookType"); pastLookType && pastLookType->getInteger() > 0) {
 		item->removeCustomAttribute("LookType");
 		item->removeCustomAttribute("PastLookType");
 	}
@@ -4555,8 +4554,7 @@ void Game::playerSetShowOffSocket(uint32_t playerId, Outfit_t &outfit, const Pos
 		item->setCustomAttribute("LookMountBody", static_cast<int64_t>(outfit.lookMountBody));
 		item->setCustomAttribute("LookMountLegs", static_cast<int64_t>(outfit.lookMountLegs));
 		item->setCustomAttribute("LookMountFeet", static_cast<int64_t>(outfit.lookMountFeet));
-	} else if (auto pastLookMount = item->getCustomAttribute("PastLookMount");
-	           pastLookMount && pastLookMount->getInteger() > 0) {
+	} else if (auto pastLookMount = item->getCustomAttribute("PastLookMount"); pastLookMount && pastLookMount->getInteger() > 0) {
 		item->removeCustomAttribute("LookMount");
 		item->removeCustomAttribute("PastLookMount");
 	}
@@ -6387,18 +6385,19 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 
 		if (!g_configManager().getBoolean(TOGGLE_MOUNT_IN_PZ) && playerTile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 			outfit.lookMount = 0;
-		}
-
-		auto deltaSpeedChange = mount->speed;
-		if (player->isMounted()) {
-			const auto prevMount = mounts->getMountByID(player->getLastMount());
-			if (prevMount) {
-				deltaSpeedChange -= prevMount->speed;
+		} else {
+			auto deltaSpeedChange = mount->speed;
+			if (player->isMounted()) {
+				const auto prevMount = mounts->getMountByID(player->getLastMount());
+				if (prevMount) {
+					deltaSpeedChange -= prevMount->speed;
+				}
 			}
+
+			player->setCurrentMount(mount->id);
+			changeSpeed(player, deltaSpeedChange);
 		}
 
-		player->setCurrentMount(mount->id);
-		changeSpeed(player, deltaSpeedChange);
 	} else if (player->isMounted()) {
 		player->dismount();
 	}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5864,9 +5864,18 @@ void Game::playerLootNearby(uint32_t playerId) {
 	// Iterate all tiles within a 1-tile radius around the player (3x3 area)
 	for (int32_t x = -1; x <= 1; ++x) {
 		for (int32_t y = -1; y <= 1; ++y) {
+			// Compute coordinates in signed integers to avoid wraparound on cast
+			const int32_t tileX = static_cast<int32_t>(playerPos.x) + x;
+			const int32_t tileY = static_cast<int32_t>(playerPos.y) + y;
+
+			// Skip positions outside the valid uint16_t coordinate range
+			if (tileX < 0 || tileX > 0xFFFF || tileY < 0 || tileY > 0xFFFF) {
+				continue;
+			}
+
 			const std::shared_ptr<Tile> &tile = map.getTile(
-				static_cast<uint16_t>(playerPos.x + x),
-				static_cast<uint16_t>(playerPos.y + y),
+				static_cast<uint16_t>(tileX),
+				static_cast<uint16_t>(tileY),
 				playerPos.z
 			);
 			if (!tile) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5931,7 +5931,7 @@ void Game::playerLootNearby(uint32_t playerId) {
 	}
 
 	if (totalCorpsesFound == 0) {
-		player->sendCancelMessage("There are no corpses nearby to loot.");
+		player->sendCancelMessage("You cannot loot any nearby corpses.");
 	} else if (totalCorpses == 0) {
 		player->sendCancelMessage("All nearby corpses are already empty.");
 	} else if (totalCorpses > 1) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5851,6 +5851,87 @@ void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Pos
 	browseField = false;
 }
 
+void Game::playerLootNearby(uint32_t playerId) {
+	const auto &player = getPlayerByID(playerId);
+	if (!player) {
+		return;
+	}
+
+	const Position &playerPos = player->getPosition();
+	uint32_t totalCorpses = 0;
+	uint32_t totalCorpsesFound = 0;
+
+	// Iterate all tiles within a 1-tile radius around the player (3x3 area)
+	for (int32_t x = -1; x <= 1; ++x) {
+		for (int32_t y = -1; y <= 1; ++y) {
+			const std::shared_ptr<Tile> &tile = map.getTile(
+				static_cast<uint16_t>(playerPos.x + x),
+				static_cast<uint16_t>(playerPos.y + y),
+				playerPos.z
+			);
+			if (!tile) {
+				continue;
+			}
+
+			const TileItemVector* itemVector = tile->getItemList();
+			if (!itemVector) {
+				continue;
+			}
+
+			for (const auto &tileItem : *itemVector) {
+				if (!tileItem) {
+					continue;
+				}
+
+				const auto &corpse = tileItem->getContainer();
+				if (!corpse || !corpse->isCorpse()
+				    || corpse->hasAttribute(ItemAttribute_t::UNIQUEID)
+				    || corpse->hasAttribute(ItemAttribute_t::ACTIONID)) {
+					continue;
+				}
+
+				if (!corpse->isRewardCorpse()
+				    && corpse->getCorpseOwner() != 0
+				    && !player->canOpenCorpse(corpse->getCorpseOwner())) {
+					continue;
+				}
+
+				// Skip completely empty corpses to avoid spam messages
+				if (corpse->empty()) {
+					++totalCorpsesFound;
+					continue;
+				}
+
+				playerQuickLootCorpse(player, corpse, corpse->getPosition());
+				++totalCorpses;
+				++totalCorpsesFound;
+
+				if (totalCorpses >= 30) {
+					break;
+				}
+			}
+
+			if (totalCorpses >= 30) {
+				break;
+			}
+		}
+
+		if (totalCorpses >= 30) {
+			break;
+		}
+	}
+
+	if (totalCorpsesFound == 0) {
+		player->sendCancelMessage("There are no corpses nearby to loot.");
+	} else if (totalCorpses == 0) {
+		player->sendCancelMessage("All nearby corpses are already empty.");
+	} else if (totalCorpses > 1) {
+		std::stringstream ss;
+		ss << "You looted " << totalCorpses << " corpses.";
+		player->sendTextMessage(MESSAGE_LOOT, ss.str());
+	}
+}
+
 void Game::playerSetManagedContainer(uint32_t playerId, ObjectCategory_t category, const Position &pos, uint16_t itemId, uint8_t stackPos, bool isLootContainer) {
 	const auto &player = getPlayerByID(playerId);
 	if (!player || pos.x != 0xffff) {

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -365,6 +365,7 @@ public:
 	void playerQuickLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position);
 	void playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem = nullptr, bool lootAllCorpses = false, bool autoLoot = false);
 	void playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool lootAllCorpses);
+	void playerLootNearby(uint32_t playerId);
 	void playerSetManagedContainer(uint32_t playerId, ObjectCategory_t category, const Position &pos, uint16_t itemId, uint8_t stackPos, bool isLootContainer);
 	void playerClearManagedContainer(uint32_t playerId, ObjectCategory_t category, bool isLootContainer);
 	void playerOpenManagedContainer(uint32_t playerId, ObjectCategory_t category, bool isLootContainer);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1941,22 +1941,20 @@ void ProtocolGame::parseQuickLoot(NetworkMessage &msg) {
 	}
 
 	uint8_t variant = msg.getByte();
-	const Position pos = msg.getPosition();
-	auto itemId = 0;
-	uint8_t stackpos = 0;
-	bool lootAllCorpses = true;
-	bool autoLoot = true;
 
 	if (variant == 2) {
-		// Loot player nearby (13.40)
-	} else {
-		itemId = msg.get<uint16_t>();
-		stackpos = msg.getByte();
-		lootAllCorpses = variant == 1;
-		autoLoot = false;
+		// Loot all nearby corpses (13.40 hotkey) - client only sends the variant byte
+		g_game().playerLootNearby(player->getID());
+		return;
 	}
+
+	const Position pos = msg.getPosition();
+	auto itemId = msg.get<uint16_t>();
+	uint8_t stackpos = msg.getByte();
+	bool lootAllCorpses = variant == 1;
+
 	g_logger().debug("[{}] variant {}, pos {}, itemId {}, stackPos {}", __FUNCTION__, variant, pos.toString(), itemId, stackpos);
-	g_game().playerQuickLoot(player->getID(), pos, itemId, stackpos, nullptr, lootAllCorpses, autoLoot);
+	g_game().playerQuickLoot(player->getID(), pos, itemId, stackpos, nullptr, lootAllCorpses, false);
 }
 
 void ProtocolGame::parseLootContainer(NetworkMessage &msg) {


### PR DESCRIPTION
# Description

Problem:
In Game::playerChangeOutfit() (game.cpp:6339), when the player is inside a Protection Zone (PZ), the code sets outfit.lookMount = 0 to hide the mount visually. However, the speed application block (changeSpeed) right below was executed regardless of this condition. As a result, every time the player opened the "Customize Character" window and selected a mount while in PZ, they would gain +10 speed without actually mounting.

Fix:
Wrapped the changeSpeed block inside an else condition, ensuring that speed is only applied when the mount is actually equipped (i.e., outside PZ). While in PZ, the code now only clears the mount's visual appearance in the outfit without modifying the player's speed.

## Behaviour
### **Actual**

It is possible to gain +10 speed repeatedly while in a Protection Zone (PZ) by reopening the "Customize Character" window and selecting a mount multiple times.

### **Expected**

Players should not gain any speed from mounts while in a Protection Zone (PZ).

### Fixes #issuenumber

## Type of change

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [ ] Test A
  - [ ] Test B

**Test Configuration**:

  - Server Version: 3.4.2
  - Client: 15.00
  - Operating System: Windows

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quick-loot nearby feature: automatically loot multiple nearby corpses with a single action. Streamlines inventory management and improves looting efficiency without requiring manual targeting.

* **Improvements**
  * Enhanced mount behavior in protection zones to provide more responsive and consistent control when toggling mounts. Mount changes now process correctly based on zone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->