### PR TITLE
fix: correct Monk avatar lookType for tier transcendence

### DIFF
--- a/data/XML/vocations.xml
+++ b/data/XML/vocations.xml
@@ -120,7 +120,7 @@
 		<gem quality="1" name="guardian gem" />
 		<gem quality="2" name="greater guardian gem" />
 	</vocation>
-	<vocation id="9" clientid="5" baseid="9" name="Monk" description="a monk" magicshield="0" gaincap="25" gainhp="10" gainmana="10" gainhpticks="6000" gainhpamount="1" gainmanaticks="6000" gainmanaamount="2" manamultiplier="1.3" attackspeed="2000" basespeed="110" soulmax="100" gainsoulticks="120000" fromvoc="9" avatarlooktype="1831">
+	<vocation id="9" clientid="5" baseid="9" name="Monk" description="a monk" magicshield="0" gaincap="25" gainhp="10" gainmana="10" gainhpticks="6000" gainhpamount="1" gainmanaticks="6000" gainmanaamount="2" manamultiplier="1.3" attackspeed="2000" basespeed="110" soulmax="100" gainsoulticks="120000" fromvoc="9" avatarlooktype="1823">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<mitigation multiplier="1.28" primaryShield="2.08" secondaryShield="1.2" />
 		<pvp damageReceivedMultiplier="1.0" damageDealtMultiplier ="1.0"/>
@@ -132,7 +132,7 @@
 		<skill id="5" multiplier="1.2" />
 		<skill id="6" multiplier="1.1" />
 	</vocation>
-	<vocation id="10" clientid="15" baseid="9" name="Exalted Monk" description="an exalted monk" magicshield="0" gaincap="25" gainhp="10" gainmana="10" gainhpticks="4000" gainhpamount="1" gainmanaticks="6000" gainmanaamount="2" manamultiplier="1.3" attackspeed="2000" basespeed="110" soulmax="200" gainsoulticks="15000" fromvoc="9" avatarlooktype="1831">
+	<vocation id="10" clientid="15" baseid="9" name="Exalted Monk" description="an exalted monk" magicshield="0" gaincap="25" gainhp="10" gainmana="10" gainhpticks="4000" gainhpamount="1" gainmanaticks="6000" gainmanaamount="2" manamultiplier="1.3" attackspeed="2000" basespeed="110" soulmax="200" gainsoulticks="15000" fromvoc="9" avatarlooktype="1823">
 		<formula meleeDamage="1.0" distDamage="1.0" defense="1.0" armor="1.0" />
 		<mitigation multiplier="1.28" primaryShield="2.08" secondaryShield="1.2" />
 		<pvp damageReceivedMultiplier="1.0" damageDealtMultiplier ="1.0"/>


### PR DESCRIPTION
## Summary

Fixes #3852.

The Monk and Exalted Monk vocations had `avatarlooktype="1831"` set in `data/XML/vocations.xml`, but lookType 1831 is the **Winged Druid** store outfit (see `data/XML/outfits.xml:252`), not the Avatar of Balance. The Avatar of Balance spell at `data/scripts/spells/support/monk/avatar_of_balance.lua:2` uses lookType **1823**, which is the canonical Monk avatar.

Tier-on-legs transcendence reads the lookType directly from the vocation via `getVocation()->getAvatarLookType()` ([src/creatures/players/player.cpp:10444](https://github.com/opentibiabr/canary/blob/main/src/creatures/players/player.cpp#L10444)), which is why casting the spell looked correct (uses spell file's hardcoded 1823) but the tier-triggered proc showed the wrong outfit (uses vocation table's 1831).

## Pattern check

The other four vocations all match between their avatar spell and the vocation entry:

| Vocation | Avatar spell lookType | `avatarlooktype` |
|---|---|---|
| Knight | Avatar of Steel — 1593 | 1593 |
| Paladin | Avatar of Light — 1594 | 1594 |
| Sorcerer | Avatar of Storm — 1595 | 1595 |
| Druid | Avatar of Nature — 1596 | 1596 |
| **Monk** | Avatar of Balance — **1823** | **1831** ← bug |

## Changes

- `data/XML/vocations.xml` — change `avatarlooktype="1831"` → `"1823"` for both Monk (id=9) and Exalted Monk (id=10).

## Test plan

- [ ] Equip a Monk character with a tier-stamped legs and trigger transcendence in combat — confirm the avatar outfit matches the one shown when casting `Avatar of Balance` manually.
- [ ] Cast `Avatar of Balance` directly to verify spell appearance is unchanged (should remain 1823).
- [ ] Confirm no regressions for other vocations' transcendence outfits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the avatar appearance for Monk and Exalted Monk vocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->