### PR TITLE
fix: update houses, monsters and NPC world data

### DIFF
--- a/data-otservbr-global/world/otservbr-house.xml
+++ b/data-otservbr-global/world/otservbr-house.xml
@@ -1,775 +1,775 @@
 <?xml version="1.0"?>
 <houses>
-	<house name="Castle of the Winds" houseid="2628" entryx="32657" entryy="31583" entryz="7" rent="500000" guildhall="true" townid="5" size="493" clientid="40112" beds="18" />
-	<house name="Ab'Dendriel Clanhall" houseid="2629" entryx="32714" entryy="31643" entryz="7" rent="250000" guildhall="true" townid="5" size="310" clientid="40111" beds="10" />
-	<house name="Underwood 9" houseid="2630" entryx="32712" entryy="31665" entryz="7" rent="50000" townid="5" size="13" clientid="40109" beds="1" />
-	<house name="Treetop 13" houseid="2631" entryx="32713" entryy="31665" entryz="6" rent="100000" townid="5" size="26" clientid="40413" beds="2" />
-	<house name="Underwood 8" houseid="2632" entryx="32690" entryy="31647" entryz="7" rent="50000" townid="5" size="17" clientid="40108" beds="2" />
-	<house name="Treetop 11" houseid="2633" entryx="32688" entryy="31642" entryz="6" rent="50000" townid="5" size="16" clientid="40411" beds="2" />
-	<house name="Great Willow 2a" houseid="2635" entryx="32662" entryy="31635" entryz="6" rent="50000" townid="5" size="17" clientid="40224" beds="1" />
-	<house name="Great Willow 2b" houseid="2637" entryx="32662" entryy="31642" entryz="6" rent="50000" townid="5" size="17" clientid="40222" beds="1" />
-	<house name="Great Willow Western Wing" houseid="2638" entryx="32660" entryy="31641" entryz="7" rent="100000" townid="5" size="53" clientid="40211" beds="4" />
-	<house name="Great Willow 1" houseid="2640" entryx="32663" entryy="31641" entryz="7" rent="100000" townid="5" size="28" clientid="40212" beds="2" />
-	<house name="Great Willow 3a" houseid="2642" entryx="32662" entryy="31635" entryz="5" rent="50000" townid="5" size="17" clientid="40234" beds="1" />
-	<house name="Great Willow 3b" houseid="2644" entryx="32662" entryy="31642" entryz="5" rent="80000" townid="5" size="32" clientid="40244" beds="1" />
-	<house name="Great Willow 4a" houseid="2645" entryx="32662" entryy="31639" entryz="4" rent="25000" townid="5" size="17" clientid="40242" beds="2" />
-	<house name="Great Willow 4b" houseid="2648" entryx="32664" entryy="31639" entryz="4" rent="25000" townid="5" size="17" clientid="40243" beds="2" />
-	<house name="Underwood 6" houseid="2649" entryx="32652" entryy="31656" entryz="7" rent="100000" townid="5" size="31" clientid="40106" beds="3" />
-	<house name="Underwood 3" houseid="2650" entryx="32643" entryy="31657" entryz="7" rent="100000" townid="5" size="33" clientid="40103" beds="3" />
-	<house name="Underwood 5" houseid="2651" entryx="32652" entryy="31668" entryz="7" rent="80000" townid="5" size="26" clientid="40105" beds="3" />
-	<house name="Underwood 2" houseid="2652" entryx="32646" entryy="31676" entryz="7" rent="100000" townid="5" size="31" clientid="40102" beds="2" />
-	<house name="Underwood 1" houseid="2653" entryx="32643" entryy="31691" entryz="7" rent="100000" townid="5" size="31" clientid="40101" beds="2" />
-	<house name="Prima Arbor" houseid="2654" entryx="32687" entryy="31686" entryz="7" rent="400000" townid="5" size="197" clientid="40414" beds="6" />
-	<house name="Underwood 7" houseid="2655" entryx="32677" entryy="31678" entryz="7" rent="200000" townid="5" size="28" clientid="40107" beds="3" />
-	<house name="Underwood 10" houseid="2656" entryx="32626" entryy="31657" entryz="7" rent="25000" townid="5" size="13" clientid="40110" beds="1" />
-	<house name="Underwood 4" houseid="2657" entryx="32626" entryy="31656" entryz="7" rent="100000" townid="5" size="43" clientid="40104" beds="4" />
-	<house name="Treetop 9" houseid="2658" entryx="32624" entryy="31654" entryz="6" rent="50000" townid="5" size="21" clientid="40409" beds="2" />
-	<house name="Treetop 10" houseid="2659" entryx="32626" entryy="31656" entryz="6" rent="80000" townid="5" size="21" clientid="40410" beds="2" />
-	<house name="Treetop 8" houseid="2660" entryx="32628" entryy="31654" entryz="6" rent="25000" townid="5" size="16" clientid="40408" beds="1" />
-	<house name="Treetop 7" houseid="2661" entryx="32642" entryy="31657" entryz="6" rent="50000" townid="5" size="16" clientid="40407" beds="1" />
-	<house name="Treetop 6" houseid="2662" entryx="32642" entryy="31661" entryz="6" rent="25000" townid="5" size="9" clientid="40406" beds="1" />
-	<house name="Treetop 5 (Shop)" houseid="2663" entryx="32656" entryy="31654" entryz="6" rent="80000" townid="5" size="27" clientid="40405" beds="1" />
-	<house name="Treetop 12 (Shop)" houseid="2664" entryx="32681" entryy="31675" entryz="6" rent="100000" townid="5" size="27" clientid="40412" beds="1" />
-	<house name="Treetop 4 (Shop)" houseid="2665" entryx="32644" entryy="31672" entryz="6" rent="80000" townid="5" size="25" clientid="40404" beds="1" />
-	<house name="Treetop 3 (Shop)" houseid="2666" entryx="32644" entryy="31676" entryz="6" rent="80000" townid="5" size="25" clientid="40403" beds="1" />
-	<house name="Northern Street 1a" houseid="2687" entryx="32356" entryy="31767" entryz="7" rent="100000" townid="6" size="21" clientid="20601" beds="2" />
-	<house name="Park Lane 3a" houseid="2688" entryx="32326" entryy="31767" entryz="7" rent="100000" townid="6" size="25" clientid="20204" beds="2" />
-	<house name="Park Lane 1a" houseid="2689" entryx="32335" entryy="31767" entryz="7" rent="150000" townid="6" size="28" clientid="20201" beds="2" />
-	<house name="Park Lane 4" houseid="2690" entryx="32327" entryy="31768" entryz="7" rent="150000" townid="6" size="22" clientid="20205" beds="2" />
-	<house name="Park Lane 2" houseid="2691" entryx="32335" entryy="31768" entryz="7" rent="150000" townid="6" size="22" clientid="20206" beds="2" />
-	<house name="Theater Avenue 7, Flat 04" houseid="2692" entryx="32348" entryy="31780" entryz="7" rent="50000" townid="6" size="11" clientid="20319" beds="1" />
-	<house name="Theater Avenue 7, Flat 03" houseid="2693" entryx="32350" entryy="31780" entryz="7" rent="25000" townid="6" size="9" clientid="20318" beds="1" />
-	<house name="Theater Avenue 7, Flat 05" houseid="2694" entryx="32347" entryy="31782" entryz="7" rent="50000" townid="6" size="9" clientid="20320" beds="1" />
-	<house name="Theater Avenue 7, Flat 06" houseid="2695" entryx="32348" entryy="31786" entryz="7" rent="25000" townid="6" size="7" clientid="20321" beds="1" />
-	<house name="Theater Avenue 7, Flat 02" houseid="2696" entryx="32350" entryy="31783" entryz="7" rent="25000" townid="6" size="9" clientid="20317" beds="1" />
-	<house name="Theater Avenue 7, Flat 01" houseid="2697" entryx="32349" entryy="31786" entryz="7" rent="25000" townid="6" size="7" clientid="20316" beds="1" />
-	<house name="Northern Street 5" houseid="2698" entryx="32380" entryy="31772" entryz="7" rent="200000" townid="6" size="47" clientid="20606" beds="2" />
-	<house name="Northern Street 7" houseid="2699" entryx="32389" entryy="31774" entryz="7" rent="150000" townid="6" size="40" clientid="20607" beds="2" />
-	<house name="Theater Avenue 6e" houseid="2700" entryx="32375" entryy="31794" entryz="7" rent="80000" townid="6" size="16" clientid="20308" beds="2" />
-	<house name="Theater Avenue 6c" houseid="2701" entryx="32376" entryy="31794" entryz="7" rent="25000" townid="6" size="5" clientid="20306" beds="1" />
-	<house name="Theater Avenue 6a" houseid="2702" entryx="32376" entryy="31794" entryz="7" rent="80000" townid="6" size="16" clientid="20304" beds="2" />
-	<house name="Theater Avenue, Tower" houseid="2703" entryx="32389" entryy="31787" entryz="7" rent="300000" townid="6" size="70" clientid="20301" beds="3" />
-	<house name="East Lane 2" houseid="2705" entryx="32399" entryy="31798" entryz="7" rent="300000" townid="6" size="108" clientid="20803" beds="2" />
-	<house name="Harbour Lane 2a (Shop)" houseid="2706" entryx="32380" entryy="31809" entryz="7" rent="80000" townid="6" size="17" clientid="20703" beds="0" />
-	<house name="Harbour Lane 2b (Shop)" houseid="2707" entryx="32383" entryy="31809" entryz="7" rent="80000" townid="6" size="17" clientid="20704" beds="0" />
-	<house name="Harbour Lane 3" houseid="2708" entryx="32362" entryy="31823" entryz="7" rent="400000" townid="6" size="84" clientid="20702" beds="3" />
-	<house name="Magician's Alley 8" houseid="2709" entryx="32331" entryy="31819" entryz="7" rent="150000" townid="6" size="26" clientid="20514" beds="2" />
-	<house name="Lonely Sea Side Hostel" houseid="2710" entryx="32319" entryy="31839" entryz="7" rent="400000" townid="6" size="281" clientid="20902" beds="8" />
-	<house name="Suntower" houseid="2711" entryx="32341" entryy="31847" entryz="7" rent="500000" guildhall="true" townid="6" size="232" clientid="20901" beds="9" />
-	<house name="House of Recreation" houseid="2712" entryx="32280" entryy="31823" entryz="7" rent="500000" guildhall="true" townid="6" size="401" clientid="20002" beds="16" />
-	<house name="Carlin Clanhall" houseid="2713" entryx="32307" entryy="31818" entryz="7" rent="250000" guildhall="true" townid="6" size="211" clientid="20515" beds="10" />
-	<house name="Magician's Alley 4" houseid="2714" entryx="32317" entryy="31820" entryz="7" rent="200000" townid="6" size="49" clientid="20513" beds="4" />
-	<house name="Theater Avenue 14 (Shop)" houseid="2715" entryx="32302" entryy="31801" entryz="7" rent="200000" townid="6" size="47" clientid="20403" beds="1" />
-	<house name="Theater Avenue 12" houseid="2716" entryx="32310" entryy="31791" entryz="7" rent="80000" townid="6" size="19" clientid="20402" beds="2" />
-	<house name="Magician's Alley 1" houseid="2717" entryx="32307" entryy="31801" entryz="7" rent="100000" townid="6" size="19" clientid="20501" beds="2" />
-	<house name="Theater Avenue 10" houseid="2718" entryx="32314" entryy="31791" entryz="7" rent="100000" townid="6" size="22" clientid="20401" beds="2" />
-	<house name="Magician's Alley 1b" houseid="2719" entryx="32311" entryy="31795" entryz="6" rent="25000" townid="6" size="13" clientid="20503" beds="2" />
-	<house name="Magician's Alley 1a" houseid="2720" entryx="32311" entryy="31798" entryz="6" rent="25000" townid="6" size="12" clientid="20502" beds="2" />
-	<house name="Magician's Alley 1c" houseid="2721" entryx="32311" entryy="31795" entryz="6" rent="25000" townid="6" size="10" clientid="20504" beds="1" />
-	<house name="Magician's Alley 1d" houseid="2722" entryx="32311" entryy="31798" entryz="6" rent="25000" townid="6" size="9" clientid="20505" beds="1" />
-	<house name="Magician's Alley 5c" houseid="2723" entryx="32322" entryy="31802" entryz="6" rent="100000" townid="6" size="21" clientid="20509" beds="2" />
-	<house name="Magician's Alley 5f" houseid="2724" entryx="32322" entryy="31807" entryz="6" rent="80000" townid="6" size="21" clientid="20512" beds="2" />
-	<house name="Magician's Alley 5b" houseid="2725" entryx="32325" entryy="31804" entryz="7" rent="50000" townid="6" size="19" clientid="20508" beds="2" />
-	<house name="Magician's Alley 5a" houseid="2727" entryx="32326" entryy="31804" entryz="7" rent="50000" townid="6" size="22" clientid="20510" beds="2" />
+	<house name="Castle of the Winds" houseid="2628" entryx="32657" entryy="31583" entryz="7" rent="500000" guildhall="true" townid="5" size="514" clientid="40112" beds="18" />
+	<house name="Ab'Dendriel Clanhall" houseid="2629" entryx="32714" entryy="31643" entryz="7" rent="250000" guildhall="true" townid="5" size="326" clientid="40111" beds="10" />
+	<house name="Underwood 9" houseid="2630" entryx="32712" entryy="31665" entryz="7" rent="50000" townid="5" size="14" clientid="40109" beds="1" />
+	<house name="Treetop 13" houseid="2631" entryx="32713" entryy="31665" entryz="6" rent="100000" townid="5" size="28" clientid="40413" beds="2" />
+	<house name="Underwood 8" houseid="2632" entryx="32690" entryy="31647" entryz="7" rent="50000" townid="5" size="23" clientid="40108" beds="2" />
+	<house name="Treetop 11" houseid="2633" entryx="32688" entryy="31642" entryz="6" rent="50000" townid="5" size="24" clientid="40411" beds="2" />
+	<house name="Great Willow 2a" houseid="2635" entryx="32662" entryy="31635" entryz="6" rent="50000" townid="5" size="20" clientid="40224" beds="1" />
+	<house name="Great Willow 2b" houseid="2637" entryx="32662" entryy="31642" entryz="6" rent="50000" townid="5" size="25" clientid="40222" beds="1" />
+	<house name="Great Willow Western Wing" houseid="2638" entryx="32660" entryy="31641" entryz="7" rent="100000" townid="5" size="61" clientid="40211" beds="4" />
+	<house name="Great Willow 1" houseid="2640" entryx="32663" entryy="31641" entryz="7" rent="100000" townid="5" size="35" clientid="40212" beds="2" />
+	<house name="Great Willow 3a" houseid="2642" entryx="32662" entryy="31635" entryz="5" rent="50000" townid="5" size="19" clientid="40234" beds="1" />
+	<house name="Great Willow 3b" houseid="2644" entryx="32662" entryy="31642" entryz="5" rent="80000" townid="5" size="40" clientid="40244" beds="1" />
+	<house name="Great Willow 4a" houseid="2645" entryx="32662" entryy="31639" entryz="4" rent="25000" townid="5" size="19" clientid="40242" beds="2" />
+	<house name="Great Willow 4b" houseid="2648" entryx="32664" entryy="31639" entryz="4" rent="25000" townid="5" size="19" clientid="40243" beds="2" />
+	<house name="Underwood 6" houseid="2649" entryx="32652" entryy="31656" entryz="7" rent="100000" townid="5" size="40" clientid="40106" beds="3" />
+	<house name="Underwood 3" houseid="2650" entryx="32643" entryy="31657" entryz="7" rent="100000" townid="5" size="39" clientid="40103" beds="3" />
+	<house name="Underwood 5" houseid="2651" entryx="32652" entryy="31668" entryz="7" rent="80000" townid="5" size="33" clientid="40105" beds="3" />
+	<house name="Underwood 2" houseid="2652" entryx="32646" entryy="31676" entryz="7" rent="100000" townid="5" size="37" clientid="40102" beds="2" />
+	<house name="Underwood 1" houseid="2653" entryx="32643" entryy="31691" entryz="7" rent="100000" townid="5" size="39" clientid="40101" beds="2" />
+	<house name="Prima Arbor" houseid="2654" entryx="32687" entryy="31686" entryz="7" rent="400000" townid="5" size="200" clientid="40414" beds="6" />
+	<house name="Underwood 7" houseid="2655" entryx="32677" entryy="31678" entryz="7" rent="200000" townid="5" size="34" clientid="40107" beds="3" />
+	<house name="Underwood 10" houseid="2656" entryx="32626" entryy="31657" entryz="7" rent="25000" townid="5" size="19" clientid="40110" beds="1" />
+	<house name="Underwood 4" houseid="2657" entryx="32626" entryy="31656" entryz="7" rent="100000" townid="5" size="50" clientid="40104" beds="4" />
+	<house name="Treetop 9" houseid="2658" entryx="32624" entryy="31654" entryz="6" rent="50000" townid="5" size="24" clientid="40409" beds="2" />
+	<house name="Treetop 10" houseid="2659" entryx="32626" entryy="31656" entryz="6" rent="80000" townid="5" size="28" clientid="40410" beds="2" />
+	<house name="Treetop 8" houseid="2660" entryx="32628" entryy="31654" entryz="6" rent="25000" townid="5" size="22" clientid="40408" beds="1" />
+	<house name="Treetop 7" houseid="2661" entryx="32642" entryy="31657" entryz="6" rent="50000" townid="5" size="20" clientid="40407" beds="1" />
+	<house name="Treetop 6" houseid="2662" entryx="32642" entryy="31661" entryz="6" rent="25000" townid="5" size="17" clientid="40406" beds="1" />
+	<house name="Treetop 5 (Shop)" houseid="2663" entryx="32656" entryy="31654" entryz="6" rent="80000" townid="5" size="36" clientid="40405" beds="1" />
+	<house name="Treetop 12 (Shop)" houseid="2664" entryx="32681" entryy="31675" entryz="6" rent="100000" townid="5" size="39" clientid="40412" beds="1" />
+	<house name="Treetop 4 (Shop)" houseid="2665" entryx="32644" entryy="31672" entryz="6" rent="80000" townid="5" size="31" clientid="40404" beds="1" />
+	<house name="Treetop 3 (Shop)" houseid="2666" entryx="32644" entryy="31676" entryz="6" rent="80000" townid="5" size="36" clientid="40403" beds="1" />
+	<house name="Northern Street 1a" houseid="2687" entryx="32356" entryy="31767" entryz="7" rent="100000" townid="6" size="26" clientid="20601" beds="2" />
+	<house name="Park Lane 3a" houseid="2688" entryx="32326" entryy="31767" entryz="7" rent="100000" townid="6" size="36" clientid="20204" beds="2" />
+	<house name="Park Lane 1a" houseid="2689" entryx="32335" entryy="31767" entryz="7" rent="150000" townid="6" size="36" clientid="20201" beds="2" />
+	<house name="Park Lane 4" houseid="2690" entryx="32327" entryy="31768" entryz="7" rent="150000" townid="6" size="27" clientid="20205" beds="2" />
+	<house name="Park Lane 2" houseid="2691" entryx="32335" entryy="31768" entryz="7" rent="150000" townid="6" size="28" clientid="20206" beds="2" />
+	<house name="Theater Avenue 7, Flat 04" houseid="2692" entryx="32348" entryy="31780" entryz="7" rent="50000" townid="6" size="15" clientid="20319" beds="1" />
+	<house name="Theater Avenue 7, Flat 03" houseid="2693" entryx="32350" entryy="31780" entryz="7" rent="25000" townid="6" size="13" clientid="20318" beds="1" />
+	<house name="Theater Avenue 7, Flat 05" houseid="2694" entryx="32347" entryy="31782" entryz="7" rent="50000" townid="6" size="13" clientid="20320" beds="1" />
+	<house name="Theater Avenue 7, Flat 06" houseid="2695" entryx="32348" entryy="31786" entryz="7" rent="25000" townid="6" size="13" clientid="20321" beds="1" />
+	<house name="Theater Avenue 7, Flat 02" houseid="2696" entryx="32350" entryy="31783" entryz="7" rent="25000" townid="6" size="15" clientid="20317" beds="1" />
+	<house name="Theater Avenue 7, Flat 01" houseid="2697" entryx="32349" entryy="31786" entryz="7" rent="25000" townid="6" size="13" clientid="20316" beds="1" />
+	<house name="Northern Street 5" houseid="2698" entryx="32380" entryy="31772" entryz="7" rent="200000" townid="6" size="52" clientid="20606" beds="2" />
+	<house name="Northern Street 7" houseid="2699" entryx="32389" entryy="31774" entryz="7" rent="150000" townid="6" size="44" clientid="20607" beds="2" />
+	<house name="Theater Avenue 6e" houseid="2700" entryx="32375" entryy="31794" entryz="7" rent="80000" townid="6" size="25" clientid="20308" beds="2" />
+	<house name="Theater Avenue 6c" houseid="2701" entryx="32376" entryy="31794" entryz="7" rent="25000" townid="6" size="9" clientid="20306" beds="1" />
+	<house name="Theater Avenue 6a" houseid="2702" entryx="32376" entryy="31794" entryz="7" rent="80000" townid="6" size="24" clientid="20304" beds="2" />
+	<house name="Theater Avenue, Tower" houseid="2703" entryx="32389" entryy="31787" entryz="7" rent="300000" townid="6" size="80" clientid="20301" beds="3" />
+	<house name="East Lane 2" houseid="2705" entryx="32399" entryy="31798" entryz="7" rent="300000" townid="6" size="93" clientid="20803" beds="2" />
+	<house name="Harbour Lane 2a (Shop)" houseid="2706" entryx="32380" entryy="31809" entryz="7" rent="80000" townid="6" size="18" clientid="20703" beds="0" />
+	<house name="Harbour Lane 2b (Shop)" houseid="2707" entryx="32383" entryy="31809" entryz="7" rent="80000" townid="6" size="21" clientid="20704" beds="0" />
+	<house name="Harbour Lane 3" houseid="2708" entryx="32362" entryy="31823" entryz="7" rent="400000" townid="6" size="92" clientid="20702" beds="3" />
+	<house name="Magician's Alley 8" houseid="2709" entryx="32331" entryy="31819" entryz="7" rent="150000" townid="6" size="31" clientid="20514" beds="2" />
+	<house name="Lonely Sea Side Hostel" houseid="2710" entryx="32319" entryy="31839" entryz="7" rent="400000" townid="6" size="331" clientid="20902" beds="8" />
+	<house name="Suntower" houseid="2711" entryx="32341" entryy="31847" entryz="7" rent="500000" guildhall="true" townid="6" size="306" clientid="20901" beds="9" />
+	<house name="House of Recreation" houseid="2712" entryx="32280" entryy="31823" entryz="7" rent="500000" guildhall="true" townid="6" size="469" clientid="20002" beds="16" />
+	<house name="Carlin Clanhall" houseid="2713" entryx="32307" entryy="31818" entryz="7" rent="250000" guildhall="true" townid="6" size="287" clientid="20515" beds="10" />
+	<house name="Magician's Alley 4" houseid="2714" entryx="32317" entryy="31820" entryz="7" rent="200000" townid="6" size="60" clientid="20513" beds="4" />
+	<house name="Theater Avenue 14 (Shop)" houseid="2715" entryx="32302" entryy="31801" entryz="7" rent="200000" townid="6" size="54" clientid="20403" beds="1" />
+	<house name="Theater Avenue 12" houseid="2716" entryx="32310" entryy="31791" entryz="7" rent="80000" townid="6" size="21" clientid="20402" beds="2" />
+	<house name="Magician's Alley 1" houseid="2717" entryx="32307" entryy="31801" entryz="7" rent="100000" townid="6" size="23" clientid="20501" beds="2" />
+	<house name="Theater Avenue 10" houseid="2718" entryx="32314" entryy="31791" entryz="7" rent="100000" townid="6" size="29" clientid="20401" beds="2" />
+	<house name="Magician's Alley 1b" houseid="2719" entryx="32311" entryy="31795" entryz="6" rent="25000" townid="6" size="16" clientid="20503" beds="2" />
+	<house name="Magician's Alley 1a" houseid="2720" entryx="32311" entryy="31798" entryz="6" rent="25000" townid="6" size="16" clientid="20502" beds="2" />
+	<house name="Magician's Alley 1c" houseid="2721" entryx="32311" entryy="31795" entryz="6" rent="25000" townid="6" size="13" clientid="20504" beds="1" />
+	<house name="Magician's Alley 1d" houseid="2722" entryx="32311" entryy="31798" entryz="6" rent="25000" townid="6" size="16" clientid="20505" beds="1" />
+	<house name="Magician's Alley 5c" houseid="2723" entryx="32322" entryy="31802" entryz="6" rent="100000" townid="6" size="25" clientid="20509" beds="2" />
+	<house name="Magician's Alley 5f" houseid="2724" entryx="32322" entryy="31807" entryz="6" rent="80000" townid="6" size="28" clientid="20512" beds="2" />
+	<house name="Magician's Alley 5b" houseid="2725" entryx="32325" entryy="31804" entryz="7" rent="50000" townid="6" size="25" clientid="20508" beds="2" />
+	<house name="Magician's Alley 5a" houseid="2727" entryx="32326" entryy="31804" entryz="7" rent="50000" townid="6" size="30" clientid="20510" beds="2" />
 	<house name="Central Plaza 3 (Shop)" houseid="2729" entryx="32345" entryy="31800" entryz="7" rent="50000" townid="6" size="17" clientid="20102" beds="1" />
-	<house name="Central Plaza 2 (Shop)" houseid="2730" entryx="32345" entryy="31806" entryz="7" rent="25000" townid="6" size="17" clientid="20103" beds="1" />
-	<house name="Central Plaza 1 (Shop)" houseid="2731" entryx="32345" entryy="31812" entryz="7" rent="50000" townid="6" size="17" clientid="20104" beds="1" />
-	<house name="Theater Avenue 8b" houseid="2732" entryx="32357" entryy="31795" entryz="6" rent="100000" townid="6" size="26" clientid="20315" beds="3" />
-	<house name="Harbour Lane 1 (Shop)" houseid="2733" entryx="32366" entryy="31799" entryz="6" rent="100000" townid="6" size="26" clientid="20701" beds="0" />
-	<house name="Theater Avenue 6f" houseid="2734" entryx="32375" entryy="31794" entryz="6" rent="80000" townid="6" size="16" clientid="20309" beds="2" />
-	<house name="Theater Avenue 6d" houseid="2735" entryx="32376" entryy="31794" entryz="6" rent="25000" townid="6" size="5" clientid="20307" beds="1" />
-	<house name="Theater Avenue 6b" houseid="2736" entryx="32376" entryy="31794" entryz="6" rent="50000" townid="6" size="16" clientid="20305" beds="2" />
-	<house name="Northern Street 3a" houseid="2737" entryx="32368" entryy="31767" entryz="6" rent="80000" townid="6" size="16" clientid="20604" beds="2" />
-	<house name="Northern Street 3b" houseid="2738" entryx="32370" entryy="31769" entryz="6" rent="80000" townid="6" size="17" clientid="20605" beds="2" />
-	<house name="Northern Street 1b" houseid="2739" entryx="32356" entryy="31767" entryz="6" rent="80000" townid="6" size="21" clientid="20602" beds="2" />
-	<house name="Northern Street 1c" houseid="2740" entryx="32357" entryy="31767" entryz="6" rent="80000" townid="6" size="16" clientid="20603" beds="2" />
-	<house name="Theater Avenue 7, Flat 14" houseid="2741" entryx="32348" entryy="31780" entryz="6" rent="25000" townid="6" size="11" clientid="20325" beds="1" />
-	<house name="Theater Avenue 7, Flat 13" houseid="2742" entryx="32350" entryy="31780" entryz="6" rent="25000" townid="6" size="9" clientid="20324" beds="1" />
-	<house name="Theater Avenue 7, Flat 15" houseid="2743" entryx="32347" entryy="31783" entryz="6" rent="25000" townid="6" size="9" clientid="20326" beds="1" />
-	<house name="Theater Avenue 7, Flat 12" houseid="2744" entryx="32350" entryy="31783" entryz="6" rent="25000" townid="6" size="9" clientid="20323" beds="1" />
-	<house name="Theater Avenue 7, Flat 11" houseid="2745" entryx="32350" entryy="31783" entryz="6" rent="50000" townid="6" size="11" clientid="20322" beds="1" />
-	<house name="Theater Avenue 7, Flat 16" houseid="2746" entryx="32347" entryy="31783" entryz="6" rent="25000" townid="6" size="9" clientid="20327" beds="1" />
-	<house name="Theater Avenue 5" houseid="2747" entryx="32365" entryy="31782" entryz="6" rent="200000" townid="6" size="81" clientid="20310" beds="4" />
-	<house name="Harbour Flats, Flat 11" houseid="2751" entryx="32378" entryy="31836" entryz="6" rent="25000" townid="6" size="13" clientid="20705" beds="1" />
-	<house name="Harbour Flats, Flat 13" houseid="2752" entryx="32382" entryy="31836" entryz="6" rent="25000" townid="6" size="13" clientid="20707" beds="1" />
-	<house name="Harbour Flats, Flat 15" houseid="2753" entryx="32387" entryy="31836" entryz="6" rent="50000" townid="6" size="21" clientid="20709" beds="2" />
-	<house name="Harbour Flats, Flat 12" houseid="2755" entryx="32378" entryy="31840" entryz="6" rent="50000" townid="6" size="22" clientid="20706" beds="2" />
-	<house name="Harbour Flats, Flat 16" houseid="2757" entryx="32386" entryy="31840" entryz="6" rent="50000" townid="6" size="22" clientid="20710" beds="2" />
-	<house name="Harbour Flats, Flat 21" houseid="2759" entryx="32381" entryy="31835" entryz="5" rent="50000" townid="6" size="19" clientid="20713" beds="2" />
-	<house name="Harbour Flats, Flat 22" houseid="2760" entryx="32385" entryy="31835" entryz="5" rent="80000" townid="6" size="22" clientid="20714" beds="2" />
-	<house name="Harbour Flats, Flat 23" houseid="2761" entryx="32385" entryy="31843" entryz="5" rent="25000" townid="6" size="10" clientid="20715" beds="1" />
-	<house name="Park Lane 1b" houseid="2763" entryx="32329" entryy="31763" entryz="6" rent="200000" townid="6" size="32" clientid="20202" beds="2" />
-	<house name="Theater Avenue 8a" houseid="2764" entryx="32357" entryy="31792" entryz="5" rent="100000" townid="6" size="26" clientid="20314" beds="2" />
-	<house name="Theater Avenue 11a" houseid="2765" entryx="32314" entryy="31781" entryz="5" rent="100000" townid="6" size="29" clientid="20404" beds="2" />
-	<house name="Theater Avenue 11b" houseid="2767" entryx="32311" entryy="31781" entryz="5" rent="100000" townid="6" size="29" clientid="20405" beds="2" />
-	<house name="Caretaker's Residence" houseid="2768" entryx="32407" entryy="31772" entryz="7" rent="600000" townid="6" size="231" clientid="20012" beds="6" />
-	<house name="Moonkeep" houseid="2769" entryx="32432" entryy="31762" entryz="7" rent="250000" guildhall="true" townid="6" size="289" clientid="20001" beds="16" />
-	<house name="Mangrove 1" houseid="2770" entryx="32648" entryy="31602" entryz="7" rent="80000" townid="5" size="31" clientid="40301" beds="3" />
-	<house name="Coastwood 2" houseid="2771" entryx="32647" entryy="31599" entryz="6" rent="50000" townid="5" size="16" clientid="40502" beds="2" />
-	<house name="Coastwood 1" houseid="2772" entryx="32647" entryy="31603" entryz="6" rent="50000" townid="5" size="16" clientid="40501" beds="2" />
-	<house name="Coastwood 3" houseid="2773" entryx="32668" entryy="31612" entryz="6" rent="50000" townid="5" size="22" clientid="40503" beds="2" />
-	<house name="Coastwood 4" houseid="2774" entryx="32671" entryy="31612" entryz="6" rent="50000" townid="5" size="19" clientid="40504" beds="2" />
-	<house name="Mangrove 4" houseid="2775" entryx="32717" entryy="31621" entryz="7" rent="50000" townid="5" size="17" clientid="40304" beds="2" />
-	<house name="Coastwood 10" houseid="2776" entryx="32717" entryy="31621" entryz="6" rent="80000" townid="5" size="26" clientid="40510" beds="3" />
-	<house name="Coastwood 5" houseid="2777" entryx="32676" entryy="31592" entryz="6" rent="50000" townid="5" size="26" clientid="40505" beds="2" />
-	<house name="Coastwood 6 (Shop)" houseid="2778" entryx="32691" entryy="31592" entryz="6" rent="80000" townid="5" size="29" clientid="40506" beds="1" />
-	<house name="Coastwood 7" houseid="2779" entryx="32695" entryy="31592" entryz="6" rent="25000" townid="5" size="12" clientid="40507" beds="1" />
-	<house name="Coastwood 8" houseid="2780" entryx="32690" entryy="31600" entryz="6" rent="50000" townid="5" size="21" clientid="40508" beds="2" />
-	<house name="Coastwood 9" houseid="2781" entryx="32688" entryy="31614" entryz="6" rent="50000" townid="5" size="17" clientid="40509" beds="1" />
-	<house name="Treetop 2" houseid="2782" entryx="32640" entryy="31689" entryz="6" rent="25000" townid="5" size="13" clientid="40402" beds="1" />
-	<house name="Treetop 1" houseid="2783" entryx="32636" entryy="31689" entryz="6" rent="25000" townid="5" size="13" clientid="40401" beds="1" />
-	<house name="Mangrove 3" houseid="2784" entryx="32693" entryy="31605" entryz="7" rent="80000" townid="5" size="21" clientid="40303" beds="2" />
-	<house name="Mangrove 2" houseid="2785" entryx="32681" entryy="31592" entryz="7" rent="50000" townid="5" size="25" clientid="40302" beds="2" />
-	<house name="The Hideout" houseid="2786" entryx="32546" entryy="31666" entryz="7" rent="250000" guildhall="true" townid="5" size="378" clientid="40002" beds="20" />
-	<house name="Shadow Towers" houseid="2787" entryx="32698" entryy="31773" entryz="7" rent="250000" guildhall="true" townid="5" size="402" clientid="40001" beds="18" />
-	<house name="Druids Retreat A" houseid="2788" entryx="32277" entryy="31729" entryz="7" rent="50000" townid="6" size="31" clientid="20004" beds="2" />
-	<house name="Druids Retreat C" houseid="2789" entryx="32284" entryy="31766" entryz="7" rent="50000" townid="6" size="22" clientid="20006" beds="2" />
-	<house name="Druids Retreat B" houseid="2790" entryx="32272" entryy="31767" entryz="7" rent="50000" townid="6" size="29" clientid="20005" beds="2" />
+	<house name="Central Plaza 2 (Shop)" houseid="2730" entryx="32345" entryy="31806" entryz="7" rent="25000" townid="6" size="15" clientid="20103" beds="1" />
+	<house name="Central Plaza 1 (Shop)" houseid="2731" entryx="32345" entryy="31812" entryz="7" rent="50000" townid="6" size="19" clientid="20104" beds="1" />
+	<house name="Theater Avenue 8b" houseid="2732" entryx="32357" entryy="31795" entryz="6" rent="100000" townid="6" size="31" clientid="20315" beds="3" />
+	<house name="Harbour Lane 1 (Shop)" houseid="2733" entryx="32366" entryy="31799" entryz="6" rent="100000" townid="6" size="31" clientid="20701" beds="0" />
+	<house name="Theater Avenue 6f" houseid="2734" entryx="32375" entryy="31794" entryz="6" rent="80000" townid="6" size="24" clientid="20309" beds="2" />
+	<house name="Theater Avenue 6d" houseid="2735" entryx="32376" entryy="31794" entryz="6" rent="25000" townid="6" size="7" clientid="20307" beds="1" />
+	<house name="Theater Avenue 6b" houseid="2736" entryx="32376" entryy="31794" entryz="6" rent="50000" townid="6" size="25" clientid="20305" beds="2" />
+	<house name="Northern Street 3a" houseid="2737" entryx="32368" entryy="31767" entryz="6" rent="80000" townid="6" size="20" clientid="20604" beds="2" />
+	<house name="Northern Street 3b" houseid="2738" entryx="32370" entryy="31769" entryz="6" rent="80000" townid="6" size="22" clientid="20605" beds="2" />
+	<house name="Northern Street 1b" houseid="2739" entryx="32356" entryy="31767" entryz="6" rent="80000" townid="6" size="25" clientid="20602" beds="2" />
+	<house name="Northern Street 1c" houseid="2740" entryx="32357" entryy="31767" entryz="6" rent="80000" townid="6" size="21" clientid="20603" beds="2" />
+	<house name="Theater Avenue 7, Flat 14" houseid="2741" entryx="32348" entryy="31780" entryz="6" rent="25000" townid="6" size="13" clientid="20325" beds="1" />
+	<house name="Theater Avenue 7, Flat 13" houseid="2742" entryx="32350" entryy="31780" entryz="6" rent="25000" townid="6" size="14" clientid="20324" beds="1" />
+	<house name="Theater Avenue 7, Flat 15" houseid="2743" entryx="32347" entryy="31783" entryz="6" rent="25000" townid="6" size="12" clientid="20326" beds="1" />
+	<house name="Theater Avenue 7, Flat 12" houseid="2744" entryx="32350" entryy="31783" entryz="6" rent="25000" townid="6" size="14" clientid="20323" beds="1" />
+	<house name="Theater Avenue 7, Flat 11" houseid="2745" entryx="32350" entryy="31783" entryz="6" rent="50000" townid="6" size="21" clientid="20322" beds="1" />
+	<house name="Theater Avenue 7, Flat 16" houseid="2746" entryx="32347" entryy="31783" entryz="6" rent="25000" townid="6" size="16" clientid="20327" beds="1" />
+	<house name="Theater Avenue 5" houseid="2747" entryx="32365" entryy="31782" entryz="6" rent="200000" townid="6" size="113" clientid="20310" beds="4" />
+	<house name="Harbour Flats, Flat 11" houseid="2751" entryx="32378" entryy="31836" entryz="6" rent="25000" townid="6" size="17" clientid="20705" beds="1" />
+	<house name="Harbour Flats, Flat 13" houseid="2752" entryx="32382" entryy="31836" entryz="6" rent="25000" townid="6" size="17" clientid="20707" beds="1" />
+	<house name="Harbour Flats, Flat 15" houseid="2753" entryx="32387" entryy="31836" entryz="6" rent="50000" townid="6" size="27" clientid="20709" beds="2" />
+	<house name="Harbour Flats, Flat 12" houseid="2755" entryx="32378" entryy="31840" entryz="6" rent="50000" townid="6" size="33" clientid="20706" beds="2" />
+	<house name="Harbour Flats, Flat 16" houseid="2757" entryx="32386" entryy="31840" entryz="6" rent="50000" townid="6" size="35" clientid="20710" beds="2" />
+	<house name="Harbour Flats, Flat 21" houseid="2759" entryx="32381" entryy="31835" entryz="5" rent="50000" townid="6" size="23" clientid="20713" beds="2" />
+	<house name="Harbour Flats, Flat 22" houseid="2760" entryx="32385" entryy="31835" entryz="5" rent="80000" townid="6" size="30" clientid="20714" beds="2" />
+	<house name="Harbour Flats, Flat 23" houseid="2761" entryx="32385" entryy="31843" entryz="5" rent="25000" townid="6" size="17" clientid="20715" beds="1" />
+	<house name="Park Lane 1b" houseid="2763" entryx="32329" entryy="31763" entryz="6" rent="200000" townid="6" size="39" clientid="20202" beds="2" />
+	<house name="Theater Avenue 8a" houseid="2764" entryx="32357" entryy="31792" entryz="5" rent="100000" townid="6" size="31" clientid="20314" beds="2" />
+	<house name="Theater Avenue 11a" houseid="2765" entryx="32314" entryy="31781" entryz="5" rent="100000" townid="6" size="32" clientid="20404" beds="2" />
+	<house name="Theater Avenue 11b" houseid="2767" entryx="32311" entryy="31781" entryz="5" rent="100000" townid="6" size="31" clientid="20405" beds="2" />
+	<house name="Caretaker's Residence" houseid="2768" entryx="32407" entryy="31772" entryz="7" rent="600000" townid="6" size="298" clientid="20012" beds="6" />
+	<house name="Moonkeep" houseid="2769" entryx="32432" entryy="31762" entryz="7" rent="250000" guildhall="true" townid="6" size="298" clientid="20001" beds="16" />
+	<house name="Mangrove 1" houseid="2770" entryx="32648" entryy="31602" entryz="7" rent="80000" townid="5" size="39" clientid="40301" beds="3" />
+	<house name="Coastwood 2" houseid="2771" entryx="32647" entryy="31599" entryz="6" rent="50000" townid="5" size="20" clientid="40502" beds="2" />
+	<house name="Coastwood 1" houseid="2772" entryx="32647" entryy="31603" entryz="6" rent="50000" townid="5" size="23" clientid="40501" beds="2" />
+	<house name="Coastwood 3" houseid="2773" entryx="32668" entryy="31612" entryz="6" rent="50000" townid="5" size="27" clientid="40503" beds="2" />
+	<house name="Coastwood 4" houseid="2774" entryx="32671" entryy="31612" entryz="6" rent="50000" townid="5" size="25" clientid="40504" beds="2" />
+	<house name="Mangrove 4" houseid="2775" entryx="32717" entryy="31621" entryz="7" rent="50000" townid="5" size="23" clientid="40304" beds="2" />
+	<house name="Coastwood 10" houseid="2776" entryx="32717" entryy="31621" entryz="6" rent="80000" townid="5" size="32" clientid="40510" beds="3" />
+	<house name="Coastwood 5" houseid="2777" entryx="32676" entryy="31592" entryz="6" rent="50000" townid="5" size="33" clientid="40505" beds="2" />
+	<house name="Coastwood 6 (Shop)" houseid="2778" entryx="32691" entryy="31592" entryz="6" rent="80000" townid="5" size="32" clientid="40506" beds="1" />
+	<house name="Coastwood 7" houseid="2779" entryx="32695" entryy="31592" entryz="6" rent="25000" townid="5" size="16" clientid="40507" beds="1" />
+	<house name="Coastwood 8" houseid="2780" entryx="32690" entryy="31600" entryz="6" rent="50000" townid="5" size="30" clientid="40508" beds="2" />
+	<house name="Coastwood 9" houseid="2781" entryx="32688" entryy="31614" entryz="6" rent="50000" townid="5" size="25" clientid="40509" beds="1" />
+	<house name="Treetop 2" houseid="2782" entryx="32640" entryy="31689" entryz="6" rent="25000" townid="5" size="18" clientid="40402" beds="1" />
+	<house name="Treetop 1" houseid="2783" entryx="32636" entryy="31689" entryz="6" rent="25000" townid="5" size="17" clientid="40401" beds="1" />
+	<house name="Mangrove 3" houseid="2784" entryx="32693" entryy="31605" entryz="7" rent="80000" townid="5" size="27" clientid="40303" beds="2" />
+	<house name="Mangrove 2" houseid="2785" entryx="32681" entryy="31592" entryz="7" rent="50000" townid="5" size="32" clientid="40302" beds="2" />
+	<house name="The Hideout" houseid="2786" entryx="32546" entryy="31666" entryz="7" rent="250000" guildhall="true" townid="5" size="449" clientid="40002" beds="20" />
+	<house name="Shadow Towers" houseid="2787" entryx="32698" entryy="31773" entryz="7" rent="250000" guildhall="true" townid="5" size="429" clientid="40001" beds="18" />
+	<house name="Druids Retreat A" houseid="2788" entryx="32277" entryy="31729" entryz="7" rent="50000" townid="6" size="32" clientid="20004" beds="2" />
+	<house name="Druids Retreat C" houseid="2789" entryx="32284" entryy="31766" entryz="7" rent="50000" townid="6" size="27" clientid="20006" beds="2" />
+	<house name="Druids Retreat B" houseid="2790" entryx="32272" entryy="31767" entryz="7" rent="50000" townid="6" size="31" clientid="20005" beds="2" />
 	<house name="Druids Retreat D" houseid="2791" entryx="32324" entryy="31724" entryz="7" rent="80000" townid="6" size="27" clientid="20007" beds="2" />
