### PR TITLE
Fix: toolgear

### DIFF
--- a/data-otservbr-global/scripts/lib/register_actions.lua
+++ b/data-otservbr-global/scripts/lib/register_actions.lua
@@ -975,8 +975,6 @@ function onUseSpoon(player, item, fromPosition, target, toPosition, isHotkey)
 			return false
 		end
 	end
-
-	return true
 end
 
 function onUseSpikedSquelcher(player, item, fromPosition, target, toPosition, isHotkey)


### PR DESCRIPTION
# Description

onUseSpoon always returned true, so the functions onUseScythe and onUseKitchenKnife were never called in toolgear.lua

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the return behavior of a spoon usage action to ensure proper default handling in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->