### PR TITLE
fix: race conditions in attack check scheduling

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5779,6 +5779,9 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 		return false;
 	}
 
+	++m_attackCheckGeneration;
+	m_pendingAttackCheckTask = false;
+
 	const auto &followCreature = getFollowCreature();
 	if (chaseMode && creature) {
 		if (followCreature != creature) {
@@ -5789,9 +5792,33 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		scheduleAttackCheck();
 	}
 	return true;
+}
+
+void Player::scheduleAttackCheck() {
+	if (m_pendingAttackCheckTask) {
+		return;
+	}
+
+	m_pendingAttackCheckTask = true;
+	const uint32_t generation = m_attackCheckGeneration;
+
+	g_dispatcher().addEvent([self = std::weak_ptr<Player>(static_self_cast<Player>()), generation] {
+		const auto &player = self.lock();
+		if (!player) {
+			return;
+		}
+
+		if (generation != player->m_attackCheckGeneration || !player->m_pendingAttackCheckTask) {
+			return;
+		}
+
+		player->m_pendingAttackCheckTask = false;
+		player->checkCreatureAttack(true);
+	},
+	                        "Player::scheduleAttackCheck");
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5779,8 +5779,12 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 		return false;
 	}
 
-	++m_attackCheckGeneration;
-	m_pendingAttackCheckTask = false;
+	{
+		const auto &self = static_self_cast<Player>();
+		PlayerLock lock(self);
+		++m_attackCheckGeneration;
+		m_pendingAttackCheckTask = false;
+	}
 
 	const auto &followCreature = getFollowCreature();
 	if (chaseMode && creature) {
@@ -5798,12 +5802,17 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 void Player::scheduleAttackCheck() {
-	if (m_pendingAttackCheckTask) {
-		return;
-	}
+	uint32_t generation = 0;
+	{
+		const auto &self = static_self_cast<Player>();
+		PlayerLock lock(self);
+		if (m_pendingAttackCheckTask) {
+			return;
+		}
 
-	m_pendingAttackCheckTask = true;
-	const uint32_t generation = m_attackCheckGeneration;
+		m_pendingAttackCheckTask = true;
+		generation = m_attackCheckGeneration;
+	}
 
 	g_dispatcher().addEvent([self = std::weak_ptr<Player>(static_self_cast<Player>()), generation] {
 		const auto &player = self.lock();
@@ -5811,12 +5820,18 @@ void Player::scheduleAttackCheck() {
 			return;
 		}
 
-		if (generation != player->m_attackCheckGeneration || !player->m_pendingAttackCheckTask) {
-			return;
+		bool shouldRun = false;
+		{
+			Player::PlayerLock lock(player);
+			if (generation == player->m_attackCheckGeneration && player->m_pendingAttackCheckTask) {
+				player->m_pendingAttackCheckTask = false;
+				shouldRun = true;
+			}
 		}
 
-		player->m_pendingAttackCheckTask = false;
-		player->checkCreatureAttack(true);
+		if (shouldRun) {
+			player->checkCreatureAttack(true);
+		}
 	},
 	                        "Player::scheduleAttackCheck");
 }

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5830,6 +5830,10 @@ void Player::scheduleAttackCheck() {
 		}
 
 		if (shouldRun) {
+			Player::PlayerLock lock(player);
+			if (generation != player->m_attackCheckGeneration) {
+				return;
+			}
 			player->checkCreatureAttack(true);
 		}
 	},

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1699,8 +1699,6 @@ private:
 	uint32_t actionTaskEvent = 0;
 	uint32_t actionTaskEventPush = 0;
 	uint32_t actionPotionTaskEvent = 0;
-	void scheduleAttackCheck();
-	bool m_pendingAttackCheckTask = false;
 	uint32_t m_attackCheckGeneration = 0;
 	uint32_t nextStepEvent = 0;
 	uint32_t walkTaskEvent = 0;
@@ -1739,6 +1737,10 @@ private:
 	int16_t lastDepotId = -1;
 	StashItemList stashItems; // [ItemID] = amount
 	uint32_t movedItems = 0;
+
+	// Schedule attack check
+	void scheduleAttackCheck();
+	bool m_pendingAttackCheckTask = false;
 
 	// Depot search system
 	bool depotSearch = false;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1699,6 +1699,9 @@ private:
 	uint32_t actionTaskEvent = 0;
 	uint32_t actionTaskEventPush = 0;
 	uint32_t actionPotionTaskEvent = 0;
+	void scheduleAttackCheck();
+	bool m_pendingAttackCheckTask = false;
+	uint32_t m_attackCheckGeneration = 0;
 	uint32_t nextStepEvent = 0;
 	uint32_t walkTaskEvent = 0;
 	uint32_t MessageBufferTicks = 0;


### PR DESCRIPTION
The goal here is to avoid scheduling duplicate attack checks and stop stale tasks from running...
Now, every time the target changes, it bumps a generation counter `m_attackCheckGeneration` and resets the pending state, so only the latest generation’s task can run. This reduces duplicate work and avoids race conditions when targets change quickly or attacks start/stop.


- Prevent duplicate or stale scheduled attack checks when a Player begins or stops being attacked to avoid redundant work and race conditions.
- Ensure only the most recent pending atack scheduler task executes for a given player generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Player attack evaluation now runs via a scheduled, deduplicated check instead of immediate synchronous checks. Result: fewer redundant re-evaluations during combat, reduced momentary stutters, and improved responsiveness and runtime stability with no change to player-facing mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->