-	<house name="East Lane 1b" houseid="2792" entryx="32396" entryy="31801" entryz="6" rent="150000" townid="6" size="40" clientid="20802" beds="2" />
-	<house name="East Lane 1a" houseid="2793" entryx="32393" entryy="31796" entryz="7" rent="200000" townid="6" size="54" clientid="20801" beds="2" />
-	<house name="Senja Village 11" houseid="2794" entryx="32141" entryy="31675" entryz="7" rent="80000" townid="6" size="56" clientid="24013" beds="2" />
-	<house name="Senja Village 10" houseid="2795" entryx="32144" entryy="31674" entryz="7" rent="50000" townid="6" size="33" clientid="24012" beds="1" />
+	<house name="East Lane 1b" houseid="2792" entryx="32396" entryy="31801" entryz="6" rent="150000" townid="6" size="43" clientid="20802" beds="2" />
+	<house name="East Lane 1a" houseid="2793" entryx="32393" entryy="31796" entryz="7" rent="200000" townid="6" size="62" clientid="20801" beds="2" />
+	<house name="Senja Village 11" houseid="2794" entryx="32141" entryy="31675" entryz="7" rent="80000" townid="6" size="59" clientid="24013" beds="2" />
+	<house name="Senja Village 10" houseid="2795" entryx="32144" entryy="31674" entryz="7" rent="50000" townid="6" size="36" clientid="24012" beds="1" />
 	<house name="Senja Village 9" houseid="2796" entryx="32132" entryy="31670" entryz="7" rent="80000" townid="6" size="55" clientid="24011" beds="2" />
-	<house name="Senja Village 8" houseid="2797" entryx="32136" entryy="31664" entryz="7" rent="50000" townid="6" size="35" clientid="24010" beds="2" />
-	<house name="Senja Village 7" houseid="2798" entryx="32132" entryy="31659" entryz="6" rent="25000" townid="6" size="17" clientid="24009" beds="2" />
-	<house name="Senja Village 6b" houseid="2799" entryx="32158" entryy="31654" entryz="6" rent="25000" townid="6" size="17" clientid="24008" beds="1" />
-	<house name="Senja Village 6a" houseid="2800" entryx="32151" entryy="31655" entryz="7" rent="50000" townid="6" size="17" clientid="24007" beds="1" />
-	<house name="Senja Village 5" houseid="2801" entryx="32150" entryy="31658" entryz="7" rent="50000" townid="6" size="25" clientid="24006" beds="2" />
-	<house name="Senja Village 4" houseid="2802" entryx="32156" entryy="31664" entryz="7" rent="50000" townid="6" size="34" clientid="24005" beds="2" />
-	<house name="Senja Village 3" houseid="2803" entryx="32155" entryy="31663" entryz="7" rent="50000" townid="6" size="37" clientid="24004" beds="2" />
-	<house name="Senja Village 1b" houseid="2804" entryx="32163" entryy="31660" entryz="6" rent="50000" townid="6" size="34" clientid="24002" beds="2" />
-	<house name="Senja Village 1a" houseid="2805" entryx="32160" entryy="31663" entryz="7" rent="25000" townid="6" size="17" clientid="24001" beds="1" />
-	<house name="Rosebud C" houseid="2806" entryx="32272" entryy="31698" entryz="7" rent="100000" townid="6" size="31" clientid="20010" beds="2" />
-	<house name="Rosebud B" houseid="2807" entryx="32263" entryy="31698" entryz="7" rent="80000" townid="6" size="25" clientid="20009" beds="1" />
-	<house name="Rosebud A" houseid="2808" entryx="32265" entryy="31701" entryz="7" rent="50000" townid="6" size="25" clientid="20008" beds="1" />
-	<house name="Park Lane 3b" houseid="2809" entryx="32329" entryy="31764" entryz="6" rent="100000" townid="6" size="25" clientid="20203" beds="2" />
-	<house name="Northport Village 6" houseid="2810" entryx="32502" entryy="31606" entryz="7" rent="80000" townid="6" size="37" clientid="22007" beds="2" />
-	<house name="Northport Village 5" houseid="2811" entryx="32503" entryy="31605" entryz="7" rent="80000" townid="6" size="31" clientid="22006" beds="2" />
-	<house name="Northport Village 4" houseid="2812" entryx="32490" entryy="31602" entryz="7" rent="100000" townid="6" size="47" clientid="22004" beds="2" />
-	<house name="Northport Village 3" houseid="2813" entryx="32482" entryy="31611" entryz="6" rent="150000" townid="6" size="97" clientid="22003" beds="2" />
-	<house name="Northport Village 2" houseid="2814" entryx="32482" entryy="31609" entryz="7" rent="50000" townid="6" size="25" clientid="22002" beds="2" />
-	<house name="Northport Village 1" houseid="2815" entryx="32482" entryy="31614" entryz="7" rent="50000" townid="6" size="25" clientid="22001" beds="2" />
-	<house name="Nautic Observer" houseid="2816" entryx="32483" entryy="31825" entryz="7" rent="200000" townid="6" size="156" clientid="20011" beds="4" />
-	<house name="Nordic Stronghold" houseid="2817" entryx="32297" entryy="31675" entryz="7" rent="250000" guildhall="true" townid="6" size="410" clientid="20003" beds="21" />
-	<house name="Senja Clanhall" houseid="2818" entryx="32168" entryy="31664" entryz="7" rent="250000" guildhall="true" townid="6" size="215" clientid="24014" beds="10" />
-	<house name="Seawatch" houseid="2819" entryx="32520" entryy="31600" entryz="7" rent="250000" guildhall="true" townid="6" size="422" clientid="22005" beds="19" />
-	<house name="Dwarven Magnate's Estate" houseid="2820" entryx="32643" entryy="31927" entryz="2" rent="300000" townid="7" size="248" clientid="30107" beds="8" />
-	<house name="Forge Master's Quarters" houseid="2821" entryx="32649" entryy="31889" entryz="8" rent="300000" townid="7" size="352" clientid="30405" beds="10" />
+	<house name="Senja Village 8" houseid="2797" entryx="32136" entryy="31664" entryz="7" rent="50000" townid="6" size="40" clientid="24010" beds="2" />
+	<house name="Senja Village 7" houseid="2798" entryx="32132" entryy="31659" entryz="6" rent="25000" townid="6" size="19" clientid="24009" beds="2" />
+	<house name="Senja Village 6b" houseid="2799" entryx="32158" entryy="31654" entryz="6" rent="25000" townid="6" size="19" clientid="24008" beds="1" />
+	<house name="Senja Village 6a" houseid="2800" entryx="32151" entryy="31655" entryz="7" rent="50000" townid="6" size="18" clientid="24007" beds="1" />
+	<house name="Senja Village 5" houseid="2801" entryx="32150" entryy="31658" entryz="7" rent="50000" townid="6" size="28" clientid="24006" beds="2" />
+	<house name="Senja Village 4" houseid="2802" entryx="32156" entryy="31664" entryz="7" rent="50000" townid="6" size="38" clientid="24005" beds="2" />
+	<house name="Senja Village 3" houseid="2803" entryx="32155" entryy="31663" entryz="7" rent="50000" townid="6" size="35" clientid="24004" beds="2" />
+	<house name="Senja Village 1b" houseid="2804" entryx="32163" entryy="31660" entryz="6" rent="50000" townid="6" size="38" clientid="24002" beds="2" />
+	<house name="Senja Village 1a" houseid="2805" entryx="32160" entryy="31663" entryz="7" rent="25000" townid="6" size="19" clientid="24001" beds="1" />
+	<house name="Rosebud C" houseid="2806" entryx="32272" entryy="31698" entryz="7" rent="100000" townid="6" size="36" clientid="20010" beds="2" />
+	<house name="Rosebud B" houseid="2807" entryx="32263" entryy="31698" entryz="7" rent="80000" townid="6" size="29" clientid="20009" beds="1" />
+	<house name="Rosebud A" houseid="2808" entryx="32265" entryy="31701" entryz="7" rent="50000" townid="6" size="29" clientid="20008" beds="1" />
+	<house name="Park Lane 3b" houseid="2809" entryx="32329" entryy="31764" entryz="6" rent="100000" townid="6" size="29" clientid="20203" beds="2" />
+	<house name="Northport Village 6" houseid="2810" entryx="32502" entryy="31606" entryz="7" rent="80000" townid="6" size="42" clientid="22007" beds="2" />
+	<house name="Northport Village 5" houseid="2811" entryx="32503" entryy="31605" entryz="7" rent="80000" townid="6" size="34" clientid="22006" beds="2" />
+	<house name="Northport Village 4" houseid="2812" entryx="32490" entryy="31602" entryz="7" rent="100000" townid="6" size="50" clientid="22004" beds="2" />
+	<house name="Northport Village 3" houseid="2813" entryx="32482" entryy="31611" entryz="6" rent="150000" townid="6" size="104" clientid="22003" beds="2" />
+	<house name="Northport Village 2" houseid="2814" entryx="32482" entryy="31609" entryz="7" rent="50000" townid="6" size="28" clientid="22002" beds="2" />
+	<house name="Northport Village 1" houseid="2815" entryx="32482" entryy="31614" entryz="7" rent="50000" townid="6" size="28" clientid="22001" beds="2" />
+	<house name="Nautic Observer" houseid="2816" entryx="32483" entryy="31825" entryz="7" rent="200000" townid="6" size="220" clientid="20011" beds="4" />
+	<house name="Nordic Stronghold" houseid="2817" entryx="32297" entryy="31675" entryz="7" rent="250000" guildhall="true" townid="6" size="536" clientid="20003" beds="21" />
+	<house name="Senja Clanhall" houseid="2818" entryx="32168" entryy="31664" entryz="7" rent="250000" guildhall="true" townid="6" size="228" clientid="24014" beds="10" />
+	<house name="Seawatch" houseid="2819" entryx="32520" entryy="31600" entryz="7" rent="250000" guildhall="true" townid="6" size="431" clientid="22005" beds="19" />
+	<house name="Dwarven Magnate's Estate" houseid="2820" entryx="32643" entryy="31927" entryz="2" rent="300000" townid="7" size="269" clientid="30107" beds="8" />
+	<house name="Forge Master's Quarters" houseid="2821" entryx="32649" entryy="31889" entryz="8" rent="300000" townid="7" size="79" clientid="30405" beds="10" />
 	<house name="Upper Barracks 13" houseid="2822" entryx="32615" entryy="31923" entryz="5" rent="25000" townid="7" size="16" clientid="30313" beds="2" />
 	<house name="Upper Barracks 5" houseid="2823" entryx="32615" entryy="31917" entryz="5" rent="80000" townid="7" size="27" clientid="30312" beds="2" />
 	<house name="Upper Barracks 3" houseid="2824" entryx="32608" entryy="31922" entryz="5" rent="80000" townid="7" size="16" clientid="30307" beds="2" />
 	<house name="Upper Barracks 4" houseid="2825" entryx="32612" entryy="31925" entryz="5" rent="50000" townid="7" size="16" clientid="30308" beds="2" />
 	<house name="Upper Barracks 2" houseid="2826" entryx="32605" entryy="31917" entryz="5" rent="80000" townid="7" size="27" clientid="30304" beds="2" />
 	<house name="Upper Barracks 1" houseid="2827" entryx="32605" entryy="31923" entryz="5" rent="50000" townid="7" size="16" clientid="30301" beds="2" />
-	<house name="Tunnel Gardens 9" houseid="2828" entryx="32603" entryy="31924" entryz="12" rent="150000" townid="7" size="81" clientid="30610" beds="4" />
-	<house name="Tunnel Gardens 8" houseid="2829" entryx="32594" entryy="31911" entryz="12" rent="25000" townid="7" size="21" clientid="30608" beds="2" />
+	<house name="Tunnel Gardens 9" houseid="2828" entryx="32603" entryy="31924" entryz="12" rent="150000" townid="7" size="74" clientid="30610" beds="4" />
+	<house name="Tunnel Gardens 8" houseid="2829" entryx="32594" entryy="31911" entryz="12" rent="25000" townid="7" size="24" clientid="30608" beds="2" />
 	<house name="Tunnel Gardens 7" houseid="2830" entryx="32594" entryy="31907" entryz="12" rent="50000" townid="7" size="21" clientid="30607" beds="2" />
 	<house name="Tunnel Gardens 6" houseid="2831" entryx="32594" entryy="31910" entryz="11" rent="25000" townid="7" size="21" clientid="30606" beds="2" />
 	<house name="Tunnel Gardens 5" houseid="2832" entryx="32594" entryy="31905" entryz="11" rent="25000" townid="7" size="21" clientid="30605" beds="2" />
-	<house name="Tunnel Gardens 4" houseid="2835" entryx="32602" entryy="31909" entryz="11" rent="80000" townid="7" size="30" clientid="30604" beds="3" />
+	<house name="Tunnel Gardens 4" houseid="2835" entryx="32602" entryy="31909" entryz="11" rent="80000" townid="7" size="33" clientid="30604" beds="3" />
 	<house name="Tunnel Gardens 2" houseid="2836" entryx="32606" entryy="31909" entryz="11" rent="80000" townid="7" size="27" clientid="30602" beds="3" />
 	<house name="Tunnel Gardens 1" houseid="2837" entryx="32606" entryy="31908" entryz="11" rent="80000" townid="7" size="27" clientid="30601" beds="3" />
-	<house name="Tunnel Gardens 3" houseid="2838" entryx="32603" entryy="31908" entryz="11" rent="80000" townid="7" size="30" clientid="30603" beds="3" />
-	<house name="The Market 4 (Shop)" houseid="2839" entryx="32635" entryy="31933" entryz="8" rent="80000" townid="7" size="36" clientid="30404" beds="1" />
-	<house name="The Market 3 (Shop)" houseid="2840" entryx="32635" entryy="31926" entryz="8" rent="80000" townid="7" size="29" clientid="30403" beds="1" />
-	<house name="The Market 2 (Shop)" houseid="2841" entryx="32634" entryy="31930" entryz="8" rent="50000" townid="7" size="22" clientid="30402" beds="1" />
-	<house name="The Market 1 (Shop)" houseid="2842" entryx="32631" entryy="31922" entryz="8" rent="25000" townid="7" size="13" clientid="30401" beds="1" />
-	<house name="The Farms 6, Fishing Hut" houseid="2843" entryx="32629" entryy="31888" entryz="7" rent="50000" townid="7" size="21" clientid="30106" beds="2" />
+	<house name="Tunnel Gardens 3" houseid="2838" entryx="32603" entryy="31908" entryz="11" rent="80000" townid="7" size="33" clientid="30603" beds="3" />
+	<house name="The Market 4 (Shop)" houseid="2839" entryx="32635" entryy="31933" entryz="8" rent="80000" townid="7" size="32" clientid="30404" beds="1" />
+	<house name="The Market 3 (Shop)" houseid="2840" entryx="32635" entryy="31926" entryz="8" rent="80000" townid="7" size="26" clientid="30403" beds="1" />
+	<house name="The Market 2 (Shop)" houseid="2841" entryx="32634" entryy="31930" entryz="8" rent="50000" townid="7" size="23" clientid="30402" beds="1" />
+	<house name="The Market 1 (Shop)" houseid="2842" entryx="32631" entryy="31922" entryz="8" rent="25000" townid="7" size="11" clientid="30401" beds="1" />
+	<house name="The Farms 6, Fishing Hut" houseid="2843" entryx="32629" entryy="31888" entryz="7" rent="50000" townid="7" size="26" clientid="30106" beds="2" />
 	<house name="The Farms 5" houseid="2844" entryx="32650" entryy="31890" entryz="2" rent="50000" townid="7" size="26" clientid="30105" beds="2" />
 	<house name="The Farms 4" houseid="2845" entryx="32648" entryy="31899" entryz="2" rent="25000" townid="7" size="26" clientid="30104" beds="2" />
 	<house name="The Farms 3" houseid="2846" entryx="32645" entryy="31908" entryz="2" rent="80000" townid="7" size="26" clientid="30103" beds="2" />
 	<house name="The Farms 2" houseid="2847" entryx="32641" entryy="31918" entryz="2" rent="50000" townid="7" size="26" clientid="30102" beds="2" />
-	<house name="The Farms 1" houseid="2849" entryx="32627" entryy="31921" entryz="2" rent="80000" townid="7" size="42" clientid="30101" beds="3" />
-	<house name="Outlaw Camp 14 (Shop)" houseid="2850" entryx="32665" entryy="32199" entryz="8" rent="25000" townid="7" size="16" clientid="32014" beds="1" />
-	<house name="Outlaw Camp 13 (Shop)" houseid="2852" entryx="32666" entryy="32200" entryz="8" rent="50000" townid="7" size="17" clientid="32013" beds="1" />
-	<house name="Outlaw Camp 9" houseid="2853" entryx="32663" entryy="32209" entryz="8" rent="80000" townid="7" size="17" clientid="32009" beds="2" />
-	<house name="Outlaw Camp 7" houseid="2854" entryx="32648" entryy="32212" entryz="8" rent="25000" townid="7" size="17" clientid="32007" beds="2" />
-	<house name="Outlaw Camp 4" houseid="2855" entryx="32663" entryy="32209" entryz="7" rent="50000" townid="7" size="17" clientid="32004" beds="2" />
-	<house name="Outlaw Camp 2" houseid="2856" entryx="32649" entryy="32212" entryz="7" rent="50000" townid="7" size="14" clientid="32002" beds="1" />
-	<house name="Outlaw Camp 3" houseid="2857" entryx="32649" entryy="32212" entryz="6" rent="50000" townid="7" size="16" clientid="32003" beds="2" />
-	<house name="Outlaw Camp 1" houseid="2858" entryx="32643" entryy="32206" entryz="7" rent="80000" townid="7" size="39" clientid="32001" beds="2" />
-	<house name="Nobility Quarter 5" houseid="2859" entryx="32612" entryy="31921" entryz="4" rent="100000" townid="7" size="79" clientid="30206" beds="5" />
-	<house name="Nobility Quarter 4" houseid="2860" entryx="32607" entryy="31921" entryz="4" rent="50000" townid="7" size="37" clientid="30204" beds="3" />
-	<house name="Nobility Quarter 3" houseid="2861" entryx="32602" entryy="31912" entryz="4" rent="80000" townid="7" size="37" clientid="30203" beds="3" />
-	<house name="Nobility Quarter 2" houseid="2862" entryx="32602" entryy="31919" entryz="4" rent="50000" townid="7" size="37" clientid="30202" beds="3" />
-	<house name="Nobility Quarter 1" houseid="2863" entryx="32595" entryy="31924" entryz="4" rent="80000" townid="7" size="37" clientid="30201" beds="3" />
+	<house name="The Farms 1" houseid="2849" entryx="32627" entryy="31921" entryz="2" rent="80000" townid="7" size="57" clientid="30101" beds="3" />
+	<house name="Outlaw Camp 14 (Shop)" houseid="2850" entryx="32665" entryy="32199" entryz="8" rent="25000" townid="7" size="31" clientid="32014" beds="1" />
+	<house name="Outlaw Camp 13 (Shop)" houseid="2852" entryx="32666" entryy="32200" entryz="8" rent="50000" townid="7" size="33" clientid="32013" beds="1" />
+	<house name="Outlaw Camp 9" houseid="2853" entryx="32663" entryy="32209" entryz="8" rent="80000" townid="7" size="36" clientid="32009" beds="2" />
+	<house name="Outlaw Camp 7" houseid="2854" entryx="32648" entryy="32212" entryz="8" rent="25000" townid="7" size="33" clientid="32007" beds="2" />
+	<house name="Outlaw Camp 4" houseid="2855" entryx="32663" entryy="32209" entryz="7" rent="50000" townid="7" size="31" clientid="32004" beds="2" />
+	<house name="Outlaw Camp 2" houseid="2856" entryx="32649" entryy="32212" entryz="7" rent="50000" townid="7" size="33" clientid="32002" beds="1" />
+	<house name="Outlaw Camp 3" houseid="2857" entryx="32649" entryy="32212" entryz="6" rent="50000" townid="7" size="29" clientid="32003" beds="2" />
+	<house name="Outlaw Camp 1" houseid="2858" entryx="32643" entryy="32206" entryz="7" rent="80000" townid="7" size="47" clientid="32001" beds="2" />
+	<house name="Nobility Quarter 5" houseid="2859" entryx="32612" entryy="31921" entryz="4" rent="100000" townid="7" size="141" clientid="30206" beds="5" />
+	<house name="Nobility Quarter 4" houseid="2860" entryx="32607" entryy="31921" entryz="4" rent="50000" townid="7" size="65" clientid="30204" beds="3" />
+	<house name="Nobility Quarter 3" houseid="2861" entryx="32602" entryy="31912" entryz="4" rent="80000" townid="7" size="51" clientid="30203" beds="3" />
+	<house name="Nobility Quarter 2" houseid="2862" entryx="32602" entryy="31919" entryz="4" rent="50000" townid="7" size="58" clientid="30202" beds="3" />
+	<house name="Nobility Quarter 1" houseid="2863" entryx="32595" entryy="31924" entryz="4" rent="80000" townid="7" size="63" clientid="30201" beds="3" />
 	<house name="Lower Barracks 10" houseid="2864" entryx="32637" entryy="31931" entryz="9" rent="80000" townid="7" size="25" clientid="30513" beds="2" />
 	<house name="Lower Barracks 9" houseid="2865" entryx="32637" entryy="31921" entryz="9" rent="80000" townid="7" size="25" clientid="30517" beds="2" />
 	<house name="Lower Barracks 8" houseid="2866" entryx="32637" entryy="31911" entryz="9" rent="80000" townid="7" size="25" clientid="30523" beds="2" />
-	<house name="Lower Barracks 1" houseid="2867" entryx="32624" entryy="31911" entryz="9" rent="80000" townid="7" size="25" clientid="30501" beds="2" />
-	<house name="Lower Barracks 2" houseid="2868" entryx="32624" entryy="31921" entryz="9" rent="80000" townid="7" size="25" clientid="30507" beds="2" />
-	<house name="Lower Barracks 3" houseid="2869" entryx="32624" entryy="31931" entryz="9" rent="80000" townid="7" size="25" clientid="30511" beds="2" />
-	<house name="Lower Barracks 4" houseid="2870" entryx="32625" entryy="31931" entryz="9" rent="50000" townid="7" size="26" clientid="30502" beds="2" />
-	<house name="Lower Barracks 5" houseid="2871" entryx="32625" entryy="31921" entryz="9" rent="100000" townid="7" size="58" clientid="30504" beds="4" />
-	<house name="Lower Barracks 6" houseid="2872" entryx="32625" entryy="31916" entryz="9" rent="100000" townid="7" size="58" clientid="30510" beds="4" />
-	<house name="Lower Barracks 7" houseid="2873" entryx="32625" entryy="31906" entryz="9" rent="80000" townid="7" size="26" clientid="30512" beds="2" />
-	<house name="Wolftower" houseid="2874" entryx="32643" entryy="32025" entryz="7" rent="500000" guildhall="true" townid="7" size="387" clientid="30001" beds="23" />
-	<house name="Riverspring" houseid="2875" entryx="32761" entryy="32128" entryz="7" rent="250000" guildhall="true" townid="7" size="353" clientid="30003" beds="19" />
-	<house name="Outlaw Castle" houseid="2876" entryx="32660" entryy="32236" entryz="7" rent="250000" guildhall="true" townid="7" size="180" clientid="32015" beds="9" />
-	<house name="Marble Guildhall" houseid="2877" entryx="32622" entryy="31954" entryz="9" rent="250000" guildhall="true" townid="7" size="338" clientid="30701" beds="17" />
-	<house name="Iron Guildhall" houseid="2878" entryx="32607" entryy="31893" entryz="9" rent="250000" guildhall="true" townid="7" size="308" clientid="30702" beds="18" />
-	<house name="Hill Hideout" houseid="2879" entryx="32593" entryy="31826" entryz="9" rent="250000" guildhall="true" townid="7" size="251" clientid="30002" beds="15" />
-	<house name="Granite Guildhall" houseid="2880" entryx="32599" entryy="31949" entryz="5" rent="250000" guildhall="true" townid="7" size="361" clientid="30703" beds="17" />
+	<house name="Lower Barracks 1" houseid="2867" entryx="32624" entryy="31911" entryz="9" rent="80000" townid="7" size="27" clientid="30501" beds="2" />
+	<house name="Lower Barracks 2" houseid="2868" entryx="32624" entryy="31921" entryz="9" rent="80000" townid="7" size="27" clientid="30507" beds="2" />
+	<house name="Lower Barracks 3" houseid="2869" entryx="32624" entryy="31931" entryz="9" rent="80000" townid="7" size="27" clientid="30511" beds="2" />
+	<house name="Lower Barracks 4" houseid="2870" entryx="32625" entryy="31931" entryz="9" rent="50000" townid="7" size="28" clientid="30502" beds="2" />
+	<house name="Lower Barracks 5" houseid="2871" entryx="32625" entryy="31921" entryz="9" rent="100000" townid="7" size="63" clientid="30504" beds="4" />
+	<house name="Lower Barracks 6" houseid="2872" entryx="32625" entryy="31916" entryz="9" rent="100000" townid="7" size="63" clientid="30510" beds="4" />
+	<house name="Lower Barracks 7" houseid="2873" entryx="32625" entryy="31906" entryz="9" rent="80000" townid="7" size="28" clientid="30512" beds="2" />
+	<house name="Wolftower" houseid="2874" entryx="32643" entryy="32025" entryz="7" rent="500000" guildhall="true" townid="7" size="402" clientid="30001" beds="23" />
+	<house name="Riverspring" houseid="2875" entryx="32761" entryy="32128" entryz="7" rent="250000" guildhall="true" townid="7" size="371" clientid="30003" beds="19" />
+	<house name="Outlaw Castle" houseid="2876" entryx="32660" entryy="32236" entryz="7" rent="250000" guildhall="true" townid="7" size="302" clientid="32015" beds="9" />
+	<house name="Marble Guildhall" houseid="2877" entryx="32622" entryy="31954" entryz="9" rent="250000" guildhall="true" townid="7" size="410" clientid="30701" beds="17" />
+	<house name="Iron Guildhall" houseid="2878" entryx="32607" entryy="31893" entryz="9" rent="250000" guildhall="true" townid="7" size="379" clientid="30702" beds="18" />
+	<house name="Hill Hideout" houseid="2879" entryx="32593" entryy="31826" entryz="9" rent="250000" guildhall="true" townid="7" size="247" clientid="30002" beds="15" />
+	<house name="Granite Guildhall" houseid="2880" entryx="32599" entryy="31949" entryz="5" rent="250000" guildhall="true" townid="7" size="506" clientid="30703" beds="17" />
 	<house name="Alai Flats, Flat 01" houseid="2881" entryx="32377" entryy="32256" entryz="7" rent="50000" townid="8" size="17" clientid="10301" beds="1" />
-	<house name="Alai Flats, Flat 02" houseid="2882" entryx="32382" entryy="32256" entryz="7" rent="50000" townid="8" size="17" clientid="10302" beds="1" />
-	<house name="Alai Flats, Flat 03" houseid="2883" entryx="32374" entryy="32264" entryz="7" rent="50000" townid="8" size="17" clientid="10303" beds="1" />
-	<house name="Alai Flats, Flat 04" houseid="2884" entryx="32386" entryy="32261" entryz="7" rent="80000" townid="8" size="17" clientid="10304" beds="1" />
-	<house name="Alai Flats, Flat 05" houseid="2885" entryx="32386" entryy="32268" entryz="7" rent="100000" townid="8" size="25" clientid="10305" beds="2" />
+	<house name="Alai Flats, Flat 02" houseid="2882" entryx="32382" entryy="32256" entryz="7" rent="50000" townid="8" size="18" clientid="10302" beds="1" />
+	<house name="Alai Flats, Flat 03" houseid="2883" entryx="32374" entryy="32264" entryz="7" rent="50000" townid="8" size="18" clientid="10303" beds="1" />
+	<house name="Alai Flats, Flat 04" houseid="2884" entryx="32386" entryy="32261" entryz="7" rent="80000" townid="8" size="19" clientid="10304" beds="1" />
+	<house name="Alai Flats, Flat 05" houseid="2885" entryx="32386" entryy="32268" entryz="7" rent="100000" townid="8" size="28" clientid="10305" beds="2" />
 	<house name="Alai Flats, Flat 06" houseid="2886" entryx="32386" entryy="32268" entryz="7" rent="100000" townid="8" size="25" clientid="10306" beds="2" />
-	<house name="Alai Flats, Flat 07" houseid="2887" entryx="32382" entryy="32268" entryz="7" rent="25000" townid="8" size="17" clientid="10307" beds="1" />
-	<house name="Alai Flats, Flat 08" houseid="2888" entryx="32377" entryy="32268" entryz="7" rent="50000" townid="8" size="17" clientid="10308" beds="1" />
-	<house name="Alai Flats, Flat 11" houseid="2889" entryx="32382" entryy="32256" entryz="6" rent="80000" townid="8" size="17" clientid="10311" beds="1" />
+	<house name="Alai Flats, Flat 07" houseid="2887" entryx="32382" entryy="32268" entryz="7" rent="25000" townid="8" size="18" clientid="10307" beds="1" />
+	<house name="Alai Flats, Flat 08" houseid="2888" entryx="32377" entryy="32268" entryz="7" rent="50000" townid="8" size="18" clientid="10308" beds="1" />
+	<house name="Alai Flats, Flat 11" houseid="2889" entryx="32382" entryy="32256" entryz="6" rent="80000" townid="8" size="19" clientid="10311" beds="1" />
 	<house name="Alai Flats, Flat 12" houseid="2890" entryx="32377" entryy="32256" entryz="6" rent="25000" townid="8" size="17" clientid="10312" beds="1" />
-	<house name="Alai Flats, Flat 13" houseid="2891" entryx="32377" entryy="32268" entryz="6" rent="50000" townid="8" size="17" clientid="10313" beds="1" />
-	<house name="Alai Flats, Flat 14" houseid="2892" entryx="32386" entryy="32261" entryz="6" rent="80000" townid="8" size="20" clientid="10314" beds="1" />
-	<house name="Alai Flats, Flat 15" houseid="2893" entryx="32386" entryy="32268" entryz="6" rent="100000" townid="8" size="30" clientid="10315" beds="2" />
-	<house name="Alai Flats, Flat 16" houseid="2894" entryx="32386" entryy="32268" entryz="6" rent="100000" townid="8" size="30" clientid="10316" beds="2" />
-	<house name="Alai Flats, Flat 17" houseid="2895" entryx="32382" entryy="32268" entryz="6" rent="80000" townid="8" size="20" clientid="10317" beds="1" />
-	<house name="Alai Flats, Flat 18" houseid="2896" entryx="32377" entryy="32268" entryz="6" rent="50000" townid="8" size="20" clientid="10318" beds="1" />
-	<house name="Alai Flats, Flat 21" houseid="2897" entryx="32382" entryy="32256" entryz="5" rent="50000" townid="8" size="17" clientid="10320" beds="1" />
+	<house name="Alai Flats, Flat 13" houseid="2891" entryx="32377" entryy="32268" entryz="6" rent="50000" townid="8" size="19" clientid="10313" beds="1" />
+	<house name="Alai Flats, Flat 14" houseid="2892" entryx="32386" entryy="32261" entryz="6" rent="80000" townid="8" size="22" clientid="10314" beds="1" />
+	<house name="Alai Flats, Flat 15" houseid="2893" entryx="32386" entryy="32268" entryz="6" rent="100000" townid="8" size="34" clientid="10315" beds="2" />
+	<house name="Alai Flats, Flat 16" houseid="2894" entryx="32386" entryy="32268" entryz="6" rent="100000" townid="8" size="31" clientid="10316" beds="2" />
+	<house name="Alai Flats, Flat 17" houseid="2895" entryx="32382" entryy="32268" entryz="6" rent="80000" townid="8" size="22" clientid="10317" beds="1" />
+	<house name="Alai Flats, Flat 18" houseid="2896" entryx="32377" entryy="32268" entryz="6" rent="50000" townid="8" size="22" clientid="10318" beds="1" />
+	<house name="Alai Flats, Flat 21" houseid="2897" entryx="32382" entryy="32256" entryz="5" rent="50000" townid="8" size="19" clientid="10320" beds="1" />
 	<house name="Alai Flats, Flat 22" houseid="2898" entryx="32377" entryy="32256" entryz="5" rent="50000" townid="8" size="17" clientid="10319" beds="1" />
