### PR TITLE
fix: match Hidden Threats forged-key action to actual door storage keys

### DIFF
--- a/data-otservbr-global/scripts/quests/hidden_threats/action-corym_works_doors.lua
+++ b/data-otservbr-global/scripts/quests/hidden_threats/action-corym_works_doors.lua
@@ -1,22 +1,29 @@
 local perfectlyForgedKey = Action()
 
+-- The Corym Works doors are registered in QuestDoorAction (door_quest.lua), and
+-- loadLuaMapAction stamps each door with an actionid equal to its storage key.
+-- Match against the same storage keys instead of unrelated literals so the
+-- forged key actually unlocks the doors.
 function perfectlyForgedKey.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local HiddenThreats = Storage.Quest.U11_50.HiddenThreats
-	if target.actionid == 10123 or target.actionid == 10124 or target.actionid == 10125 then
-		if target.actionid == 10123 and player:getStorageValue(HiddenThreats.CorymWorksDoor01) < 0 then
-			player:setStorageValue(HiddenThreats.CorymWorksDoor01, 1)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The forged key unlocks the door.")
-			return true
-		elseif target.actionid == 10124 and player:getStorageValue(HiddenThreats.CorymWorksDoor02) < 0 then
-			player:setStorageValue(HiddenThreats.CorymWorksDoor02, 1)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The forged key unlocks the door.")
-			return true
-		elseif target.actionid == 10125 and player:getStorageValue(HiddenThreats.CorymWorksDoor03) < 0 then
-			player:setStorageValue(HiddenThreats.CorymWorksDoor03, 1)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The forged key unlocks the door.")
-			return true
-		end
+	local actionid = target.actionid
+
+	local doorStorage
+	if actionid == HiddenThreats.CorymWorksDoor01 then
+		doorStorage = HiddenThreats.CorymWorksDoor01
+	elseif actionid == HiddenThreats.CorymWorksDoor02 then
+		doorStorage = HiddenThreats.CorymWorksDoor02
+	elseif actionid == HiddenThreats.CorymWorksDoor03 then
+		doorStorage = HiddenThreats.CorymWorksDoor03
+	else
+		return false
 	end
+
+	if player:getStorageValue(doorStorage) < 0 then
+		player:setStorageValue(doorStorage, 1)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The forged key unlocks the door.")
+	end
+	return true
 end
 
 perfectlyForgedKey:id(27269)


### PR DESCRIPTION
## Summary

Fixes #3768.

The forged key (`item id 27269`) action for the Corym Works doors in the Hidden Threats quest checked `target.actionid` against literals `10123`, `10124`, `10125`. Those values are **unrelated storage keys** belonging to *Killing in the Name of* (`Door`, `TravelCarlin`, `TravelEdron` — see [`storages.lua:445-447`](https://github.com/opentibiabr/canary/blob/main/data-otservbr-global/lib/core/storages.lua#L445-L447)).

The actual Corym Works doors are registered in `QuestDoorAction` ([`door_quest.lua:685-696`](https://github.com/opentibiabr/canary/blob/main/data-otservbr-global/startup/tables/door_quest.lua#L685-L696)) with their `HiddenThreats` storage values (`45974`-`45976`). `loadLuaMapAction` then stamps each door with an `ITEM_ATTRIBUTE_ACTIONID` equal to its table key — so the doors in-game carry actionids `45974`-`45976`, not `10123`-`10125`. The script never matched, the storage was never set, and the door stayed locked.

## Changes

`data-otservbr-global/scripts/quests/hidden_threats/action-corym_works_doors.lua`:

- Compare against the storage constants directly (`HiddenThreats.CorymWorksDoor01..03`) instead of the literal numbers, so the comparison follows whatever values `storages.lua` holds at the time.
- Collapse the three nearly-identical branches now that the only thing that varies is which storage key gets toggled.
- Add a comment pointing at the registration mechanism so a future reader does not lose this thread again.

## Test plan

- [ ] Progress a character to the Corym Works section of Hidden Threats and obtain the perfectly forged key (`27269`).
- [ ] Use the key on each of the three doors at:
  - `(33025, 32008, 12)` (CorymWorksDoor01)
  - `(33045, 32007, 12)` (CorymWorksDoor02)
  - `(33001, 32047, 12)` (CorymWorksDoor03)
- [ ] Confirm the `"The forged key unlocks the door."` message appears once per door and the door opens on subsequent walk-through.
- [ ] Confirm the key on a *non-quest* door does nothing (function returns false now instead of returning true with no effect).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Corym Works door unlocking mechanism to properly recognize and respond to key interactions, ensuring doors unlock correctly when using the Perfectly Forged Key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->