### PR TITLE
ci: strip redundant WIP from Copilot PR titles

### DIFF
--- a/.github/workflows/copilot-pr-title.yml
+++ b/.github/workflows/copilot-pr-title.yml
@@ -1,0 +1,36 @@
+---
+name: Copilot - Normalize PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip-wip-prefix:
+    name: Strip redundant WIP prefix
+    if: ${{ github.event.pull_request.user.login == 'Copilot' && startsWith(github.event.pull_request.title, '[WIP]') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove WIP title prefix from draft Copilot PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          clean_title="$(printf '%s' "$PR_TITLE" | sed -E 's/^\[WIP\][[:space:]]*//')"
+          if [ -z "$clean_title" ] || [ "$clean_title" = "$PR_TITLE" ]; then
+            exit 0
+          fi
+
+          gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" --title "$clean_title"


### PR DESCRIPTION
## Summary

- add a small `pull_request_target` workflow that removes a leading `[WIP]` prefix from Copilot-authored PR titles
- keep the PR draft state as the source of WIP status instead of duplicating it in the title
- avoid checkout and secrets; the workflow only edits PR metadata for PRs authored by Copilot

## Validation

- `git diff --check`
- renamed existing Copilot PR #3924 to remove the redundant `[WIP]` prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions workflow to streamline pull request title management by removing `[WIP]` prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->