-	<house name="Alai Flats, Flat 23" houseid="2899" entryx="32377" entryy="32268" entryz="5" rent="25000" townid="8" size="17" clientid="10321" beds="1" />
-	<house name="Alai Flats, Flat 28" houseid="2900" entryx="32377" entryy="32268" entryz="5" rent="80000" townid="8" size="20" clientid="10326" beds="1" />
-	<house name="Alai Flats, Flat 27" houseid="2901" entryx="32382" entryy="32268" entryz="5" rent="80000" townid="8" size="20" clientid="10325" beds="1" />
-	<house name="Alai Flats, Flat 26" houseid="2902" entryx="32386" entryy="32268" entryz="5" rent="100000" townid="8" size="30" clientid="10324" beds="2" />
-	<house name="Alai Flats, Flat 25" houseid="2903" entryx="32386" entryy="32268" entryz="5" rent="100000" townid="8" size="30" clientid="10323" beds="2" />
-	<house name="Alai Flats, Flat 24" houseid="2904" entryx="32386" entryy="32261" entryz="5" rent="80000" townid="8" size="20" clientid="10322" beds="1" />
-	<house name="Beach Home Apartments, Flat 01" houseid="2905" entryx="32314" entryy="32245" entryz="7" rent="50000" townid="8" size="13" clientid="10201" beds="1" />
-	<house name="Beach Home Apartments, Flat 02" houseid="2906" entryx="32314" entryy="32240" entryz="7" rent="80000" townid="8" size="13" clientid="10202" beds="1" />
-	<house name="Beach Home Apartments, Flat 03" houseid="2907" entryx="32317" entryy="32235" entryz="7" rent="80000" townid="8" size="13" clientid="10203" beds="1" />
-	<house name="Beach Home Apartments, Flat 04" houseid="2908" entryx="32313" entryy="32235" entryz="7" rent="50000" townid="8" size="13" clientid="10204" beds="1" />
-	<house name="Beach Home Apartments, Flat 05" houseid="2909" entryx="32309" entryy="32235" entryz="7" rent="80000" townid="8" size="13" clientid="10205" beds="1" />
-	<house name="Beach Home Apartments, Flat 06" houseid="2910" entryx="32309" entryy="32243" entryz="7" rent="100000" townid="8" size="19" clientid="10206" beds="2" />
-	<house name="Beach Home Apartments, Flat 11" houseid="2911" entryx="32314" entryy="32243" entryz="6" rent="25000" townid="8" size="13" clientid="10211" beds="1" />
-	<house name="Beach Home Apartments, Flat 12" houseid="2912" entryx="32314" entryy="32238" entryz="6" rent="50000" townid="8" size="16" clientid="10212" beds="1" />
-	<house name="Beach Home Apartments, Flat 13" houseid="2913" entryx="32314" entryy="32234" entryz="6" rent="80000" townid="8" size="16" clientid="10213" beds="1" />
-	<house name="Beach Home Apartments, Flat 14" houseid="2914" entryx="32312" entryy="32234" entryz="6" rent="25000" townid="8" size="7" clientid="10214" beds="1" />
-	<house name="Beach Home Apartments, Flat 15" houseid="2915" entryx="32309" entryy="32234" entryz="6" rent="25000" townid="8" size="7" clientid="10215" beds="1" />
-	<house name="Beach Home Apartments, Flat 16" houseid="2916" entryx="32303" entryy="32244" entryz="6" rent="80000" townid="8" size="19" clientid="10216" beds="2" />
-	<house name="Demon Tower" houseid="2917" entryx="32601" entryy="32116" entryz="7" rent="100000" townid="8" size="72" clientid="10006" beds="2" />
-	<house name="Farm Lane, 1st floor (Shop)" houseid="2918" entryx="32382" entryy="32232" entryz="7" rent="80000" townid="8" size="21" clientid="10702" beds="0" />
-	<house name="Farm Lane, 2nd Floor (Shop)" houseid="2919" entryx="32382" entryy="32233" entryz="6" rent="50000" townid="8" size="21" clientid="10703" beds="0" />
+	<house name="Alai Flats, Flat 23" houseid="2899" entryx="32377" entryy="32268" entryz="5" rent="25000" townid="8" size="19" clientid="10321" beds="1" />
+	<house name="Alai Flats, Flat 28" houseid="2900" entryx="32377" entryy="32268" entryz="5" rent="80000" townid="8" size="22" clientid="10326" beds="1" />
+	<house name="Alai Flats, Flat 27" houseid="2901" entryx="32382" entryy="32268" entryz="5" rent="80000" townid="8" size="22" clientid="10325" beds="1" />
+	<house name="Alai Flats, Flat 26" houseid="2902" entryx="32386" entryy="32268" entryz="5" rent="100000" townid="8" size="31" clientid="10324" beds="2" />
+	<house name="Alai Flats, Flat 25" houseid="2903" entryx="32386" entryy="32268" entryz="5" rent="100000" townid="8" size="34" clientid="10323" beds="2" />
+	<house name="Alai Flats, Flat 24" houseid="2904" entryx="32386" entryy="32261" entryz="5" rent="80000" townid="8" size="23" clientid="10322" beds="1" />
+	<house name="Beach Home Apartments, Flat 01" houseid="2905" entryx="32314" entryy="32245" entryz="7" rent="50000" townid="8" size="16" clientid="10201" beds="1" />
+	<house name="Beach Home Apartments, Flat 02" houseid="2906" entryx="32314" entryy="32240" entryz="7" rent="80000" townid="8" size="16" clientid="10202" beds="1" />
+	<house name="Beach Home Apartments, Flat 03" houseid="2907" entryx="32317" entryy="32235" entryz="7" rent="80000" townid="8" size="15" clientid="10203" beds="1" />
+	<house name="Beach Home Apartments, Flat 04" houseid="2908" entryx="32313" entryy="32235" entryz="7" rent="50000" townid="8" size="14" clientid="10204" beds="1" />
+	<house name="Beach Home Apartments, Flat 05" houseid="2909" entryx="32309" entryy="32235" entryz="7" rent="80000" townid="8" size="15" clientid="10205" beds="1" />
+	<house name="Beach Home Apartments, Flat 06" houseid="2910" entryx="32309" entryy="32243" entryz="7" rent="100000" townid="8" size="24" clientid="10206" beds="2" />
+	<house name="Beach Home Apartments, Flat 11" houseid="2911" entryx="32314" entryy="32243" entryz="6" rent="25000" townid="8" size="15" clientid="10211" beds="1" />
+	<house name="Beach Home Apartments, Flat 12" houseid="2912" entryx="32314" entryy="32238" entryz="6" rent="50000" townid="8" size="18" clientid="10212" beds="1" />
+	<house name="Beach Home Apartments, Flat 13" houseid="2913" entryx="32314" entryy="32234" entryz="6" rent="80000" townid="8" size="19" clientid="10213" beds="1" />
+	<house name="Beach Home Apartments, Flat 14" houseid="2914" entryx="32312" entryy="32234" entryz="6" rent="25000" townid="8" size="8" clientid="10214" beds="1" />
+	<house name="Beach Home Apartments, Flat 15" houseid="2915" entryx="32309" entryy="32234" entryz="6" rent="25000" townid="8" size="9" clientid="10215" beds="1" />
+	<house name="Beach Home Apartments, Flat 16" houseid="2916" entryx="32303" entryy="32244" entryz="6" rent="80000" townid="8" size="21" clientid="10216" beds="2" />
+	<house name="Demon Tower" houseid="2917" entryx="32601" entryy="32116" entryz="7" rent="100000" townid="8" size="75" clientid="10006" beds="2" />
+	<house name="Farm Lane, 1st floor (Shop)" houseid="2918" entryx="32382" entryy="32232" entryz="7" rent="80000" townid="8" size="18" clientid="10702" beds="0" />
+	<house name="Farm Lane, 2nd Floor (Shop)" houseid="2919" entryx="32382" entryy="32233" entryz="6" rent="50000" townid="8" size="17" clientid="10703" beds="0" />
 	<house name="Farm Lane, Basement (Shop)" houseid="2920" entryx="32382" entryy="32231" entryz="8" rent="50000" townid="8" size="21" clientid="10701" beds="0" />
-	<house name="Fibula Village 1" houseid="2921" entryx="32176" entryy="32433" entryz="7" rent="25000" townid="8" size="13" clientid="12003" beds="1" />
-	<house name="Fibula Village 2" houseid="2922" entryx="32184" entryy="32433" entryz="7" rent="25000" townid="8" size="13" clientid="12004" beds="1" />
-	<house name="Fibula Village 4" houseid="2923" entryx="32175" entryy="32440" entryz="7" rent="25000" townid="8" size="26" clientid="12006" beds="2" />
-	<house name="Fibula Village 5" houseid="2924" entryx="32171" entryy="32440" entryz="7" rent="50000" townid="8" size="26" clientid="12007" beds="2" />
-	<house name="Fibula Village 3" houseid="2925" entryx="32196" entryy="32438" entryz="7" rent="80000" townid="8" size="54" clientid="12005" beds="4" />
-	<house name="Fibula Village, Tower Flat" houseid="2926" entryx="32159" entryy="32439" entryz="7" rent="100000" townid="8" size="78" clientid="12008" beds="2" />
-	<house name="Guildhall of the Red Rose" houseid="2927" entryx="32180" entryy="32427" entryz="7" rent="250000" guildhall="true" townid="8" size="405" clientid="12002" beds="15" />
-	<house name="Fibula Village, Bar (Shop)" houseid="2928" entryx="32151" entryy="32399" entryz="7" rent="100000" townid="8" size="79" clientid="12009" beds="2" />
-	<house name="Fibula Village, Villa" houseid="2929" entryx="32140" entryy="32374" entryz="7" rent="200000" townid="8" size="222" clientid="12100" beds="7" />
-	<house name="Greenshore Village 1" houseid="2930" entryx="32274" entryy="32062" entryz="7" rent="80000" townid="8" size="37" clientid="14005" beds="3" />
-	<house name="Greenshore Clanhall" houseid="2931" entryx="32278" entryy="32069" entryz="7" rent="250000" guildhall="true" townid="8" size="165" clientid="14012" beds="10" />
-	<house name="Castle of Greenshore" houseid="2932" entryx="32290" entryy="32070" entryz="7" rent="250000" guildhall="true" townid="8" size="296" clientid="14002" beds="12" />
-	<house name="Greenshore Village, Shop" houseid="2933" entryx="32278" entryy="32052" entryz="7" rent="80000" townid="8" size="30" clientid="14004" beds="1" />
-	<house name="Greenshore Village, Villa" houseid="2934" entryx="32276" entryy="32045" entryz="7" rent="300000" townid="8" size="155" clientid="14003" beds="4" />
-	<house name="Greenshore Village 7" houseid="2935" entryx="32266" entryy="32032" entryz="7" rent="25000" townid="8" size="21" clientid="14011" beds="1" />
-	<house name="Greenshore Village 3" houseid="2936" entryx="32264" entryy="32041" entryz="7" rent="50000" townid="8" size="26" clientid="14008" beds="2" />
-	<house name="Greenshore Village 2" houseid="2939" entryx="32264" entryy="32042" entryz="7" rent="50000" townid="8" size="26" clientid="14006" beds="2" />
-	<house name="Greenshore Village 6" houseid="2940" entryx="32258" entryy="32041" entryz="6" rent="150000" townid="8" size="71" clientid="14010" beds="2" />
-	<house name="Harbour Place 1 (Shop)" houseid="2941" entryx="32336" entryy="32222" entryz="7" rent="800000" townid="8" size="22" clientid="11404" beds="1" />
-	<house name="Harbour Place 2 (Shop)" houseid="2942" entryx="32336" entryy="32210" entryz="7" rent="600000" townid="8" size="26" clientid="11401" beds="1" />
-	<house name="Harbour Place 3" houseid="2943" entryx="32331" entryy="32208" entryz="7" rent="800000" townid="8" size="87" clientid="11402" beds="5" />
-	<house name="Harbour Place 4" houseid="2944" entryx="32332" entryy="32257" entryz="7" rent="80000" townid="8" size="17" clientid="10602" beds="1" />
-	<house name="Lower Swamp Lane 1" houseid="2945" entryx="32356" entryy="32262" entryz="7" rent="400000" townid="8" size="74" clientid="10403" beds="4" />
-	<house name="Lower Swamp Lane 3" houseid="2946" entryx="32368" entryy="32262" entryz="7" rent="400000" townid="8" size="74" clientid="10404" beds="4" />
-	<house name="Main Street 9, 1st floor (Shop)" houseid="2947" entryx="32377" entryy="32224" entryz="7" rent="200000" townid="8" size="32" clientid="10802" beds="1" />
-	<house name="Main Street 9a, 2nd floor (Shop)" houseid="2948" entryx="32377" entryy="32222" entryz="6" rent="100000" townid="8" size="17" clientid="10803" beds="1" />
-	<house name="Main Street 9b, 2nd floor (Shop)" houseid="2949" entryx="32377" entryy="32224" entryz="6" rent="150000" townid="8" size="28" clientid="10804" beds="1" />
-	<house name="Mill Avenue 1 (Shop)" houseid="2950" entryx="32398" entryy="32181" entryz="7" rent="200000" townid="8" size="26" clientid="10901" beds="1" />
-	<house name="Mill Avenue 2 (Shop)" houseid="2951" entryx="32404" entryy="32181" entryz="7" rent="200000" townid="8" size="45" clientid="10902" beds="2" />
-	<house name="Mill Avenue 3" houseid="2952" entryx="32410" entryy="32184" entryz="7" rent="100000" townid="8" size="26" clientid="10903" beds="2" />
-	<house name="Mill Avenue 4" houseid="2953" entryx="32413" entryy="32189" entryz="6" rent="100000" townid="8" size="26" clientid="10904" beds="2" />
-	<house name="Mill Avenue 5" houseid="2954" entryx="32422" entryy="32178" entryz="7" rent="300000" townid="8" size="59" clientid="10905" beds="4" />
-	<house name="Open-Air Theatre" houseid="2955" entryx="32262" entryy="32238" entryz="7" rent="150000" townid="8" size="60" clientid="10007" beds="1" />
-	<house name="Smuggler's Den" houseid="2956" entryx="32419" entryy="32262" entryz="9" rent="400000" townid="8" size="219" clientid="11024" beds="7" />
-	<house name="Sorcerer's Avenue 1a" houseid="2957" entryx="32300" entryy="32254" entryz="7" rent="100000" townid="8" size="21" clientid="10501" beds="2" />
-	<house name="Sorcerer's Avenue 5 (Shop)" houseid="2958" entryx="32284" entryy="32256" entryz="7" rent="150000" townid="8" size="49" clientid="10504" beds="1" />
-	<house name="Sorcerer's Avenue 1b" houseid="2959" entryx="32300" entryy="32251" entryz="6" rent="80000" townid="8" size="17" clientid="10502" beds="2" />
-	<house name="Sorcerer's Avenue 1c" houseid="2960" entryx="32300" entryy="32249" entryz="6" rent="100000" townid="8" size="21" clientid="10503" beds="2" />
+	<house name="Fibula Village 1" houseid="2921" entryx="32176" entryy="32433" entryz="7" rent="25000" townid="8" size="15" clientid="12003" beds="1" />
+	<house name="Fibula Village 2" houseid="2922" entryx="32184" entryy="32433" entryz="7" rent="25000" townid="8" size="15" clientid="12004" beds="1" />
+	<house name="Fibula Village 4" houseid="2923" entryx="32175" entryy="32440" entryz="7" rent="25000" townid="8" size="27" clientid="12006" beds="2" />
+	<house name="Fibula Village 5" houseid="2924" entryx="32171" entryy="32440" entryz="7" rent="50000" townid="8" size="27" clientid="12007" beds="2" />
+	<house name="Fibula Village 3" houseid="2925" entryx="32196" entryy="32438" entryz="7" rent="80000" townid="8" size="60" clientid="12005" beds="4" />
+	<house name="Fibula Village, Tower Flat" houseid="2926" entryx="32159" entryy="32439" entryz="7" rent="100000" townid="8" size="94" clientid="12008" beds="2" />
+	<house name="Guildhall of the Red Rose" houseid="2927" entryx="32180" entryy="32427" entryz="7" rent="250000" guildhall="true" townid="8" size="396" clientid="12002" beds="15" />
+	<house name="Fibula Village, Bar (Shop)" houseid="2928" entryx="32151" entryy="32399" entryz="7" rent="100000" townid="8" size="74" clientid="12009" beds="2" />
+	<house name="Fibula Village, Villa" houseid="2929" entryx="32140" entryy="32374" entryz="7" rent="200000" townid="8" size="264" clientid="12100" beds="7" />
+	<house name="Greenshore Village 1" houseid="2930" entryx="32274" entryy="32062" entryz="7" rent="80000" townid="8" size="39" clientid="14005" beds="3" />
+	<house name="Greenshore Clanhall" houseid="2931" entryx="32278" entryy="32069" entryz="7" rent="250000" guildhall="true" townid="8" size="176" clientid="14012" beds="10" />
+	<house name="Castle of Greenshore" houseid="2932" entryx="32290" entryy="32070" entryz="7" rent="250000" guildhall="true" townid="8" size="325" clientid="14002" beds="12" />
+	<house name="Greenshore Village, Shop" houseid="2933" entryx="32278" entryy="32052" entryz="7" rent="80000" townid="8" size="31" clientid="14004" beds="1" />
+	<house name="Greenshore Village, Villa" houseid="2934" entryx="32276" entryy="32045" entryz="7" rent="300000" townid="8" size="178" clientid="14003" beds="4" />
+	<house name="Greenshore Village 7" houseid="2935" entryx="32266" entryy="32032" entryz="7" rent="25000" townid="8" size="23" clientid="14011" beds="1" />
+	<house name="Greenshore Village 3" houseid="2936" entryx="32264" entryy="32041" entryz="7" rent="50000" townid="8" size="30" clientid="14008" beds="2" />
+	<house name="Greenshore Village 2" houseid="2939" entryx="32264" entryy="32042" entryz="7" rent="50000" townid="8" size="30" clientid="14006" beds="2" />
+	<house name="Greenshore Village 6" houseid="2940" entryx="32258" entryy="32041" entryz="6" rent="150000" townid="8" size="79" clientid="14010" beds="2" />
+	<house name="Harbour Place 1 (Shop)" houseid="2941" entryx="32336" entryy="32222" entryz="7" rent="800000" townid="8" size="21" clientid="11404" beds="1" />
+	<house name="Harbour Place 2 (Shop)" houseid="2942" entryx="32336" entryy="32210" entryz="7" rent="600000" townid="8" size="25" clientid="11401" beds="1" />
+	<house name="Harbour Place 3" houseid="2943" entryx="32331" entryy="32208" entryz="7" rent="800000" townid="8" size="88" clientid="11402" beds="5" />
+	<house name="Harbour Place 4" houseid="2944" entryx="32332" entryy="32257" entryz="7" rent="80000" townid="8" size="18" clientid="10602" beds="1" />
+	<house name="Lower Swamp Lane 1" houseid="2945" entryx="32356" entryy="32262" entryz="7" rent="400000" townid="8" size="80" clientid="10403" beds="4" />
+	<house name="Lower Swamp Lane 3" houseid="2946" entryx="32368" entryy="32262" entryz="7" rent="400000" townid="8" size="80" clientid="10404" beds="4" />
+	<house name="Main Street 9, 1st floor (Shop)" houseid="2947" entryx="32377" entryy="32224" entryz="7" rent="200000" townid="8" size="30" clientid="10802" beds="1" />
+	<house name="Main Street 9a, 2nd floor (Shop)" houseid="2948" entryx="32377" entryy="32222" entryz="6" rent="100000" townid="8" size="15" clientid="10803" beds="1" />
+	<house name="Main Street 9b, 2nd floor (Shop)" houseid="2949" entryx="32377" entryy="32224" entryz="6" rent="150000" townid="8" size="27" clientid="10804" beds="1" />
+	<house name="Mill Avenue 1 (Shop)" houseid="2950" entryx="32398" entryy="32181" entryz="7" rent="200000" townid="8" size="28" clientid="10901" beds="1" />
+	<house name="Mill Avenue 2 (Shop)" houseid="2951" entryx="32404" entryy="32181" entryz="7" rent="200000" townid="8" size="47" clientid="10902" beds="2" />
+	<house name="Mill Avenue 3" houseid="2952" entryx="32410" entryy="32184" entryz="7" rent="100000" townid="8" size="32" clientid="10903" beds="2" />
+	<house name="Mill Avenue 4" houseid="2953" entryx="32413" entryy="32189" entryz="6" rent="100000" townid="8" size="33" clientid="10904" beds="2" />
+	<house name="Mill Avenue 5" houseid="2954" entryx="32422" entryy="32178" entryz="7" rent="300000" townid="8" size="69" clientid="10905" beds="4" />
+	<house name="Open-Air Theatre" houseid="2955" entryx="32262" entryy="32238" entryz="7" rent="150000" townid="8" size="81" clientid="10007" beds="1" />
+	<house name="Smuggler's Den" houseid="2956" entryx="32419" entryy="32262" entryz="9" rent="400000" townid="8" size="226" clientid="11024" beds="7" />
+	<house name="Sorcerer's Avenue 1a" houseid="2957" entryx="32300" entryy="32254" entryz="7" rent="100000" townid="8" size="24" clientid="10501" beds="2" />
+	<house name="Sorcerer's Avenue 5 (Shop)" houseid="2958" entryx="32284" entryy="32256" entryz="7" rent="150000" townid="8" size="54" clientid="10504" beds="1" />
+	<house name="Sorcerer's Avenue 1b" houseid="2959" entryx="32300" entryy="32251" entryz="6" rent="80000" townid="8" size="19" clientid="10502" beds="2" />
+	<house name="Sorcerer's Avenue 1c" houseid="2960" entryx="32300" entryy="32249" entryz="6" rent="100000" townid="8" size="25" clientid="10503" beds="2" />
 	<house name="Sorcerer's Avenue Labs 2a" houseid="2961" entryx="32297" entryy="32273" entryz="8" rent="50000" townid="8" size="29" clientid="10505" beds="2" />
 	<house name="Sorcerer's Avenue Labs 2c" houseid="2962" entryx="32297" entryy="32274" entryz="8" rent="50000" townid="8" size="29" clientid="10510" beds="2" />
 	<house name="Sorcerer's Avenue Labs 2b" houseid="2963" entryx="32301" entryy="32274" entryz="8" rent="50000" townid="8" size="29" clientid="10508" beds="2" />
