### PR TITLE
fix: deplete the clicked exercise weapon, not the first in inventory

### DIFF
--- a/data/scripts/actions/items/exercise_training_weapons.lua
+++ b/data/scripts/actions/items/exercise_training_weapons.lua
@@ -82,14 +82,15 @@ local function exerciseTrainingEvent(playerId, tilePosition, weaponId, dummyId)
 		return false
 	end
 
-	if player:getItemCount(weaponId) <= 0 then
+	local trainingData = _G.OnExerciseTraining[playerId]
+	local weapon = trainingData and trainingData.weapon
+	if not weapon or not weapon:isItem() or weapon:getPosition() ~= playerPosition then
 		player:sendTextMessage(MESSAGE_FAILURE, "You need the training weapon in the backpack, the training has stopped.")
 		leaveExerciseTraining(playerId, targetItem)
 		return false
 	end
 
-	local weapon = player:getItemById(weaponId, true)
-	if not weapon:isItem() or not weapon:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
+	if not weapon:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
 		player:sendTextMessage(MESSAGE_FAILURE, "The selected item is not a training weapon, the training has stopped.")
 		leaveExerciseTraining(playerId, targetItem)
 		return false
@@ -203,6 +204,7 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 
 		_G.OnExerciseTraining[playerId] = {}
 		if not _G.OnExerciseTraining[playerId].event then
+			_G.OnExerciseTraining[playerId].weapon = item
 			_G.OnExerciseTraining[playerId].event = addEvent(exerciseTrainingEvent, 0, playerId, targetPos, item.itemid, targetId)
 			_G.OnExerciseTraining[playerId].dummyPos = targetPos
 			targetItem:actor(true)


### PR DESCRIPTION
## Summary

Fixes #3855.

When a player carries multiple exercise weapons of the same type, using
the second (or any non-first) weapon on a training dummy was draining
charges from the first weapon in the inventory instead of the one the
player actually clicked.

## Root cause

Inside `exerciseTrainingEvent` in `data/scripts/actions/items/exercise_training_weapons.lua`,
the per-tick weapon lookup used:

```lua
local weapon = player:getItemById(weaponId, true)
```

`Player:getItemById` returns the **first** matching item found while
walking the inventory — it has no notion of which specific instance the
player clicked. So as long as two weapons shared the same item id, the
charges were always written back to whichever one the iteration found
first, regardless of the click target.

## Fix

Persist the userdata reference of the clicked item in
`_G.OnExerciseTraining[playerId].weapon` at `onUse`, then operate on
that exact instance every tick:

- The Lua userdata holds a `shared_ptr<Item>`, so the specific instance
  stays alive across `addEvent` callbacks even though the script
  environment (and its `localMap`) is reset between timer events.
- The previous `player:getItemCount(weaponId) <= 0` check is replaced
  with a per-instance validation: `weapon:isItem()` plus a comparison of
  the weapon's reported position against the player's position. Items
  inside a container bubble up to the holder's tile position, so the
  comparison passes while the weapon stays in the player's inventory and
  fails immediately if it's dropped, sent to depot/stash, or otherwise
  removed from the player.

This keeps every existing safety check (player still training, in PZ,
charges remaining, dummy still on the tile) intact.

## Test plan

- [ ] Place two exercise weapons of the **same type** in the backpack.
- [ ] Click the **second** one on a Ferumbras Mortal Shell / training
      dummy and confirm its own charge counter goes down (the first one
      is no longer touched).
- [ ] Click the **first** one and confirm it depletes as expected.
- [ ] Drop the active weapon mid-training → training stops with the
      "you need the training weapon in the backpack" message.
- [ ] Let an exercise weapon hit zero charges → it is removed and the
      training session ends as before.
- [ ] Repeat with rod / wand / bow (allowFarUse) to cover the ranged path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training weapon tracking during exercise events to ensure the weapon remains valid and properly positioned throughout the training session.
  * Training will now correctly stop if the weapon is removed or moved during active training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->