### PR TITLE
fix: random mount outfit crash

### DIFF
--- a/data/scripts/creaturescripts/player/login.lua
+++ b/data/scripts/creaturescripts/player/login.lua
@@ -149,7 +149,7 @@ function playerLoginGlobal.onLogin(player)
 
 	-- Change support outfit to a normal outfit to open customize character without crashes
 	local playerOutfit = player:getOutfit()
-	if table.contains({ 75, 266, 302 }, playerOutfit.lookType) then
+	if table.contains({ 75, 266, 302 }, playerOutfit.lookType) and not player:getGroup():getAccess() then
 		playerOutfit.lookType = 136
 		playerOutfit.lookAddons = 0
 		player:setOutfit(playerOutfit)

--- a/data/scripts/creaturescripts/player/login.lua
+++ b/data/scripts/creaturescripts/player/login.lua
@@ -150,7 +150,7 @@ function playerLoginGlobal.onLogin(player)
 	-- Change support outfit to a normal outfit to open customize character without crashes
 	local playerOutfit = player:getOutfit()
 	if table.contains({ 75, 266, 302 }, playerOutfit.lookType) and not player:getGroup():getAccess() then
-		playerOutfit.lookType = 136
+		playerOutfit.lookType = player:getSex() == 1 and 128 or 136
 		playerOutfit.lookAddons = 0
 		player:setOutfit(playerOutfit)
 	end

--- a/data/scripts/creaturescripts/player/login.lua
+++ b/data/scripts/creaturescripts/player/login.lua
@@ -150,7 +150,7 @@ function playerLoginGlobal.onLogin(player)
 	-- Change support outfit to a normal outfit to open customize character without crashes
 	local playerOutfit = player:getOutfit()
 	if table.contains({ 75, 266, 302 }, playerOutfit.lookType) and not player:getGroup():getAccess() then
-		playerOutfit.lookType = player:getSex() == 1 and 128 or 136
+		playerOutfit.lookType = player:getSex() == PLAYERSEX_FEMALE and 136 or 128
 		playerOutfit.lookAddons = 0
 		player:setOutfit(playerOutfit)
 	end

--- a/src/creatures/appearance/mounts/mounts.cpp
+++ b/src/creatures/appearance/mounts/mounts.cpp
@@ -35,19 +35,12 @@ bool Mounts::loadFromXml() {
 			continue;
 		}
 
-		mounts.emplace(std::make_shared<Mount>(
-			static_cast<uint8_t>(pugi::cast<uint16_t>(mountNode.attribute("id").value())),
-			lookType,
-			mountNode.attribute("name").as_string(),
-			pugi::cast<int32_t>(mountNode.attribute("speed").value()),
-			mountNode.attribute("premium").as_bool(),
-			mountNode.attribute("type").as_string()
-		));
+		mounts.emplace(std::make_shared<Mount>(static_cast<uint8_t>(pugi::cast<uint16_t>(mountNode.attribute("id").value())), lookType, mountNode.attribute("name").as_string(), pugi::cast<int32_t>(mountNode.attribute("speed").value()), mountNode.attribute("premium").as_bool(), mountNode.attribute("type").as_string()));
 	}
 	return true;
 }
 