-	<house name="Sunset Homes, Flat 01" houseid="2964" entryx="32333" entryy="32232" entryz="7" rent="100000" townid="8" size="13" clientid="10101" beds="1" />
-	<house name="Sunset Homes, Flat 02" houseid="2965" entryx="32333" entryy="32237" entryz="7" rent="80000" townid="8" size="13" clientid="10102" beds="1" />
-	<house name="Sunset Homes, Flat 03" houseid="2966" entryx="32334" entryy="32244" entryz="7" rent="80000" townid="8" size="13" clientid="10103" beds="1" />
-	<house name="Sunset Homes, Flat 11" houseid="2967" entryx="32333" entryy="32232" entryz="6" rent="80000" townid="8" size="13" clientid="10104" beds="1" />
-	<house name="Sunset Homes, Flat 12" houseid="2968" entryx="32333" entryy="32237" entryz="6" rent="50000" townid="8" size="13" clientid="10112" beds="1" />
-	<house name="Sunset Homes, Flat 13" houseid="2969" entryx="32334" entryy="32244" entryz="6" rent="100000" townid="8" size="19" clientid="10113" beds="2" />
-	<house name="Sunset Homes, Flat 14" houseid="2970" entryx="32334" entryy="32249" entryz="6" rent="50000" townid="8" size="13" clientid="10114" beds="1" />
-	<house name="Sunset Homes, Flat 21" houseid="2971" entryx="32333" entryy="32232" entryz="5" rent="50000" townid="8" size="13" clientid="10121" beds="1" />
-	<house name="Sunset Homes, Flat 22" houseid="2972" entryx="32333" entryy="32237" entryz="5" rent="50000" townid="8" size="13" clientid="10122" beds="1" />
-	<house name="Sunset Homes, Flat 23" houseid="2973" entryx="32334" entryy="32244" entryz="5" rent="80000" townid="8" size="19" clientid="10123" beds="2" />
-	<house name="Sunset Homes, Flat 24" houseid="2974" entryx="32334" entryy="32249" entryz="5" rent="50000" townid="8" size="13" clientid="10124" beds="1" />
-	<house name="Thais Hostel" houseid="2975" entryx="32333" entryy="32255" entryz="6" rent="200000" townid="8" size="117" clientid="10603" beds="24" />
-	<house name="The City Wall 1a" houseid="2976" entryx="32422" entryy="32189" entryz="7" rent="150000" townid="8" size="26" clientid="11022" beds="2" />
-	<house name="The City Wall 1b" houseid="2977" entryx="32422" entryy="32189" entryz="6" rent="100000" townid="8" size="26" clientid="11023" beds="2" />
-	<house name="The City Wall 3a" houseid="2978" entryx="32423" entryy="32208" entryz="7" rent="100000" townid="8" size="21" clientid="11016" beds="2" />
-	<house name="The City Wall 3b" houseid="2979" entryx="32423" entryy="32203" entryz="7" rent="100000" townid="8" size="21" clientid="11017" beds="2" />
-	<house name="The City Wall 3c" houseid="2980" entryx="32423" entryy="32198" entryz="7" rent="100000" townid="8" size="21" clientid="11018" beds="2" />
-	<house name="The City Wall 3d" houseid="2981" entryx="32423" entryy="32208" entryz="6" rent="100000" townid="8" size="21" clientid="11019" beds="2" />
-	<house name="The City Wall 3e" houseid="2982" entryx="32423" entryy="32203" entryz="6" rent="100000" townid="8" size="21" clientid="11020" beds="2" />
-	<house name="The City Wall 3f" houseid="2983" entryx="32423" entryy="32198" entryz="6" rent="100000" townid="8" size="21" clientid="11021" beds="2" />
-	<house name="Upper Swamp Lane 12" houseid="2984" entryx="32419" entryy="32256" entryz="7" rent="300000" townid="8" size="60" clientid="10408" beds="3" />
-	<house name="Upper Swamp Lane 10" houseid="2985" entryx="32412" entryy="32256" entryz="7" rent="150000" townid="8" size="31" clientid="10407" beds="3" />
-	<house name="Upper Swamp Lane 8" houseid="2986" entryx="32398" entryy="32256" entryz="7" rent="600000" townid="8" size="132" clientid="10405" beds="3" />
-	<house name="Upper Swamp Lane 4" houseid="2987" entryx="32360" entryy="32252" entryz="7" rent="600000" townid="8" size="74" clientid="10402" beds="4" />
-	<house name="Upper Swamp Lane 2" houseid="2988" entryx="32348" entryy="32252" entryz="7" rent="600000" townid="8" size="74" clientid="10401" beds="4" />
-	<house name="The City Wall 9" houseid="2989" entryx="32419" entryy="32247" entryz="7" rent="80000" townid="8" size="19" clientid="11015" beds="2" />
-	<house name="The City Wall 7h" houseid="2990" entryx="32419" entryy="32238" entryz="6" rent="50000" townid="8" size="13" clientid="11014" beds="1" />
-	<house name="The City Wall 7b" houseid="2991" entryx="32419" entryy="32237" entryz="6" rent="25000" townid="8" size="13" clientid="11008" beds="1" />
-	<house name="The City Wall 7d" houseid="2992" entryx="32413" entryy="32237" entryz="6" rent="50000" townid="8" size="17" clientid="11010" beds="2" />
-	<house name="The City Wall 7f" houseid="2993" entryx="32413" entryy="32238" entryz="6" rent="80000" townid="8" size="17" clientid="11012" beds="2" />
-	<house name="The City Wall 7c" houseid="2994" entryx="32413" entryy="32237" entryz="7" rent="80000" townid="8" size="17" clientid="11009" beds="2" />
-	<house name="The City Wall 7a" houseid="2995" entryx="32419" entryy="32237" entryz="7" rent="80000" townid="8" size="13" clientid="11007" beds="1" />
-	<house name="The City Wall 7g" houseid="2996" entryx="32419" entryy="32238" entryz="7" rent="50000" townid="8" size="13" clientid="11013" beds="1" />
-	<house name="The City Wall 7e" houseid="2997" entryx="32413" entryy="32238" entryz="7" rent="80000" townid="8" size="17" clientid="11011" beds="2" />
-	<house name="The City Wall 5b" houseid="2998" entryx="32416" entryy="32220" entryz="6" rent="50000" townid="8" size="13" clientid="11002" beds="1" />
-	<house name="The City Wall 5d" houseid="2999" entryx="32416" entryy="32223" entryz="6" rent="50000" townid="8" size="13" clientid="11004" beds="1" />
-	<house name="The City Wall 5f" houseid="3000" entryx="32416" entryy="32226" entryz="6" rent="25000" townid="8" size="13" clientid="11006" beds="1" />
-	<house name="The City Wall 5a" houseid="3001" entryx="32416" entryy="32220" entryz="7" rent="50000" townid="8" size="13" clientid="11001" beds="1" />
-	<house name="The City Wall 5c" houseid="3002" entryx="32416" entryy="32223" entryz="7" rent="50000" townid="8" size="13" clientid="11003" beds="1" />
-	<house name="The City Wall 5e" houseid="3003" entryx="32416" entryy="32226" entryz="7" rent="50000" townid="8" size="13" clientid="11005" beds="1" />
-	<house name="Warriors' Guildhall" houseid="3004" entryx="32348" entryy="32213" entryz="7" rent="5000000" guildhall="true" townid="8" size="307" clientid="10801" beds="11" />
-	<house name="The Tibianic" houseid="3005" entryx="32277" entryy="32011" entryz="5" rent="500000" guildhall="true" townid="8" size="540" clientid="14001" beds="22" />
-	<house name="Bloodhall" houseid="3006" entryx="32469" entryy="32170" entryz="7" rent="500000" guildhall="true" townid="8" size="306" clientid="10005" beds="16" />
-	<house name="Fibula Clanhall" houseid="3007" entryx="32178" entryy="32373" entryz="7" rent="250000" guildhall="true" townid="8" size="162" clientid="12010" beds="10" />
-	<house name="Dark Mansion" houseid="3008" entryx="32397" entryy="32155" entryz="7" rent="1000000" guildhall="true" townid="8" size="361" clientid="10004" beds="17" />
-	<house name="Halls of the Adventurers" houseid="3009" entryx="32396" entryy="32042" entryz="7" rent="250000" guildhall="true" townid="8" size="304" clientid="10003" beds="18" />
-	<house name="Mercenary Tower" houseid="3010" entryx="32208" entryy="32437" entryz="7" rent="250000" guildhall="true" townid="8" size="607" clientid="12001" beds="26" />
-	<house name="Snake Tower" houseid="3011" entryx="32435" entryy="32359" entryz="7" rent="500000" guildhall="true" townid="8" size="616" clientid="10002" beds="21" />
-	<house name="Southern Thais Guildhall" houseid="3012" entryx="32401" entryy="32254" entryz="7" rent="1000000" guildhall="true" townid="8" size="349" clientid="10406" beds="16" />
-	<house name="Spiritkeep" houseid="3013" entryx="32265" entryy="32316" entryz="7" rent="500000" guildhall="true" townid="8" size="382" clientid="10001" beds="23" />
-	<house name="Thais Clanhall" houseid="3014" entryx="32326" entryy="32272" entryz="7" rent="500000" guildhall="true" townid="8" size="188" clientid="10601" beds="10" />
-	<house name="The Lair" houseid="3015" entryx="32993" entryy="32152" entryz="7" rent="200000" townid="9" size="166" clientid="35065" beds="3" />
-	<house name="Silver Street 4" houseid="3016" entryx="32997" entryy="32077" entryz="6" rent="300000" townid="9" size="71" clientid="35055" beds="2" />
-	<house name="Dream Street 1 (Shop)" houseid="3017" entryx="32897" entryy="32107" entryz="6" rent="600000" townid="9" size="94" clientid="35009" beds="2" />
-	<house name="Dagger Alley 1" houseid="3018" entryx="32921" entryy="32134" entryz="6" rent="200000" townid="9" size="57" clientid="35006" beds="2" />
-	<house name="Dream Street 2" houseid="3019" entryx="32898" entryy="32077" entryz="6" rent="400000" townid="9" size="72" clientid="35010" beds="2" />
-	<house name="Dream Street 3" houseid="3020" entryx="32897" entryy="32069" entryz="6" rent="300000" townid="9" size="58" clientid="35011" beds="2" />
-	<house name="Elm Street 1" houseid="3021" entryx="32894" entryy="32056" entryz="6" rent="300000" townid="9" size="58" clientid="35013" beds="2" />
-	<house name="Elm Street 3" houseid="3022" entryx="32902" entryy="32056" entryz="6" rent="300000" townid="9" size="59" clientid="35015" beds="3" />
-	<house name="Elm Street 2" houseid="3023" entryx="32894" entryy="32055" entryz="6" rent="300000" townid="9" size="57" clientid="35014" beds="2" />
-	<house name="Elm Street 4" houseid="3024" entryx="32902" entryy="32055" entryz="6" rent="300000" townid="9" size="56" clientid="35016" beds="2" />
-	<house name="Seagull Walk 1" houseid="3025" entryx="32918" entryy="32052" entryz="6" rent="800000" townid="9" size="111" clientid="35017" beds="2" />
-	<house name="Seagull Walk 2" houseid="3026" entryx="32915" entryy="32037" entryz="6" rent="300000" townid="9" size="57" clientid="35018" beds="3" />
-	<house name="Dream Street 4" houseid="3027" entryx="32898" entryy="32042" entryz="6" rent="400000" townid="9" size="77" clientid="35012" beds="4" />
-	<house name="Old Lighthouse" houseid="3028" entryx="32926" entryy="32037" entryz="6" rent="200000" townid="9" size="78" clientid="35057" beds="2" />
-	<house name="Market Street 1" houseid="3029" entryx="32932" entryy="32051" entryz="6" rent="600000" townid="9" size="144" clientid="35058" beds="3" />
-	<house name="Market Street 3" houseid="3030" entryx="32950" entryy="32052" entryz="6" rent="600000" townid="9" size="75" clientid="35060" beds="2" />
-	<house name="Market Street 4 (Shop)" houseid="3031" entryx="32960" entryy="32052" entryz="6" rent="800000" townid="9" size="109" clientid="35061" beds="3" />
-	<house name="Market Street 5 (Shop)" houseid="3032" entryx="32964" entryy="32053" entryz="6" rent="800000" townid="9" size="135" clientid="35062" beds="4" />
-	<house name="Market Street 2" houseid="3033" entryx="32944" entryy="32053" entryz="6" rent="600000" townid="9" size="105" clientid="35059" beds="3" />
-	<house name="Loot Lane 1 (Shop)" houseid="3034" entryx="32981" entryy="32059" entryz="6" rent="600000" townid="9" size="97" clientid="35056" beds="3" />
-	<house name="Mystic Lane 1" houseid="3035" entryx="32975" entryy="32072" entryz="6" rent="300000" townid="9" size="61" clientid="35050" beds="3" />
-	<house name="Mystic Lane 2" houseid="3036" entryx="32979" entryy="32072" entryz="6" rent="200000" townid="9" size="64" clientid="35051" beds="2" />
-	<house name="Lucky Lane 2 (Tower)" houseid="3037" entryx="32935" entryy="32152" entryz="6" rent="600000" townid="9" size="118" clientid="35067" beds="5" />
-	<house name="Lucky Lane 3 (Tower)" houseid="3038" entryx="32936" entryy="32152" entryz="6" rent="600000" townid="9" size="118" clientid="35068" beds="5" />
-	<house name="Iron Alley 1" houseid="3039" entryx="32942" entryy="32126" entryz="6" rent="300000" townid="9" size="70" clientid="35007" beds="4" />
-	<house name="Iron Alley 2" houseid="3040" entryx="32948" entryy="32126" entryz="6" rent="300000" townid="9" size="70" clientid="35008" beds="4" />
-	<house name="Swamp Watch" houseid="3041" entryx="32958" entryy="32119" entryz="6" rent="500000" guildhall="true" townid="9" size="222" clientid="35003" beds="12" />
-	<house name="Golden Axe Guildhall" houseid="3042" entryx="32987" entryy="32109" entryz="6" rent="500000" guildhall="true" townid="9" size="213" clientid="35004" beds="10" />
-	<house name="Silver Street 1" houseid="3043" entryx="32998" entryy="32109" entryz="6" rent="200000" townid="9" size="57" clientid="35052" beds="1" />
-	<house name="Valorous Venore" houseid="3044" entryx="32979" entryy="32096" entryz="6" rent="500000" guildhall="true" townid="9" size="303" clientid="35005" beds="9" />
-	<house name="Salvation Street 2" houseid="3045" entryx="32967" entryy="32096" entryz="6" rent="300000" townid="9" size="82" clientid="35048" beds="2" />
-	<house name="Salvation Street 3" houseid="3046" entryx="32972" entryy="32096" entryz="6" rent="300000" townid="9" size="82" clientid="35049" beds="2" />
-	<house name="Silver Street 2" houseid="3047" entryx="32998" entryy="32088" entryz="6" rent="200000" townid="9" size="44" clientid="35053" beds="1" />
-	<house name="Silver Street 3" houseid="3048" entryx="32998" entryy="32084" entryz="6" rent="200000" townid="9" size="44" clientid="35054" beds="1" />
-	<house name="Mystic Lane 3 (Tower)" houseid="3049" entryx="33008" entryy="32072" entryz="6" rent="800000" townid="9" size="118" clientid="35066" beds="5" />
-	<house name="Market Street 7" houseid="3050" entryx="33004" entryy="32052" entryz="6" rent="200000" townid="9" size="49" clientid="35064" beds="2" />
-	<house name="Market Street 6" houseid="3051" entryx="32993" entryy="32052" entryz="6" rent="600000" townid="9" size="113" clientid="35063" beds="5" />
-	<house name="Iron Alley Watch, Upper" houseid="3052" entryx="32869" entryy="32125" entryz="6" rent="600000" townid="9" size="114" clientid="35069" beds="5" />
-	<house name="Iron Alley Watch, Lower" houseid="3053" entryx="32869" entryy="32126" entryz="6" rent="600000" townid="9" size="115" clientid="35070" beds="5" />
-	<house name="Blessed Shield Guildhall" houseid="3054" entryx="32908" entryy="32126" entryz="6" rent="500000" guildhall="true" townid="9" size="162" clientid="35001" beds="9" />
-	<house name="Steel Home" houseid="3055" entryx="32929" entryy="32125" entryz="6" rent="500000" guildhall="true" townid="9" size="281" clientid="35002" beds="13" />
-	<house name="Salvation Street 1 (Shop)" houseid="3056" entryx="32929" entryy="32096" entryz="6" rent="600000" townid="9" size="132" clientid="35047" beds="4" />
-	<house name="Lucky Lane 1 (Shop)" houseid="3057" entryx="32936" entryy="32090" entryz="6" rent="800000" townid="9" size="148" clientid="35019" beds="4" />
-	<house name="Paupers Palace, Flat 34" houseid="3058" entryx="32906" entryy="32095" entryz="4" rent="100000" townid="9" size="35" clientid="35046" beds="2" />
-	<house name="Paupers Palace, Flat 33" houseid="3059" entryx="32911" entryy="32095" entryz="4" rent="50000" townid="9" size="17" clientid="35045" beds="1" />
-	<house name="Paupers Palace, Flat 32" houseid="3060" entryx="32914" entryy="32096" entryz="4" rent="100000" townid="9" size="23" clientid="35044" beds="2" />
-	<house name="Paupers Palace, Flat 31" houseid="3061" entryx="32918" entryy="32095" entryz="4" rent="80000" townid="9" size="19" clientid="35043" beds="1" />
-	<house name="Paupers Palace, Flat 28" houseid="3062" entryx="32903" entryy="32095" entryz="5" rent="25000" townid="9" size="7" clientid="35042" beds="1" />
-	<house name="Paupers Palace, Flat 26" houseid="3063" entryx="32907" entryy="32095" entryz="5" rent="25000" townid="9" size="10" clientid="35040" beds="1" />
-	<house name="Paupers Palace, Flat 24" houseid="3064" entryx="32911" entryy="32095" entryz="5" rent="25000" townid="9" size="10" clientid="35038" beds="1" />
-	<house name="Paupers Palace, Flat 22" houseid="3065" entryx="32915" entryy="32095" entryz="5" rent="25000" townid="9" size="10" clientid="35036" beds="1" />
-	<house name="Paupers Palace, Flat 21" houseid="3066" entryx="32918" entryy="32095" entryz="5" rent="25000" townid="9" size="7" clientid="35035" beds="1" />
-	<house name="Paupers Palace, Flat 27" houseid="3067" entryx="32904" entryy="32096" entryz="5" rent="50000" townid="9" size="13" clientid="35041" beds="2" />
-	<house name="Paupers Palace, Flat 25" houseid="3068" entryx="32909" entryy="32096" entryz="5" rent="50000" townid="9" size="13" clientid="35039" beds="1" />
-	<house name="Paupers Palace, Flat 23" houseid="3069" entryx="32914" entryy="32096" entryz="5" rent="50000" townid="9" size="13" clientid="35037" beds="1" />
-	<house name="Paupers Palace, Flat 11" houseid="3070" entryx="32903" entryy="32095" entryz="6" rent="25000" townid="9" size="7" clientid="35027" beds="1" />
-	<house name="Paupers Palace, Flat 13" houseid="3071" entryx="32907" entryy="32095" entryz="6" rent="50000" townid="9" size="10" clientid="35029" beds="1" />
-	<house name="Paupers Palace, Flat 15" houseid="3072" entryx="32911" entryy="32095" entryz="6" rent="50000" townid="9" size="10" clientid="35031" beds="1" />
-	<house name="Paupers Palace, Flat 17" houseid="3073" entryx="32915" entryy="32095" entryz="6" rent="25000" townid="9" size="10" clientid="35033" beds="1" />
-	<house name="Paupers Palace, Flat 18" houseid="3074" entryx="32918" entryy="32095" entryz="6" rent="25000" townid="9" size="7" clientid="35034" beds="1" />
-	<house name="Paupers Palace, Flat 12" houseid="3075" entryx="32904" entryy="32096" entryz="6" rent="50000" townid="9" size="13" clientid="35028" beds="2" />
-	<house name="Paupers Palace, Flat 14" houseid="3076" entryx="32909" entryy="32096" entryz="6" rent="50000" townid="9" size="13" clientid="35030" beds="1" />
-	<house name="Paupers Palace, Flat 16" houseid="3077" entryx="32914" entryy="32096" entryz="6" rent="50000" townid="9" size="13" clientid="35032" beds="1" />
-	<house name="Paupers Palace, Flat 06" houseid="3078" entryx="32906" entryy="32092" entryz="7" rent="25000" townid="9" size="10" clientid="35025" beds="1" />
-	<house name="Paupers Palace, Flat 05" houseid="3079" entryx="32906" entryy="32096" entryz="7" rent="25000" townid="9" size="7" clientid="35024" beds="1" />
-	<house name="Paupers Palace, Flat 04" houseid="3080" entryx="32906" entryy="32099" entryz="7" rent="25000" townid="9" size="10" clientid="35023" beds="1" />
-	<house name="Paupers Palace, Flat 07" houseid="3081" entryx="32910" entryy="32091" entryz="7" rent="50000" townid="9" size="13" clientid="35026" beds="2" />
-	<house name="Paupers Palace, Flat 03" houseid="3082" entryx="32911" entryy="32100" entryz="7" rent="25000" townid="9" size="9" clientid="35022" beds="1" />
-	<house name="Paupers Palace, Flat 02" houseid="3083" entryx="32914" entryy="32094" entryz="7" rent="25000" townid="9" size="10" clientid="35021" beds="1" />
-	<house name="Paupers Palace, Flat 01" houseid="3084" entryx="32918" entryy="32094" entryz="7" rent="25000" townid="9" size="9" clientid="35020" beds="1" />
+	<house name="Sunset Homes, Flat 01" houseid="2964" entryx="32333" entryy="32232" entryz="7" rent="100000" townid="8" size="15" clientid="10101" beds="1" />
+	<house name="Sunset Homes, Flat 02" houseid="2965" entryx="32333" entryy="32237" entryz="7" rent="80000" townid="8" size="14" clientid="10102" beds="1" />
+	<house name="Sunset Homes, Flat 03" houseid="2966" entryx="32334" entryy="32244" entryz="7" rent="80000" townid="8" size="14" clientid="10103" beds="1" />
+	<house name="Sunset Homes, Flat 11" houseid="2967" entryx="32333" entryy="32232" entryz="6" rent="80000" townid="8" size="15" clientid="10104" beds="1" />
+	<house name="Sunset Homes, Flat 12" houseid="2968" entryx="32333" entryy="32237" entryz="6" rent="50000" townid="8" size="15" clientid="10112" beds="1" />
+	<house name="Sunset Homes, Flat 13" houseid="2969" entryx="32334" entryy="32244" entryz="6" rent="100000" townid="8" size="22" clientid="10113" beds="2" />
+	<house name="Sunset Homes, Flat 14" houseid="2970" entryx="32334" entryy="32249" entryz="6" rent="50000" townid="8" size="17" clientid="10114" beds="1" />
+	<house name="Sunset Homes, Flat 21" houseid="2971" entryx="32333" entryy="32232" entryz="5" rent="50000" townid="8" size="15" clientid="10121" beds="1" />
+	<house name="Sunset Homes, Flat 22" houseid="2972" entryx="32333" entryy="32237" entryz="5" rent="50000" townid="8" size="15" clientid="10122" beds="1" />
+	<house name="Sunset Homes, Flat 23" houseid="2973" entryx="32334" entryy="32244" entryz="5" rent="80000" townid="8" size="22" clientid="10123" beds="2" />
+	<house name="Sunset Homes, Flat 24" houseid="2974" entryx="32334" entryy="32249" entryz="5" rent="50000" townid="8" size="17" clientid="10124" beds="1" />
+	<house name="Thais Hostel" houseid="2975" entryx="32333" entryy="32255" entryz="6" rent="200000" townid="8" size="129" clientid="10603" beds="24" />
+	<house name="The City Wall 1a" houseid="2976" entryx="32422" entryy="32189" entryz="7" rent="150000" townid="8" size="32" clientid="11022" beds="2" />
+	<house name="The City Wall 1b" houseid="2977" entryx="32422" entryy="32189" entryz="6" rent="100000" townid="8" size="31" clientid="11023" beds="2" />
+	<house name="The City Wall 3a" houseid="2978" entryx="32423" entryy="32208" entryz="7" rent="100000" townid="8" size="23" clientid="11016" beds="2" />
+	<house name="The City Wall 3b" houseid="2979" entryx="32423" entryy="32203" entryz="7" rent="100000" townid="8" size="23" clientid="11017" beds="2" />
+	<house name="The City Wall 3c" houseid="2980" entryx="32423" entryy="32198" entryz="7" rent="100000" townid="8" size="23" clientid="11018" beds="2" />
+	<house name="The City Wall 3d" houseid="2981" entryx="32423" entryy="32208" entryz="6" rent="100000" townid="8" size="23" clientid="11019" beds="2" />
+	<house name="The City Wall 3e" houseid="2982" entryx="32423" entryy="32203" entryz="6" rent="100000" townid="8" size="23" clientid="11020" beds="2" />
+	<house name="The City Wall 3f" houseid="2983" entryx="32423" entryy="32198" entryz="6" rent="100000" townid="8" size="23" clientid="11021" beds="2" />
+	<house name="Upper Swamp Lane 12" houseid="2984" entryx="32419" entryy="32256" entryz="7" rent="300000" townid="8" size="76" clientid="10408" beds="3" />
+	<house name="Upper Swamp Lane 10" houseid="2985" entryx="32412" entryy="32256" entryz="7" rent="150000" townid="8" size="40" clientid="10407" beds="3" />
+	<house name="Upper Swamp Lane 8" houseid="2986" entryx="32398" entryy="32256" entryz="7" rent="600000" townid="8" size="159" clientid="10405" beds="3" />
+	<house name="Upper Swamp Lane 4" houseid="2987" entryx="32360" entryy="32252" entryz="7" rent="600000" townid="8" size="100" clientid="10402" beds="4" />
+	<house name="Upper Swamp Lane 2" houseid="2988" entryx="32348" entryy="32252" entryz="7" rent="600000" townid="8" size="100" clientid="10401" beds="4" />
+	<house name="The City Wall 9" houseid="2989" entryx="32419" entryy="32247" entryz="7" rent="80000" townid="8" size="25" clientid="11015" beds="2" />
+	<house name="The City Wall 7h" houseid="2990" entryx="32419" entryy="32238" entryz="6" rent="50000" townid="8" size="18" clientid="11014" beds="1" />
+	<house name="The City Wall 7b" houseid="2991" entryx="32419" entryy="32237" entryz="6" rent="25000" townid="8" size="18" clientid="11008" beds="1" />
+	<house name="The City Wall 7d" houseid="2992" entryx="32413" entryy="32237" entryz="6" rent="50000" townid="8" size="22" clientid="11010" beds="2" />
+	<house name="The City Wall 7f" houseid="2993" entryx="32413" entryy="32238" entryz="6" rent="80000" townid="8" size="22" clientid="11012" beds="2" />
+	<house name="The City Wall 7c" houseid="2994" entryx="32413" entryy="32237" entryz="7" rent="80000" townid="8" size="22" clientid="11009" beds="2" />
+	<house name="The City Wall 7a" houseid="2995" entryx="32419" entryy="32237" entryz="7" rent="80000" townid="8" size="18" clientid="11007" beds="1" />
+	<house name="The City Wall 7g" houseid="2996" entryx="32419" entryy="32238" entryz="7" rent="50000" townid="8" size="18" clientid="11013" beds="1" />
+	<house name="The City Wall 7e" houseid="2997" entryx="32413" entryy="32238" entryz="7" rent="80000" townid="8" size="22" clientid="11011" beds="2" />
+	<house name="The City Wall 5b" houseid="2998" entryx="32416" entryy="32220" entryz="6" rent="50000" townid="8" size="17" clientid="11002" beds="1" />
+	<house name="The City Wall 5d" houseid="2999" entryx="32416" entryy="32223" entryz="6" rent="50000" townid="8" size="15" clientid="11004" beds="1" />
+	<house name="The City Wall 5f" houseid="3000" entryx="32416" entryy="32226" entryz="6" rent="25000" townid="8" size="17" clientid="11006" beds="1" />
+	<house name="The City Wall 5a" houseid="3001" entryx="32416" entryy="32220" entryz="7" rent="50000" townid="8" size="17" clientid="11001" beds="1" />
+	<house name="The City Wall 5c" houseid="3002" entryx="32416" entryy="32223" entryz="7" rent="50000" townid="8" size="15" clientid="11003" beds="1" />
+	<house name="The City Wall 5e" houseid="3003" entryx="32416" entryy="32226" entryz="7" rent="50000" townid="8" size="17" clientid="11005" beds="1" />
+	<house name="Warriors' Guildhall" houseid="3004" entryx="32348" entryy="32213" entryz="7" rent="5000000" guildhall="true" townid="8" size="334" clientid="10801" beds="11" />
+	<house name="The Tibianic" houseid="3005" entryx="32277" entryy="32011" entryz="5" rent="500000" guildhall="true" townid="8" size="809" clientid="14001" beds="22" />
+	<house name="Bloodhall" houseid="3006" entryx="32469" entryy="32170" entryz="7" rent="500000" guildhall="true" townid="8" size="321" clientid="10005" beds="16" />
+	<house name="Fibula Clanhall" houseid="3007" entryx="32178" entryy="32373" entryz="7" rent="250000" guildhall="true" townid="8" size="178" clientid="12010" beds="10" />
+	<house name="Dark Mansion" houseid="3008" entryx="32397" entryy="32155" entryz="7" rent="1000000" guildhall="true" townid="8" size="375" clientid="10004" beds="17" />
+	<house name="Halls of the Adventurers" houseid="3009" entryx="32396" entryy="32042" entryz="7" rent="250000" guildhall="true" townid="8" size="317" clientid="10003" beds="18" />
+	<house name="Mercenary Tower" houseid="3010" entryx="32208" entryy="32437" entryz="7" rent="250000" guildhall="true" townid="8" size="619" clientid="12001" beds="26" />
+	<house name="Snake Tower" houseid="3011" entryx="32435" entryy="32359" entryz="7" rent="500000" guildhall="true" townid="8" size="627" clientid="10002" beds="21" />
+	<house name="Southern Thais Guildhall" houseid="3012" entryx="32401" entryy="32254" entryz="7" rent="1000000" guildhall="true" townid="8" size="374" clientid="10406" beds="16" />
+	<house name="Spiritkeep" houseid="3013" entryx="32265" entryy="32316" entryz="7" rent="500000" guildhall="true" townid="8" size="289" clientid="10001" beds="23" />
+	<house name="Thais Clanhall" houseid="3014" entryx="32326" entryy="32272" entryz="7" rent="500000" guildhall="true" townid="8" size="206" clientid="10601" beds="10" />
+	<house name="The Lair" houseid="3015" entryx="32993" entryy="32152" entryz="7" rent="200000" townid="9" size="259" clientid="35065" beds="3" />
+	<house name="Silver Street 4" houseid="3016" entryx="32997" entryy="32077" entryz="6" rent="300000" townid="9" size="119" clientid="35055" beds="2" />
+	<house name="Dream Street 1 (Shop)" houseid="3017" entryx="32897" entryy="32107" entryz="6" rent="600000" townid="9" size="149" clientid="35009" beds="2" />
+	<house name="Dagger Alley 1" houseid="3018" entryx="32921" entryy="32134" entryz="6" rent="200000" townid="9" size="103" clientid="35006" beds="2" />
+	<house name="Dream Street 2" houseid="3019" entryx="32898" entryy="32077" entryz="6" rent="400000" townid="9" size="113" clientid="35010" beds="2" />
+	<house name="Dream Street 3" houseid="3020" entryx="32897" entryy="32069" entryz="6" rent="300000" townid="9" size="104" clientid="35011" beds="2" />
+	<house name="Elm Street 1" houseid="3021" entryx="32894" entryy="32056" entryz="6" rent="300000" townid="9" size="99" clientid="35013" beds="2" />
+	<house name="Elm Street 3" houseid="3022" entryx="32902" entryy="32056" entryz="6" rent="300000" townid="9" size="107" clientid="35015" beds="3" />
+	<house name="Elm Street 2" houseid="3023" entryx="32894" entryy="32055" entryz="6" rent="300000" townid="9" size="98" clientid="35014" beds="2" />
+	<house name="Elm Street 4" houseid="3024" entryx="32902" entryy="32055" entryz="6" rent="300000" townid="9" size="108" clientid="35016" beds="2" />
+	<house name="Seagull Walk 1" houseid="3025" entryx="32918" entryy="32052" entryz="6" rent="800000" townid="9" size="169" clientid="35017" beds="2" />
+	<house name="Seagull Walk 2" houseid="3026" entryx="32915" entryy="32037" entryz="6" rent="300000" townid="9" size="102" clientid="35018" beds="3" />
+	<house name="Dream Street 4" houseid="3027" entryx="32898" entryy="32042" entryz="6" rent="400000" townid="9" size="128" clientid="35012" beds="4" />
+	<house name="Old Lighthouse" houseid="3028" entryx="32926" entryy="32037" entryz="6" rent="200000" townid="9" size="157" clientid="35057" beds="2" />
+	<house name="Market Street 1" houseid="3029" entryx="32932" entryy="32051" entryz="6" rent="600000" townid="9" size="220" clientid="35058" beds="3" />
+	<house name="Market Street 3" houseid="3030" entryx="32950" entryy="32052" entryz="6" rent="600000" townid="9" size="127" clientid="35060" beds="2" />
+	<house name="Market Street 4 (Shop)" houseid="3031" entryx="32960" entryy="32052" entryz="6" rent="800000" townid="9" size="176" clientid="35061" beds="3" />
+	<house name="Market Street 5 (Shop)" houseid="3032" entryx="32964" entryy="32053" entryz="6" rent="800000" townid="9" size="230" clientid="35062" beds="4" />
+	<house name="Market Street 2" houseid="3033" entryx="32944" entryy="32053" entryz="6" rent="600000" townid="9" size="173" clientid="35059" beds="3" />
+	<house name="Loot Lane 1 (Shop)" houseid="3034" entryx="32981" entryy="32059" entryz="6" rent="600000" townid="9" size="159" clientid="35056" beds="3" />
+	<house name="Mystic Lane 1" houseid="3035" entryx="32975" entryy="32072" entryz="6" rent="300000" townid="9" size="92" clientid="35050" beds="3" />
+	<house name="Mystic Lane 2" houseid="3036" entryx="32979" entryy="32072" entryz="6" rent="200000" townid="9" size="119" clientid="35051" beds="2" />
+	<house name="Lucky Lane 2 (Tower)" houseid="3037" entryx="32935" entryy="32152" entryz="6" rent="600000" townid="9" size="216" clientid="35067" beds="5" />
+	<house name="Lucky Lane 3 (Tower)" houseid="3038" entryx="32936" entryy="32152" entryz="6" rent="600000" townid="9" size="216" clientid="35068" beds="5" />
+	<house name="Iron Alley 1" houseid="3039" entryx="32942" entryy="32126" entryz="6" rent="300000" townid="9" size="101" clientid="35007" beds="4" />
+	<house name="Iron Alley 2" houseid="3040" entryx="32948" entryy="32126" entryz="6" rent="300000" townid="9" size="128" clientid="35008" beds="4" />
+	<house name="Swamp Watch" houseid="3041" entryx="32958" entryy="32119" entryz="6" rent="500000" guildhall="true" townid="9" size="379" clientid="35003" beds="12" />
+	<house name="Golden Axe Guildhall" houseid="3042" entryx="32987" entryy="32109" entryz="6" rent="500000" guildhall="true" townid="9" size="344" clientid="35004" beds="10" />
+	<house name="Silver Street 1" houseid="3043" entryx="32998" entryy="32109" entryz="6" rent="200000" townid="9" size="108" clientid="35052" beds="1" />
+	<house name="Valorous Venore" houseid="3044" entryx="32979" entryy="32096" entryz="6" rent="500000" guildhall="true" townid="9" size="457" clientid="35005" beds="9" />
+	<house name="Salvation Street 2" houseid="3045" entryx="32967" entryy="32096" entryz="6" rent="300000" townid="9" size="113" clientid="35048" beds="2" />
+	<house name="Salvation Street 3" houseid="3046" entryx="32972" entryy="32096" entryz="6" rent="300000" townid="9" size="143" clientid="35049" beds="2" />
+	<house name="Silver Street 2" houseid="3047" entryx="32998" entryy="32088" entryz="6" rent="200000" townid="9" size="76" clientid="35053" beds="1" />
+	<house name="Silver Street 3" houseid="3048" entryx="32998" entryy="32084" entryz="6" rent="200000" townid="9" size="82" clientid="35054" beds="1" />
+	<house name="Mystic Lane 3 (Tower)" houseid="3049" entryx="33008" entryy="32072" entryz="6" rent="800000" townid="9" size="214" clientid="35066" beds="5" />
+	<house name="Market Street 7" houseid="3050" entryx="33004" entryy="32052" entryz="6" rent="200000" townid="9" size="90" clientid="35064" beds="2" />
+	<house name="Market Street 6" houseid="3051" entryx="32993" entryy="32052" entryz="6" rent="600000" townid="9" size="186" clientid="35063" beds="5" />
+	<house name="Iron Alley Watch, Upper" houseid="3052" entryx="32869" entryy="32125" entryz="6" rent="600000" townid="9" size="215" clientid="35069" beds="5" />
+	<house name="Iron Alley Watch, Lower" houseid="3053" entryx="32869" entryy="32126" entryz="6" rent="600000" townid="9" size="217" clientid="35070" beds="5" />
+	<house name="Blessed Shield Guildhall" houseid="3054" entryx="32908" entryy="32126" entryz="6" rent="500000" guildhall="true" townid="9" size="250" clientid="35001" beds="9" />
+	<house name="Steel Home" houseid="3055" entryx="32929" entryy="32125" entryz="6" rent="500000" guildhall="true" townid="9" size="388" clientid="35002" beds="13" />
+	<house name="Salvation Street 1 (Shop)" houseid="3056" entryx="32929" entryy="32096" entryz="6" rent="600000" townid="9" size="215" clientid="35047" beds="4" />
+	<house name="Lucky Lane 1 (Shop)" houseid="3057" entryx="32936" entryy="32090" entryz="6" rent="800000" townid="9" size="220" clientid="35019" beds="4" />
+	<house name="Paupers Palace, Flat 34" houseid="3058" entryx="32906" entryy="32095" entryz="4" rent="100000" townid="9" size="59" clientid="35046" beds="2" />
+	<house name="Paupers Palace, Flat 33" houseid="3059" entryx="32911" entryy="32095" entryz="4" rent="50000" townid="9" size="35" clientid="35045" beds="1" />
+	<house name="Paupers Palace, Flat 32" houseid="3060" entryx="32914" entryy="32096" entryz="4" rent="100000" townid="9" size="50" clientid="35044" beds="2" />
+	<house name="Paupers Palace, Flat 31" houseid="3061" entryx="32918" entryy="32095" entryz="4" rent="80000" townid="9" size="40" clientid="35043" beds="1" />
+	<house name="Paupers Palace, Flat 28" houseid="3062" entryx="32903" entryy="32095" entryz="5" rent="25000" townid="9" size="13" clientid="35042" beds="1" />
+	<house name="Paupers Palace, Flat 26" houseid="3063" entryx="32907" entryy="32095" entryz="5" rent="25000" townid="9" size="19" clientid="35040" beds="1" />
+	<house name="Paupers Palace, Flat 24" houseid="3064" entryx="32911" entryy="32095" entryz="5" rent="25000" townid="9" size="19" clientid="35038" beds="1" />
+	<house name="Paupers Palace, Flat 22" houseid="3065" entryx="32915" entryy="32095" entryz="5" rent="25000" townid="9" size="19" clientid="35036" beds="1" />
+	<house name="Paupers Palace, Flat 21" houseid="3066" entryx="32918" entryy="32095" entryz="5" rent="25000" townid="9" size="18" clientid="35035" beds="1" />
+	<house name="Paupers Palace, Flat 27" houseid="3067" entryx="32904" entryy="32096" entryz="5" rent="50000" townid="9" size="23" clientid="35041" beds="2" />
+	<house name="Paupers Palace, Flat 25" houseid="3068" entryx="32909" entryy="32096" entryz="5" rent="50000" townid="9" size="24" clientid="35039" beds="1" />
+	<house name="Paupers Palace, Flat 23" houseid="3069" entryx="32914" entryy="32096" entryz="5" rent="50000" townid="9" size="29" clientid="35037" beds="1" />
+	<house name="Paupers Palace, Flat 11" houseid="3070" entryx="32903" entryy="32095" entryz="6" rent="25000" townid="9" size="14" clientid="35027" beds="1" />
+	<house name="Paupers Palace, Flat 13" houseid="3071" entryx="32907" entryy="32095" entryz="6" rent="50000" townid="9" size="20" clientid="35029" beds="1" />
+	<house name="Paupers Palace, Flat 15" houseid="3072" entryx="32911" entryy="32095" entryz="6" rent="50000" townid="9" size="20" clientid="35031" beds="1" />
+	<house name="Paupers Palace, Flat 17" houseid="3073" entryx="32915" entryy="32095" entryz="6" rent="25000" townid="9" size="20" clientid="35033" beds="1" />
+	<house name="Paupers Palace, Flat 18" houseid="3074" entryx="32918" entryy="32095" entryz="6" rent="25000" townid="9" size="20" clientid="35034" beds="1" />
+	<house name="Paupers Palace, Flat 12" houseid="3075" entryx="32904" entryy="32096" entryz="6" rent="50000" townid="9" size="25" clientid="35028" beds="2" />
+	<house name="Paupers Palace, Flat 14" houseid="3076" entryx="32909" entryy="32096" entryz="6" rent="50000" townid="9" size="25" clientid="35030" beds="1" />
+	<house name="Paupers Palace, Flat 16" houseid="3077" entryx="32914" entryy="32096" entryz="6" rent="50000" townid="9" size="30" clientid="35032" beds="1" />
+	<house name="Paupers Palace, Flat 06" houseid="3078" entryx="32906" entryy="32092" entryz="7" rent="25000" townid="9" size="11" clientid="35025" beds="1" />
+	<house name="Paupers Palace, Flat 05" houseid="3079" entryx="32906" entryy="32096" entryz="7" rent="25000" townid="9" size="9" clientid="35024" beds="1" />
+	<house name="Paupers Palace, Flat 04" houseid="3080" entryx="32906" entryy="32099" entryz="7" rent="25000" townid="9" size="17" clientid="35023" beds="1" />
+	<house name="Paupers Palace, Flat 07" houseid="3081" entryx="32910" entryy="32091" entryz="7" rent="50000" townid="9" size="14" clientid="35026" beds="2" />
+	<house name="Paupers Palace, Flat 03" houseid="3082" entryx="32911" entryy="32100" entryz="7" rent="25000" townid="9" size="11" clientid="35022" beds="1" />
+	<house name="Paupers Palace, Flat 02" houseid="3083" entryx="32914" entryy="32094" entryz="7" rent="25000" townid="9" size="14" clientid="35021" beds="1" />
+	<house name="Paupers Palace, Flat 01" houseid="3084" entryx="32918" entryy="32094" entryz="7" rent="25000" townid="9" size="15" clientid="35020" beds="1" />
 	<house name="Castle, Residence" houseid="3085" entryx="33168" entryy="31792" entryz="6" rent="600000" townid="11" size="104" clientid="50129" beds="6" />
-	<house name="Castle, 3rd Floor, Flat 07" houseid="3086" entryx="33169" entryy="31802" entryz="5" rent="80000" townid="11" size="16" clientid="50110" beds="1" />
+	<house name="Castle, 3rd Floor, Flat 07" houseid="3086" entryx="33169" entryy="31802" entryz="5" rent="80000" townid="11" size="17" clientid="50110" beds="1" />
 	<house name="Castle, 3rd Floor, Flat 04" houseid="3087" entryx="33169" entryy="31807" entryz="5" rent="25000" townid="11" size="13" clientid="50107" beds="1" />
 	<house name="Castle, 3rd Floor, Flat 03" houseid="3088" entryx="33169" entryy="31812" entryz="5" rent="50000" townid="11" size="13" clientid="50106" beds="1" />
-	<house name="Castle, 3rd Floor, Flat 06" houseid="3089" entryx="33170" entryy="31802" entryz="5" rent="100000" townid="11" size="21" clientid="50109" beds="2" />
-	<house name="Castle, 3rd Floor, Flat 05" houseid="3090" entryx="33170" entryy="31807" entryz="5" rent="80000" townid="11" size="17" clientid="50108" beds="1" />
-	<house name="Castle, 3rd Floor, Flat 02" houseid="3091" entryx="33170" entryy="31812" entryz="5" rent="80000" townid="11" size="17" clientid="50105" beds="1" />
-	<house name="Castle, 3rd Floor, Flat 01" houseid="3092" entryx="33170" entryy="31817" entryz="5" rent="50000" townid="11" size="13" clientid="50104" beds="1" />
-	<house name="Castle, 4th Floor, Flat 09" houseid="3093" entryx="33166" entryy="31789" entryz="4" rent="50000" townid="11" size="16" clientid="50119" beds="1" />
-	<house name="Castle, 4th Floor, Flat 08" houseid="3094" entryx="33166" entryy="31794" entryz="4" rent="80000" townid="11" size="21" clientid="50118" beds="1" />
-	<house name="Castle, 4th Floor, Flat 07" houseid="3095" entryx="33169" entryy="31802" entryz="4" rent="80000" townid="11" size="16" clientid="50117" beds="1" />
-	<house name="Castle, 4th Floor, Flat 04" houseid="3096" entryx="33169" entryy="31807" entryz="4" rent="50000" townid="11" size="13" clientid="50114" beds="1" />
-	<house name="Castle, 4th Floor, Flat 03" houseid="3097" entryx="33169" entryy="31812" entryz="4" rent="50000" townid="11" size="13" clientid="50113" beds="1" />
+	<house name="Castle, 3rd Floor, Flat 06" houseid="3089" entryx="33170" entryy="31802" entryz="5" rent="100000" townid="11" size="22" clientid="50109" beds="2" />
+	<house name="Castle, 3rd Floor, Flat 05" houseid="3090" entryx="33170" entryy="31807" entryz="5" rent="80000" townid="11" size="18" clientid="50108" beds="1" />
+	<house name="Castle, 3rd Floor, Flat 02" houseid="3091" entryx="33170" entryy="31812" entryz="5" rent="80000" townid="11" size="18" clientid="50105" beds="1" />
+	<house name="Castle, 3rd Floor, Flat 01" houseid="3092" entryx="33170" entryy="31817" entryz="5" rent="50000" townid="11" size="15" clientid="50104" beds="1" />
+	<house name="Castle, 4th Floor, Flat 09" houseid="3093" entryx="33166" entryy="31789" entryz="4" rent="50000" townid="11" size="17" clientid="50119" beds="1" />
+	<house name="Castle, 4th Floor, Flat 08" houseid="3094" entryx="33166" entryy="31794" entryz="4" rent="80000" townid="11" size="22" clientid="50118" beds="1" />
+	<house name="Castle, 4th Floor, Flat 07" houseid="3095" entryx="33169" entryy="31802" entryz="4" rent="80000" townid="11" size="17" clientid="50117" beds="1" />
+	<house name="Castle, 4th Floor, Flat 04" houseid="3096" entryx="33169" entryy="31807" entryz="4" rent="50000" townid="11" size="14" clientid="50114" beds="1" />
+	<house name="Castle, 4th Floor, Flat 03" houseid="3097" entryx="33169" entryy="31812" entryz="4" rent="50000" townid="11" size="14" clientid="50113" beds="1" />
 	<house name="Castle, 4th Floor, Flat 06" houseid="3098" entryx="33170" entryy="31802" entryz="4" rent="100000" townid="11" size="21" clientid="50116" beds="1" />
-	<house name="Castle, 4th Floor, Flat 05" houseid="3099" entryx="33170" entryy="31807" entryz="4" rent="80000" townid="11" size="17" clientid="50115" beds="1" />
-	<house name="Castle, 4th Floor, Flat 02" houseid="3100" entryx="33170" entryy="31812" entryz="4" rent="80000" townid="11" size="17" clientid="50112" beds="1" />
-	<house name="Castle, 4th Floor, Flat 01" houseid="3101" entryx="33170" entryy="31817" entryz="4" rent="50000" townid="11" size="13" clientid="50111" beds="1" />
-	<house name="Castle Street 2" houseid="3102" entryx="33154" entryy="31798" entryz="7" rent="150000" townid="11" size="31" clientid="50202" beds="2" />
-	<house name="Castle Street 3" houseid="3103" entryx="33150" entryy="31797" entryz="7" rent="150000" townid="11" size="37" clientid="50203" beds="2" />
-	<house name="Castle Street 4" houseid="3104" entryx="33155" entryy="31791" entryz="7" rent="150000" townid="11" size="37" clientid="50204" beds="2" />
-	<house name="Castle Street 5" houseid="3105" entryx="33148" entryy="31784" entryz="7" rent="150000" townid="11" size="37" clientid="50205" beds="2" />
-	<house name="Castle Street 1" houseid="3106" entryx="33167" entryy="31835" entryz="7" rent="300000" townid="11" size="60" clientid="50201" beds="3" />
+	<house name="Castle, 4th Floor, Flat 05" houseid="3099" entryx="33170" entryy="31807" entryz="4" rent="80000" townid="11" size="18" clientid="50115" beds="1" />
+	<house name="Castle, 4th Floor, Flat 02" houseid="3100" entryx="33170" entryy="31812" entryz="4" rent="80000" townid="11" size="18" clientid="50112" beds="1" />
+	<house name="Castle, 4th Floor, Flat 01" houseid="3101" entryx="33170" entryy="31817" entryz="4" rent="50000" townid="11" size="14" clientid="50111" beds="1" />
+	<house name="Castle Street 2" houseid="3102" entryx="33154" entryy="31798" entryz="7" rent="150000" townid="11" size="35" clientid="50202" beds="2" />
+	<house name="Castle Street 3" houseid="3103" entryx="33150" entryy="31797" entryz="7" rent="150000" townid="11" size="41" clientid="50203" beds="2" />
+	<house name="Castle Street 4" houseid="3104" entryx="33155" entryy="31791" entryz="7" rent="150000" townid="11" size="40" clientid="50204" beds="2" />
+	<house name="Castle Street 5" houseid="3105" entryx="33148" entryy="31784" entryz="7" rent="150000" townid="11" size="40" clientid="50205" beds="2" />
+	<house name="Castle Street 1" houseid="3106" entryx="33167" entryy="31835" entryz="7" rent="300000" townid="11" size="71" clientid="50201" beds="3" />
 	<house name="Edron Flats, Flat 08" houseid="3107" entryx="33175" entryy="31844" entryz="7" rent="25000" townid="11" size="10" clientid="50308" beds="1" />
 	<house name="Edron Flats, Flat 05" houseid="3108" entryx="33179" entryy="31844" entryz="7" rent="25000" townid="11" size="10" clientid="50305" beds="1" />
 	<house name="Edron Flats, Flat 04" houseid="3109" entryx="33183" entryy="31844" entryz="7" rent="25000" townid="11" size="10" clientid="50304" beds="1" />
-	<house name="Edron Flats, Flat 01" houseid="3110" entryx="33189" entryy="31844" entryz="7" rent="50000" townid="11" size="10" clientid="50301" beds="1" />
-	<house name="Edron Flats, Flat 07" houseid="3111" entryx="33175" entryy="31845" entryz="7" rent="25000" townid="11" size="10" clientid="50307" beds="1" />
-	<house name="Edron Flats, Flat 06" houseid="3112" entryx="33179" entryy="31845" entryz="7" rent="25000" townid="11" size="10" clientid="50306" beds="1" />
-	<house name="Edron Flats, Flat 03" houseid="3113" entryx="33183" entryy="31845" entryz="7" rent="25000" townid="11" size="10" clientid="50303" beds="1" />
-	<house name="Edron Flats, Flat 02" houseid="3114" entryx="33189" entryy="31845" entryz="7" rent="100000" townid="11" size="19" clientid="50302" beds="2" />
+	<house name="Edron Flats, Flat 01" houseid="3110" entryx="33189" entryy="31844" entryz="7" rent="50000" townid="11" size="11" clientid="50301" beds="1" />
+	<house name="Edron Flats, Flat 07" houseid="3111" entryx="33175" entryy="31845" entryz="7" rent="25000" townid="11" size="11" clientid="50307" beds="1" />
+	<house name="Edron Flats, Flat 06" houseid="3112" entryx="33179" entryy="31845" entryz="7" rent="25000" townid="11" size="11" clientid="50306" beds="1" />
+	<house name="Edron Flats, Flat 03" houseid="3113" entryx="33183" entryy="31845" entryz="7" rent="25000" townid="11" size="11" clientid="50303" beds="1" />
+	<house name="Edron Flats, Flat 02" houseid="3114" entryx="33189" entryy="31845" entryz="7" rent="100000" townid="11" size="20" clientid="50302" beds="2" />
 	<house name="Edron Flats, Basement Flat 2" houseid="3115" entryx="33183" entryy="31841" entryz="8" rent="100000" townid="11" size="36" clientid="50326" beds="2" />
 	<house name="Edron Flats, Basement Flat 1" houseid="3116" entryx="33187" entryy="31841" entryz="8" rent="100000" townid="11" size="36" clientid="50325" beds="2" />
 	<house name="Edron Flats, Flat 13" houseid="3119" entryx="33183" entryy="31844" entryz="6" rent="80000" townid="11" size="22" clientid="50312" beds="2" />
-	<house name="Edron Flats, Flat 14" houseid="3121" entryx="33177" entryy="31844" entryz="6" rent="100000" townid="11" size="29" clientid="50315" beds="2" />
-	<house name="Edron Flats, Flat 12" houseid="3123" entryx="33183" entryy="31845" entryz="6" rent="80000" townid="11" size="22" clientid="50311" beds="2" />
-	<house name="Edron Flats, Flat 11" houseid="3124" entryx="33186" entryy="31844" entryz="6" rent="100000" townid="11" size="29" clientid="50309" beds="2" />
-	<house name="Edron Flats, Flat 25" houseid="3125" entryx="33177" entryy="31844" entryz="5" rent="80000" townid="11" size="29" clientid="50323" beds="2" />
+	<house name="Edron Flats, Flat 14" houseid="3121" entryx="33177" entryy="31844" entryz="6" rent="100000" townid="11" size="31" clientid="50315" beds="2" />
+	<house name="Edron Flats, Flat 12" houseid="3123" entryx="33183" entryy="31845" entryz="6" rent="80000" townid="11" size="24" clientid="50311" beds="2" />
+	<house name="Edron Flats, Flat 11" houseid="3124" entryx="33186" entryy="31844" entryz="6" rent="100000" townid="11" size="32" clientid="50309" beds="2" />
+	<house name="Edron Flats, Flat 25" houseid="3125" entryx="33177" entryy="31844" entryz="5" rent="80000" townid="11" size="31" clientid="50323" beds="2" />
 	<house name="Edron Flats, Flat 24" houseid="3127" entryx="33183" entryy="31844" entryz="5" rent="80000" townid="11" size="22" clientid="50321" beds="2" />
