### PR TITLE
fix: restore The Horned Fox stats and summons

### DIFF
--- a/data-otservbr-global/monster/raids/the_horned_fox.lua
+++ b/data-otservbr-global/monster/raids/the_horned_fox.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("The Horned Fox")
 local monster = {}
 
 monster.description = "the Horned Fox"
-monster.experience = 4400
+monster.experience = 300
 monster.outfit = {
 	lookType = 202,
 	lookHead = 0,
@@ -13,8 +13,8 @@ monster.outfit = {
 	lookMount = 0,
 }
 
-monster.health = 7990
-monster.maxHealth = 7990
+monster.health = 265
+monster.maxHealth = 265
 monster.race = "blood"
 monster.corpse = 5983
 monster.speed = 105
@@ -57,11 +57,11 @@ monster.light = {
 }
 
 monster.summon = {
-	maxSummons = 5,
+	maxSummons = 6,
 	summons = {
-		{ name = "Minotaur Hunter", chance = 15, interval = 1000, count = 2 },
-		{ name = "Minotaur Amazon", chance = 15, interval = 1000, count = 1 },
-		{ name = "Worm Princess", chance = 15, interval = 1000, count = 2 },
+		{ name = "Minotaur Archer", chance = 13, interval = 1000, count = 2 },
+		{ name = "Minotaur Guard", chance = 13, interval = 1000, count = 2 },
+		{ name = "Minotaur Mage", chance = 13, interval = 1000, count = 2 },
 	},
 }
 
@@ -71,38 +71,36 @@ monster.voices = {
 	{ text = "You will never get me!", yell = false },
 	{ text = "I'll be back!", yell = false },
 	{ text = "Catch me, if you can!", yell = false },
-	{ text = "Help me, Gang!", yell = false },
+	{ text = "Help me, Boys!", yell = false },
 }
 
 monster.loot = {
 	{ id = 5804, chance = 100000 }, -- nose ring
 	{ id = 3031, chance = 96000, maxCount = 99 }, -- gold coin
-	{ id = 3035, chance = 38890, maxCount = 3 }, -- platinum coin
-	{ id = 5878, chance = 100000 }, -- minotaur leather
+	{ id = 5878, chance = 96000 }, -- minotaur leather
 	{ id = 11472, chance = 92590, maxCount = 2 }, -- minotaur horn
 	{ id = 11482, chance = 85000 }, -- piece of warrior armor
-	{ id = 3450, chance = 48000, maxCount = 14 }, -- power bolt
-	{ id = 3577, chance = 18000, maxCount = 3 }, -- meat
-	{ id = 3049, chance = 10000 }, -- stealth ring
+	{ id = 7363, chance = 48000, maxCount = 14 }, -- piercing bolt
+	{ id = 3359, chance = 25000 }, -- brass armor
+	{ id = 3577, chance = 18000, maxCount = 2 }, -- meat
+	{ id = 3413, chance = 14000 }, -- battle shield
+	{ name = "dwarven helmet", chance = 5000 },
 	{ id = 3483, chance = 7410 }, -- fishing rod
 	{ id = 236, chance = 7410 }, -- strong health potion
-	{ id = 7401, chance = 900 }, -- minotaur trophy,
-	{ name = "dwarven helmet", chance = 10000 },
-	{ id = 21174, chance = 12000 }, -- mino lance
-	{ id = 21175, chance = 6000 }, -- mino shield
+	{ id = 3275, chance = 3700 }, -- double axe
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -525 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
 	{ name = "combat", interval = 1000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -20, range = 7, shootEffect = CONST_ANI_BOLT, target = false },
 	-- poison
-	{ name = "condition", type = CONDITION_POISON, interval = 1000, chance = 40, minDamage = -10, maxDamage = -200, range = 10, shootEffect = CONST_ANI_POISON, target = false },
+	{ name = "condition", type = CONDITION_POISON, interval = 1000, chance = 17, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 }
 
 monster.defenses = {
-	defense = 33,
-	armor = 30,
-	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_HEALING, minDamage = 80, maxDamage = 100, effect = CONST_ME_MAGIC_RED, target = false },
+	defense = 16,
+	armor = 17,
+	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_HEALING, minDamage = 25, maxDamage = 75, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "invisible", interval = 1000, chance = 10, effect = CONST_ME_MAGIC_BLUE },
 }
 


