### PR TITLE
fix: monster re-target and field-walking when current target is unreachable

### DIFF
--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2519,7 +2519,12 @@ void Monster::setNormalCreatureLight() {
 void Monster::drainHealth(const std::shared_ptr<Creature> &attacker, int32_t damage) {
 	Creature::drainHealth(attacker, damage);
 
-	if (damage > 0 && randomStepping) {
+	// Allow walking through harmful fields when the monster is being damaged and either
+	// has no target (random stepping) or its current target is unreachable. Without the
+	// !hasFollowPath branch, a melee monster locked onto a target it cannot path to (magic
+	// walled, behind a non-traversable field) stays unable to push through fields even
+	// while taking damage from the very fields/bombs blocking its way.
+	if (damage > 0 && (randomStepping || !hasFollowPath)) {
 		ignoreFieldDamage = true;
 	}
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -756,7 +756,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	// exclude it so a reachable alternative can be chosen instead of repeatedly picking
 	// the same unreachable creature as "nearest".
 	const auto &currentAttacked = getAttackedCreature();
-	const bool skipCurrentUnreachable = currentAttacked && static_self_cast<Monster>()->targetDistance == 1 && !hasFollowPath;
+	const bool skipCurrentUnreachable = currentAttacked && static_self_cast<Monster>()->targetDistance <= 1 && !hasFollowPath;
 
 	for (const auto &cref : targetList) {
 		const auto &creature = cref.lock();
@@ -2524,7 +2524,7 @@ void Monster::drainHealth(const std::shared_ptr<Creature> &attacker, int32_t dam
 	// !hasFollowPath branch, a melee monster locked onto a target it cannot path to (magic
 	// walled, behind a non-traversable field) stays unable to push through fields even
 	// while taking damage from the very fields/bombs blocking its way.
-	if (damage > 0 && (randomStepping || !hasFollowPath)) {
+	if (damage > 0 && (randomStepping || (!hasFollowPath && getFollowCreature()))) {
 		ignoreFieldDamage = true;
 	}
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -752,9 +752,18 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	std::vector<std::shared_ptr<Creature>> resultList;
 	const Position &myPos = getPosition();
 
+	// When the current melee target is path-blocked (magic wall, untraversable field),
+	// exclude it so a reachable alternative can be chosen instead of repeatedly picking
+	// the same unreachable creature as "nearest".
+	const auto &currentAttacked = getAttackedCreature();
+	const bool skipCurrentUnreachable = currentAttacked && static_self_cast<Monster>()->targetDistance == 1 && !hasFollowPath;
+
 	for (const auto &cref : targetList) {
 		const auto &creature = cref.lock();
 		if (creature && isTarget(creature)) {
+			if (skipCurrentUnreachable && creature == currentAttacked) {
+				continue;
+			}
 			if ((static_self_cast<Monster>()->targetDistance == 1) || canUseAttack(myPos, creature)) {
 				resultList.emplace_back(creature);
 			}
@@ -867,7 +876,10 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	}
 
 	// lets just pick the first target in the list
-	return std::ranges::any_of(getTargetList(), [this](const std::shared_ptr<Creature> &creature) {
+	return std::ranges::any_of(getTargetList(), [this, skipCurrentUnreachable, &currentAttacked](const std::shared_ptr<Creature> &creature) {
+		if (skipCurrentUnreachable && creature == currentAttacked) {
+			return false;
+		}
 		return selectTarget(creature);
 	});
 }


### PR DESCRIPTION
## Summary

Fixes #3826.

Two related fixes for the long-standing complaint that melee monsters get permanently stuck when their current target becomes unreachable (magic walled, or behind a field type the monster cannot walk through). Both fixes live in `src/creatures/monsters/monster.cpp`.

### Variant 1 — `searchTarget` re-picks the same unreachable target

The retarget trigger in `Monster::onThink_async` already runs when `hasFollowPath` is false:

```cpp
const bool attackedCreatureIsUnreachable = targetDistance <= 1 && attackedCreature && followCreature && !hasFollowPath;
if (!attackedCreature || attackedCreatureIsUnattackable || attackedCreatureIsUnreachable) {
    if (!followCreature || !hasFollowPath) {
        searchTarget(TARGETSEARCH_NEAREST);
    }
    ...
}
```

But inside `Monster::searchTarget`, the strategy filter accepts every creature in `targetList` for melee monsters (`targetDistance == 1`) without any reachability check, so `TARGETSEARCH_NEAREST` re-picks the same unreachable creature based on raw distance. The retargeting never escapes.

**Fix:** when the current `attackedCreature` has `hasFollowPath == false`, exclude it from both the strategy filter and the fallback iteration so the search has to consider an alternative. If only the unreachable target is in the list, `searchTarget` returns false and the existing follow state is preserved (no regression vs. the prior stuck state).

### Variant 2 — `ignoreFieldDamage` only flips while idle

`Monster::drainHealth` previously gated `ignoreFieldDamage` on `randomStepping` only:

```cpp
if (damage > 0 && randomStepping) {
    ignoreFieldDamage = true;
}
```

Tile pathfinding rejects field tiles for monsters whose `canWalkOnFieldType(combatType)` is false unless `ignoreFieldDamage` is true ([`src/items/tile.cpp:670-680`](https://github.com/opentibiabr/canary/blob/main/src/items/tile.cpp#L670-L680)). A melee monster that has already locked onto a target it cannot reach is no longer in random-stepping mode, so the flag never flips even while it stands in a fire/energy/poison bomb. This was diagnosed by @twolfvb in the issue thread on Burster Spectre hunts.

**Fix:** also flip `ignoreFieldDamage` when `hasFollowPath` is false. The follow loop sets `hasFollowPath` to the result of the most recent A* attempt, so this triggers exactly when the monster is genuinely stuck — not when it has a reachable target and is merely standing on a field tile.

## Field-bomb safety preserved

The PvE balance concern @twolfvb raised — that a naive removal of the gate would let monsters chase mages through every field bomb — does not apply here. The new condition only activates when `hasFollowPath == false`. As long as A* finds any path to the target (e.g., the mage is in line of sight and the monster can walk around the bomb), `hasFollowPath` stays true and the flag is not set. Only when the target is genuinely unreachable does the monster push through fields.

| Scenario | Before | After |
|---|---|---|
| Mage solo, line-of-sight, throws fire bomb at Dark Torturer | DT walks around bomb to mage | unchanged ✓ |
| Knight + mage. Knight magic-walled in fire field. Multiple targets in list. | DT loops on knight forever | DT switches to mage (variant 1) ✓ |
| Burster Spectre, only target is a mage who walls + bombs | Burster permanently stuck | Burster pushes through fire to reach mage (variant 2) ✓ |
| Single unreachable target, no damage | Stuck on target | Stuck on target (no behavior change) ✓ |
| Two reachable melee targets, one closer | Picks nearest (existing behavior) | Picks nearest (no behavior change) ✓ |

## Out of scope

Variant where a monster whose `canWalkOnFieldType` is *true* still appears stuck (e.g., dragon vs poison field). With my fix that scenario is already correct: `canWalkOnFieldType` short-circuits the field block in tile pathfinding, so A* finds a path through the field naturally and `hasFollowPath` stays true. If a separate bug exists there, it lives in pathfinding cost or distance limits, not in the gates touched here.

## Test plan

- [ ] Reproduce #3826 setup: two players + a Dark Torturer (or similar `canWalkOnEnergy = false` melee), trap player 1 behind a magic wall + energy field, confirm the Dark Torturer switches to player 2 within one think cycle.
- [ ] Reproduce on Burster Spectre: single player walls themselves and throws fire bomb, confirm the spectre pushes through fire to reach them within a few think cycles after taking field damage.
- [ ] Confirm a mage in line of sight can still field-bomb a Burster Spectre safely (spectre walks around the bomb, does not push through).
- [ ] Verify single-target hunts and summon behavior are unchanged.
- [ ] Run existing monster integration tests if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Monsters no longer pursue melee targets they cannot reach, reducing futile chases and improving combat behavior.
  * Monsters will better traverse hazardous terrain when pursuing unreachable follow targets, allowing more effective engagement after taking damage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->