-	<house name="Edron Flats, Flat 21" houseid="3128" entryx="33189" entryy="31844" entryz="5" rent="80000" townid="11" size="19" clientid="50317" beds="2" />
-	<house name="Edron Flats, Flat 23" houseid="3131" entryx="33183" entryy="31845" entryz="5" rent="80000" townid="11" size="22" clientid="50319" beds="2" />
-	<house name="Castle Shop 1" houseid="3133" entryx="33205" entryy="31794" entryz="7" rent="400000" townid="11" size="42" clientid="50101" beds="1" />
-	<house name="Castle Shop 2" houseid="3134" entryx="33205" entryy="31801" entryz="7" rent="400000" townid="11" size="42" clientid="50102" beds="1" />
-	<house name="Castle Shop 3" houseid="3135" entryx="33205" entryy="31808" entryz="7" rent="300000" townid="11" size="42" clientid="50103" beds="1" />
-	<house name="Central Circle 1" houseid="3136" entryx="33203" entryy="31841" entryz="7" rent="800000" townid="11" size="73" clientid="50401" beds="2" />
-	<house name="Central Circle 2" houseid="3137" entryx="33210" entryy="31841" entryz="7" rent="800000" townid="11" size="80" clientid="50402" beds="2" />
-	<house name="Central Circle 3" houseid="3138" entryx="33201" entryy="31848" entryz="7" rent="800000" townid="11" size="94" clientid="50403" beds="5" />
-	<house name="Central Circle 4" houseid="3139" entryx="33208" entryy="31848" entryz="7" rent="800000" townid="11" size="94" clientid="50404" beds="5" />
-	<house name="Central Circle 5" houseid="3140" entryx="33215" entryy="31848" entryz="7" rent="800000" townid="11" size="94" clientid="50405" beds="5" />
-	<house name="Central Circle 8 (Shop)" houseid="3141" entryx="33200" entryy="31864" entryz="7" rent="400000" townid="11" size="97" clientid="50408" beds="2" />
-	<house name="Central Circle 7 (Shop)" houseid="3142" entryx="33207" entryy="31864" entryz="7" rent="400000" townid="11" size="97" clientid="50407" beds="2" />
-	<house name="Central Circle 6 (Shop)" houseid="3143" entryx="33214" entryy="31864" entryz="7" rent="400000" townid="11" size="97" clientid="50406" beds="2" />
-	<house name="Central Circle 9a" houseid="3144" entryx="33191" entryy="31864" entryz="7" rent="150000" townid="11" size="21" clientid="50409" beds="2" />
-	<house name="Central Circle 9b" houseid="3145" entryx="33191" entryy="31864" entryz="6" rent="150000" townid="11" size="21" clientid="50410" beds="2" />
-	<house name="Sky Lane, Guild 1" houseid="3146" entryx="33221" entryy="31874" entryz="7" rent="1000000" guildhall="true" townid="11" size="421" clientid="50601" beds="23" />
-	<house name="Sky Lane, Sea Tower" houseid="3147" entryx="33245" entryy="31890" entryz="7" rent="300000" townid="11" size="95" clientid="50604" beds="6" />
-	<house name="Sky Lane, Guild 3" houseid="3148" entryx="33230" entryy="31889" entryz="7" rent="1000000" guildhall="true" townid="11" size="347" clientid="50603" beds="18" />
-	<house name="Sky Lane, Guild 2" houseid="3149" entryx="33226" entryy="31876" entryz="7" rent="1000000" guildhall="true" townid="11" size="400" clientid="50602" beds="14" />
-	<house name="Wood Avenue 11" houseid="3150" entryx="33231" entryy="31861" entryz="7" rent="600000" townid="11" size="149" clientid="50514" beds="6" />
-	<house name="Wood Avenue 8" houseid="3151" entryx="33231" entryy="31854" entryz="7" rent="800000" townid="11" size="128" clientid="50509" beds="3" />
-	<house name="Wood Avenue 7" houseid="3152" entryx="33231" entryy="31847" entryz="7" rent="800000" townid="11" size="128" clientid="50508" beds="3" />
-	<house name="Wood Avenue 10a" houseid="3153" entryx="33228" entryy="31859" entryz="7" rent="200000" townid="11" size="32" clientid="50512" beds="2" />
-	<house name="Wood Avenue 9a" houseid="3154" entryx="33228" entryy="31854" entryz="7" rent="200000" townid="11" size="32" clientid="50510" beds="2" />
-	<house name="Wood Avenue 6a" houseid="3155" entryx="33225" entryy="31841" entryz="7" rent="300000" townid="11" size="30" clientid="50506" beds="2" />
-	<house name="Wood Avenue 6b" houseid="3156" entryx="33228" entryy="31843" entryz="6" rent="200000" townid="11" size="30" clientid="50507" beds="2" />
-	<house name="Wood Avenue 9b" houseid="3157" entryx="33228" entryy="31850" entryz="6" rent="200000" townid="11" size="31" clientid="50511" beds="2" />
-	<house name="Wood Avenue 10b" houseid="3158" entryx="33228" entryy="31857" entryz="6" rent="200000" townid="11" size="31" clientid="50513" beds="3" />
-	<house name="Stronghold" houseid="3159" entryx="33255" entryy="31867" entryz="6" rent="800000" townid="11" size="215" clientid="50518" beds="6" />
-	<house name="Wood Avenue 5" houseid="3160" entryx="33238" entryy="31831" entryz="7" rent="300000" townid="11" size="37" clientid="50505" beds="2" />
-	<house name="Wood Avenue 3" houseid="3161" entryx="33225" entryy="31817" entryz="7" rent="200000" townid="11" size="37" clientid="50503" beds="2" />
-	<house name="Wood Avenue 4" houseid="3162" entryx="33237" entryy="31821" entryz="7" rent="200000" townid="11" size="37" clientid="50504" beds="2" />
-	<house name="Wood Avenue 2" houseid="3163" entryx="33228" entryy="31810" entryz="7" rent="200000" townid="11" size="37" clientid="50502" beds="2" />
-	<house name="Wood Avenue 1" houseid="3164" entryx="33230" entryy="31801" entryz="7" rent="200000" townid="11" size="37" clientid="50501" beds="2" />
-	<house name="Wood Avenue 4c" houseid="3165" entryx="33237" entryy="31811" entryz="6" rent="200000" townid="11" size="37" clientid="50517" beds="2" />
-	<house name="Wood Avenue 4a" houseid="3166" entryx="33231" entryy="31821" entryz="6" rent="150000" townid="11" size="31" clientid="50515" beds="2" />
-	<house name="Wood Avenue 4b" houseid="3167" entryx="33236" entryy="31821" entryz="6" rent="150000" townid="11" size="31" clientid="50516" beds="2" />
-	<house name="Stonehome Village 1" houseid="3168" entryx="33287" entryy="31765" entryz="7" rent="150000" townid="11" size="42" clientid="52001" beds="2" />
-	<house name="Stonehome Flats, Flat 04" houseid="3169" entryx="33294" entryy="31781" entryz="7" rent="80000" townid="11" size="22" clientid="52013" beds="2" />
-	<house name="Stonehome Flats, Flat 03" houseid="3171" entryx="33294" entryy="31782" entryz="7" rent="80000" townid="11" size="22" clientid="52012" beds="2" />
-	<house name="Stonehome Flats, Flat 02" houseid="3173" entryx="33299" entryy="31782" entryz="7" rent="25000" townid="11" size="16" clientid="52011" beds="2" />
-	<house name="Stonehome Flats, Flat 01" houseid="3174" entryx="33299" entryy="31781" entryz="7" rent="25000" townid="11" size="10" clientid="52010" beds="1" />
-	<house name="Stonehome Flats, Flat 13" houseid="3175" entryx="33294" entryy="31781" entryz="6" rent="80000" townid="11" size="22" clientid="52020" beds="2" />
-	<house name="Stonehome Flats, Flat 11" houseid="3177" entryx="33297" entryy="31781" entryz="6" rent="50000" townid="11" size="16" clientid="52016" beds="2" />
-	<house name="Stonehome Flats, Flat 14" houseid="3178" entryx="33294" entryy="31782" entryz="6" rent="80000" townid="11" size="22" clientid="52021" beds="2" />
-	<house name="Stonehome Flats, Flat 12" houseid="3180" entryx="33297" entryy="31782" entryz="6" rent="50000" townid="11" size="16" clientid="52017" beds="2" />
-	<house name="Stonehome Village 2" houseid="3181" entryx="33311" entryy="31774" entryz="6" rent="50000" townid="11" size="16" clientid="52002" beds="1" />
-	<house name="Stonehome Village 3" houseid="3182" entryx="33305" entryy="31767" entryz="6" rent="50000" townid="11" size="17" clientid="52003" beds="1" />
-	<house name="Stonehome Village 4" houseid="3183" entryx="33302" entryy="31759" entryz="6" rent="80000" townid="11" size="21" clientid="52004" beds="2" />
-	<house name="Stonehome Village 6" houseid="3184" entryx="33326" entryy="31766" entryz="6" rent="100000" townid="11" size="30" clientid="52006" beds="2" />
-	<house name="Stonehome Village 5" houseid="3185" entryx="33326" entryy="31771" entryz="6" rent="80000" townid="11" size="26" clientid="52005" beds="2" />
-	<house name="Stonehome Village 7" houseid="3186" entryx="33313" entryy="31753" entryz="7" rent="100000" townid="11" size="26" clientid="52007" beds="2" />
-	<house name="Stonehome Village 8" houseid="3187" entryx="33318" entryy="31753" entryz="7" rent="25000" townid="11" size="17" clientid="52008" beds="1" />
-	<house name="Stonehome Village 9" houseid="3188" entryx="33324" entryy="31755" entryz="7" rent="50000" townid="11" size="17" clientid="52009" beds="1" />
-	<house name="Stonehome Clanhall" houseid="3189" entryx="33333" entryy="31760" entryz="7" rent="250000" guildhall="true" townid="11" size="192" clientid="52022" beds="10" />
-	<house name="Mad Scientist's Lab" houseid="3190" entryx="32754" entryy="31245" entryz="7" rent="600000" townid="17" size="169" clientid="37020" beds="6" />
-	<house name="Radiant Plaza 4" houseid="3191" entryx="32769" entryy="31231" entryz="7" rent="800000" townid="17" size="186" clientid="37016" beds="3" />
-	<house name="Radiant Plaza 3" houseid="3192" entryx="32766" entryy="31224" entryz="7" rent="800000" townid="17" size="120" clientid="37015" beds="2" />
-	<house name="Radiant Plaza 2" houseid="3193" entryx="32770" entryy="31222" entryz="7" rent="600000" townid="17" size="93" clientid="37014" beds="2" />
-	<house name="Radiant Plaza 1" houseid="3194" entryx="32771" entryy="31224" entryz="7" rent="800000" townid="17" size="133" clientid="37013" beds="4" />
-	<house name="Aureate Court 3" houseid="3195" entryx="32766" entryy="31185" entryz="7" rent="400000" townid="17" size="105" clientid="37003" beds="2" />
-	<house name="Aureate Court 4" houseid="3196" entryx="32763" entryy="31183" entryz="7" rent="400000" townid="17" size="92" clientid="37004" beds="4" />
-	<house name="Aureate Court 5" houseid="3197" entryx="32774" entryy="31200" entryz="7" rent="600000" townid="17" size="142" clientid="37019" beds="6" />
-	<house name="Aureate Court 2" houseid="3198" entryx="32768" entryy="31185" entryz="7" rent="400000" townid="17" size="119" clientid="37002" beds="2" />
-	<house name="Aureate Court 1" houseid="3199" entryx="32767" entryy="31181" entryz="7" rent="600000" townid="17" size="126" clientid="37001" beds="3" />
-	<house name="Halls of Serenity" houseid="3205" entryx="32783" entryy="31167" entryz="7" rent="5000000" guildhall="true" townid="17" size="504" clientid="38001" beds="33" />
-	<house name="Fortune Wing 3" houseid="3206" entryx="32822" entryy="31171" entryz="7" rent="600000" townid="17" size="141" clientid="37007" beds="2" />
-	<house name="Fortune Wing 4" houseid="3207" entryx="32825" entryy="31172" entryz="7" rent="600000" townid="17" size="141" clientid="37008" beds="4" />
-	<house name="Fortune Wing 2" houseid="3208" entryx="32819" entryy="31179" entryz="7" rent="600000" townid="17" size="137" clientid="37006" beds="2" />
-	<house name="Fortune Wing 1" houseid="3209" entryx="32844" entryy="31173" entryz="7" rent="800000" townid="17" size="247" clientid="37005" beds="4" />
-	<house name="Cascade Towers" houseid="3211" entryx="32844" entryy="31195" entryz="7" rent="5000000" guildhall="true" townid="17" size="405" clientid="38002" beds="34" />
-	<house name="Luminous Arc 5" houseid="3212" entryx="32858" entryy="31199" entryz="7" rent="800000" townid="17" size="117" clientid="37018" beds="6" />
-	<house name="Luminous Arc 2" houseid="3213" entryx="32840" entryy="31217" entryz="7" rent="600000" townid="17" size="154" clientid="37010" beds="4" />
-	<house name="Luminous Arc 1" houseid="3214" entryx="32849" entryy="31229" entryz="7" rent="800000" townid="17" size="159" clientid="37009" beds="2" />
-	<house name="Luminous Arc 3" houseid="3215" entryx="32834" entryy="31220" entryz="7" rent="600000" townid="17" size="130" clientid="37011" beds="3" />
-	<house name="Luminous Arc 4" houseid="3216" entryx="32834" entryy="31243" entryz="7" rent="800000" townid="17" size="190" clientid="37012" beds="5" />
-	<house name="Harbour Promenade 1" houseid="3217" entryx="32780" entryy="31259" entryz="6" rent="800000" townid="17" size="129" clientid="37017" beds="5" />
-	<house name="Sun Palace" houseid="3218" entryx="32760" entryy="31209" entryz="7" rent="5000000" guildhall="true" townid="17" size="513" clientid="38003" beds="27" />
-	<house name="Haggler's Hangout 3" houseid="3219" entryx="32612" entryy="32739" entryz="7" rent="300000" townid="15" size="145" clientid="45003" beds="4" />
-	<house name="Haggler's Hangout 7" houseid="3220" entryx="32614" entryy="32728" entryz="7" rent="400000" townid="15" size="141" clientid="45008" beds="7" />
+	<house name="Edron Flats, Flat 21" houseid="3128" entryx="33189" entryy="31844" entryz="5" rent="80000" townid="11" size="20" clientid="50317" beds="2" />
+	<house name="Edron Flats, Flat 23" houseid="3131" entryx="33183" entryy="31845" entryz="5" rent="80000" townid="11" size="24" clientid="50319" beds="2" />
+	<house name="Castle Shop 1" houseid="3133" entryx="33205" entryy="31794" entryz="7" rent="400000" townid="11" size="38" clientid="50101" beds="1" />
+	<house name="Castle Shop 2" houseid="3134" entryx="33205" entryy="31801" entryz="7" rent="400000" townid="11" size="38" clientid="50102" beds="1" />
+	<house name="Castle Shop 3" houseid="3135" entryx="33205" entryy="31808" entryz="7" rent="300000" townid="11" size="38" clientid="50103" beds="1" />
+	<house name="Central Circle 1" houseid="3136" entryx="33203" entryy="31841" entryz="7" rent="800000" townid="11" size="76" clientid="50401" beds="2" />
+	<house name="Central Circle 2" houseid="3137" entryx="33210" entryy="31841" entryz="7" rent="800000" townid="11" size="90" clientid="50402" beds="2" />
+	<house name="Central Circle 3" houseid="3138" entryx="33201" entryy="31848" entryz="7" rent="800000" townid="11" size="99" clientid="50403" beds="5" />
+	<house name="Central Circle 4" houseid="3139" entryx="33208" entryy="31848" entryz="7" rent="800000" townid="11" size="97" clientid="50404" beds="5" />
+	<house name="Central Circle 5" houseid="3140" entryx="33215" entryy="31848" entryz="7" rent="800000" townid="11" size="99" clientid="50405" beds="5" />
+	<house name="Central Circle 8 (Shop)" houseid="3141" entryx="33200" entryy="31864" entryz="7" rent="400000" townid="11" size="101" clientid="50408" beds="2" />
+	<house name="Central Circle 7 (Shop)" houseid="3142" entryx="33207" entryy="31864" entryz="7" rent="400000" townid="11" size="101" clientid="50407" beds="2" />
+	<house name="Central Circle 6 (Shop)" houseid="3143" entryx="33214" entryy="31864" entryz="7" rent="400000" townid="11" size="101" clientid="50406" beds="2" />
+	<house name="Central Circle 9a" houseid="3144" entryx="33191" entryy="31864" entryz="7" rent="150000" townid="11" size="23" clientid="50409" beds="2" />
+	<house name="Central Circle 9b" houseid="3145" entryx="33191" entryy="31864" entryz="6" rent="150000" townid="11" size="23" clientid="50410" beds="2" />
+	<house name="Sky Lane, Guild 1" houseid="3146" entryx="33221" entryy="31874" entryz="7" rent="1000000" guildhall="true" townid="11" size="459" clientid="50601" beds="23" />
+	<house name="Sky Lane, Sea Tower" houseid="3147" entryx="33245" entryy="31890" entryz="7" rent="300000" townid="11" size="106" clientid="50604" beds="6" />
+	<house name="Sky Lane, Guild 3" houseid="3148" entryx="33230" entryy="31889" entryz="7" rent="1000000" guildhall="true" townid="11" size="391" clientid="50603" beds="18" />
+	<house name="Sky Lane, Guild 2" houseid="3149" entryx="33226" entryy="31876" entryz="7" rent="1000000" guildhall="true" townid="11" size="440" clientid="50602" beds="14" />
+	<house name="Wood Avenue 11" houseid="3150" entryx="33231" entryy="31861" entryz="7" rent="600000" townid="11" size="165" clientid="50514" beds="6" />
+	<house name="Wood Avenue 8" houseid="3151" entryx="33231" entryy="31854" entryz="7" rent="800000" townid="11" size="147" clientid="50509" beds="3" />
+	<house name="Wood Avenue 7" houseid="3152" entryx="33231" entryy="31847" entryz="7" rent="800000" townid="11" size="145" clientid="50508" beds="3" />
+	<house name="Wood Avenue 10a" houseid="3153" entryx="33228" entryy="31859" entryz="7" rent="200000" townid="11" size="35" clientid="50512" beds="2" />
+	<house name="Wood Avenue 9a" houseid="3154" entryx="33228" entryy="31854" entryz="7" rent="200000" townid="11" size="33" clientid="50510" beds="2" />
+	<house name="Wood Avenue 6a" houseid="3155" entryx="33225" entryy="31841" entryz="7" rent="300000" townid="11" size="34" clientid="50506" beds="2" />
+	<house name="Wood Avenue 6b" houseid="3156" entryx="33228" entryy="31843" entryz="6" rent="200000" townid="11" size="35" clientid="50507" beds="2" />
+	<house name="Wood Avenue 9b" houseid="3157" entryx="33228" entryy="31850" entryz="6" rent="200000" townid="11" size="33" clientid="50511" beds="2" />
+	<house name="Wood Avenue 10b" houseid="3158" entryx="33228" entryy="31857" entryz="6" rent="200000" townid="11" size="35" clientid="50513" beds="3" />
+	<house name="Stronghold" houseid="3159" entryx="33255" entryy="31867" entryz="6" rent="800000" townid="11" size="194" clientid="50518" beds="6" />
+	<house name="Wood Avenue 5" houseid="3160" entryx="33238" entryy="31831" entryz="7" rent="300000" townid="11" size="40" clientid="50505" beds="2" />
+	<house name="Wood Avenue 3" houseid="3161" entryx="33225" entryy="31817" entryz="7" rent="200000" townid="11" size="39" clientid="50503" beds="2" />
+	<house name="Wood Avenue 4" houseid="3162" entryx="33237" entryy="31821" entryz="7" rent="200000" townid="11" size="40" clientid="50504" beds="2" />
+	<house name="Wood Avenue 2" houseid="3163" entryx="33228" entryy="31810" entryz="7" rent="200000" townid="11" size="39" clientid="50502" beds="2" />
+	<house name="Wood Avenue 1" houseid="3164" entryx="33230" entryy="31801" entryz="7" rent="200000" townid="11" size="41" clientid="50501" beds="2" />
+	<house name="Wood Avenue 4c" houseid="3165" entryx="33237" entryy="31811" entryz="6" rent="200000" townid="11" size="41" clientid="50517" beds="2" />
+	<house name="Wood Avenue 4a" houseid="3166" entryx="33231" entryy="31821" entryz="6" rent="150000" townid="11" size="33" clientid="50515" beds="2" />
+	<house name="Wood Avenue 4b" houseid="3167" entryx="33236" entryy="31821" entryz="6" rent="150000" townid="11" size="35" clientid="50516" beds="2" />
+	<house name="Stonehome Village 1" houseid="3168" entryx="33287" entryy="31765" entryz="7" rent="150000" townid="11" size="45" clientid="52001" beds="2" />
+	<house name="Stonehome Flats, Flat 04" houseid="3169" entryx="33294" entryy="31781" entryz="7" rent="80000" townid="11" size="24" clientid="52013" beds="2" />
+	<house name="Stonehome Flats, Flat 03" houseid="3171" entryx="33294" entryy="31782" entryz="7" rent="80000" townid="11" size="24" clientid="52012" beds="2" />
+	<house name="Stonehome Flats, Flat 02" houseid="3173" entryx="33299" entryy="31782" entryz="7" rent="25000" townid="11" size="18" clientid="52011" beds="2" />
+	<house name="Stonehome Flats, Flat 01" houseid="3174" entryx="33299" entryy="31781" entryz="7" rent="25000" townid="11" size="11" clientid="52010" beds="1" />
+	<house name="Stonehome Flats, Flat 13" houseid="3175" entryx="33294" entryy="31781" entryz="6" rent="80000" townid="11" size="24" clientid="52020" beds="2" />
+	<house name="Stonehome Flats, Flat 11" houseid="3177" entryx="33297" entryy="31781" entryz="6" rent="50000" townid="11" size="17" clientid="52016" beds="2" />
+	<house name="Stonehome Flats, Flat 14" houseid="3178" entryx="33294" entryy="31782" entryz="6" rent="80000" townid="11" size="24" clientid="52021" beds="2" />
+	<house name="Stonehome Flats, Flat 12" houseid="3180" entryx="33297" entryy="31782" entryz="6" rent="50000" townid="11" size="18" clientid="52017" beds="2" />
+	<house name="Stonehome Village 2" houseid="3181" entryx="33311" entryy="31774" entryz="6" rent="50000" townid="11" size="19" clientid="52002" beds="1" />
+	<house name="Stonehome Village 3" houseid="3182" entryx="33305" entryy="31767" entryz="6" rent="50000" townid="11" size="20" clientid="52003" beds="1" />
+	<house name="Stonehome Village 4" houseid="3183" entryx="33302" entryy="31759" entryz="6" rent="80000" townid="11" size="23" clientid="52004" beds="2" />
+	<house name="Stonehome Village 6" houseid="3184" entryx="33326" entryy="31766" entryz="6" rent="100000" townid="11" size="34" clientid="52006" beds="2" />
+	<house name="Stonehome Village 5" houseid="3185" entryx="33326" entryy="31771" entryz="6" rent="80000" townid="11" size="29" clientid="52005" beds="2" />
+	<house name="Stonehome Village 7" houseid="3186" entryx="33313" entryy="31753" entryz="7" rent="100000" townid="11" size="28" clientid="52007" beds="2" />
+	<house name="Stonehome Village 8" houseid="3187" entryx="33318" entryy="31753" entryz="7" rent="25000" townid="11" size="19" clientid="52008" beds="1" />
+	<house name="Stonehome Village 9" houseid="3188" entryx="33324" entryy="31755" entryz="7" rent="50000" townid="11" size="19" clientid="52009" beds="1" />
+	<house name="Stonehome Clanhall" houseid="3189" entryx="33333" entryy="31760" entryz="7" rent="250000" guildhall="true" townid="11" size="205" clientid="52022" beds="10" />
+	<house name="Mad Scientist's Lab" houseid="3190" entryx="32754" entryy="31245" entryz="7" rent="600000" townid="17" size="63" clientid="37020" beds="6" />
+	<house name="Radiant Plaza 4" houseid="3191" entryx="32769" entryy="31231" entryz="7" rent="800000" townid="17" size="197" clientid="37016" beds="3" />
+	<house name="Radiant Plaza 3" houseid="3192" entryx="32766" entryy="31224" entryz="7" rent="800000" townid="17" size="126" clientid="37015" beds="2" />
+	<house name="Radiant Plaza 2" houseid="3193" entryx="32770" entryy="31222" entryz="7" rent="600000" townid="17" size="99" clientid="37014" beds="2" />
+	<house name="Radiant Plaza 1" houseid="3194" entryx="32771" entryy="31224" entryz="7" rent="800000" townid="17" size="138" clientid="37013" beds="4" />
+	<house name="Aureate Court 3" houseid="3195" entryx="32766" entryy="31185" entryz="7" rent="400000" townid="17" size="131" clientid="37003" beds="2" />
+	<house name="Aureate Court 4" houseid="3196" entryx="32763" entryy="31183" entryz="7" rent="400000" townid="17" size="104" clientid="37004" beds="4" />
+	<house name="Aureate Court 5" houseid="3197" entryx="32774" entryy="31200" entryz="7" rent="600000" townid="17" size="138" clientid="37019" beds="6" />
+	<house name="Aureate Court 2" houseid="3198" entryx="32768" entryy="31185" entryz="7" rent="400000" townid="17" size="125" clientid="37002" beds="2" />
+	<house name="Aureate Court 1" houseid="3199" entryx="32767" entryy="31181" entryz="7" rent="600000" townid="17" size="131" clientid="37001" beds="3" />
+	<house name="Halls of Serenity" houseid="3205" entryx="32783" entryy="31167" entryz="7" rent="5000000" guildhall="true" townid="17" size="517" clientid="38001" beds="33" />
+	<house name="Fortune Wing 3" houseid="3206" entryx="32822" entryy="31171" entryz="7" rent="600000" townid="17" size="148" clientid="37007" beds="2" />
+	<house name="Fortune Wing 4" houseid="3207" entryx="32825" entryy="31172" entryz="7" rent="600000" townid="17" size="147" clientid="37008" beds="4" />
+	<house name="Fortune Wing 2" houseid="3208" entryx="32819" entryy="31179" entryz="7" rent="600000" townid="17" size="148" clientid="37006" beds="2" />
+	<house name="Fortune Wing 1" houseid="3209" entryx="32844" entryy="31173" entryz="7" rent="800000" townid="17" size="254" clientid="37005" beds="4" />
+	<house name="Cascade Towers" houseid="3211" entryx="32844" entryy="31195" entryz="7" rent="5000000" guildhall="true" townid="17" size="419" clientid="38002" beds="34" />
+	<house name="Luminous Arc 5" houseid="3212" entryx="32858" entryy="31199" entryz="7" rent="800000" townid="17" size="145" clientid="37018" beds="6" />
+	<house name="Luminous Arc 2" houseid="3213" entryx="32840" entryy="31217" entryz="7" rent="600000" townid="17" size="161" clientid="37010" beds="4" />
+	<house name="Luminous Arc 1" houseid="3214" entryx="32849" entryy="31229" entryz="7" rent="800000" townid="17" size="167" clientid="37009" beds="2" />
+	<house name="Luminous Arc 3" houseid="3215" entryx="32834" entryy="31220" entryz="7" rent="600000" townid="17" size="139" clientid="37011" beds="3" />
+	<house name="Luminous Arc 4" houseid="3216" entryx="32834" entryy="31243" entryz="7" rent="800000" townid="17" size="200" clientid="37012" beds="5" />
+	<house name="Harbour Promenade 1" houseid="3217" entryx="32780" entryy="31259" entryz="6" rent="800000" townid="17" size="137" clientid="37017" beds="5" />
+	<house name="Sun Palace" houseid="3218" entryx="32760" entryy="31209" entryz="7" rent="5000000" guildhall="true" townid="17" size="533" clientid="38003" beds="27" />
+	<house name="Haggler's Hangout 3" houseid="3219" entryx="32612" entryy="32739" entryz="7" rent="300000" townid="15" size="186" clientid="45003" beds="4" />
+	<house name="Haggler's Hangout 7" houseid="3220" entryx="32614" entryy="32728" entryz="7" rent="400000" townid="15" size="155" clientid="45008" beds="7" />
 	<house name="Big Game Hunter's Lodge" houseid="3221" entryx="32627" entryy="32731" entryz="7" rent="600000" townid="15" size="164" clientid="45009" beds="8" />