### PR DESCRIPTION
## Summary

Fixes #3853.

The Horned Fox (lookType 202) is a low-tier raid miniboss with 265 HP that summons regular minotaurs. PR #1548 ("review global datapack monster basic details") accidentally overwrote its entire stat block with values from a much stronger boss, leaving an actively broken monster on `main`.

This PR restores the pre-#1548 baseline that matches both the issue reporter's expectation and external Tibia references ([TibiaWiki](https://tibia.fandom.com/wiki/The_Horned_Fox), [TibiaBosses.pl](https://tibiabosses.pl/the_horned_fox)).

## Changes

| Field | Before (broken) | After (restored) |
|---|---|---|
| `health` / `maxHealth` | 7990 | **265** |
| `experience` | 4400 | 300 |
| `summons` | Minotaur Hunter / Minotaur Amazon / **Worm Princess** | Minotaur Archer / Minotaur Guard / Minotaur Mage |
| `maxSummons` | 5 | 6 |
| Voice | "Help me, Gang!" | "Help me, Boys!" |
| Melee `maxDamage` | -525 | -100 |
| Poison condition | 40% chance, -200 dmg | 17% chance, effect-only |
| `defense` / `armor` | 33 / 30 | 16 / 17 |
| Self-heal | 80-100 | 25-75 |
| Loot | inflated (mino lance, mino shield, power bolt, platinum coin, stealth ring, minotaur trophy) | original (piercing bolt, brass armor, battle shield, double axe, dwarven helmet) |

The dwarven helmet entry from #3815 is preserved using the modern `name = "dwarven helmet"` syntax (with the original chance).

## Extra evidence: "Worm Princess" does not exist

The broken summon list referenced `Worm Princess`, which is **not a real monster** — there is no `data-otservbr-global/monster/**/worm_princess*.lua`, no string `"Worm Princess"` anywhere in the repo, and the canonical Tibia name is `Worm Priestess`. The boss has been silently failing to spawn its third summon slot for years, which is consistent with the reporter only seeing Hunter/Amazon in their screenshots.

## External validation

| Stat | This PR | TibiaWiki / TibiaBosses.pl |
|---|---|---|
| HP | 265 | "approximately 265 HP" |
| Experience | 300 | "around 300 XP" |
| Summons | Archer / Guard / Mage, up to 2 each | "summons 1-2 Minotaur Guard/Archer/Mage" |
| Melee max | -100 | "melee attacks (0-100 damage)" |
| Bolt max | -20 | "shoots bolts (0-20 damage)" |
| Self-heal | 25-75 | "self-heal (25-75)" |
| Invisibility | yes | "uses invisibility (2 seconds)" |

## Test plan

- [ ] Spawn The Horned Fox via `/m "The Horned Fox"` and confirm HP shows 265/265.
- [ ] Confirm summons that appear during the fight are Minotaur Archer / Guard / Mage (no Hunter, Amazon, or non-existent "Worm Princess").
- [ ] Confirm no engine warnings/errors about an unknown monster type when summons trigger.
- [ ] Verify To Outfox a Fox quest still completes (boss death credits the quest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Balance Changes**
  * The Horned Fox encounter has been comprehensively rebalanced with reduced combat difficulty, lower health pools, and decreased experience rewards to provide a different challenge level.
  * Monster summoning mechanics have been reworked with different creature types and frequencies, while loot drops have been completely revised with new item rewards and updated drop probabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->