-std::shared_ptr<Mount> Mounts::getMountByID(uint8_t id) {
+std::shared_ptr<Mount> Mounts::getMountByID(uint8_t id) const {
 	auto it = std::find_if(mounts.begin(), mounts.end(), [id](const std::shared_ptr<Mount> &mount) {
 		return mount->id == id; // Note the use of -> operator to access the members of the Mount object
 	});
@@ -55,7 +48,7 @@ std::shared_ptr<Mount> Mounts::getMountByID(uint8_t id) {
 	return it != mounts.end() ? *it : nullptr; // Returning the shared_ptr to the Mount object
 }
 
-std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) {
+std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) const {
 	auto mountName = name.c_str();
 	auto it = std::find_if(mounts.begin(), mounts.end(), [mountName](const std::shared_ptr<Mount> &mount) {
 		return strcasecmp(mountName, mount->name.c_str()) == 0;
@@ -64,7 +57,7 @@ std::shared_ptr<Mount> Mounts::getMountByName(const std::string &name) {
 	return it != mounts.end() ? *it : nullptr;
 }
 
-std::shared_ptr<Mount> Mounts::getMountByClientID(uint16_t clientId) {
+std::shared_ptr<Mount> Mounts::getMountByClientID(uint16_t clientId) const {
 	auto it = std::find_if(mounts.begin(), mounts.end(), [clientId](const std::shared_ptr<Mount> &mount) {
 		return mount->clientId == clientId; // Note the use of -> operator to access the members of the Mount object
 	});

--- a/src/creatures/appearance/mounts/mounts.hpp
+++ b/src/creatures/appearance/mounts/mounts.hpp
@@ -26,9 +26,9 @@ class Mounts {
 public:
 	bool reload();
 	bool loadFromXml();
-	std::shared_ptr<Mount> getMountByID(uint8_t id);
-	std::shared_ptr<Mount> getMountByName(const std::string &name);
-	std::shared_ptr<Mount> getMountByClientID(uint16_t clientId);
+	std::shared_ptr<Mount> getMountByID(uint8_t id) const;
+	std::shared_ptr<Mount> getMountByName(const std::string &name) const;
+	std::shared_ptr<Mount> getMountByClientID(uint16_t clientId) const;
 
 	[[nodiscard]] const phmap::parallel_flat_hash_set<std::shared_ptr<Mount>> &getMounts() const {
 		return mounts;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7540,6 +7540,10 @@ bool Player::toggleMount(bool mount) {
 	}
 
 	if (mount) {
+		if (!g_game().outfitSupportsMount(defaultOutfit.lookType)) {
+			return false;
+		}
+
 		if (isMounted()) {
 			return false;
 		}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -7541,6 +7541,7 @@ bool Player::toggleMount(bool mount) {
 
 	if (mount) {
 		if (!g_game().outfitSupportsMount(defaultOutfit.lookType)) {
+			sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 			return false;
 		}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6493,12 +6493,16 @@ void Game::playerToggleMount(uint32_t playerId, bool mount) {
 }
 
 void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount, uint8_t isMountRandomized /* = 0*/) {
+	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT)) {
+		return;
+	}
+
 	const auto &player = getPlayerByID(playerId);
 	playerChangeOutfit(player, outfit, setMount, isMountRandomized);
 }
 
 void Game::playerChangeOutfit(const std::shared_ptr<Player> &player, Outfit_t outfit, bool setMount, uint8_t isMountRandomized /* = 0*/) {
-	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT) || !player) {
+	if (!player) {
 		return;
 	}
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1313,17 +1313,18 @@ FILELOADER_ERRORS Game::loadAppearanceProtobuf(const std::string &file) {
 	// Verify that the version of the library that we linked against is
 	// compatible with the version of the headers we compiled against.
 	GOOGLE_PROTOBUF_VERIFY_VERSION;
+	outfitMountSupportedLookTypes.clear();
 	m_appearancesPtr = std::make_unique<Appearances>();
 	if (!m_appearancesPtr->ParseFromIstream(&fileStream)) {
 		g_logger().error("[Game::loadAppearanceProtobuf] - Failed to parse binary file {}, file is invalid", file);
 		fileStream.close();
+		m_appearancesPtr.reset();
 		return ERROR_NOT_OPEN;
 	}
 
 	// Parsing all items into ItemType
 	Item::items.loadFromProtobuf();
 
-	outfitMountSupportedLookTypes.clear();
 	for (const auto &appearance : m_appearancesPtr->outfit()) {
 		if (outfitAppearanceSupportsMount(appearance)) {
 			outfitMountSupportedLookTypes.emplace(static_cast<uint16_t>(appearance.id()));
@@ -1349,9 +1350,6 @@ FILELOADER_ERRORS Game::loadAppearanceProtobuf(const std::string &file) {
 	}
 
 	fileStream.close();
-
-	// Disposing allocated objects.
-	google::protobuf::ShutdownProtobufLibrary();
 
 	return ERROR_NONE;
 }
@@ -9253,7 +9251,7 @@ void Game::processHighscoreResults(const DBResult_ptr &result, uint32_t playerID
 	return static_cast<uint16_t>((totalEntries + entriesPerPage - 1) / entriesPerPage);
 }
 
-[[nodiscard]] uint16_t Game::resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId) {
+[[nodiscard]] uint16_t Game::resolveRandomMountClientId(const Mounts &mounts, uint8_t randomMountId) {
 	const auto randomMount = randomMountId != 0 ? mounts.getMountByID(randomMountId) : nullptr;
 	return randomMount ? randomMount->clientId : 0;
 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6493,12 +6493,12 @@ void Game::playerToggleMount(uint32_t playerId, bool mount) {
 }
 
 void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount, uint8_t isMountRandomized /* = 0*/) {
-	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT)) {
-		return;
-	}
-
 	const auto &player = getPlayerByID(playerId);
-	if (!player) {
+	playerChangeOutfit(player, outfit, setMount, isMountRandomized);
+}
+
+void Game::playerChangeOutfit(const std::shared_ptr<Player> &player, Outfit_t outfit, bool setMount, uint8_t isMountRandomized /* = 0*/) {
+	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT) || !player) {
 		return;
 	}
 
@@ -6520,6 +6520,8 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 	const auto playerOutfit = Outfits::getInstance().getOutfitByLookType(player, outfit.lookType);
 	if (!playerOutfit || !setMount) {
 		outfit.lookMount = 0;
+		isMountRandomized = 0;
+		player->setRandomMount(0);
 	}
 
 	if (outfit.lookMount != 0 && !outfitSupportsMount(outfit.lookType)) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6504,14 +6504,8 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 
 	player->setRandomMount(isMountRandomized);
 
-	if (isMountRandomized && outfit.lookMount != 0 && player->hasAnyMount()) {
-		const auto randomMountId = player->getRandomMountId();
-		const auto randomMount = randomMountId != 0 ? mounts->getMountByID(randomMountId) : nullptr;
-		if (!randomMount) {
-			outfit.lookMount = 0;
-		} else {
-			outfit.lookMount = randomMount->clientId;
-		}
+	if (isMountRandomized && setMount && player->hasAnyMount()) {
+		outfit.lookMount = resolveRandomMountClientId(*mounts, player->getRandomMountId());
 	}
 
 	const auto playerOutfit = Outfits::getInstance().getOutfitByLookType(player, outfit.lookType);
@@ -9240,6 +9234,11 @@ void Game::processHighscoreResults(const DBResult_ptr &result, uint32_t playerID
 	}
 
 	return static_cast<uint16_t>((totalEntries + entriesPerPage - 1) / entriesPerPage);
+}
+
+[[nodiscard]] uint16_t Game::resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId) {
+	const auto randomMount = randomMountId != 0 ? mounts.getMountByID(randomMountId) : nullptr;
+	return randomMount ? randomMount->clientId : 0;
 }
 
 void Game::cacheQueryHighscore(const std::string &key, const std::string &query, uint32_t page, uint8_t entriesPerPage) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6505,8 +6505,13 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 	player->setRandomMount(isMountRandomized);
 
 	if (isMountRandomized && outfit.lookMount != 0 && player->hasAnyMount()) {
-		auto randomMount = mounts->getMountByID(player->getRandomMountId());
-		outfit.lookMount = randomMount->clientId;
+		const auto randomMountId = player->getRandomMountId();
+		const auto randomMount = randomMountId != 0 ? mounts->getMountByID(randomMountId) : nullptr;
+		if (!randomMount) {
+			outfit.lookMount = 0;
+		} else {
+			outfit.lookMount = randomMount->clientId;
+		}
 	}
 
 	const auto playerOutfit = Outfits::getInstance().getOutfitByLookType(player, outfit.lookType);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1323,6 +1323,13 @@ FILELOADER_ERRORS Game::loadAppearanceProtobuf(const std::string &file) {
 	// Parsing all items into ItemType
 	Item::items.loadFromProtobuf();
 
+	outfitMountSupportedLookTypes.clear();
+	for (const auto &appearance : m_appearancesPtr->outfit()) {
+		if (outfitAppearanceSupportsMount(appearance)) {
+			outfitMountSupportedLookTypes.emplace(static_cast<uint16_t>(appearance.id()));
+		}
+	}
+
 	// Only iterate other objects if necessary
 	if (g_configManager().getBoolean(WARN_UNSAFE_SCRIPTS)) {
 		// Registering distance effects
@@ -9271,13 +9278,7 @@ bool Game::outfitSupportsMount(uint16_t lookType) const {
 		return true;
 	}
 
-	for (const auto &appearance : m_appearancesPtr->outfit()) {
-		if (appearance.id() == lookType) {
-			return outfitAppearanceSupportsMount(appearance);
-		}
-	}
-
-	return false;
+	return outfitMountSupportedLookTypes.contains(lookType);
 }
 
 void Game::cacheQueryHighscore(const std::string &key, const std::string &query, uint32_t page, uint8_t entriesPerPage) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6513,6 +6513,10 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 
 	if (isMountRandomized && setMount && player->hasAnyMount()) {
 		outfit.lookMount = resolveRandomMountClientId(*mounts, player->getRandomMountId());
+		if (outfit.lookMount == 0) {
+			isMountRandomized = 0;
+			player->setRandomMount(0);
+		}
 	}
 
 	const auto playerOutfit = Outfits::getInstance().getOutfitByLookType(player, outfit.lookType);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9259,20 +9259,26 @@ void Game::processHighscoreResults(const DBResult_ptr &result, uint32_t playerID
 [[nodiscard]] bool Game::outfitAppearanceSupportsMount(const Canary::protobuf::appearances::Appearance &appearance) {
 	using namespace Canary::protobuf::appearances;
 
-	bool hasOutfitFrameGroup = false;
+	bool hasIdleFrameGroup = false;
+	bool hasMovingFrameGroup = false;
 	for (const auto &frameGroup : appearance.frame_group()) {
 		const auto fixedFrameGroup = frameGroup.fixed_frame_group();
 		if (fixedFrameGroup != FIXED_FRAME_GROUP_OUTFIT_IDLE && fixedFrameGroup != FIXED_FRAME_GROUP_OUTFIT_MOVING) {
 			continue;
 		}
 
-		hasOutfitFrameGroup = true;
+		if (fixedFrameGroup == FIXED_FRAME_GROUP_OUTFIT_IDLE) {
+			hasIdleFrameGroup = true;
+		} else {
+			hasMovingFrameGroup = true;
+		}
+
 		if (!frameGroup.has_sprite_info() || frameGroup.sprite_info().pattern_depth() <= 1) {
 			return false;
 		}
 	}
 
-	return hasOutfitFrameGroup;
+	return hasIdleFrameGroup && hasMovingFrameGroup;
 }
 
 bool Game::outfitSupportsMount(uint16_t lookType) const {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6513,6 +6513,12 @@ void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount,
 		outfit.lookMount = 0;
 	}
 
+	if (outfit.lookMount != 0 && !outfitSupportsMount(outfit.lookType)) {
+		outfit.lookMount = 0;
+		isMountRandomized = 0;
+		player->setRandomMount(0);
+	}
+
 	if (outfit.lookMount != 0) {
 		const auto mount = mounts->getMountByClientID(outfit.lookMount);
 		if (!mount) {
@@ -9239,6 +9245,39 @@ void Game::processHighscoreResults(const DBResult_ptr &result, uint32_t playerID
 [[nodiscard]] uint16_t Game::resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId) {
 	const auto randomMount = randomMountId != 0 ? mounts.getMountByID(randomMountId) : nullptr;
 	return randomMount ? randomMount->clientId : 0;
+}
+
+[[nodiscard]] bool Game::outfitAppearanceSupportsMount(const Canary::protobuf::appearances::Appearance &appearance) {
+	using namespace Canary::protobuf::appearances;
+
+	bool hasOutfitFrameGroup = false;
+	for (const auto &frameGroup : appearance.frame_group()) {
+		const auto fixedFrameGroup = frameGroup.fixed_frame_group();
+		if (fixedFrameGroup != FIXED_FRAME_GROUP_OUTFIT_IDLE && fixedFrameGroup != FIXED_FRAME_GROUP_OUTFIT_MOVING) {
+			continue;
+		}
+
+		hasOutfitFrameGroup = true;
+		if (!frameGroup.has_sprite_info() || frameGroup.sprite_info().pattern_depth() <= 1) {
+			return false;
+		}
+	}
+
+	return hasOutfitFrameGroup;
+}
+
+bool Game::outfitSupportsMount(uint16_t lookType) const {
+	if (!m_appearancesPtr) {
+		return true;
+	}
+
+	for (const auto &appearance : m_appearancesPtr->outfit()) {
+		if (appearance.id() == lookType) {
+			return outfitAppearanceSupportsMount(appearance);
+		}
+	}
+
+	return false;
 }
 
 void Game::cacheQueryHighscore(const std::string &key, const std::string &query, uint32_t page, uint8_t entriesPerPage) {

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -393,6 +393,7 @@ public:
 	void playerShowQuestLog(uint32_t playerId);
 	void playerShowQuestLine(uint32_t playerId, uint16_t questId);
 	void playerSay(uint32_t playerId, uint16_t channelId, SpeakClasses type, const std::string &receiver, const std::string &text);
+	void playerChangeOutfit(const std::shared_ptr<Player> &player, Outfit_t outfit, bool setMount, uint8_t isMountRandomized = 0);
 	void playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool setMount, uint8_t isMountRandomized = 0);
 	void playerInviteToParty(uint32_t playerId, uint32_t invitedId);
 	void playerJoinParty(uint32_t playerId, uint32_t leaderId);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -290,6 +290,7 @@ public:
 
 	void playerHighscores(const std::shared_ptr<Player> &player, HighscoreType_t type, uint8_t category, uint32_t vocation, const std::string &worldName, uint16_t page, uint8_t entriesPerPage);
 	[[nodiscard]] static uint16_t calculateHighscorePages(uint32_t totalEntries, uint8_t entriesPerPage);
+	[[nodiscard]] static uint16_t resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId);
 	static std::string getSkillNameById(uint8_t &skill);
 
 	// House Auction

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -826,6 +826,7 @@ private:
 	std::vector<uint16_t> registeredMagicEffects;
 	std::vector<uint16_t> registeredDistanceEffects;
 	std::vector<uint16_t> registeredLookTypes;
+	phmap::flat_hash_set<uint16_t> outfitMountSupportedLookTypes;
 
 	size_t lastBucket = 0;
 	size_t lastImbuedBucket = 0;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -23,6 +23,7 @@
 namespace Canary {
 	namespace protobuf {
 		namespace appearances {
+			class Appearance;
 			class Appearances;
 		} // namespace appearances
 	} // namespace protobuf
@@ -291,6 +292,7 @@ public:
 	void playerHighscores(const std::shared_ptr<Player> &player, HighscoreType_t type, uint8_t category, uint32_t vocation, const std::string &worldName, uint16_t page, uint8_t entriesPerPage);
 	[[nodiscard]] static uint16_t calculateHighscorePages(uint32_t totalEntries, uint8_t entriesPerPage);
 	[[nodiscard]] static uint16_t resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId);
+	[[nodiscard]] static bool outfitAppearanceSupportsMount(const Canary::protobuf::appearances::Appearance &appearance);
 	static std::string getSkillNameById(uint8_t &skill);
 
 	// House Auction
@@ -615,6 +617,7 @@ public:
 	bool isLookTypeRegistered(uint16_t type) const {
 		return std::ranges::find(registeredLookTypes, type) != registeredLookTypes.end();
 	}
+	bool outfitSupportsMount(uint16_t lookType) const;
 
 	void setCreateLuaItems(Position position, uint16_t itemId) {
 		mapLuaItemsStored[position] = itemId;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -291,7 +291,7 @@ public:
 
 	void playerHighscores(const std::shared_ptr<Player> &player, HighscoreType_t type, uint8_t category, uint32_t vocation, const std::string &worldName, uint16_t page, uint8_t entriesPerPage);
 	[[nodiscard]] static uint16_t calculateHighscorePages(uint32_t totalEntries, uint8_t entriesPerPage);
-	[[nodiscard]] static uint16_t resolveRandomMountClientId(Mounts &mounts, uint8_t randomMountId);
+	[[nodiscard]] static uint16_t resolveRandomMountClientId(const Mounts &mounts, uint8_t randomMountId);
 	[[nodiscard]] static bool outfitAppearanceSupportsMount(const Canary::protobuf::appearances::Appearance &appearance);
 	static std::string getSkillNameById(uint8_t &skill);
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7713,7 +7713,7 @@ void ProtocolGame::sendOutfitWindow() {
 	msg.addByte(mounted ? 0x01 : 0x00);
 
 	// Version 12.81 - Random mount 'bool'
-	msg.addByte(isSupportOutfit ? 0x00 : (player->isRandomMounted() ? 0x01 : 0x00));
+	msg.addByte(isSupportOutfit || !currentOutfitSupportsMount ? 0x00 : (player->isRandomMounted() ? 0x01 : 0x00));
 
 	if (isOTCR) {
 		sendOutfitWindowCustomOTCR(msg); // g_game.enableFeature(GameWingsAurasEffectsShader)

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7494,9 +7494,10 @@ void ProtocolGame::sendOutfitWindow() {
 
 	Outfit_t currentOutfit = player->getDefaultOutfit();
 	auto isSupportOutfit = player->isWearingSupportOutfit();
+	const auto currentOutfitSupportsMount = g_game().outfitSupportsMount(currentOutfit.lookType);
 	bool mounted = false;
 
-	if (!isSupportOutfit) {
+	if (!isSupportOutfit && currentOutfitSupportsMount) {
 		const auto currentMount = g_game().mounts->getMountByID(player->getLastMount());
 		if (currentMount) {
 			mounted = (currentOutfit.lookMount == currentMount->clientId);
@@ -7575,10 +7576,10 @@ void ProtocolGame::sendOutfitWindow() {
 	}
 
 	if (currentOutfit.lookMount == 0) {
-		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountHead);
-		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountBody);
-		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountLegs);
-		msg.addByte(isSupportOutfit ? 0 : currentOutfit.lookMountFeet);
+		msg.addByte(isSupportOutfit || !currentOutfitSupportsMount ? 0 : currentOutfit.lookMountHead);
+		msg.addByte(isSupportOutfit || !currentOutfitSupportsMount ? 0 : currentOutfit.lookMountBody);
+		msg.addByte(isSupportOutfit || !currentOutfitSupportsMount ? 0 : currentOutfit.lookMountLegs);
+		msg.addByte(isSupportOutfit || !currentOutfitSupportsMount ? 0 : currentOutfit.lookMountFeet);
 	}
 	msg.add<uint16_t>(currentOutfit.lookFamiliarsType);
 

--- a/tests/unit/game/CMakeLists.txt
+++ b/tests/unit/game/CMakeLists.txt
@@ -1,4 +1,6 @@
 target_sources(
     canary_ut
-    PRIVATE events_scheduler_test.cpp highscores_test.cpp random_mount_test.cpp
+    PRIVATE events_scheduler_test.cpp
+            highscores_test.cpp
+            random_mount_test.cpp
 )

--- a/tests/unit/game/CMakeLists.txt
+++ b/tests/unit/game/CMakeLists.txt
@@ -1,4 +1,4 @@
 target_sources(
     canary_ut
-    PRIVATE events_scheduler_test.cpp highscores_test.cpp
+    PRIVATE events_scheduler_test.cpp highscores_test.cpp random_mount_test.cpp
 )

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -10,8 +10,38 @@
 #include "creatures/appearance/mounts/mounts.hpp"
 #include "game/game.hpp"
 
+#include <appearances.pb.h>
+
 TEST(RandomMountOutfitRegressionTest, InvalidRandomMountIdResolvesToNoMount) {
 	Mounts mounts;
 
 	EXPECT_EQ(0, Game::resolveRandomMountClientId(mounts, 42));
+}
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithoutMountedPatternDepthRejectsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	auto &idleFrameGroup = *appearance.add_frame_group();
+	idleFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE);
+	idleFrameGroup.mutable_sprite_info()->set_pattern_depth(1);
+
+	auto &movingFrameGroup = *appearance.add_frame_group();
+	movingFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING);
+	movingFrameGroup.mutable_sprite_info()->set_pattern_depth(1);
+
+	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
+}
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithMountedPatternDepthAllowsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	auto &idleFrameGroup = *appearance.add_frame_group();
+	idleFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE);
+	idleFrameGroup.mutable_sprite_info()->set_pattern_depth(2);
+
+	auto &movingFrameGroup = *appearance.add_frame_group();
+	movingFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING);
+	movingFrameGroup.mutable_sprite_info()->set_pattern_depth(2);
+
+	EXPECT_TRUE(Game::outfitAppearanceSupportsMount(appearance));
 }

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -8,6 +8,8 @@
  */
 
 #include "creatures/appearance/mounts/mounts.hpp"
+#include "creatures/players/player.hpp"
+#include "config/configmanager.hpp"
 #include "game/game.hpp"
 
 #include <appearances.pb.h>
@@ -25,6 +27,27 @@ TEST(RandomMountOutfitRegressionTest, InvalidRandomMountIdResolvesToNoMount) {
 	constexpr uint8_t nonExistentRandomMountId = 42;
 
 	EXPECT_EQ(0, Game::resolveRandomMountClientId(mounts, nonExistentRandomMountId));
+}
+
+TEST(RandomMountOutfitRegressionTest, PlayerChangeOutfitWithoutMountClearsMountedAndRandomState) {
+	g_configManager().setConfigFileLua("config.lua.dist");
+	ASSERT_TRUE(g_configManager().load());
+
+	auto player = std::make_shared<Player>();
+
+	Outfit_t currentOutfit;
+	currentOutfit.lookType = 128;
+	currentOutfit.lookMount = 1;
+	player->setDefaultOutfit(currentOutfit);
+	player->setRandomMount(1);
+
+	Outfit_t requestedOutfit = currentOutfit;
+	requestedOutfit.lookMount = 1;
+
+	g_game().playerChangeOutfit(player, requestedOutfit, false, 1);
+
+	EXPECT_FALSE(player->isMounted());
+	EXPECT_EQ(0, player->isRandomMounted());
 }
 
 TEST(RandomMountOutfitRegressionTest, OutfitWithoutMountedPatternDepthRejectsMount) {

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -9,7 +9,6 @@
 
 #include "creatures/appearance/mounts/mounts.hpp"
 #include "creatures/players/player.hpp"
-#include "config/configmanager.hpp"
 #include "game/game.hpp"
 
 #include <appearances.pb.h>
@@ -30,9 +29,6 @@ TEST(RandomMountOutfitRegressionTest, InvalidRandomMountIdResolvesToNoMount) {
 }
 
 TEST(RandomMountOutfitRegressionTest, PlayerChangeOutfitWithoutMountClearsMountedAndRandomState) {
-	g_configManager().setConfigFileLua("config.lua.dist");
-	ASSERT_TRUE(g_configManager().load());
-
 	auto player = std::make_shared<Player>();
 
 	Outfit_t currentOutfit;

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -12,22 +12,26 @@
 
 #include <appearances.pb.h>
 
+namespace {
+	void addOutfitFrameGroup(Canary::protobuf::appearances::Appearance &appearance, Canary::protobuf::appearances::FixedFrameGroup fixedFrameGroup, uint32_t patternDepth) {
+		auto &frameGroup = *appearance.add_frame_group();
+		frameGroup.set_fixed_frame_group(fixedFrameGroup);
+		frameGroup.mutable_sprite_info()->set_pattern_depth(patternDepth);
+	}
+}
+
 TEST(RandomMountOutfitRegressionTest, InvalidRandomMountIdResolvesToNoMount) {
 	Mounts mounts;
+	constexpr uint8_t nonExistentRandomMountId = 42;
 
-	EXPECT_EQ(0, Game::resolveRandomMountClientId(mounts, 42));
+	EXPECT_EQ(0, Game::resolveRandomMountClientId(mounts, nonExistentRandomMountId));
 }
 
 TEST(RandomMountOutfitRegressionTest, OutfitWithoutMountedPatternDepthRejectsMount) {
 	Canary::protobuf::appearances::Appearance appearance;
 
-	auto &idleFrameGroup = *appearance.add_frame_group();
-	idleFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE);
-	idleFrameGroup.mutable_sprite_info()->set_pattern_depth(1);
-
-	auto &movingFrameGroup = *appearance.add_frame_group();
-	movingFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING);
-	movingFrameGroup.mutable_sprite_info()->set_pattern_depth(1);
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE, 1);
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING, 1);
 
 	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
 }
@@ -35,13 +39,29 @@ TEST(RandomMountOutfitRegressionTest, OutfitWithoutMountedPatternDepthRejectsMou
 TEST(RandomMountOutfitRegressionTest, OutfitWithMountedPatternDepthAllowsMount) {
 	Canary::protobuf::appearances::Appearance appearance;
 
-	auto &idleFrameGroup = *appearance.add_frame_group();
-	idleFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE);
-	idleFrameGroup.mutable_sprite_info()->set_pattern_depth(2);
-
-	auto &movingFrameGroup = *appearance.add_frame_group();
-	movingFrameGroup.set_fixed_frame_group(Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING);
-	movingFrameGroup.mutable_sprite_info()->set_pattern_depth(2);
+	// pattern_depth == 2 encodes the mounted/unmounted sprite-variant axis.
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE, 2);
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING, 2);
 
 	EXPECT_TRUE(Game::outfitAppearanceSupportsMount(appearance));
+}
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithOnlyIdleMountedPatternDepthRejectsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	// Both outfit frame groups need the mounted/unmounted sprite-variant axis.
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE, 2);
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING, 1);
+
+	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
+}
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithOnlyMovingMountedPatternDepthRejectsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	// Both outfit frame groups need the mounted/unmounted sprite-variant axis.
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE, 1);
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING, 2);
+
+	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
 }

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -1,0 +1,17 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019–present OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "creatures/appearance/mounts/mounts.hpp"
+#include "game/game.hpp"
+
+TEST(RandomMountOutfitRegressionTest, InvalidRandomMountIdResolvesToNoMount) {
+	Mounts mounts;
+
+	EXPECT_EQ(0, Game::resolveRandomMountClientId(mounts, 42));
+}

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -65,3 +65,19 @@ TEST(RandomMountOutfitRegressionTest, OutfitWithOnlyMovingMountedPatternDepthRej
 
 	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
 }
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithOnlyIdleFrameGroupRejectsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_IDLE, 2);
+
+	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
+}
+
+TEST(RandomMountOutfitRegressionTest, OutfitWithOnlyMovingFrameGroupRejectsMount) {
+	Canary::protobuf::appearances::Appearance appearance;
+
+	addOutfitFrameGroup(appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP_OUTFIT_MOVING, 2);
+
+	EXPECT_FALSE(Game::outfitAppearanceSupportsMount(appearance));
+}

--- a/tests/unit/game/random_mount_test.cpp
+++ b/tests/unit/game/random_mount_test.cpp
@@ -13,7 +13,7 @@
 #include <appearances.pb.h>
 
 namespace {
-	void addOutfitFrameGroup(Canary::protobuf::appearances::Appearance &appearance, Canary::protobuf::appearances::FixedFrameGroup fixedFrameGroup, uint32_t patternDepth) {
+	void addOutfitFrameGroup(Canary::protobuf::appearances::Appearance &appearance, Canary::protobuf::appearances::FIXED_FRAME_GROUP fixedFrameGroup, uint32_t patternDepth) {
 		auto &frameGroup = *appearance.add_frame_group();
 		frameGroup.set_fixed_frame_group(fixedFrameGroup);
 		frameGroup.mutable_sprite_info()->set_pattern_depth(patternDepth);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable mount handling during outfit changes: randomized mounts now resolve to no mount when invalid/unavailable and incompatible mounts are cleared.
  * Login outfit replacement now only applies for specific looks when the player lacks group access.
  * Outfit mount compatibility is pre-evaluated to ensure accurate validation.
* **Tests**
  * Added unit tests for randomized-mount resolution and mount-compatibility checks.
* **Chores**
  * Test target updated to include the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->