-	<house name="Haggler's Hangout 6" houseid="3222" entryx="32638" entryy="32750" entryz="7" rent="400000" townid="15" size="123" clientid="45007" beds="4" />
-	<house name="Haggler's Hangout 5 (Shop)" houseid="3223" entryx="32630" entryy="32757" entryz="7" rent="200000" townid="15" size="31" clientid="45006" beds="1" />
-	<house name="Haggler's Hangout 4b (Shop)" houseid="3224" entryx="32616" entryy="32758" entryz="7" rent="150000" townid="15" size="31" clientid="45005" beds="1" />
-	<house name="Haggler's Hangout 4a (Shop)" houseid="3225" entryx="32616" entryy="32752" entryz="7" rent="200000" townid="15" size="37" clientid="45004" beds="1" />
-	<house name="Haggler's Hangout 2" houseid="3226" entryx="32601" entryy="32761" entryz="7" rent="100000" townid="15" size="26" clientid="45002" beds="1" />
-	<house name="Haggler's Hangout 1" houseid="3227" entryx="32593" entryy="32759" entryz="7" rent="100000" townid="15" size="26" clientid="45001" beds="2" />
-	<house name="Bamboo Garden 3" houseid="3228" entryx="32645" entryy="32789" entryz="7" rent="150000" townid="15" size="32" clientid="46021" beds="2" />
-	<house name="Bamboo Fortress" houseid="3229" entryx="32664" entryy="32791" entryz="7" rent="500000" guildhall="true" townid="15" size="446" clientid="46041" beds="20" />
-	<house name="Bamboo Garden 2" houseid="3230" entryx="32622" entryy="32796" entryz="7" rent="80000" townid="15" size="21" clientid="46020" beds="2" />
-	<house name="Bamboo Garden 1" houseid="3231" entryx="32574" entryy="32795" entryz="7" rent="100000" townid="15" size="32" clientid="46019" beds="3" />
-	<house name="Banana Bay 4" houseid="3232" entryx="32556" entryy="32814" entryz="6" rent="25000" townid="15" size="10" clientid="46004" beds="1" />
-	<house name="Banana Bay 2" houseid="3233" entryx="32550" entryy="32803" entryz="6" rent="50000" townid="15" size="17" clientid="46002" beds="1" />
-	<house name="Banana Bay 3" houseid="3234" entryx="32561" entryy="32805" entryz="6" rent="50000" townid="15" size="10" clientid="46003" beds="1" />
-	<house name="Banana Bay 1" houseid="3235" entryx="32553" entryy="32799" entryz="6" rent="25000" townid="15" size="10" clientid="46001" beds="1" />
-	<house name="Crocodile Bridge 1" houseid="3236" entryx="32571" entryy="32794" entryz="6" rent="80000" townid="15" size="21" clientid="46005" beds="2" />
-	<house name="Crocodile Bridge 2" houseid="3237" entryx="32571" entryy="32787" entryz="6" rent="80000" townid="15" size="17" clientid="46006" beds="2" />
-	<house name="Crocodile Bridge 3" houseid="3238" entryx="32579" entryy="32788" entryz="6" rent="100000" townid="15" size="26" clientid="46007" beds="2" />
-	<house name="Crocodile Bridge 4" houseid="3239" entryx="32592" entryy="32792" entryz="6" rent="300000" townid="15" size="99" clientid="46008" beds="4" />
-	<house name="Crocodile Bridge 5" houseid="3240" entryx="32605" entryy="32793" entryz="6" rent="200000" townid="15" size="86" clientid="46009" beds="2" />
-	<house name="Woodway 1" houseid="3241" entryx="32618" entryy="32787" entryz="6" rent="80000" townid="15" size="17" clientid="46010" beds="1" />
-	<house name="Woodway 2" houseid="3242" entryx="32629" entryy="32784" entryz="6" rent="50000" townid="15" size="13" clientid="46011" beds="1" />
-	<house name="Woodway 3" houseid="3243" entryx="32642" entryy="32784" entryz="6" rent="150000" townid="15" size="32" clientid="46012" beds="2" />
-	<house name="Woodway 4" houseid="3244" entryx="32653" entryy="32782" entryz="6" rent="25000" townid="15" size="9" clientid="46013" beds="1" />
-	<house name="Flamingo Flats 5" houseid="3245" entryx="32664" entryy="32786" entryz="6" rent="150000" townid="15" size="41" clientid="46018" beds="1" />
-	<house name="Flamingo Flats 4" houseid="3246" entryx="32674" entryy="32783" entryz="6" rent="80000" townid="15" size="17" clientid="46017" beds="2" />
-	<house name="Flamingo Flats 1" houseid="3247" entryx="32664" entryy="32773" entryz="6" rent="50000" townid="15" size="13" clientid="46014" beds="2" />
-	<house name="Flamingo Flats 2" houseid="3248" entryx="32672" entryy="32774" entryz="6" rent="80000" townid="15" size="21" clientid="46015" beds="2" />
-	<house name="Flamingo Flats 3" houseid="3249" entryx="32681" entryy="32770" entryz="6" rent="50000" townid="15" size="13" clientid="46016" beds="2" />
-	<house name="Jungle Edge 1" houseid="3250" entryx="32662" entryy="32752" entryz="6" rent="200000" townid="15" size="51" clientid="46030" beds="3" />
-	<house name="Jungle Edge 2" houseid="3251" entryx="32673" entryy="32746" entryz="6" rent="200000" townid="15" size="66" clientid="46031" beds="3" />
-	<house name="Jungle Edge 4" houseid="3252" entryx="32674" entryy="32757" entryz="6" rent="80000" townid="15" size="17" clientid="46033" beds="2" />
-	<house name="Jungle Edge 5" houseid="3253" entryx="32680" entryy="32756" entryz="6" rent="80000" townid="15" size="17" clientid="46034" beds="2" />
-	<house name="Jungle Edge 6" houseid="3254" entryx="32690" entryy="32757" entryz="6" rent="25000" townid="15" size="10" clientid="46035" beds="1" />
-	<house name="Jungle Edge 3" houseid="3255" entryx="32680" entryy="32745" entryz="6" rent="80000" townid="15" size="17" clientid="46032" beds="2" />
-	<house name="River Homes 3" houseid="3256" entryx="32647" entryy="32769" entryz="6" rent="200000" townid="15" size="99" clientid="46029" beds="7" />
-	<house name="River Homes 2b" houseid="3257" entryx="32634" entryy="32773" entryz="6" rent="150000" townid="15" size="31" clientid="46028" beds="3" />
-	<house name="River Homes 2a" houseid="3258" entryx="32627" entryy="32773" entryz="6" rent="100000" townid="15" size="26" clientid="46027" beds="2" />
-	<house name="River Homes 1" houseid="3259" entryx="32618" entryy="32773" entryz="6" rent="300000" townid="15" size="73" clientid="46026" beds="3" />
-	<house name="Coconut Quay 4" houseid="3260" entryx="32598" entryy="32773" entryz="6" rent="150000" townid="15" size="43" clientid="46025" beds="3" />
-	<house name="Coconut Quay 3" houseid="3261" entryx="32586" entryy="32773" entryz="6" rent="200000" townid="15" size="41" clientid="46024" beds="4" />
-	<house name="Coconut Quay 2" houseid="3262" entryx="32577" entryy="32766" entryz="6" rent="100000" townid="15" size="21" clientid="46023" beds="2" />
-	<house name="Coconut Quay 1" houseid="3263" entryx="32568" entryy="32775" entryz="6" rent="150000" townid="15" size="37" clientid="46022" beds="2" />
-	<house name="Shark Manor" houseid="3264" entryx="32556" entryy="32767" entryz="6" rent="250000" guildhall="true" townid="15" size="164" clientid="46040" beds="15" />
-	<house name="Glacier Side 2" houseid="3265" entryx="32203" entryy="31132" entryz="7" rent="300000" townid="16" size="91" clientid="55003" beds="3" />
-	<house name="Glacier Side 1" houseid="3266" entryx="32206" entryy="31126" entryz="7" rent="150000" townid="16" size="30" clientid="55002" beds="2" />
-	<house name="Glacier Side 3" houseid="3267" entryx="32206" entryy="31140" entryz="7" rent="150000" townid="16" size="37" clientid="55004" beds="2" />
-	<house name="Glacier Side 4" houseid="3268" entryx="32204" entryy="31147" entryz="6" rent="150000" townid="16" size="41" clientid="55005" beds="1" />
-	<house name="Shelf Site" houseid="3269" entryx="32197" entryy="31150" entryz="6" rent="300000" townid="16" size="92" clientid="55001" beds="3" />
-	<house name="Spirit Homes 5" houseid="3270" entryx="32223" entryy="31142" entryz="7" rent="150000" townid="16" size="27" clientid="55010" beds="2" />
-	<house name="Spirit Homes 4" houseid="3271" entryx="32220" entryy="31129" entryz="7" rent="80000" townid="16" size="22" clientid="55009" beds="1" />
-	<house name="Spirit Homes 1" houseid="3272" entryx="32210" entryy="31124" entryz="7" rent="150000" townid="16" size="32" clientid="55006" beds="2" />
-	<house name="Spirit Homes 2" houseid="3273" entryx="32219" entryy="31124" entryz="7" rent="150000" townid="16" size="36" clientid="55007" beds="2" />
-	<house name="Spirit Homes 3" houseid="3274" entryx="32216" entryy="31124" entryz="6" rent="300000" townid="16" size="81" clientid="55008" beds="3" />
-	<house name="Arena Walk 3" houseid="3275" entryx="32235" entryy="31118" entryz="7" rent="300000" townid="16" size="67" clientid="55013" beds="3" />
-	<house name="Arena Walk 2" houseid="3276" entryx="32239" entryy="31126" entryz="7" rent="150000" townid="16" size="26" clientid="55012" beds="2" />
-	<house name="Arena Walk 1" houseid="3277" entryx="32238" entryy="31134" entryz="7" rent="300000" townid="16" size="61" clientid="55011" beds="3" />
-	<house name="Bears Paw 2" houseid="3278" entryx="32241" entryy="31133" entryz="7" rent="300000" townid="16" size="49" clientid="55102" beds="2" />
-	<house name="Bears Paw 1" houseid="3279" entryx="32264" entryy="31132" entryz="7" rent="200000" townid="16" size="38" clientid="55101" beds="2" />
-	<house name="Crystal Glance" houseid="3280" entryx="32246" entryy="31118" entryz="7" rent="1000000" guildhall="true" townid="16" size="315" clientid="55302" beds="24" />
-	<house name="Shady Rocks 2" houseid="3281" entryx="32259" entryy="31119" entryz="7" rent="200000" townid="16" size="38" clientid="55127" beds="4" />
-	<house name="Shady Rocks 1" houseid="3282" entryx="32259" entryy="31110" entryz="7" rent="300000" townid="16" size="74" clientid="55126" beds="4" />
-	<house name="Shady Rocks 3" houseid="3283" entryx="32277" entryy="31121" entryz="7" rent="300000" townid="16" size="87" clientid="55128" beds="3" />
-	<house name="Shady Rocks 4 (Shop)" houseid="3284" entryx="32282" entryy="31123" entryz="7" rent="200000" townid="16" size="58" clientid="55129" beds="2" />
-	<house name="Shady Rocks 5" houseid="3285" entryx="32288" entryy="31125" entryz="7" rent="300000" townid="16" size="62" clientid="55130" beds="2" />
-	<house name="Tusk Flats 2" houseid="3286" entryx="32301" entryy="31117" entryz="7" rent="80000" townid="16" size="21" clientid="55202" beds="2" />
-	<house name="Tusk Flats 1" houseid="3287" entryx="32300" entryy="31124" entryz="7" rent="80000" townid="16" size="19" clientid="55201" beds="2" />
-	<house name="Tusk Flats 3" houseid="3288" entryx="32308" entryy="31111" entryz="7" rent="80000" townid="16" size="16" clientid="55203" beds="2" />
-	<house name="Tusk Flats 4" houseid="3289" entryx="32307" entryy="31105" entryz="7" rent="25000" townid="16" size="9" clientid="55204" beds="1" />
-	<house name="Tusk Flats 6" houseid="3290" entryx="32308" entryy="31099" entryz="7" rent="50000" townid="16" size="16" clientid="55206" beds="2" />
-	<house name="Tusk Flats 5" houseid="3291" entryx="32320" entryy="31108" entryz="7" rent="25000" townid="16" size="13" clientid="55205" beds="1" />
-	<house name="Corner Shop (Shop)" houseid="3292" entryx="32304" entryy="31141" entryz="7" rent="200000" townid="16" size="47" clientid="55131" beds="2" />
-	<house name="Bears Paw 5" houseid="3293" entryx="32272" entryy="31157" entryz="7" rent="200000" townid="16" size="41" clientid="55105" beds="3" />
-	<house name="Bears Paw 4" houseid="3294" entryx="32256" entryy="31158" entryz="7" rent="400000" townid="16" size="109" clientid="55104" beds="4" />
-	<house name="Trout Plaza 2" houseid="3295" entryx="32260" entryy="31161" entryz="7" rent="150000" townid="16" size="32" clientid="55112" beds="2" />
-	<house name="Trout Plaza 1" houseid="3296" entryx="32248" entryy="31166" entryz="7" rent="200000" townid="16" size="51" clientid="55111" beds="2" />
-	<house name="Trout Plaza 5 (Shop)" houseid="3297" entryx="32275" entryy="31167" entryz="7" rent="300000" townid="16" size="84" clientid="55115" beds="2" />
-	<house name="Trout Plaza 3" houseid="3298" entryx="32255" entryy="31173" entryz="7" rent="80000" townid="16" size="20" clientid="55113" beds="1" />
-	<house name="Trout Plaza 4" houseid="3299" entryx="32255" entryy="31177" entryz="7" rent="80000" townid="16" size="20" clientid="55114" beds="1" />
-	<house name="Skiffs End 2" houseid="3300" entryx="32257" entryy="31189" entryz="7" rent="80000" townid="16" size="18" clientid="55110" beds="2" />
-	<house name="Skiffs End 1" houseid="3301" entryx="32250" entryy="31187" entryz="7" rent="100000" townid="16" size="32" clientid="55109" beds="2" />
-	<house name="Furrier Quarter 3" houseid="3302" entryx="32232" entryy="31191" entryz="7" rent="100000" townid="16" size="26" clientid="55213" beds="2" />
-	<house name="Fimbul Shelf 4" houseid="3303" entryx="32218" entryy="31191" entryz="7" rent="100000" townid="16" size="27" clientid="55210" beds="2" />
-	<house name="Fimbul Shelf 3" houseid="3304" entryx="32215" entryy="31177" entryz="7" rent="100000" townid="16" size="33" clientid="55209" beds="2" />
-	<house name="Furrier Quarter 2" houseid="3305" entryx="32225" entryy="31177" entryz="7" rent="80000" townid="16" size="27" clientid="55212" beds="2" />
-	<house name="Furrier Quarter 1" houseid="3306" entryx="32221" entryy="31176" entryz="7" rent="150000" townid="16" size="41" clientid="55211" beds="3" />
-	<house name="Fimbul Shelf 2" houseid="3307" entryx="32209" entryy="31175" entryz="7" rent="100000" townid="16" size="27" clientid="55208" beds="2" />
-	<house name="Fimbul Shelf 1" houseid="3308" entryx="32204" entryy="31169" entryz="7" rent="80000" townid="16" size="25" clientid="55207" beds="2" />
-	<house name="Bears Paw 3" houseid="3309" entryx="32248" entryy="31157" entryz="7" rent="200000" townid="16" size="42" clientid="55103" beds="3" />
-	<house name="Raven Corner 2" houseid="3310" entryx="32233" entryy="31156" entryz="7" rent="150000" townid="16" size="33" clientid="55107" beds="3" />
-	<house name="Raven Corner 1" houseid="3311" entryx="32234" entryy="31154" entryz="7" rent="80000" townid="16" size="19" clientid="55106" beds="1" />
-	<house name="Raven Corner 3" houseid="3312" entryx="32234" entryy="31157" entryz="7" rent="100000" townid="16" size="19" clientid="55108" beds="1" />
-	<house name="Mammoth Belly" houseid="3313" entryx="32241" entryy="31174" entryz="7" rent="1000000" guildhall="true" townid="16" size="362" clientid="55301" beds="30" />
-	<house name="Darashia 3, Flat 01" houseid="3314" entryx="33229" entryy="32442" entryz="7" rent="150000" townid="13" size="25" clientid="61024" beds="2" />
-	<house name="Darashia 3, Flat 05" houseid="3315" entryx="33230" entryy="32442" entryz="7" rent="150000" townid="13" size="25" clientid="61028" beds="1" />
-	<house name="Darashia 3, Flat 02" houseid="3316" entryx="33227" entryy="32447" entryz="7" rent="200000" townid="13" size="38" clientid="61025" beds="2" />
-	<house name="Darashia 3, Flat 04" houseid="3317" entryx="33232" entryy="32447" entryz="7" rent="150000" townid="13" size="38" clientid="61027" beds="2" />
-	<house name="Darashia 3, Flat 03" houseid="3318" entryx="33230" entryy="32449" entryz="7" rent="150000" townid="13" size="25" clientid="61026" beds="2" />
-	<house name="Darashia 3, Flat 12" houseid="3319" entryx="33227" entryy="32446" entryz="6" rent="200000" townid="13" size="55" clientid="61030" beds="5" />
-	<house name="Darashia 3, Flat 11" houseid="3320" entryx="33228" entryy="32445" entryz="6" rent="100000" townid="13" size="25" clientid="61029" beds="1" />
-	<house name="Darashia 3, Flat 14" houseid="3321" entryx="33232" entryy="32449" entryz="6" rent="200000" townid="13" size="55" clientid="61032" beds="3" />
-	<house name="Darashia 3, Flat 13" houseid="3322" entryx="33232" entryy="32449" entryz="6" rent="100000" townid="13" size="25" clientid="61031" beds="2" />
-	<house name="Darashia 8, Flat 01" houseid="3323" entryx="33251" entryy="32442" entryz="7" rent="300000" townid="13" size="53" clientid="62011" beds="2" />
-	<house name="Darashia 8, Flat 05" houseid="3325" entryx="33252" entryy="32442" entryz="7" rent="300000" townid="13" size="57" clientid="62015" beds="2" />
-	<house name="Darashia 8, Flat 04" houseid="3326" entryx="33254" entryy="32447" entryz="7" rent="200000" townid="13" size="61" clientid="62014" beds="2" />
-	<house name="Darashia 8, Flat 03" houseid="3327" entryx="33252" entryy="32449" entryz="7" rent="300000" townid="13" size="100" clientid="62013" beds="3" />
-	<house name="Darashia 8, Flat 12" houseid="3328" entryx="33249" entryy="32446" entryz="6" rent="150000" townid="13" size="38" clientid="62020" beds="2" />
-	<house name="Darashia 8, Flat 11" houseid="3329" entryx="33250" entryy="32445" entryz="6" rent="200000" townid="13" size="42" clientid="62019" beds="2" />
-	<house name="Darashia 8, Flat 14" houseid="3330" entryx="33254" entryy="32449" entryz="6" rent="150000" townid="13" size="38" clientid="62022" beds="2" />
-	<house name="Darashia 8, Flat 13" houseid="3331" entryx="33254" entryy="32449" entryz="6" rent="150000" townid="13" size="42" clientid="62021" beds="2" />
-	<house name="Darashia, Villa" houseid="3332" entryx="33266" entryy="32453" entryz="7" rent="800000" townid="13" size="113" clientid="62016" beds="4" />
-	<house name="Darashia, Eastern Guildhall" houseid="3333" entryx="33232" entryy="32470" entryz="7" rent="1000000" guildhall="true" townid="13" size="248" clientid="62018" beds="16" />
-	<house name="Darashia, Western Guildhall" houseid="3334" entryx="33228" entryy="32470" entryz="7" rent="500000" guildhall="true" townid="13" size="203" clientid="62017" beds="14" />
-	<house name="Darashia 2, Flat 03" houseid="3335" entryx="33204" entryy="32435" entryz="7" rent="100000" townid="13" size="29" clientid="61011" beds="1" />
-	<house name="Darashia 2, Flat 02" houseid="3336" entryx="33207" entryy="32434" entryz="7" rent="100000" townid="13" size="25" clientid="61010" beds="1" />
-	<house name="Darashia 2, Flat 01" houseid="3337" entryx="33212" entryy="32436" entryz="7" rent="150000" townid="13" size="25" clientid="61009" beds="1" />
-	<house name="Darashia 2, Flat 04" houseid="3338" entryx="33204" entryy="32438" entryz="7" rent="80000" townid="13" size="13" clientid="61012" beds="1" />
-	<house name="Darashia 2, Flat 05" houseid="3339" entryx="33205" entryy="32439" entryz="7" rent="150000" townid="13" size="29" clientid="61013" beds="2" />
-	<house name="Darashia 2, Flat 06" houseid="3340" entryx="33208" entryy="32439" entryz="7" rent="80000" townid="13" size="13" clientid="61014" beds="1" />
-	<house name="Darashia 2, Flat 07" houseid="3341" entryx="33212" entryy="32437" entryz="7" rent="150000" townid="13" size="25" clientid="61015" beds="1" />
-	<house name="Darashia 2, Flat 13" houseid="3342" entryx="33205" entryy="32434" entryz="6" rent="100000" townid="13" size="29" clientid="61018" beds="1" />
-	<house name="Darashia 2, Flat 14" houseid="3343" entryx="33204" entryy="32435" entryz="6" rent="50000" townid="13" size="13" clientid="61019" beds="1" />
-	<house name="Darashia 2, Flat 15" houseid="3344" entryx="33204" entryy="32439" entryz="6" rent="100000" townid="13" size="29" clientid="61020" beds="2" />
-	<house name="Darashia 2, Flat 16" houseid="3345" entryx="33205" entryy="32439" entryz="6" rent="80000" townid="13" size="17" clientid="61021" beds="1" />
-	<house name="Darashia 2, Flat 17" houseid="3346" entryx="33209" entryy="32439" entryz="6" rent="100000" townid="13" size="25" clientid="61022" beds="1" />
+	<house name="Haggler's Hangout 6" houseid="3222" entryx="32638" entryy="32750" entryz="7" rent="400000" townid="15" size="143" clientid="45007" beds="4" />
+	<house name="Haggler's Hangout 5 (Shop)" houseid="3223" entryx="32630" entryy="32757" entryz="7" rent="200000" townid="15" size="42" clientid="45006" beds="1" />
+	<house name="Haggler's Hangout 4b (Shop)" houseid="3224" entryx="32616" entryy="32758" entryz="7" rent="150000" townid="15" size="34" clientid="45005" beds="1" />
+	<house name="Haggler's Hangout 4a (Shop)" houseid="3225" entryx="32616" entryy="32752" entryz="7" rent="200000" townid="15" size="44" clientid="45004" beds="1" />
+	<house name="Haggler's Hangout 2" houseid="3226" entryx="32601" entryy="32761" entryz="7" rent="100000" townid="15" size="35" clientid="45002" beds="1" />
+	<house name="Haggler's Hangout 1" houseid="3227" entryx="32593" entryy="32759" entryz="7" rent="100000" townid="15" size="37" clientid="45001" beds="2" />
+	<house name="Bamboo Garden 3" houseid="3228" entryx="32645" entryy="32789" entryz="7" rent="150000" townid="15" size="44" clientid="46021" beds="2" />
+	<house name="Bamboo Fortress" houseid="3229" entryx="32664" entryy="32791" entryz="7" rent="500000" guildhall="true" townid="15" size="531" clientid="46041" beds="20" />
+	<house name="Bamboo Garden 2" houseid="3230" entryx="32622" entryy="32796" entryz="7" rent="80000" townid="15" size="30" clientid="46020" beds="2" />
+	<house name="Bamboo Garden 1" houseid="3231" entryx="32574" entryy="32795" entryz="7" rent="100000" townid="15" size="44" clientid="46019" beds="3" />
+	<house name="Banana Bay 4" houseid="3232" entryx="32556" entryy="32814" entryz="6" rent="25000" townid="15" size="17" clientid="46004" beds="1" />
+	<house name="Banana Bay 2" houseid="3233" entryx="32550" entryy="32803" entryz="6" rent="50000" townid="15" size="27" clientid="46002" beds="1" />
+	<house name="Banana Bay 3" houseid="3234" entryx="32561" entryy="32805" entryz="6" rent="50000" townid="15" size="18" clientid="46003" beds="1" />
+	<house name="Banana Bay 1" houseid="3235" entryx="32553" entryy="32799" entryz="6" rent="25000" townid="15" size="17" clientid="46001" beds="1" />
+	<house name="Crocodile Bridge 1" houseid="3236" entryx="32571" entryy="32794" entryz="6" rent="80000" townid="15" size="29" clientid="46005" beds="2" />
+	<house name="Crocodile Bridge 2" houseid="3237" entryx="32571" entryy="32787" entryz="6" rent="80000" townid="15" size="25" clientid="46006" beds="2" />
+	<house name="Crocodile Bridge 3" houseid="3238" entryx="32579" entryy="32788" entryz="6" rent="100000" townid="15" size="34" clientid="46007" beds="2" />
+	<house name="Crocodile Bridge 4" houseid="3239" entryx="32592" entryy="32792" entryz="6" rent="300000" townid="15" size="119" clientid="46008" beds="4" />
+	<house name="Crocodile Bridge 5" houseid="3240" entryx="32605" entryy="32793" entryz="6" rent="200000" townid="15" size="102" clientid="46009" beds="2" />
+	<house name="Woodway 1" houseid="3241" entryx="32618" entryy="32787" entryz="6" rent="80000" townid="15" size="18" clientid="46010" beds="1" />
+	<house name="Woodway 2" houseid="3242" entryx="32629" entryy="32784" entryz="6" rent="50000" townid="15" size="17" clientid="46011" beds="1" />
+	<house name="Woodway 3" houseid="3243" entryx="32642" entryy="32784" entryz="6" rent="150000" townid="15" size="42" clientid="46012" beds="2" />
+	<house name="Woodway 4" houseid="3244" entryx="32653" entryy="32782" entryz="6" rent="25000" townid="15" size="17" clientid="46013" beds="1" />
+	<house name="Flamingo Flats 5" houseid="3245" entryx="32664" entryy="32786" entryz="6" rent="150000" townid="15" size="53" clientid="46018" beds="1" />
+	<house name="Flamingo Flats 4" houseid="3246" entryx="32674" entryy="32783" entryz="6" rent="80000" townid="15" size="23" clientid="46017" beds="2" />
+	<house name="Flamingo Flats 1" houseid="3247" entryx="32664" entryy="32773" entryz="6" rent="50000" townid="15" size="19" clientid="46014" beds="2" />
+	<house name="Flamingo Flats 2" houseid="3248" entryx="32672" entryy="32774" entryz="6" rent="80000" townid="15" size="28" clientid="46015" beds="2" />
+	<house name="Flamingo Flats 3" houseid="3249" entryx="32681" entryy="32770" entryz="6" rent="50000" townid="15" size="20" clientid="46016" beds="2" />
+	<house name="Jungle Edge 1" houseid="3250" entryx="32662" entryy="32752" entryz="6" rent="200000" townid="15" size="63" clientid="46030" beds="3" />
+	<house name="Jungle Edge 2" houseid="3251" entryx="32673" entryy="32746" entryz="6" rent="200000" townid="15" size="89" clientid="46031" beds="3" />
+	<house name="Jungle Edge 4" houseid="3252" entryx="32674" entryy="32757" entryz="6" rent="80000" townid="15" size="23" clientid="46033" beds="2" />
+	<house name="Jungle Edge 5" houseid="3253" entryx="32680" entryy="32756" entryz="6" rent="80000" townid="15" size="27" clientid="46034" beds="2" />
+	<house name="Jungle Edge 6" houseid="3254" entryx="32690" entryy="32757" entryz="6" rent="25000" townid="15" size="17" clientid="46035" beds="1" />
+	<house name="Jungle Edge 3" houseid="3255" entryx="32680" entryy="32745" entryz="6" rent="80000" townid="15" size="27" clientid="46032" beds="2" />
+	<house name="River Homes 3" houseid="3256" entryx="32647" entryy="32769" entryz="6" rent="200000" townid="15" size="111" clientid="46029" beds="7" />
+	<house name="River Homes 2b" houseid="3257" entryx="32634" entryy="32773" entryz="6" rent="150000" townid="15" size="37" clientid="46028" beds="3" />
+	<house name="River Homes 2a" houseid="3258" entryx="32627" entryy="32773" entryz="6" rent="100000" townid="15" size="33" clientid="46027" beds="2" />
+	<house name="River Homes 1" houseid="3259" entryx="32618" entryy="32773" entryz="6" rent="300000" townid="15" size="96" clientid="46026" beds="3" />
+	<house name="Coconut Quay 4" houseid="3260" entryx="32598" entryy="32773" entryz="6" rent="150000" townid="15" size="52" clientid="46025" beds="3" />
+	<house name="Coconut Quay 3" houseid="3261" entryx="32586" entryy="32773" entryz="6" rent="200000" townid="15" size="50" clientid="46024" beds="4" />
+	<house name="Coconut Quay 2" houseid="3262" entryx="32577" entryy="32766" entryz="6" rent="100000" townid="15" size="27" clientid="46023" beds="2" />
+	<house name="Coconut Quay 1" houseid="3263" entryx="32568" entryy="32775" entryz="6" rent="150000" townid="15" size="47" clientid="46022" beds="2" />
+	<house name="Shark Manor" houseid="3264" entryx="32556" entryy="32767" entryz="6" rent="250000" guildhall="true" townid="15" size="173" clientid="46040" beds="15" />
+	<house name="Glacier Side 2" houseid="3265" entryx="32203" entryy="31132" entryz="7" rent="300000" townid="16" size="102" clientid="55003" beds="3" />
+	<house name="Glacier Side 1" houseid="3266" entryx="32206" entryy="31126" entryz="7" rent="150000" townid="16" size="34" clientid="55002" beds="2" />
+	<house name="Glacier Side 3" houseid="3267" entryx="32206" entryy="31140" entryz="7" rent="150000" townid="16" size="41" clientid="55004" beds="2" />
+	<house name="Glacier Side 4" houseid="3268" entryx="32204" entryy="31147" entryz="6" rent="150000" townid="16" size="46" clientid="55005" beds="1" />
+	<house name="Shelf Site" houseid="3269" entryx="32197" entryy="31150" entryz="6" rent="300000" townid="16" size="98" clientid="55001" beds="3" />
+	<house name="Spirit Homes 5" houseid="3270" entryx="32223" entryy="31142" entryz="7" rent="150000" townid="16" size="29" clientid="55010" beds="2" />
+	<house name="Spirit Homes 4" houseid="3271" entryx="32220" entryy="31129" entryz="7" rent="80000" townid="16" size="24" clientid="55009" beds="1" />
+	<house name="Spirit Homes 1" houseid="3272" entryx="32210" entryy="31124" entryz="7" rent="150000" townid="16" size="35" clientid="55006" beds="2" />
+	<house name="Spirit Homes 2" houseid="3273" entryx="32219" entryy="31124" entryz="7" rent="150000" townid="16" size="39" clientid="55007" beds="2" />
+	<house name="Spirit Homes 3" houseid="3274" entryx="32216" entryy="31124" entryz="6" rent="300000" townid="16" size="90" clientid="55008" beds="3" />
+	<house name="Arena Walk 3" houseid="3275" entryx="32235" entryy="31118" entryz="7" rent="300000" townid="16" size="74" clientid="55013" beds="3" />
+	<house name="Arena Walk 2" houseid="3276" entryx="32239" entryy="31126" entryz="7" rent="150000" townid="16" size="29" clientid="55012" beds="2" />
+	<house name="Arena Walk 1" houseid="3277" entryx="32238" entryy="31134" entryz="7" rent="300000" townid="16" size="67" clientid="55011" beds="3" />
+	<house name="Bears Paw 2" houseid="3278" entryx="32241" entryy="31133" entryz="7" rent="300000" townid="16" size="54" clientid="55102" beds="2" />
+	<house name="Bears Paw 1" houseid="3279" entryx="32264" entryy="31132" entryz="7" rent="200000" townid="16" size="42" clientid="55101" beds="2" />
+	<house name="Crystal Glance" houseid="3280" entryx="32246" entryy="31118" entryz="7" rent="1000000" guildhall="true" townid="16" size="321" clientid="55302" beds="24" />
+	<house name="Shady Rocks 2" houseid="3281" entryx="32259" entryy="31119" entryz="7" rent="200000" townid="16" size="41" clientid="55127" beds="4" />
+	<house name="Shady Rocks 1" houseid="3282" entryx="32259" entryy="31110" entryz="7" rent="300000" townid="16" size="79" clientid="55126" beds="4" />
+	<house name="Shady Rocks 3" houseid="3283" entryx="32277" entryy="31121" entryz="7" rent="300000" townid="16" size="94" clientid="55128" beds="3" />
+	<house name="Shady Rocks 4 (Shop)" houseid="3284" entryx="32282" entryy="31123" entryz="7" rent="200000" townid="16" size="61" clientid="55129" beds="2" />
+	<house name="Shady Rocks 5" houseid="3285" entryx="32288" entryy="31125" entryz="7" rent="300000" townid="16" size="66" clientid="55130" beds="2" />
+	<house name="Tusk Flats 2" houseid="3286" entryx="32301" entryy="31117" entryz="7" rent="80000" townid="16" size="28" clientid="55202" beds="2" />
+	<house name="Tusk Flats 1" houseid="3287" entryx="32300" entryy="31124" entryz="7" rent="80000" townid="16" size="25" clientid="55201" beds="2" />
+	<house name="Tusk Flats 3" houseid="3288" entryx="32308" entryy="31111" entryz="7" rent="80000" townid="16" size="26" clientid="55203" beds="2" />
+	<house name="Tusk Flats 4" houseid="3289" entryx="32307" entryy="31105" entryz="7" rent="25000" townid="16" size="13" clientid="55204" beds="1" />
+	<house name="Tusk Flats 6" houseid="3290" entryx="32308" entryy="31099" entryz="7" rent="50000" townid="16" size="23" clientid="55206" beds="2" />
+	<house name="Tusk Flats 5" houseid="3291" entryx="32320" entryy="31108" entryz="7" rent="25000" townid="16" size="18" clientid="55205" beds="1" />
+	<house name="Corner Shop (Shop)" houseid="3292" entryx="32304" entryy="31141" entryz="7" rent="200000" townid="16" size="50" clientid="55131" beds="2" />
+	<house name="Bears Paw 5" houseid="3293" entryx="32272" entryy="31157" entryz="7" rent="200000" townid="16" size="45" clientid="55105" beds="3" />
+	<house name="Bears Paw 4" houseid="3294" entryx="32256" entryy="31158" entryz="7" rent="400000" townid="16" size="119" clientid="55104" beds="4" />
+	<house name="Trout Plaza 2" houseid="3295" entryx="32260" entryy="31161" entryz="7" rent="150000" townid="16" size="36" clientid="55112" beds="2" />
+	<house name="Trout Plaza 1" houseid="3296" entryx="32248" entryy="31166" entryz="7" rent="200000" townid="16" size="56" clientid="55111" beds="2" />
+	<house name="Trout Plaza 5 (Shop)" houseid="3297" entryx="32275" entryy="31167" entryz="7" rent="300000" townid="16" size="89" clientid="55115" beds="2" />
+	<house name="Trout Plaza 3" houseid="3298" entryx="32255" entryy="31173" entryz="7" rent="80000" townid="16" size="22" clientid="55113" beds="1" />
+	<house name="Trout Plaza 4" houseid="3299" entryx="32255" entryy="31177" entryz="7" rent="80000" townid="16" size="22" clientid="55114" beds="1" />
+	<house name="Skiffs End 2" houseid="3300" entryx="32257" entryy="31189" entryz="7" rent="80000" townid="16" size="21" clientid="55110" beds="2" />
+	<house name="Skiffs End 1" houseid="3301" entryx="32250" entryy="31187" entryz="7" rent="100000" townid="16" size="35" clientid="55109" beds="2" />
+	<house name="Furrier Quarter 3" houseid="3302" entryx="32232" entryy="31191" entryz="7" rent="100000" townid="16" size="40" clientid="55213" beds="2" />
+	<house name="Fimbul Shelf 4" houseid="3303" entryx="32218" entryy="31191" entryz="7" rent="100000" townid="16" size="42" clientid="55210" beds="2" />
+	<house name="Fimbul Shelf 3" houseid="3304" entryx="32215" entryy="31177" entryz="7" rent="100000" townid="16" size="49" clientid="55209" beds="2" />
+	<house name="Furrier Quarter 2" houseid="3305" entryx="32225" entryy="31177" entryz="7" rent="80000" townid="16" size="37" clientid="55212" beds="2" />
+	<house name="Furrier Quarter 1" houseid="3306" entryx="32221" entryy="31176" entryz="7" rent="150000" townid="16" size="53" clientid="55211" beds="3" />
+	<house name="Fimbul Shelf 2" houseid="3307" entryx="32209" entryy="31175" entryz="7" rent="100000" townid="16" size="43" clientid="55208" beds="2" />
+	<house name="Fimbul Shelf 1" houseid="3308" entryx="32204" entryy="31169" entryz="7" rent="80000" townid="16" size="36" clientid="55207" beds="2" />
+	<house name="Bears Paw 3" houseid="3309" entryx="32248" entryy="31157" entryz="7" rent="200000" townid="16" size="47" clientid="55103" beds="3" />
+	<house name="Raven Corner 2" houseid="3310" entryx="32233" entryy="31156" entryz="7" rent="150000" townid="16" size="36" clientid="55107" beds="3" />
+	<house name="Raven Corner 1" houseid="3311" entryx="32234" entryy="31154" entryz="7" rent="80000" townid="16" size="22" clientid="55106" beds="1" />
+	<house name="Raven Corner 3" houseid="3312" entryx="32234" entryy="31157" entryz="7" rent="100000" townid="16" size="22" clientid="55108" beds="1" />
+	<house name="Mammoth Belly" houseid="3313" entryx="32241" entryy="31174" entryz="7" rent="1000000" guildhall="true" townid="16" size="404" clientid="55301" beds="30" />
+	<house name="Darashia 3, Flat 01" houseid="3314" entryx="33229" entryy="32442" entryz="7" rent="150000" townid="13" size="27" clientid="61024" beds="2" />
+	<house name="Darashia 3, Flat 05" houseid="3315" entryx="33230" entryy="32442" entryz="7" rent="150000" townid="13" size="26" clientid="61028" beds="1" />
+	<house name="Darashia 3, Flat 02" houseid="3316" entryx="33227" entryy="32447" entryz="7" rent="200000" townid="13" size="41" clientid="61025" beds="2" />
+	<house name="Darashia 3, Flat 04" houseid="3317" entryx="33232" entryy="32447" entryz="7" rent="150000" townid="13" size="39" clientid="61027" beds="2" />
+	<house name="Darashia 3, Flat 03" houseid="3318" entryx="33230" entryy="32449" entryz="7" rent="150000" townid="13" size="28" clientid="61026" beds="2" />
+	<house name="Darashia 3, Flat 12" houseid="3319" entryx="33227" entryy="32446" entryz="6" rent="200000" townid="13" size="56" clientid="61030" beds="5" />
+	<house name="Darashia 3, Flat 11" houseid="3320" entryx="33228" entryy="32445" entryz="6" rent="100000" townid="13" size="27" clientid="61029" beds="1" />
+	<house name="Darashia 3, Flat 14" houseid="3321" entryx="33232" entryy="32449" entryz="6" rent="200000" townid="13" size="59" clientid="61032" beds="3" />
+	<house name="Darashia 3, Flat 13" houseid="3322" entryx="33232" entryy="32449" entryz="6" rent="100000" townid="13" size="27" clientid="61031" beds="2" />
+	<house name="Darashia 8, Flat 01" houseid="3323" entryx="33251" entryy="32442" entryz="7" rent="300000" townid="13" size="55" clientid="62011" beds="2" />
+	<house name="Darashia 8, Flat 05" houseid="3325" entryx="33252" entryy="32442" entryz="7" rent="300000" townid="13" size="58" clientid="62015" beds="2" />
+	<house name="Darashia 8, Flat 04" houseid="3326" entryx="33254" entryy="32447" entryz="7" rent="200000" townid="13" size="63" clientid="62014" beds="2" />
+	<house name="Darashia 8, Flat 03" houseid="3327" entryx="33252" entryy="32449" entryz="7" rent="300000" townid="13" size="105" clientid="62013" beds="3" />
+	<house name="Darashia 8, Flat 12" houseid="3328" entryx="33249" entryy="32446" entryz="6" rent="150000" townid="13" size="39" clientid="62020" beds="2" />
+	<house name="Darashia 8, Flat 11" houseid="3329" entryx="33250" entryy="32445" entryz="6" rent="200000" townid="13" size="46" clientid="62019" beds="2" />
+	<house name="Darashia 8, Flat 14" houseid="3330" entryx="33254" entryy="32449" entryz="6" rent="150000" townid="13" size="42" clientid="62022" beds="2" />
+	<house name="Darashia 8, Flat 13" houseid="3331" entryx="33254" entryy="32449" entryz="6" rent="150000" townid="13" size="46" clientid="62021" beds="2" />
+	<house name="Darashia, Villa" houseid="3332" entryx="33266" entryy="32453" entryz="7" rent="800000" townid="13" size="120" clientid="62016" beds="4" />
+	<house name="Darashia, Eastern Guildhall" houseid="3333" entryx="33232" entryy="32470" entryz="7" rent="1000000" guildhall="true" townid="13" size="272" clientid="62018" beds="16" />
+	<house name="Darashia, Western Guildhall" houseid="3334" entryx="33228" entryy="32470" entryz="7" rent="500000" guildhall="true" townid="13" size="223" clientid="62017" beds="14" />
+	<house name="Darashia 2, Flat 03" houseid="3335" entryx="33204" entryy="32435" entryz="7" rent="100000" townid="13" size="31" clientid="61011" beds="1" />
+	<house name="Darashia 2, Flat 02" houseid="3336" entryx="33207" entryy="32434" entryz="7" rent="100000" townid="13" size="26" clientid="61010" beds="1" />
+	<house name="Darashia 2, Flat 01" houseid="3337" entryx="33212" entryy="32436" entryz="7" rent="150000" townid="13" size="29" clientid="61009" beds="1" />
+	<house name="Darashia 2, Flat 04" houseid="3338" entryx="33204" entryy="32438" entryz="7" rent="80000" townid="13" size="14" clientid="61012" beds="1" />
+	<house name="Darashia 2, Flat 05" houseid="3339" entryx="33205" entryy="32439" entryz="7" rent="150000" townid="13" size="31" clientid="61013" beds="2" />
+	<house name="Darashia 2, Flat 06" houseid="3340" entryx="33208" entryy="32439" entryz="7" rent="80000" townid="13" size="14" clientid="61014" beds="1" />
+	<house name="Darashia 2, Flat 07" houseid="3341" entryx="33212" entryy="32437" entryz="7" rent="150000" townid="13" size="29" clientid="61015" beds="1" />
+	<house name="Darashia 2, Flat 13" houseid="3342" entryx="33205" entryy="32434" entryz="6" rent="100000" townid="13" size="31" clientid="61018" beds="1" />
+	<house name="Darashia 2, Flat 14" houseid="3343" entryx="33204" entryy="32435" entryz="6" rent="50000" townid="13" size="14" clientid="61019" beds="1" />
+	<house name="Darashia 2, Flat 15" houseid="3344" entryx="33204" entryy="32439" entryz="6" rent="100000" townid="13" size="30" clientid="61020" beds="2" />
+	<house name="Darashia 2, Flat 16" houseid="3345" entryx="33205" entryy="32439" entryz="6" rent="80000" townid="13" size="18" clientid="61021" beds="1" />
+	<house name="Darashia 2, Flat 17" houseid="3346" entryx="33209" entryy="32439" entryz="6" rent="100000" townid="13" size="27" clientid="61022" beds="1" />
 	<house name="Darashia 2, Flat 18" houseid="3347" entryx="33209" entryy="32439" entryz="6" rent="100000" townid="13" size="17" clientid="61023" beds="1" />
-	<house name="Darashia 2, Flat 11" houseid="3348" entryx="33209" entryy="32434" entryz="6" rent="100000" townid="13" size="25" clientid="61016" beds="1" />
+	<house name="Darashia 2, Flat 11" houseid="3348" entryx="33209" entryy="32434" entryz="6" rent="100000" townid="13" size="27" clientid="61016" beds="1" />
 	<house name="Darashia 2, Flat 12" houseid="3349" entryx="33208" entryy="32434" entryz="6" rent="80000" townid="13" size="13" clientid="61017" beds="1" />
-	<house name="Darashia 1, Flat 03" houseid="3350" entryx="33201" entryy="32414" entryz="7" rent="300000" townid="13" size="59" clientid="61002" beds="4" />
-	<house name="Darashia 1, Flat 04" houseid="3351" entryx="33202" entryy="32416" entryz="7" rent="100000" townid="13" size="25" clientid="61003" beds="1" />
-	<house name="Darashia 1, Flat 02" houseid="3352" entryx="33202" entryy="32411" entryz="7" rent="100000" townid="13" size="25" clientid="61001" beds="1" />
-	<house name="Darashia 1, Flat 01" houseid="3353" entryx="33210" entryy="32413" entryz="7" rent="100000" townid="13" size="25" clientid="61000" beds="2" />
-	<house name="Darashia 1, Flat 05" houseid="3354" entryx="33210" entryy="32414" entryz="7" rent="100000" townid="13" size="25" clientid="61004" beds="2" />
-	<house name="Darashia 1, Flat 12" houseid="3355" entryx="33201" entryy="32412" entryz="6" rent="150000" townid="13" size="42" clientid="61006" beds="2" />
-	<house name="Darashia 1, Flat 13" houseid="3356" entryx="33206" entryy="32416" entryz="6" rent="150000" townid="13" size="42" clientid="61007" beds="2" />
-	<house name="Darashia 1, Flat 14" houseid="3357" entryx="33206" entryy="32416" entryz="6" rent="200000" townid="13" size="59" clientid="61008" beds="5" />
-	<house name="Darashia 1, Flat 11" houseid="3358" entryx="33202" entryy="32411" entryz="6" rent="100000" townid="13" size="25" clientid="61005" beds="2" />
-	<house name="Darashia 5, Flat 02" houseid="3359" entryx="33254" entryy="32403" entryz="7" rent="150000" townid="13" size="38" clientid="61043" beds="2" />
-	<house name="Darashia 5, Flat 01" houseid="3360" entryx="33256" entryy="32409" entryz="7" rent="150000" townid="13" size="25" clientid="61042" beds="1" />
-	<house name="Darashia 5, Flat 05" houseid="3361" entryx="33257" entryy="32409" entryz="7" rent="100000" townid="13" size="25" clientid="61046" beds="1" />
-	<house name="Darashia 5, Flat 04" houseid="3362" entryx="33259" entryy="32403" entryz="7" rent="150000" townid="13" size="38" clientid="61045" beds="2" />
-	<house name="Darashia 5, Flat 03" houseid="3363" entryx="33256" entryy="32401" entryz="7" rent="150000" townid="13" size="25" clientid="61044" beds="1" />
-	<house name="Darashia 5, Flat 11" houseid="3364" entryx="33255" entryy="32401" entryz="6" rent="150000" townid="13" size="42" clientid="61047" beds="2" />
-	<house name="Darashia 5, Flat 12" houseid="3365" entryx="33254" entryy="32402" entryz="6" rent="150000" townid="13" size="38" clientid="61048" beds="2" />
+	<house name="Darashia 1, Flat 03" houseid="3350" entryx="33201" entryy="32414" entryz="7" rent="300000" townid="13" size="65" clientid="61002" beds="4" />
+	<house name="Darashia 1, Flat 04" houseid="3351" entryx="33202" entryy="32416" entryz="7" rent="100000" townid="13" size="28" clientid="61003" beds="1" />
+	<house name="Darashia 1, Flat 02" houseid="3352" entryx="33202" entryy="32411" entryz="7" rent="100000" townid="13" size="26" clientid="61001" beds="1" />
+	<house name="Darashia 1, Flat 01" houseid="3353" entryx="33210" entryy="32413" entryz="7" rent="100000" townid="13" size="29" clientid="61000" beds="2" />
+	<house name="Darashia 1, Flat 05" houseid="3354" entryx="33210" entryy="32414" entryz="7" rent="100000" townid="13" size="29" clientid="61004" beds="2" />
+	<house name="Darashia 1, Flat 12" houseid="3355" entryx="33201" entryy="32412" entryz="6" rent="150000" townid="13" size="46" clientid="61006" beds="2" />
+	<house name="Darashia 1, Flat 13" houseid="3356" entryx="33206" entryy="32416" entryz="6" rent="150000" townid="13" size="50" clientid="61007" beds="2" />
+	<house name="Darashia 1, Flat 14" houseid="3357" entryx="33206" entryy="32416" entryz="6" rent="200000" townid="13" size="69" clientid="61008" beds="5" />
+	<house name="Darashia 1, Flat 11" houseid="3358" entryx="33202" entryy="32411" entryz="6" rent="100000" townid="13" size="27" clientid="61005" beds="2" />
+	<house name="Darashia 5, Flat 02" houseid="3359" entryx="33254" entryy="32403" entryz="7" rent="150000" townid="13" size="41" clientid="61043" beds="2" />
+	<house name="Darashia 5, Flat 01" houseid="3360" entryx="33256" entryy="32409" entryz="7" rent="150000" townid="13" size="29" clientid="61042" beds="1" />
+	<house name="Darashia 5, Flat 05" houseid="3361" entryx="33257" entryy="32409" entryz="7" rent="100000" townid="13" size="29" clientid="61046" beds="1" />
+	<house name="Darashia 5, Flat 04" houseid="3362" entryx="33259" entryy="32403" entryz="7" rent="150000" townid="13" size="42" clientid="61045" beds="2" />
+	<house name="Darashia 5, Flat 03" houseid="3363" entryx="33256" entryy="32401" entryz="7" rent="150000" townid="13" size="27" clientid="61044" beds="1" />
+	<house name="Darashia 5, Flat 11" houseid="3364" entryx="33255" entryy="32401" entryz="6" rent="150000" townid="13" size="46" clientid="61047" beds="2" />
+	<house name="Darashia 5, Flat 12" houseid="3365" entryx="33254" entryy="32402" entryz="6" rent="150000" townid="13" size="39" clientid="61048" beds="2" />
 	<house name="Darashia 5, Flat 13" houseid="3366" entryx="33259" entryy="32405" entryz="6" rent="150000" townid="13" size="42" clientid="61049" beds="2" />
 	<house name="Darashia 5, Flat 14" houseid="3367" entryx="33259" entryy="32405" entryz="6" rent="150000" townid="13" size="38" clientid="61050" beds="2" />
 	<house name="Darashia 6a" houseid="3368" entryx="33273" entryy="32405" entryz="7" rent="300000" townid="13" size="67" clientid="62000" beds="2" />
-	<house name="Darashia 6b" houseid="3369" entryx="33273" entryy="32406" entryz="7" rent="300000" townid="13" size="74" clientid="62001" beds="2" />
-	<house name="Darashia 4, Flat 02" houseid="3370" entryx="33244" entryy="32422" entryz="7" rent="200000" townid="13" size="42" clientid="61034" beds="2" />
-	<house name="Darashia 4, Flat 03" houseid="3371" entryx="33241" entryy="32425" entryz="7" rent="150000" townid="13" size="25" clientid="61035" beds="1" />
-	<house name="Darashia 4, Flat 04" houseid="3372" entryx="33244" entryy="32427" entryz="7" rent="200000" townid="13" size="42" clientid="61036" beds="2" />
-	<house name="Darashia 4, Flat 05" houseid="3373" entryx="33250" entryy="32425" entryz="7" rent="150000" townid="13" size="25" clientid="61037" beds="2" />
-	<house name="Darashia 4, Flat 01" houseid="3374" entryx="33250" entryy="32424" entryz="7" rent="100000" townid="13" size="25" clientid="61033" beds="1" />
-	<house name="Darashia 4, Flat 12" houseid="3375" entryx="33241" entryy="32423" entryz="6" rent="200000" townid="13" size="59" clientid="61039" beds="3" />
-	<house name="Darashia 4, Flat 11" houseid="3376" entryx="33242" entryy="32422" entryz="6" rent="100000" townid="13" size="25" clientid="61038" beds="1" />
-	<house name="Darashia 4, Flat 13" houseid="3377" entryx="33246" entryy="32427" entryz="6" rent="200000" townid="13" size="42" clientid="61040" beds="2" />
-	<house name="Darashia 4, Flat 14" houseid="3378" entryx="33246" entryy="32427" entryz="6" rent="150000" townid="13" size="42" clientid="61041" beds="2" />
-	<house name="Darashia 7, Flat 01" houseid="3379" entryx="33259" entryy="32424" entryz="7" rent="100000" townid="13" size="25" clientid="62002" beds="1" />
-	<house name="Darashia 7, Flat 02" houseid="3380" entryx="33265" entryy="32422" entryz="7" rent="100000" townid="13" size="25" clientid="62003" beds="1" />
-	<house name="Darashia 7, Flat 03" houseid="3381" entryx="33267" entryy="32425" entryz="7" rent="200000" townid="13" size="59" clientid="62004" beds="4" />
-	<house name="Darashia 7, Flat 05" houseid="3382" entryx="33259" entryy="32425" entryz="7" rent="150000" townid="13" size="25" clientid="62006" beds="2" />
-	<house name="Darashia 7, Flat 04" houseid="3383" entryx="33265" entryy="32427" entryz="7" rent="150000" townid="13" size="25" clientid="62005" beds="1" />
-	<house name="Darashia 7, Flat 12" houseid="3384" entryx="33262" entryy="32423" entryz="6" rent="200000" townid="13" size="59" clientid="62008" beds="4" />
-	<house name="Darashia 7, Flat 11" houseid="3385" entryx="33263" entryy="32422" entryz="6" rent="100000" townid="13" size="25" clientid="62007" beds="1" />
-	<house name="Darashia 7, Flat 14" houseid="3386" entryx="33267" entryy="32427" entryz="6" rent="200000" townid="13" size="59" clientid="62010" beds="4" />
+	<house name="Darashia 6b" houseid="3369" entryx="33273" entryy="32406" entryz="7" rent="300000" townid="13" size="80" clientid="62001" beds="2" />
+	<house name="Darashia 4, Flat 02" houseid="3370" entryx="33244" entryy="32422" entryz="7" rent="200000" townid="13" size="44" clientid="61034" beds="2" />
+	<house name="Darashia 4, Flat 03" houseid="3371" entryx="33241" entryy="32425" entryz="7" rent="150000" townid="13" size="27" clientid="61035" beds="1" />
+	<house name="Darashia 4, Flat 04" houseid="3372" entryx="33244" entryy="32427" entryz="7" rent="200000" townid="13" size="45" clientid="61036" beds="2" />
+	<house name="Darashia 4, Flat 05" houseid="3373" entryx="33250" entryy="32425" entryz="7" rent="150000" townid="13" size="30" clientid="61037" beds="2" />
+	<house name="Darashia 4, Flat 01" houseid="3374" entryx="33250" entryy="32424" entryz="7" rent="100000" townid="13" size="31" clientid="61033" beds="1" />
+	<house name="Darashia 4, Flat 12" houseid="3375" entryx="33241" entryy="32423" entryz="6" rent="200000" townid="13" size="64" clientid="61039" beds="3" />
+	<house name="Darashia 4, Flat 11" houseid="3376" entryx="33242" entryy="32422" entryz="6" rent="100000" townid="13" size="26" clientid="61038" beds="1" />
+	<house name="Darashia 4, Flat 13" houseid="3377" entryx="33246" entryy="32427" entryz="6" rent="200000" townid="13" size="44" clientid="61040" beds="2" />
+	<house name="Darashia 4, Flat 14" houseid="3378" entryx="33246" entryy="32427" entryz="6" rent="150000" townid="13" size="46" clientid="61041" beds="2" />
+	<house name="Darashia 7, Flat 01" houseid="3379" entryx="33259" entryy="32424" entryz="7" rent="100000" townid="13" size="26" clientid="62002" beds="1" />
+	<house name="Darashia 7, Flat 02" houseid="3380" entryx="33265" entryy="32422" entryz="7" rent="100000" townid="13" size="27" clientid="62003" beds="1" />
+	<house name="Darashia 7, Flat 03" houseid="3381" entryx="33267" entryy="32425" entryz="7" rent="200000" townid="13" size="65" clientid="62004" beds="4" />
+	<house name="Darashia 7, Flat 05" houseid="3382" entryx="33259" entryy="32425" entryz="7" rent="150000" townid="13" size="27" clientid="62006" beds="2" />
+	<house name="Darashia 7, Flat 04" houseid="3383" entryx="33265" entryy="32427" entryz="7" rent="150000" townid="13" size="27" clientid="62005" beds="1" />
+	<house name="Darashia 7, Flat 12" houseid="3384" entryx="33262" entryy="32423" entryz="6" rent="200000" townid="13" size="60" clientid="62008" beds="4" />
+	<house name="Darashia 7, Flat 11" houseid="3385" entryx="33263" entryy="32422" entryz="6" rent="100000" townid="13" size="26" clientid="62007" beds="1" />
+	<house name="Darashia 7, Flat 14" houseid="3386" entryx="33267" entryy="32427" entryz="6" rent="200000" townid="13" size="60" clientid="62010" beds="4" />
 	<house name="Darashia 7, Flat 13" houseid="3387" entryx="33267" entryy="32427" entryz="6" rent="100000" townid="13" size="25" clientid="62009" beds="1" />
-	<house name="Pirate Shipwreck 1" houseid="3388" entryx="33278" entryy="32422" entryz="7" rent="800000" townid="13" size="147" clientid="62023" beds="6" />
-	<house name="Pirate Shipwreck 2" houseid="3389" entryx="33281" entryy="32431" entryz="7" rent="800000" townid="13" size="177" clientid="62024" beds="8" />
-	<house name="The Shelter" houseid="3390" entryx="32267" entryy="32859" entryz="7" rent="250000" guildhall="true" townid="14" size="353" clientid="65023" beds="31" />
-	<house name="Litter Promenade 1" houseid="3391" entryx="32271" entryy="32862" entryz="7" rent="25000" townid="14" size="10" clientid="65018" beds="2" />
-	<house name="Litter Promenade 2" houseid="3392" entryx="32277" entryy="32861" entryz="7" rent="50000" townid="14" size="10" clientid="65019" beds="1" />
-	<house name="Litter Promenade 3" houseid="3394" entryx="32286" entryy="32865" entryz="7" rent="25000" townid="14" size="15" clientid="65020" beds="1" />
-	<house name="Litter Promenade 4" houseid="3395" entryx="32288" entryy="32865" entryz="7" rent="25000" townid="14" size="13" clientid="65021" beds="1" />
-	<house name="Rum Alley 3" houseid="3396" entryx="32272" entryy="32854" entryz="7" rent="25000" townid="14" size="11" clientid="65011" beds="1" />
-	<house name="Straycat's Corner 5" houseid="3397" entryx="32281" entryy="32853" entryz="7" rent="80000" townid="14" size="22" clientid="65016" beds="2" />
-	<house name="Straycat's Corner 6" houseid="3398" entryx="32281" entryy="32858" entryz="7" rent="25000" townid="14" size="10" clientid="65017" beds="1" />
-	<house name="Litter Promenade 5" houseid="3399" entryx="32290" entryy="32859" entryz="7" rent="25000" townid="14" size="16" clientid="65022" beds="2" />
-	<house name="Straycat's Corner 4" houseid="3401" entryx="32291" entryy="32852" entryz="7" rent="50000" townid="14" size="17" clientid="65015" beds="2" />
-	<house name="Straycat's Corner 2" houseid="3402" entryx="32284" entryy="32845" entryz="7" rent="50000" townid="14" size="22" clientid="65013" beds="1" />
-	<house name="Straycat's Corner 1" houseid="3403" entryx="32280" entryy="32843" entryz="7" rent="25000" townid="14" size="10" clientid="65012" beds="1" />
-	<house name="Rum Alley 2" houseid="3404" entryx="32260" entryy="32846" entryz="7" rent="25000" townid="14" size="10" clientid="65010" beds="1" />
-	<house name="Rum Alley 1" houseid="3405" entryx="32257" entryy="32839" entryz="7" rent="25000" townid="14" size="17" clientid="65009" beds="1" />
-	<house name="Smuggler Backyard 3" houseid="3406" entryx="32263" entryy="32838" entryz="7" rent="50000" townid="14" size="20" clientid="65003" beds="2" />
-	<house name="Shady Trail 3" houseid="3407" entryx="32274" entryy="32835" entryz="7" rent="25000" townid="14" size="10" clientid="65008" beds="1" />
-	<house name="Shady Trail 1" houseid="3408" entryx="32283" entryy="32834" entryz="7" rent="100000" townid="14" size="25" clientid="65006" beds="5" />
-	<house name="Shady Trail 2" houseid="3409" entryx="32274" entryy="32830" entryz="7" rent="25000" townid="14" size="13" clientid="65007" beds="2" />
-	<house name="Smuggler Backyard 4" houseid="3410" entryx="32263" entryy="32830" entryz="7" rent="25000" townid="14" size="13" clientid="65004" beds="1" />
-	<house name="Smuggler Backyard 2" houseid="3411" entryx="32261" entryy="32829" entryz="7" rent="25000" townid="14" size="19" clientid="65002" beds="2" />
-	<house name="Smuggler Backyard 1" houseid="3412" entryx="32264" entryy="32823" entryz="7" rent="25000" townid="14" size="19" clientid="65001" beds="2" />
-	<house name="Smuggler Backyard 5" houseid="3413" entryx="32272" entryy="32823" entryz="7" rent="25000" townid="14" size="17" clientid="65005" beds="2" />
-	<house name="Sugar Street 1" houseid="3414" entryx="32256" entryy="32815" entryz="7" rent="200000" townid="14" size="56" clientid="64006" beds="3" />
-	<house name="Sugar Street 2" houseid="3415" entryx="32262" entryy="32815" entryz="7" rent="150000" townid="14" size="47" clientid="64007" beds="3" />
-	<house name="Sugar Street 3a" houseid="3416" entryx="32271" entryy="32813" entryz="7" rent="100000" townid="14" size="29" clientid="64008" beds="3" />
-	<house name="Sugar Street 3b" houseid="3417" entryx="32275" entryy="32798" entryz="7" rent="150000" townid="14" size="37" clientid="64009" beds="3" />
-	<house name="Sugar Street 4d" houseid="3418" entryx="32287" entryy="32801" entryz="7" rent="50000" townid="14" size="13" clientid="64013" beds="2" />
-	<house name="Sugar Street 4c" houseid="3419" entryx="32287" entryy="32805" entryz="7" rent="25000" townid="14" size="13" clientid="64012" beds="1" />
-	<house name="Sugar Street 4b" houseid="3420" entryx="32287" entryy="32810" entryz="7" rent="100000" townid="14" size="17" clientid="64011" beds="2" />
-	<house name="Sugar Street 4a" houseid="3421" entryx="32279" entryy="32813" entryz="7" rent="80000" townid="14" size="17" clientid="64010" beds="2" />
+	<house name="Pirate Shipwreck 1" houseid="3388" entryx="33278" entryy="32422" entryz="7" rent="800000" townid="13" size="187" clientid="62023" beds="6" />
+	<house name="Pirate Shipwreck 2" houseid="3389" entryx="33281" entryy="32431" entryz="7" rent="800000" townid="13" size="276" clientid="62024" beds="8" />
+	<house name="The Shelter" houseid="3390" entryx="32267" entryy="32859" entryz="7" rent="250000" guildhall="true" townid="14" size="422" clientid="65023" beds="31" />
+	<house name="Litter Promenade 1" houseid="3391" entryx="32271" entryy="32862" entryz="7" rent="25000" townid="14" size="15" clientid="65018" beds="2" />
+	<house name="Litter Promenade 2" houseid="3392" entryx="32277" entryy="32861" entryz="7" rent="50000" townid="14" size="14" clientid="65019" beds="1" />
+	<house name="Litter Promenade 3" houseid="3394" entryx="32286" entryy="32865" entryz="7" rent="25000" townid="14" size="21" clientid="65020" beds="1" />
+	<house name="Litter Promenade 4" houseid="3395" entryx="32288" entryy="32865" entryz="7" rent="25000" townid="14" size="18" clientid="65021" beds="1" />
+	<house name="Rum Alley 3" houseid="3396" entryx="32272" entryy="32854" entryz="7" rent="25000" townid="14" size="18" clientid="65011" beds="1" />
+	<house name="Straycat's Corner 5" houseid="3397" entryx="32281" entryy="32853" entryz="7" rent="80000" townid="14" size="25" clientid="65016" beds="2" />
+	<house name="Straycat's Corner 6" houseid="3398" entryx="32281" entryy="32858" entryz="7" rent="25000" townid="14" size="13" clientid="65017" beds="1" />
+	<house name="Litter Promenade 5" houseid="3399" entryx="32290" entryy="32859" entryz="7" rent="25000" townid="14" size="23" clientid="65022" beds="2" />
+	<house name="Straycat's Corner 4" houseid="3401" entryx="32291" entryy="32852" entryz="7" rent="50000" townid="14" size="23" clientid="65015" beds="2" />
+	<house name="Straycat's Corner 2" houseid="3402" entryx="32284" entryy="32845" entryz="7" rent="50000" townid="14" size="27" clientid="65013" beds="1" />
+	<house name="Straycat's Corner 1" houseid="3403" entryx="32280" entryy="32843" entryz="7" rent="25000" townid="14" size="14" clientid="65012" beds="1" />
+	<house name="Rum Alley 2" houseid="3404" entryx="32260" entryy="32846" entryz="7" rent="25000" townid="14" size="18" clientid="65010" beds="1" />
+	<house name="Rum Alley 1" houseid="3405" entryx="32257" entryy="32839" entryz="7" rent="25000" townid="14" size="25" clientid="65009" beds="1" />
+	<house name="Smuggler Backyard 3" houseid="3406" entryx="32263" entryy="32838" entryz="7" rent="50000" townid="14" size="27" clientid="65003" beds="2" />
+	<house name="Shady Trail 3" houseid="3407" entryx="32274" entryy="32835" entryz="7" rent="25000" townid="14" size="16" clientid="65008" beds="1" />
+	<house name="Shady Trail 1" houseid="3408" entryx="32283" entryy="32834" entryz="7" rent="100000" townid="14" size="34" clientid="65006" beds="5" />
+	<house name="Shady Trail 2" houseid="3409" entryx="32274" entryy="32830" entryz="7" rent="25000" townid="14" size="19" clientid="65007" beds="2" />
+	<house name="Smuggler Backyard 4" houseid="3410" entryx="32263" entryy="32830" entryz="7" rent="25000" townid="14" size="22" clientid="65004" beds="1" />
+	<house name="Smuggler Backyard 2" houseid="3411" entryx="32261" entryy="32829" entryz="7" rent="25000" townid="14" size="31" clientid="65002" beds="2" />
+	<house name="Smuggler Backyard 1" houseid="3412" entryx="32264" entryy="32823" entryz="7" rent="25000" townid="14" size="27" clientid="65001" beds="2" />
+	<house name="Smuggler Backyard 5" houseid="3413" entryx="32272" entryy="32823" entryz="7" rent="25000" townid="14" size="25" clientid="65005" beds="2" />
+	<house name="Sugar Street 1" houseid="3414" entryx="32256" entryy="32815" entryz="7" rent="200000" townid="14" size="60" clientid="64006" beds="3" />
+	<house name="Sugar Street 2" houseid="3415" entryx="32262" entryy="32815" entryz="7" rent="150000" townid="14" size="51" clientid="64007" beds="3" />
+	<house name="Sugar Street 3a" houseid="3416" entryx="32271" entryy="32813" entryz="7" rent="100000" townid="14" size="33" clientid="64008" beds="3" />
+	<house name="Sugar Street 3b" houseid="3417" entryx="32275" entryy="32798" entryz="7" rent="150000" townid="14" size="41" clientid="64009" beds="3" />
+	<house name="Sugar Street 4d" houseid="3418" entryx="32287" entryy="32801" entryz="7" rent="50000" townid="14" size="15" clientid="64013" beds="2" />
+	<house name="Sugar Street 4c" houseid="3419" entryx="32287" entryy="32805" entryz="7" rent="25000" townid="14" size="14" clientid="64012" beds="1" />
+	<house name="Sugar Street 4b" houseid="3420" entryx="32287" entryy="32810" entryz="7" rent="100000" townid="14" size="19" clientid="64011" beds="2" />
+	<house name="Sugar Street 4a" houseid="3421" entryx="32279" entryy="32813" entryz="7" rent="80000" townid="14" size="19" clientid="64010" beds="2" />
 	<house name="Harvester's Haven, Flat 01" houseid="3422" entryx="32274" entryy="32792" entryz="7" rent="50000" townid="14" size="17" clientid="64014" beds="2" />
 	<house name="Harvester's Haven, Flat 03" houseid="3423" entryx="32274" entryy="32787" entryz="7" rent="50000" townid="14" size="17" clientid="64016" beds="2" />
 	<house name="Harvester's Haven, Flat 05" houseid="3424" entryx="32274" entryy="32783" entryz="7" rent="50000" townid="14" size="17" clientid="64018" beds="2" />
 	<house name="Harvester's Haven, Flat 06" houseid="3425" entryx="32276" entryy="32783" entryz="7" rent="50000" townid="14" size="17" clientid="64019" beds="2" />
 	<house name="Harvester's Haven, Flat 04" houseid="3426" entryx="32276" entryy="32786" entryz="7" rent="50000" townid="14" size="17" clientid="64017" beds="2" />
 	<house name="Harvester's Haven, Flat 02" houseid="3427" entryx="32276" entryy="32791" entryz="7" rent="50000" townid="14" size="17" clientid="64015" beds="2" />
-	<house name="Harvester's Haven, Flat 07" houseid="3428" entryx="32274" entryy="32783" entryz="6" rent="80000" townid="14" size="17" clientid="64020" beds="2" />
-	<house name="Harvester's Haven, Flat 09" houseid="3429" entryx="32274" entryy="32787" entryz="6" rent="50000" townid="14" size="17" clientid="64022" beds="2" />
-	<house name="Harvester's Haven, Flat 11" houseid="3430" entryx="32274" entryy="32792" entryz="6" rent="25000" townid="14" size="17" clientid="64024" beds="2" />
-	<house name="Harvester's Haven, Flat 08" houseid="3431" entryx="32276" entryy="32783" entryz="6" rent="50000" townid="14" size="17" clientid="64021" beds="2" />
-	<house name="Harvester's Haven, Flat 10" houseid="3432" entryx="32276" entryy="32786" entryz="6" rent="50000" townid="14" size="17" clientid="64023" beds="2" />
-	<house name="Harvester's Haven, Flat 12" houseid="3433" entryx="32276" entryy="32791" entryz="6" rent="25000" townid="14" size="17" clientid="64025" beds="2" />
-	<house name="Marble Lane 3" houseid="3434" entryx="32301" entryy="32782" entryz="7" rent="600000" townid="14" size="141" clientid="63003" beds="4" />
-	<house name="Marble Lane 2" houseid="3435" entryx="32298" entryy="32782" entryz="7" rent="400000" townid="14" size="113" clientid="63002" beds="3" />
-	<house name="Marble Lane 4" houseid="3436" entryx="32298" entryy="32792" entryz="7" rent="400000" townid="14" size="110" clientid="63004" beds="4" />
-	<house name="Admiral's Avenue 1" houseid="3437" entryx="32309" entryy="32805" entryz="7" rent="400000" townid="14" size="91" clientid="63005" beds="2" />
-	<house name="Admiral's Avenue 2" houseid="3438" entryx="32326" entryy="32806" entryz="7" rent="400000" townid="14" size="94" clientid="63006" beds="4" />
-	<house name="Admiral's Avenue 3" houseid="3439" entryx="32336" entryy="32806" entryz="7" rent="300000" townid="14" size="73" clientid="63007" beds="2" />
-	<house name="Ivory Circle 1" houseid="3440" entryx="32347" entryy="32799" entryz="7" rent="400000" townid="14" size="76" clientid="63008" beds="2" />
+	<house name="Harvester's Haven, Flat 07" houseid="3428" entryx="32274" entryy="32783" entryz="6" rent="80000" townid="14" size="19" clientid="64020" beds="2" />
+	<house name="Harvester's Haven, Flat 09" houseid="3429" entryx="32274" entryy="32787" entryz="6" rent="50000" townid="14" size="18" clientid="64022" beds="2" />
+	<house name="Harvester's Haven, Flat 11" houseid="3430" entryx="32274" entryy="32792" entryz="6" rent="25000" townid="14" size="19" clientid="64024" beds="2" />
+	<house name="Harvester's Haven, Flat 08" houseid="3431" entryx="32276" entryy="32783" entryz="6" rent="50000" townid="14" size="19" clientid="64021" beds="2" />
+	<house name="Harvester's Haven, Flat 10" houseid="3432" entryx="32276" entryy="32786" entryz="6" rent="50000" townid="14" size="18" clientid="64023" beds="2" />
+	<house name="Harvester's Haven, Flat 12" houseid="3433" entryx="32276" entryy="32791" entryz="6" rent="25000" townid="14" size="19" clientid="64025" beds="2" />
+	<house name="Marble Lane 3" houseid="3434" entryx="32301" entryy="32782" entryz="7" rent="600000" townid="14" size="163" clientid="63003" beds="4" />
+	<house name="Marble Lane 2" houseid="3435" entryx="32298" entryy="32782" entryz="7" rent="400000" townid="14" size="141" clientid="63002" beds="3" />
+	<house name="Marble Lane 4" houseid="3436" entryx="32298" entryy="32792" entryz="7" rent="400000" townid="14" size="134" clientid="63004" beds="4" />
+	<house name="Admiral's Avenue 1" houseid="3437" entryx="32309" entryy="32805" entryz="7" rent="400000" townid="14" size="97" clientid="63005" beds="2" />
+	<house name="Admiral's Avenue 2" houseid="3438" entryx="32326" entryy="32806" entryz="7" rent="400000" townid="14" size="111" clientid="63006" beds="4" />
+	<house name="Admiral's Avenue 3" houseid="3439" entryx="32336" entryy="32806" entryz="7" rent="300000" townid="14" size="99" clientid="63007" beds="2" />
+	<house name="Ivory Circle 1" houseid="3440" entryx="32347" entryy="32799" entryz="7" rent="400000" townid="14" size="101" clientid="63008" beds="2" />
 	<house name="Sugar Street 5" houseid="3441" entryx="32301" entryy="32811" entryz="7" rent="150000" townid="14" size="25" clientid="64027" beds="2" />
 	<house name="Freedom Street 1" houseid="3442" entryx="32323" entryy="32812" entryz="7" rent="200000" townid="14" size="47" clientid="64001" beds="2" />
 	<house name="Trader's Point 1" houseid="3443" entryx="32306" entryy="32826" entryz="7" rent="200000" townid="14" size="42" clientid="64003" beds="2" />
-	<house name="Trader's Point 2 (Shop)" houseid="3444" entryx="32330" entryy="32826" entryz="7" rent="600000" townid="14" size="105" clientid="64004" beds="2" />
-	<house name="Trader's Point 3 (Shop)" houseid="3445" entryx="32344" entryy="32826" entryz="7" rent="600000" townid="14" size="117" clientid="64005" beds="2" />
-	<house name="Ivory Mansion" houseid="3446" entryx="32345" entryy="32843" entryz="7" rent="800000" townid="14" size="265" clientid="63012" beds="7" />
-	<house name="Ivory Circle 2" houseid="3447" entryx="32364" entryy="32818" entryz="7" rent="400000" townid="14" size="126" clientid="63009" beds="2" />
-	<house name="Ivy Cottage" houseid="3448" entryx="32277" entryy="32775" entryz="7" rent="500000" guildhall="true" townid="14" size="563" clientid="64026" beds="26" />
-	<house name="Marble Lane 1" houseid="3449" entryx="32300" entryy="32772" entryz="7" rent="600000" townid="14" size="192" clientid="63001" beds="6" />
-	<house name="Freedom Street 2" houseid="3450" entryx="32325" entryy="32812" entryz="7" rent="400000" townid="14" size="115" clientid="64002" beds="4" />
-	<house name="Meriana Beach" houseid="3452" entryx="32383" entryy="32584" entryz="7" rent="150000" townid="14" size="146" clientid="63010" beds="3" />
-	<house name="The Tavern 1a" houseid="3453" entryx="32295" entryy="32837" entryz="6" rent="150000" townid="14" size="49" clientid="64029" beds="4" />
-	<house name="The Tavern 1b" houseid="3454" entryx="32297" entryy="32836" entryz="6" rent="100000" townid="14" size="36" clientid="64030" beds="2" />
-	<house name="The Tavern 1c" houseid="3455" entryx="32299" entryy="32839" entryz="6" rent="200000" townid="14" size="79" clientid="64031" beds="3" />
-	<house name="The Tavern 1d" houseid="3456" entryx="32297" entryy="32840" entryz="6" rent="100000" townid="14" size="29" clientid="64032" beds="2" />
-	<house name="The Tavern 2a" houseid="3457" entryx="32301" entryy="32835" entryz="5" rent="300000" townid="14" size="103" clientid="64033" beds="5" />
-	<house name="The Tavern 2b" houseid="3458" entryx="32303" entryy="32838" entryz="5" rent="100000" townid="14" size="32" clientid="64034" beds="2" />
-	<house name="The Tavern 2d" houseid="3459" entryx="32298" entryy="32838" entryz="5" rent="100000" townid="14" size="25" clientid="64036" beds="2" />
-	<house name="The Tavern 2c" houseid="3460" entryx="32302" entryy="32838" entryz="5" rent="50000" townid="14" size="19" clientid="64035" beds="1" />
-	<house name="The Yeah Beach Project" houseid="3461" entryx="32294" entryy="32555" entryz="6" rent="150000" townid="14" size="115" clientid="63011" beds="3" />
-	<house name="Mountain Hideout" houseid="3462" entryx="32392" entryy="32705" entryz="6" rent="500000" guildhall="true" townid="14" size="279" clientid="64028" beds="17" />
-	<house name="Darashia 8, Flat 02" houseid="3463" entryx="33249" entryy="32447" entryz="7" rent="300000" townid="13" size="73" clientid="62012" beds="2" />
+	<house name="Trader's Point 2 (Shop)" houseid="3444" entryx="32330" entryy="32826" entryz="7" rent="600000" townid="14" size="122" clientid="64004" beds="2" />
+	<house name="Trader's Point 3 (Shop)" houseid="3445" entryx="32344" entryy="32826" entryz="7" rent="600000" townid="14" size="130" clientid="64005" beds="2" />
+	<house name="Ivory Mansion" houseid="3446" entryx="32345" entryy="32843" entryz="7" rent="800000" townid="14" size="319" clientid="63012" beds="7" />
+	<house name="Ivory Circle 2" houseid="3447" entryx="32364" entryy="32818" entryz="7" rent="400000" townid="14" size="142" clientid="63009" beds="2" />
+	<house name="Ivy Cottage" houseid="3448" entryx="32277" entryy="32775" entryz="7" rent="500000" guildhall="true" townid="14" size="587" clientid="64026" beds="26" />
+	<house name="Marble Lane 1" houseid="3449" entryx="32300" entryy="32772" entryz="7" rent="600000" townid="14" size="228" clientid="63001" beds="6" />
+	<house name="Freedom Street 2" houseid="3450" entryx="32325" entryy="32812" entryz="7" rent="400000" townid="14" size="123" clientid="64002" beds="4" />
+	<house name="Meriana Beach" houseid="3452" entryx="32383" entryy="32584" entryz="7" rent="150000" townid="14" size="172" clientid="63010" beds="3" />
+	<house name="The Tavern 1a" houseid="3453" entryx="32295" entryy="32837" entryz="6" rent="150000" townid="14" size="52" clientid="64029" beds="4" />
+	<house name="The Tavern 1b" houseid="3454" entryx="32297" entryy="32836" entryz="6" rent="100000" townid="14" size="38" clientid="64030" beds="2" />
+	<house name="The Tavern 1c" houseid="3455" entryx="32299" entryy="32839" entryz="6" rent="200000" townid="14" size="85" clientid="64031" beds="3" />
+	<house name="The Tavern 1d" houseid="3456" entryx="32297" entryy="32840" entryz="6" rent="100000" townid="14" size="33" clientid="64032" beds="2" />
+	<house name="The Tavern 2a" houseid="3457" entryx="32301" entryy="32835" entryz="5" rent="300000" townid="14" size="111" clientid="64033" beds="5" />
+	<house name="The Tavern 2b" houseid="3458" entryx="32303" entryy="32838" entryz="5" rent="100000" townid="14" size="36" clientid="64034" beds="2" />
+	<house name="The Tavern 2d" houseid="3459" entryx="32298" entryy="32838" entryz="5" rent="100000" townid="14" size="27" clientid="64036" beds="2" />
+	<house name="The Tavern 2c" houseid="3460" entryx="32302" entryy="32838" entryz="5" rent="50000" townid="14" size="20" clientid="64035" beds="1" />
+	<house name="The Yeah Beach Project" houseid="3461" entryx="32294" entryy="32555" entryz="6" rent="150000" townid="14" size="155" clientid="63011" beds="3" />
+	<house name="Mountain Hideout" houseid="3462" entryx="32392" entryy="32705" entryz="6" rent="500000" guildhall="true" townid="14" size="321" clientid="64028" beds="17" />
+	<house name="Darashia 8, Flat 02" houseid="3463" entryx="33249" entryy="32447" entryz="7" rent="300000" townid="13" size="76" clientid="62012" beds="2" />
 	<house name="Castle, Basement, Flat 01" houseid="3464" entryx="33204" entryy="31790" entryz="8" rent="50000" townid="11" size="13" clientid="50120" beds="1" />
 	<house name="Castle, Basement, Flat 02" houseid="3465" entryx="33204" entryy="31791" entryz="8" rent="50000" townid="11" size="13" clientid="50121" beds="1" />
 	<house name="Castle, Basement, Flat 03" houseid="3466" entryx="33208" entryy="31791" entryz="8" rent="50000" townid="11" size="13" clientid="50122" beds="1" />
@@ -779,33 +779,33 @@
 	<house name="Castle, Basement, Flat 07" houseid="3470" entryx="33216" entryy="31791" entryz="8" rent="50000" townid="11" size="13" clientid="50126" beds="1" />
 	<house name="Castle, Basement, Flat 09" houseid="3471" entryx="33220" entryy="31790" entryz="8" rent="25000" townid="11" size="13" clientid="50128" beds="1" />
 	<house name="Castle, Basement, Flat 08" houseid="3472" entryx="33220" entryy="31791" entryz="8" rent="50000" townid="11" size="13" clientid="50127" beds="1" />
-	<house name="Cormaya 1" houseid="3473" entryx="33302" entryy="31963" entryz="7" rent="150000" townid="11" size="26" clientid="54013" beds="2" />
-	<house name="Cormaya Flats, Flat 01" houseid="3474" entryx="33311" entryy="31965" entryz="7" rent="25000" townid="11" size="10" clientid="54001" beds="1" />
-	<house name="Cormaya Flats, Flat 02" houseid="3475" entryx="33315" entryy="31965" entryz="7" rent="25000" townid="11" size="10" clientid="54002" beds="1" />
-	<house name="Cormaya Flats, Flat 03" houseid="3476" entryx="33320" entryy="31965" entryz="7" rent="50000" townid="11" size="16" clientid="54003" beds="2" />
-	<house name="Cormaya Flats, Flat 06" houseid="3477" entryx="33311" entryy="31966" entryz="7" rent="25000" townid="11" size="10" clientid="54006" beds="1" />
-	<house name="Cormaya Flats, Flat 05" houseid="3478" entryx="33315" entryy="31966" entryz="7" rent="25000" townid="11" size="10" clientid="54005" beds="1" />
-	<house name="Cormaya Flats, Flat 04" houseid="3479" entryx="33320" entryy="31966" entryz="7" rent="50000" townid="11" size="16" clientid="54004" beds="2" />
-	<house name="Cormaya Flats, Flat 11" houseid="3480" entryx="33311" entryy="31965" entryz="6" rent="100000" townid="11" size="22" clientid="54007" beds="2" />
-	<house name="Cormaya Flats, Flat 13" houseid="3482" entryx="33318" entryy="31965" entryz="6" rent="25000" townid="11" size="16" clientid="54009" beds="2" />
-	<house name="Cormaya Flats, Flat 12" houseid="3483" entryx="33311" entryy="31966" entryz="6" rent="100000" townid="11" size="22" clientid="54012" beds="2" />
-	<house name="Cormaya Flats, Flat 14" houseid="3485" entryx="33318" entryy="31966" entryz="6" rent="25000" townid="11" size="16" clientid="54010" beds="2" />
-	<house name="Cormaya 2" houseid="3486" entryx="33297" entryy="31968" entryz="7" rent="300000" townid="11" size="78" clientid="54014" beds="3" />
-	<house name="Cormaya 4" houseid="3487" entryx="33292" entryy="31982" entryz="7" rent="150000" townid="11" size="36" clientid="54016" beds="2" />
-	<house name="Cormaya 3" houseid="3488" entryx="33304" entryy="31978" entryz="7" rent="200000" townid="11" size="43" clientid="54015" beds="2" />
-	<house name="Cormaya 6" houseid="3489" entryx="33287" entryy="31988" entryz="7" rent="200000" townid="11" size="51" clientid="54018" beds="2" />
-	<house name="Cormaya 7" houseid="3490" entryx="33287" entryy="31994" entryz="7" rent="200000" townid="11" size="51" clientid="54019" beds="2" />
-	<house name="Cormaya 8" houseid="3491" entryx="33287" entryy="32000" entryz="7" rent="200000" townid="11" size="58" clientid="54020" beds="2" />
-	<house name="Cormaya 5" houseid="3492" entryx="33278" entryy="31980" entryz="7" rent="300000" townid="11" size="115" clientid="54017" beds="3" />
-	<house name="Castle of the White Dragon" houseid="3493" entryx="33297" entryy="31986" entryz="7" rent="1000000" guildhall="true" townid="11" size="518" clientid="54027" beds="19" />
-	<house name="Cormaya 9b" houseid="3494" entryx="33286" entryy="32012" entryz="7" rent="150000" townid="11" size="56" clientid="54022" beds="2" />
-	<house name="Cormaya 9a" houseid="3495" entryx="33288" entryy="32013" entryz="7" rent="80000" townid="11" size="25" clientid="54021" beds="2" />
-	<house name="Cormaya 9d" houseid="3496" entryx="33286" entryy="32012" entryz="6" rent="150000" townid="11" size="56" clientid="54024" beds="2" />
-	<house name="Cormaya 9c" houseid="3497" entryx="33288" entryy="32013" entryz="6" rent="80000" townid="11" size="25" clientid="54023" beds="2" />
-	<house name="Cormaya 10" houseid="3498" entryx="33294" entryy="32005" entryz="7" rent="300000" townid="11" size="80" clientid="54025" beds="3" />
-	<house name="Cormaya 11" houseid="3499" entryx="33305" entryy="32005" entryz="7" rent="150000" townid="11" size="43" clientid="54026" beds="2" />
-	<house name="Edron Flats, Flat 22" houseid="3500" entryx="33189" entryy="31845" entryz="5" rent="50000" townid="11" size="10" clientid="50318" beds="1" />
-	<house name="Magic Academy, Shop" houseid="3501" entryx="33254" entryy="31840" entryz="8" rent="150000" townid="11" size="29" clientid="50702" beds="1" />
+	<house name="Cormaya 1" houseid="3473" entryx="33302" entryy="31963" entryz="7" rent="150000" townid="11" size="30" clientid="54013" beds="2" />
+	<house name="Cormaya Flats, Flat 01" houseid="3474" entryx="33311" entryy="31965" entryz="7" rent="25000" townid="11" size="11" clientid="54001" beds="1" />
+	<house name="Cormaya Flats, Flat 02" houseid="3475" entryx="33315" entryy="31965" entryz="7" rent="25000" townid="11" size="11" clientid="54002" beds="1" />
+	<house name="Cormaya Flats, Flat 03" houseid="3476" entryx="33320" entryy="31965" entryz="7" rent="50000" townid="11" size="17" clientid="54003" beds="2" />
+	<house name="Cormaya Flats, Flat 06" houseid="3477" entryx="33311" entryy="31966" entryz="7" rent="25000" townid="11" size="11" clientid="54006" beds="1" />
+	<house name="Cormaya Flats, Flat 05" houseid="3478" entryx="33315" entryy="31966" entryz="7" rent="25000" townid="11" size="11" clientid="54005" beds="1" />
+	<house name="Cormaya Flats, Flat 04" houseid="3479" entryx="33320" entryy="31966" entryz="7" rent="50000" townid="11" size="17" clientid="54004" beds="2" />
+	<house name="Cormaya Flats, Flat 11" houseid="3480" entryx="33311" entryy="31965" entryz="6" rent="100000" townid="11" size="24" clientid="54007" beds="2" />
+	<house name="Cormaya Flats, Flat 13" houseid="3482" entryx="33318" entryy="31965" entryz="6" rent="25000" townid="11" size="17" clientid="54009" beds="2" />
+	<house name="Cormaya Flats, Flat 12" houseid="3483" entryx="33311" entryy="31966" entryz="6" rent="100000" townid="11" size="24" clientid="54012" beds="2" />
+	<house name="Cormaya Flats, Flat 14" houseid="3485" entryx="33318" entryy="31966" entryz="6" rent="25000" townid="11" size="17" clientid="54010" beds="2" />
+	<house name="Cormaya 2" houseid="3486" entryx="33297" entryy="31968" entryz="7" rent="300000" townid="11" size="84" clientid="54014" beds="3" />
+	<house name="Cormaya 4" houseid="3487" entryx="33292" entryy="31982" entryz="7" rent="150000" townid="11" size="39" clientid="54016" beds="2" />
+	<house name="Cormaya 3" houseid="3488" entryx="33304" entryy="31978" entryz="7" rent="200000" townid="11" size="47" clientid="54015" beds="2" />
+	<house name="Cormaya 6" houseid="3489" entryx="33287" entryy="31988" entryz="7" rent="200000" townid="11" size="56" clientid="54018" beds="2" />
+	<house name="Cormaya 7" houseid="3490" entryx="33287" entryy="31994" entryz="7" rent="200000" townid="11" size="54" clientid="54019" beds="2" />
+	<house name="Cormaya 8" houseid="3491" entryx="33287" entryy="32000" entryz="7" rent="200000" townid="11" size="65" clientid="54020" beds="2" />
+	<house name="Cormaya 5" houseid="3492" entryx="33278" entryy="31980" entryz="7" rent="300000" townid="11" size="123" clientid="54017" beds="3" />
+	<house name="Castle of the White Dragon" houseid="3493" entryx="33297" entryy="31986" entryz="7" rent="1000000" guildhall="true" townid="11" size="532" clientid="54027" beds="19" />
+	<house name="Cormaya 9b" houseid="3494" entryx="33286" entryy="32012" entryz="7" rent="150000" townid="11" size="58" clientid="54022" beds="2" />
+	<house name="Cormaya 9a" houseid="3495" entryx="33288" entryy="32013" entryz="7" rent="80000" townid="11" size="28" clientid="54021" beds="2" />
+	<house name="Cormaya 9d" houseid="3496" entryx="33286" entryy="32012" entryz="6" rent="150000" townid="11" size="60" clientid="54024" beds="2" />
+	<house name="Cormaya 9c" houseid="3497" entryx="33288" entryy="32013" entryz="6" rent="80000" townid="11" size="28" clientid="54023" beds="2" />
+	<house name="Cormaya 10" houseid="3498" entryx="33294" entryy="32005" entryz="7" rent="300000" townid="11" size="85" clientid="54025" beds="3" />
+	<house name="Cormaya 11" houseid="3499" entryx="33305" entryy="32005" entryz="7" rent="150000" townid="11" size="47" clientid="54026" beds="2" />
+	<house name="Edron Flats, Flat 22" houseid="3500" entryx="33189" entryy="31845" entryz="5" rent="50000" townid="11" size="12" clientid="50318" beds="1" />
+	<house name="Magic Academy, Shop" houseid="3501" entryx="33254" entryy="31840" entryz="8" rent="150000" townid="11" size="23" clientid="50702" beds="1" />
 	<house name="Magic Academy, Flat 1" houseid="3502" entryx="33282" entryy="31832" entryz="8" rent="100000" townid="11" size="23" clientid="50703" beds="3" />
 	<house name="Magic Academy, Guild" houseid="3503" entryx="33271" entryy="31825" entryz="6" rent="500000" guildhall="true" townid="11" size="195" clientid="50701" beds="14" />
 	<house name="Magic Academy, Flat 2" houseid="3504" entryx="33282" entryy="31832" entryz="7" rent="80000" townid="11" size="26" clientid="50704" beds="2" />
@@ -829,7 +829,7 @@
 	<house name="Murkhol I c" houseid="3523" entryx="33084" entryy="32841" entryz="7" rent="50000" townid="10" size="11" clientid="59023" beds="1" />
 	<house name="Murkhol I b" houseid="3524" entryx="33084" entryy="32841" entryz="7" rent="50000" townid="10" size="11" clientid="59022" beds="1" />
 	<house name="Charsirakh I b" houseid="3525" entryx="33073" entryy="32820" entryz="7" rent="150000" townid="10" size="37" clientid="59001" beds="2" />
-	<house name="Harrah I" houseid="3526" entryx="33088" entryy="32827" entryz="7" rent="250000" guildhall="true" townid="10" size="121" clientid="59020" beds="10" />
+	<house name="Harrah I" houseid="3526" entryx="33088" entryy="32827" entryz="7" rent="250000" guildhall="true" townid="10" size="124" clientid="59020" beds="10" />
 	<house name="Thanah I d" houseid="3527" entryx="33109" entryy="32826" entryz="7" rent="200000" townid="10" size="52" clientid="58005" beds="4" />
 	<house name="Thanah I c" houseid="3528" entryx="33109" entryy="32811" entryz="7" rent="200000" townid="10" size="61" clientid="58004" beds="3" />
 	<house name="Thanah I b" houseid="3529" entryx="33114" entryy="32821" entryz="6" rent="150000" townid="10" size="56" clientid="58003" beds="3" />
@@ -869,7 +869,7 @@
 	<house name="Esuph IV c" houseid="3564" entryx="33239" entryy="32832" entryz="7" rent="80000" townid="10" size="23" clientid="59074" beds="2" />
 	<house name="Esuph IV d" houseid="3565" entryx="33236" entryy="32839" entryz="7" rent="25000" townid="10" size="20" clientid="59075" beds="1" />
 	<house name="Esuph IV a" houseid="3566" entryx="33234" entryy="32831" entryz="6" rent="25000" townid="10" size="10" clientid="59072" beds="1" />
-	<house name="Horakhal" houseid="3567" entryx="33217" entryy="32836" entryz="6" rent="250000" guildhall="true" townid="10" size="203" clientid="59076" beds="14" />
+	<house name="Horakhal" houseid="3567" entryx="33217" entryy="32836" entryz="6" rent="250000" guildhall="true" townid="10" size="205" clientid="59076" beds="14" />
 	<house name="Botham II d" houseid="3568" entryx="33209" entryy="32849" entryz="7" rent="100000" townid="10" size="37" clientid="58026" beds="2" />
 	<house name="Botham II e" houseid="3569" entryx="33220" entryy="32845" entryz="7" rent="100000" townid="10" size="31" clientid="58027" beds="2" />
 	<house name="Botham II f" houseid="3570" entryx="33213" entryy="32860" entryz="7" rent="80000" townid="10" size="31" clientid="58028" beds="2" />
@@ -888,16 +888,16 @@
 	<house name="Botham IV h" houseid="3584" entryx="33167" entryy="32861" entryz="7" rent="100000" townid="10" size="37" clientid="58045" beds="1" />
 	<house name="Botham IV i" houseid="3585" entryx="33180" entryy="32865" entryz="7" rent="150000" townid="10" size="32" clientid="58046" beds="3" />
 	<house name="Botham IV g" houseid="3586" entryx="33179" entryy="32849" entryz="7" rent="100000" townid="10" size="31" clientid="58044" beds="2" />
-	<house name="Botham IV e" houseid="3587" entryx="33169" entryy="32855" entryz="6" rent="100000" townid="10" size="84" clientid="58042" beds="5" />
+	<house name="Botham IV e" houseid="3587" entryx="33169" entryy="32855" entryz="6" rent="100000" townid="10" size="85" clientid="58042" beds="5" />
 	<house name="Botham IV a" houseid="3591" entryx="33175" entryy="32853" entryz="5" rent="100000" townid="10" size="26" clientid="58038" beds="2" />
-	<house name="Ramen Tah" houseid="3592" entryx="33174" entryy="32843" entryz="7" rent="250000" guildhall="true" townid="10" size="124" clientid="58047" beds="16" />
+	<house name="Ramen Tah" houseid="3592" entryx="33174" entryy="32843" entryz="7" rent="250000" guildhall="true" townid="10" size="125" clientid="58047" beds="16" />
 	<house name="Botham I c" houseid="3593" entryx="33187" entryy="32830" entryz="7" rent="150000" townid="10" size="32" clientid="58020" beds="2" />
 	<house name="Botham I e" houseid="3594" entryx="33192" entryy="32838" entryz="7" rent="80000" townid="10" size="31" clientid="58022" beds="2" />
 	<house name="Botham I d" houseid="3595" entryx="33199" entryy="32838" entryz="7" rent="150000" townid="10" size="57" clientid="58021" beds="3" />
 	<house name="Botham I b" houseid="3596" entryx="33195" entryy="32836" entryz="6" rent="150000" townid="10" size="56" clientid="58019" beds="3" />
 	<house name="Botham I a" houseid="3597" entryx="33199" entryy="32831" entryz="5" rent="50000" townid="10" size="19" clientid="58018" beds="1" />
 	<house name="Charsirakh I a" houseid="3598" entryx="33076" entryy="32816" entryz="6" rent="25000" townid="10" size="7" clientid="59000" beds="1" />
-	<house name="Low Waters Observatory" houseid="3599" entryx="33335" entryy="32763" entryz="6" rent="400000" townid="10" size="480" clientid="57001" beds="5" />
+	<house name="Low Waters Observatory" houseid="3599" entryx="33335" entryy="32763" entryz="6" rent="400000" townid="10" size="525" clientid="57001" beds="5" />
 	<house name="Oskahl I a" houseid="3600" entryx="33077" entryy="32865" entryz="5" rent="150000" townid="10" size="37" clientid="59025" beds="2" />
 	<house name="Othehothep I a" houseid="3601" entryx="33089" entryy="32805" entryz="5" rent="25000" townid="10" size="7" clientid="59004" beds="1" />
 	<house name="Othehothep III a" houseid="3602" entryx="33131" entryy="32793" entryz="5" rent="25000" townid="10" size="7" clientid="59014" beds="1" />
@@ -921,70 +921,70 @@
 	<house name="Thanah II f" houseid="3620" entryx="33105" entryy="32840" entryz="7" rent="150000" townid="10" size="53" clientid="58011" beds="3" />
 	<house name="Thanah II g" houseid="3621" entryx="33104" entryy="32841" entryz="7" rent="100000" townid="10" size="31" clientid="58012" beds="2" />
 	<house name="Thanah II h" houseid="3622" entryx="33105" entryy="32841" entryz="7" rent="100000" townid="10" size="26" clientid="58013" beds="2" />
-	<house name="Thrarhor I a (Shop)" houseid="3623" entryx="33128" entryy="32811" entryz="7" rent="50000" townid="10" size="21" clientid="58014" beds="1" />
-	<house name="Thrarhor I c (Shop)" houseid="3624" entryx="33128" entryy="32819" entryz="7" rent="50000" townid="10" size="21" clientid="58016" beds="1" />
-	<house name="Thrarhor I d (Shop)" houseid="3625" entryx="33132" entryy="32819" entryz="7" rent="80000" townid="10" size="21" clientid="58017" beds="1" />
-	<house name="Thrarhor I b (Shop)" houseid="3626" entryx="33132" entryy="32811" entryz="7" rent="50000" townid="10" size="21" clientid="58015" beds="1" />
+	<house name="Thrarhor I a (Shop)" houseid="3623" entryx="33128" entryy="32811" entryz="7" rent="50000" townid="10" size="15" clientid="58014" beds="1" />
+	<house name="Thrarhor I c (Shop)" houseid="3624" entryx="33128" entryy="32819" entryz="7" rent="50000" townid="10" size="15" clientid="58016" beds="1" />
+	<house name="Thrarhor I d (Shop)" houseid="3625" entryx="33132" entryy="32819" entryz="7" rent="80000" townid="10" size="15" clientid="58017" beds="1" />
+	<house name="Thrarhor I b (Shop)" houseid="3626" entryx="33132" entryy="32811" entryz="7" rent="50000" townid="10" size="15" clientid="58015" beds="1" />
 	<house name="Uthemath I a" houseid="3627" entryx="33188" entryy="32812" entryz="5" rent="25000" townid="10" size="10" clientid="59060" beds="1" />
 	<house name="Uthemath I b" houseid="3628" entryx="33183" entryy="32811" entryz="6" rent="50000" townid="10" size="20" clientid="59061" beds="1" />
 	<house name="Uthemath I c" houseid="3629" entryx="33193" entryy="32811" entryz="6" rent="80000" townid="10" size="20" clientid="59062" beds="2" />
 	<house name="Uthemath I d" houseid="3630" entryx="33181" entryy="32806" entryz="7" rent="80000" townid="10" size="21" clientid="59063" beds="1" />
 	<house name="Uthemath I e" houseid="3631" entryx="33195" entryy="32806" entryz="7" rent="80000" townid="10" size="21" clientid="59064" beds="2" />
 	<house name="Uthemath I f" houseid="3632" entryx="33189" entryy="32816" entryz="7" rent="150000" townid="10" size="56" clientid="59065" beds="3" />
-	<house name="Uthemath II" houseid="3633" entryx="33208" entryy="32816" entryz="7" rent="250000" guildhall="true" townid="10" size="94" clientid="59066" beds="8" />
-	<house name="Marketplace 1" houseid="3634" entryx="33937" entryy="31505" entryz="7" rent="400000" townid="22" size="74" clientid="48001" beds="2" />
-	<house name="Marketplace 2" houseid="3635" entryx="33951" entryy="31501" entryz="7" rent="400000" townid="22" size="81" clientid="48002" beds="2" />
-	<house name="Quay 1" houseid="3636" entryx="33885" entryy="31552" entryz="7" rent="200000" townid="22" size="124" clientid="48003" beds="4" />
-	<house name="Quay 2" houseid="3637" entryx="33896" entryy="31544" entryz="7" rent="200000" townid="22" size="81" clientid="48004" beds="3" />
-	<house name="Halls of Sun and Sea" houseid="3638" entryx="33909" entryy="31535" entryz="7" rent="1000000" guildhall="true" townid="22" size="369" clientid="48007" beds="15" />
-	<house name="Palace Vicinity" houseid="3639" entryx="33866" entryy="31516" entryz="7" rent="200000" townid="22" size="114" clientid="48006" beds="4" />
-	<house name="Wave Tower" houseid="3640" entryx="33879" entryy="31525" entryz="7" rent="400000" townid="22" size="178" clientid="48005" beds="6" />
-	<house name="Old Sanctuary of God King Qjell" houseid="3641" entryx="33473" entryy="31310" entryz="9" rent="300000" townid="18" size="537" clientid="17001" beds="6" />
-	<house name="Old Heritage Estate" houseid="3642" entryx="33598" entryy="31909" entryz="6" rent="600000" townid="20" size="255" clientid="19009" beds="7" />
-	<house name="Rathleton Plaza 4" houseid="3643" entryx="33604" entryy="31915" entryz="6" rent="400000" townid="20" size="109" clientid="19018" beds="2" />
-	<house name="Rathleton Plaza 3" houseid="3644" entryx="33615" entryy="31913" entryz="6" rent="400000" townid="20" size="123" clientid="19006" beds="3" />
-	<house name="Rathleton Plaza 2" houseid="3645" entryx="33625" entryy="31912" entryz="6" rent="400000" townid="20" size="56" clientid="19005" beds="2" />
-	<house name="Rathleton Plaza 1" houseid="3646" entryx="33637" entryy="31911" entryz="6" rent="300000" townid="20" size="62" clientid="19004" beds="2" />
-	<house name="Antimony Lane 2" houseid="3647" entryx="33637" entryy="31921" entryz="6" rent="400000" townid="20" size="101" clientid="19015" beds="3" />
-	<house name="Antimony Lane 1" houseid="3648" entryx="33656" entryy="31915" entryz="6" rent="400000" townid="20" size="149" clientid="19014" beds="5" />
-	<house name="Wallside Residence" houseid="3649" entryx="33658" entryy="31921" entryz="6" rent="400000" townid="20" size="144" clientid="19001" beds="4" />
-	<house name="Wallside Lane 1" houseid="3650" entryx="33646" entryy="31933" entryz="6" rent="800000" townid="20" size="162" clientid="19010" beds="4" />
-	<house name="Wallside Lane 2" houseid="3651" entryx="33637" entryy="31928" entryz="6" rent="600000" townid="20" size="181" clientid="19011" beds="4" />
-	<house name="Vanward Flats B" houseid="3652" entryx="33614" entryy="31935" entryz="6" rent="400000" townid="20" size="158" clientid="19013" beds="4" />
-	<house name="Vanward Flats A" houseid="3653" entryx="33621" entryy="31935" entryz="6" rent="400000" townid="20" size="158" clientid="19012" beds="4" />
-	<house name="Bronze Brothers Bastion" houseid="3654" entryx="33599" entryy="31933" entryz="6" rent="5000000" guildhall="true" townid="20" size="749" clientid="19007" beds="16" />
-	<house name="Cistern Ave" houseid="3655" entryx="33588" entryy="31926" entryz="6" rent="300000" townid="20" size="81" clientid="19008" beds="2" />
-	<house name="Antimony Lane 4" houseid="3656" entryx="33614" entryy="31922" entryz="6" rent="400000" townid="20" size="110" clientid="19017" beds="3" />
-	<house name="Antimony Lane 3" houseid="3657" entryx="33630" entryy="31921" entryz="6" rent="400000" townid="20" size="77" clientid="19016" beds="3" />
-	<house name="Rathleton Hills Residence" houseid="3658" entryx="33651" entryy="31910" entryz="6" rent="400000" townid="20" size="155" clientid="19003" beds="3" />
-	<house name="Rathleton Hills Estate" houseid="3659" entryx="33662" entryy="31917" entryz="6" rent="1000000" guildhall="true" townid="20" size="433" clientid="19002" beds="13" />
-	<house name="Lion's Head Reef" houseid="3660" entryx="32365" entryy="32501" entryz="7" rent="400000" townid="14" size="149" clientid="63013" beds="5" />
-	<house name="Shadow Caves 1" houseid="3661" entryx="32654" entryy="31672" entryz="8" rent="50000" townid="5" size="22" clientid="40611" beds="2" />
-	<house name="Shadow Caves 2" houseid="3662" entryx="32656" entryy="31672" entryz="8" rent="50000" townid="5" size="22" clientid="40614" beds="2" />
-	<house name="Shadow Caves 3" houseid="3663" entryx="32654" entryy="31664" entryz="9" rent="100000" townid="5" size="44" clientid="40621" beds="4" />
-	<house name="Shadow Caves 4" houseid="3664" entryx="32656" entryy="31664" entryz="9" rent="100000" townid="5" size="44" clientid="40622" beds="4" />
-	<house name="Shadow Caves 5" houseid="3665" entryx="32654" entryy="31672" entryz="9" rent="100000" townid="5" size="44" clientid="40625" beds="4" />
-	<house name="Shadow Caves 6" houseid="3666" entryx="32656" entryy="31672" entryz="9" rent="100000" townid="5" size="44" clientid="40638" beds="4" />
-	<house name="Northport Clanhall" houseid="3667" entryx="32468" entryy="31614" entryz="7" rent="250000" guildhall="true" townid="6" size="162" clientid="22008" beds="10" />
-	<house name="The Treehouse" houseid="3668" entryx="32747" entryy="32697" entryz="7" rent="250000" guildhall="true" townid="15" size="548" clientid="47001" beds="23" />
-	<house name="Frost Manor" houseid="3669" entryx="32287" entryy="31106" entryz="5" rent="500000" guildhall="true" townid="16" size="434" clientid="55303" beds="26" />
-	<house name="Hare's Den" houseid="3670" entryx="32687" entryy="32193" entryz="10" rent="150000" townid="7" size="180" clientid="32016" beds="4" />
-	<house name="Lost Cavern" houseid="3671" entryx="32559" entryy="31856" entryz="7" rent="200000" townid="7" size="471" clientid="33001" beds="7" />
-	<house name="Caveman Shelter" houseid="3673" entryx="33007" entryy="31426" entryz="6" rent="150000" townid="12" size="87" clientid="15001" beds="4" />
-	<house name="Eastern House of Tranquility" houseid="3674" entryx="33389" entryy="31453" entryz="4" rent="200000" townid="12" size="268" clientid="15002" beds="5" />
-	<house name="Lakeside Mansion" houseid="3675" entryx="32322" entryy="31147" entryz="6" rent="300000" townid="16" size="149" clientid="55015" beds="5" />
-	<house name="Pilchard Bin 1" houseid="3676" entryx="32280" entryy="31164" entryz="7" rent="80000" townid="16" size="13" clientid="55116" beds="2" />
-	<house name="Pilchard Bin 2" houseid="3677" entryx="32280" entryy="31160" entryz="7" rent="50000" townid="16" size="13" clientid="55117" beds="2" />
-	<house name="Pilchard Bin 3" houseid="3678" entryx="32280" entryy="31156" entryz="7" rent="50000" townid="16" size="13" clientid="55118" beds="1" />
-	<house name="Pilchard Bin 4" houseid="3679" entryx="32280" entryy="31152" entryz="7" rent="50000" townid="16" size="13" clientid="55119" beds="1" />
-	<house name="Pilchard Bin 5" houseid="3680" entryx="32280" entryy="31148" entryz="7" rent="80000" townid="16" size="13" clientid="55120" beds="2" />
-	<house name="Pilchard Bin 6" houseid="3681" entryx="32281" entryy="31164" entryz="6" rent="25000" townid="16" size="10" clientid="55121" beds="1" />
-	<house name="Pilchard Bin 7" houseid="3682" entryx="32281" entryy="31160" entryz="6" rent="25000" townid="16" size="10" clientid="55122" beds="1" />
-	<house name="Pilchard Bin 8" houseid="3683" entryx="32281" entryy="31156" entryz="6" rent="25000" townid="16" size="10" clientid="55123" beds="2" />
-	<house name="Pilchard Bin 9" houseid="3684" entryx="32281" entryy="31152" entryz="6" rent="50000" townid="16" size="10" clientid="55124" beds="1" />
-	<house name="Pilchard Bin 10" houseid="3685" entryx="32281" entryy="31148" entryz="6" rent="50000" townid="16" size="10" clientid="55125" beds="1" />
-	<house name="Mammoth House" houseid="3686" entryx="32234" entryy="31227" entryz="7" rent="300000" townid="16" size="176" clientid="55014" beds="6" />
-	<house name="Cherry Cake Tower" houseid="3687" entryx="33450" entryy="32103" entryz="7" rent="800000" townid="29" size="153" clientid="53503" beds="7" />
+	<house name="Uthemath II" houseid="3633" entryx="33208" entryy="32816" entryz="7" rent="250000" guildhall="true" townid="10" size="93" clientid="59066" beds="8" />
+	<house name="Marketplace 1" houseid="3634" entryx="33937" entryy="31505" entryz="7" rent="400000" townid="22" size="79" clientid="48001" beds="2" />
+	<house name="Marketplace 2" houseid="3635" entryx="33951" entryy="31501" entryz="7" rent="400000" townid="22" size="92" clientid="48002" beds="2" />
+	<house name="Quay 1" houseid="3636" entryx="33885" entryy="31552" entryz="7" rent="200000" townid="22" size="81" clientid="48003" beds="4" />
+	<house name="Quay 2" houseid="3637" entryx="33896" entryy="31544" entryz="7" rent="200000" townid="22" size="130" clientid="48004" beds="3" />
+	<house name="Halls of Sun and Sea" houseid="3638" entryx="33909" entryy="31535" entryz="7" rent="1000000" guildhall="true" townid="22" size="423" clientid="48007" beds="15" />
+	<house name="Palace Vicinity" houseid="3639" entryx="33866" entryy="31516" entryz="7" rent="200000" townid="22" size="132" clientid="48006" beds="4" />
+	<house name="Wave Tower" houseid="3640" entryx="33879" entryy="31525" entryz="7" rent="400000" townid="22" size="212" clientid="48005" beds="6" />
+	<house name="Old Sanctuary of God King Qjell" houseid="3641" entryx="33473" entryy="31310" entryz="9" rent="300000" townid="18" size="699" clientid="17001" beds="6" />
+	<house name="Old Heritage Estate" houseid="3642" entryx="33598" entryy="31909" entryz="6" rent="600000" townid="20" size="335" clientid="19009" beds="7" />
+	<house name="Rathleton Plaza 4" houseid="3643" entryx="33604" entryy="31915" entryz="6" rent="400000" townid="20" size="144" clientid="19018" beds="2" />
+	<house name="Rathleton Plaza 3" houseid="3644" entryx="33615" entryy="31913" entryz="6" rent="400000" townid="20" size="157" clientid="19006" beds="3" />
+	<house name="Rathleton Plaza 2" houseid="3645" entryx="33625" entryy="31912" entryz="6" rent="400000" townid="20" size="77" clientid="19005" beds="2" />
+	<house name="Rathleton Plaza 1" houseid="3646" entryx="33637" entryy="31911" entryz="6" rent="300000" townid="20" size="80" clientid="19004" beds="2" />
+	<house name="Antimony Lane 2" houseid="3647" entryx="33637" entryy="31921" entryz="6" rent="400000" townid="20" size="127" clientid="19015" beds="3" />
+	<house name="Antimony Lane 1" houseid="3648" entryx="33656" entryy="31915" entryz="6" rent="400000" townid="20" size="189" clientid="19014" beds="5" />
+	<house name="Wallside Residence" houseid="3649" entryx="33658" entryy="31921" entryz="6" rent="400000" townid="20" size="182" clientid="19001" beds="4" />
+	<house name="Wallside Lane 1" houseid="3650" entryx="33646" entryy="31933" entryz="6" rent="800000" townid="20" size="216" clientid="19010" beds="4" />
+	<house name="Wallside Lane 2" houseid="3651" entryx="33637" entryy="31928" entryz="6" rent="600000" townid="20" size="227" clientid="19011" beds="4" />
+	<house name="Vanward Flats B" houseid="3652" entryx="33614" entryy="31935" entryz="6" rent="400000" townid="20" size="179" clientid="19013" beds="4" />
+	<house name="Vanward Flats A" houseid="3653" entryx="33621" entryy="31935" entryz="6" rent="400000" townid="20" size="189" clientid="19012" beds="4" />
+	<house name="Bronze Brothers Bastion" houseid="3654" entryx="33599" entryy="31933" entryz="6" rent="5000000" guildhall="true" townid="20" size="976" clientid="19007" beds="16" />
+	<house name="Cistern Ave" houseid="3655" entryx="33588" entryy="31926" entryz="6" rent="300000" townid="20" size="111" clientid="19008" beds="2" />
+	<house name="Antimony Lane 4" houseid="3656" entryx="33614" entryy="31922" entryz="6" rent="400000" townid="20" size="159" clientid="19017" beds="3" />
+	<house name="Antimony Lane 3" houseid="3657" entryx="33630" entryy="31921" entryz="6" rent="400000" townid="20" size="101" clientid="19016" beds="3" />
+	<house name="Rathleton Hills Residence" houseid="3658" entryx="33651" entryy="31910" entryz="6" rent="400000" townid="20" size="186" clientid="19003" beds="3" />
+	<house name="Rathleton Hills Estate" houseid="3659" entryx="33662" entryy="31917" entryz="6" rent="1000000" guildhall="true" townid="20" size="534" clientid="19002" beds="13" />
+	<house name="Lion's Head Reef" houseid="3660" entryx="32365" entryy="32501" entryz="7" rent="400000" townid="14" size="166" clientid="63013" beds="5" />
+	<house name="Shadow Caves 1" houseid="3661" entryx="32654" entryy="31672" entryz="8" rent="50000" townid="5" size="32" clientid="40611" beds="2" />
+	<house name="Shadow Caves 2" houseid="3662" entryx="32656" entryy="31672" entryz="8" rent="50000" townid="5" size="37" clientid="40614" beds="2" />
+	<house name="Shadow Caves 3" houseid="3663" entryx="32654" entryy="31664" entryz="9" rent="100000" townid="5" size="61" clientid="40621" beds="4" />
+	<house name="Shadow Caves 4" houseid="3664" entryx="32656" entryy="31664" entryz="9" rent="100000" townid="5" size="53" clientid="40622" beds="4" />
+	<house name="Shadow Caves 5" houseid="3665" entryx="32654" entryy="31672" entryz="9" rent="100000" townid="5" size="61" clientid="40625" beds="4" />
+	<house name="Shadow Caves 6" houseid="3666" entryx="32656" entryy="31672" entryz="9" rent="100000" townid="5" size="50" clientid="40638" beds="4" />
+	<house name="Northport Clanhall" houseid="3667" entryx="32468" entryy="31614" entryz="7" rent="250000" guildhall="true" townid="6" size="172" clientid="22008" beds="10" />
+	<house name="The Treehouse" houseid="3668" entryx="32747" entryy="32697" entryz="7" rent="250000" guildhall="true" townid="15" size="972" clientid="47001" beds="23" />
+	<house name="Frost Manor" houseid="3669" entryx="32287" entryy="31106" entryz="5" rent="500000" guildhall="true" townid="16" size="505" clientid="55303" beds="26" />
+	<house name="Hare's Den" houseid="3670" entryx="32687" entryy="32193" entryz="10" rent="150000" townid="7" size="304" clientid="32016" beds="4" />
+	<house name="Lost Cavern" houseid="3671" entryx="32559" entryy="31856" entryz="7" rent="200000" townid="7" size="705" clientid="33001" beds="7" />
+	<house name="Caveman Shelter" houseid="3673" entryx="33007" entryy="31426" entryz="6" rent="150000" townid="12" size="137" clientid="15001" beds="4" />
+	<house name="Eastern House of Tranquility" houseid="3674" entryx="33389" entryy="31453" entryz="4" rent="200000" townid="12" size="313" clientid="15002" beds="5" />
+	<house name="Lakeside Mansion" houseid="3675" entryx="32322" entryy="31147" entryz="6" rent="300000" townid="16" size="136" clientid="55015" beds="5" />
+	<house name="Pilchard Bin 1" houseid="3676" entryx="32280" entryy="31164" entryz="7" rent="80000" townid="16" size="14" clientid="55116" beds="2" />
+	<house name="Pilchard Bin 2" houseid="3677" entryx="32280" entryy="31160" entryz="7" rent="50000" townid="16" size="14" clientid="55117" beds="2" />
+	<house name="Pilchard Bin 3" houseid="3678" entryx="32280" entryy="31156" entryz="7" rent="50000" townid="16" size="14" clientid="55118" beds="1" />
+	<house name="Pilchard Bin 4" houseid="3679" entryx="32280" entryy="31152" entryz="7" rent="50000" townid="16" size="14" clientid="55119" beds="1" />
+	<house name="Pilchard Bin 5" houseid="3680" entryx="32280" entryy="31148" entryz="7" rent="80000" townid="16" size="14" clientid="55120" beds="2" />
+	<house name="Pilchard Bin 6" houseid="3681" entryx="32281" entryy="31164" entryz="6" rent="25000" townid="16" size="11" clientid="55121" beds="1" />
+	<house name="Pilchard Bin 7" houseid="3682" entryx="32281" entryy="31160" entryz="6" rent="25000" townid="16" size="11" clientid="55122" beds="1" />
+	<house name="Pilchard Bin 8" houseid="3683" entryx="32281" entryy="31156" entryz="6" rent="25000" townid="16" size="11" clientid="55123" beds="2" />
+	<house name="Pilchard Bin 9" houseid="3684" entryx="32281" entryy="31152" entryz="6" rent="50000" townid="16" size="11" clientid="55124" beds="1" />
+	<house name="Pilchard Bin 10" houseid="3685" entryx="32281" entryy="31148" entryz="6" rent="50000" townid="16" size="11" clientid="55125" beds="1" />
+	<house name="Mammoth House" houseid="3686" entryx="32234" entryy="31227" entryz="7" rent="300000" townid="16" size="280" clientid="55014" beds="6" />
+	<house name="Cherry Cake Tower" houseid="3687" entryx="33450" entryy="32103" entryz="7" rent="800000" townid="29" size="189" clientid="53503" beds="7" />
 	<house name="Blueberry Bay" houseid="3688" entryx="33414" entryy="32114" entryz="7" rent="600000" townid="29" size="130" clientid="53501" beds="4" />
 	<house name="Vanilla Beach" houseid="3689" entryx="33402" entryy="32166" entryz="7" rent="600000" townid="29" size="129" clientid="53502" beds="4" />
 	<house name="Centre 1" houseid="3690" entryx="33751" entryy="32856" entryz="7" rent="600000" townid="30" size="126" clientid="49001" beds="4" />

--- a/data-otservbr-global/world/otservbr-npc.xml
+++ b/data-otservbr-global/world/otservbr-npc.xml
@@ -97,13 +97,13 @@
 		<npc name="Sholley" x="0" y="0" z="3" spawntime="60" />
 	</npc>
 	<npc centerx="32628" centery="31921" centerz="3" radius="1">
-		<npc name="Humnog, The Guard" x="-1" y="0" z="3" spawntime="60" />
+		<npc name="Humnog, the guard" x="-1" y="0" z="3" spawntime="60" />
 	</npc>
 	<npc centerx="32625" centery="31923" centerz="3" radius="1">
 		<npc name="Emperor Kruzak" x="1" y="0" z="3" spawntime="60" />
 	</npc>
 	<npc centerx="32628" centery="31925" centerz="3" radius="1">
-		<npc name="Hemor, The Guard" x="-1" y="0" z="3" spawntime="60" />
+		<npc name="Hemor, the guard" x="-1" y="0" z="3" spawntime="60" />
 	</npc>
 	<npc centerx="32587" centery="31926" centerz="3" radius="1">
 		<npc name="Tulf" x="0" y="0" z="3" spawntime="60" />
@@ -445,7 +445,7 @@
 		<npc name="Captain Cookie" x="0" y="0" z="6" spawntime="60" />
 	</npc>
 	<npc centerx="32157" centery="31290" centerz="6" radius="1">
-		<npc name="Messenger Of Heaven" x="0" y="0" z="6" spawntime="60" />
+		<npc name="Messenger of Heaven" x="0" y="0" z="6" spawntime="60" />
 	</npc>
 	<npc centerx="32648" centery="31292" centerz="6" radius="1">
 		<npc name="Maris" x="0" y="0" z="6" spawntime="60" />
@@ -1171,7 +1171,7 @@
 		<npc name="Harlow" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="33038" centery="31367" centerz="7" radius="1">
-		<npc name="Messenger Of Heaven" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Messenger of Heaven" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32224" centery="31381" centerz="7" radius="1">
 		<npc name="Buddel (Okolnir)" x="0" y="0" z="7" spawntime="60" />
@@ -1279,7 +1279,7 @@
 		<npc name="Tired Tree" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="33195" centery="31646" centerz="7" radius="1">
-		<npc name="Messenger Of Heaven" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Messenger of Heaven" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="33657" centery="31654" centerz="7" radius="1">
 		<npc name="Nibble" x="0" y="0" z="7" spawntime="60" />
@@ -1600,7 +1600,7 @@
 		<npc name="Willem" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32536" centery="32026" centerz="7" radius="1">
-		<npc name="Lesser Messenger Of Heaven" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Lesser Messenger of Heaven" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32076" centery="32027" centerz="7" radius="1">
 		<npc name="Neill" x="0" y="0" z="7" spawntime="60" />
@@ -1762,7 +1762,7 @@
 		<npc name="Naji" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32389" centery="32229" centerz="7" radius="1">
-		<npc name="Donald Mcronald" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Donald McRonald" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32401" centery="32232" centerz="7" radius="1">
 		<npc name="Pig" x="0" y="0" z="7" spawntime="60" />
@@ -1774,7 +1774,7 @@
 		<npc name="Maelyrra" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32391" centery="32237" centerz="7" radius="1">
-		<npc name="Sherry Mcronald" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Sherry McRonald" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="33530" centery="32238" centerz="7" radius="1">
 		<npc name="Peaceful Pooka" x="0" y="0" z="7" spawntime="60" />
@@ -1984,7 +1984,7 @@
 		<npc name="Andrew Lyze" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="33172" centery="32634" centerz="7" radius="1">
-		<npc name="Messenger Of Heaven" x="0" y="0" z="7" spawntime="60" />
+		<npc name="Messenger of Heaven" x="0" y="0" z="7" spawntime="60" />
 	</npc>
 	<npc centerx="32565" centery="32651" centerz="7" radius="1">
 		<npc name="Vescu" x="0" y="0" z="7" spawntime="60" />
@@ -2350,16 +2350,16 @@
 		<npc name="A Strange Chalice" x="0" y="0" z="9" spawntime="60" />
 	</npc>
 	<npc centerx="33361" centery="31316" centerz="9" radius="1">
-		<npc name="Oberon'S Bile" x="0" y="0" z="9" spawntime="60" />
+		<npc name="Oberon's Bile" x="0" y="0" z="9" spawntime="60" />
 	</npc>
 	<npc centerx="33367" centery="31316" centerz="9" radius="1">
-		<npc name="Oberon'S Hate" x="0" y="0" z="9" spawntime="60" />
+		<npc name="Oberon's Hate" x="0" y="0" z="9" spawntime="60" />
 	</npc>
 	<npc centerx="33361" centery="31320" centerz="9" radius="1">
-		<npc name="Oberon'S Spite" x="0" y="0" z="9" spawntime="60" />
+		<npc name="Oberon's Spite" x="0" y="0" z="9" spawntime="60" />
 	</npc>
 	<npc centerx="33367" centery="31320" centerz="9" radius="1">
-		<npc name="Oberon'S Ire" x="0" y="0" z="9" spawntime="60" />
+		<npc name="Oberon's Ire" x="0" y="0" z="9" spawntime="60" />
 	</npc>
 	<npc centerx="33444" centery="31321" centerz="9" radius="1">
 		<npc name="Rock With A Soft Spot" x="0" y="0" z="9" spawntime="60" />
@@ -2831,7 +2831,7 @@
 		<npc name="Kizar" x="-1" y="0" z="14" spawntime="60" />
 	</npc>
 	<npc centerx="32207" centery="31377" centerz="14" radius="1">
-		<npc name="Messenger Of Heaven" x="0" y="0" z="14" spawntime="60" />
+		<npc name="Messenger of Heaven" x="0" y="0" z="14" spawntime="60" />
 	</npc>
 	<npc centerx="33388" centery="31411" centerz="14" radius="1">
 		<npc name="Heavenly Messenger" x="0" y="0" z="14" spawntime="60" />

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5895,13 +5895,13 @@ namespace {
 		uint32_t looseItems = 0;
 
 		[[nodiscard]] bool hasLoot() const noexcept {
-	    return goldValue != 0 || stackableAmount != 0 || looseItems != 0;
+			return goldValue != 0 || stackableAmount != 0 || looseItems != 0;
 		}
 
 		bool operator!=(const NearbyQuickLootSnapshot &other) const {
 			return goldValue != other.goldValue
-			    || stackableAmount != other.stackableAmount
-			    || looseItems != other.looseItems;
+				|| stackableAmount != other.stackableAmount
+				|| looseItems != other.looseItems;
 		}
 	};
 
@@ -6534,7 +6534,7 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 			outfit.lookMount = 0;
 		} else {
 			auto deltaSpeedChange = mount->speed;
-			const auto prevMount = player->isMounted()? mounts->getMountByID(player->getCurrentMount()): nullptr;
+			const auto prevMount = player->isMounted() ? mounts->getMountByID(player->getCurrentMount()) : nullptr;
 
 			if (prevMount) {
 				deltaSpeedChange -= prevMount->speed;


### PR DESCRIPTION
## Summary

This PR updates world data related to houses, monsters, and NPCs.

## Changes

- Updated house definitions in `otservbr-house.xml`
- Updated monster spawn/world data in `otservbr-monster.xml`
- Updated NPC world data in `otservbr-npc.xml`

## Notes

Most of the changes are data adjustments in XML files, including house size corrections and world entity updates.

## Validation

- XML files should be validated for proper formatting
- Server should be started locally to confirm the world data loads without errors
- House, monster, and NPC data should be checked in-game where applicable