### PR TITLE
build: add Windows link audit preset and extraction helper

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -236,7 +236,7 @@
       "binaryDir": "${sourceDir}/build/windows-release-link-audit",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO": "/VERBOSE:LIB /MAP:\"${sourceDir}/build/windows-release-link-audit/canary-link-audit.map\""
+        "CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO": "/VERBOSE:LIB /MAP:\"${sourceDir}/build/${presetName}/canary-link-audit.map\""
       }
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -227,6 +227,17 @@
         "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/arm64-osx-metrics",
         "VCPKG_MANIFEST_FEATURES": "metrics"
       }
+    },
+    {
+      "name": "windows-release-link-audit",
+      "inherits": "windows-release",
+      "displayName": "Windows - Release Link Audit",
+      "description": "Windows Release build with link diagnostics (/VERBOSE:LIB, /MAP, compile_commands)",
+      "binaryDir": "${sourceDir}/build/windows-release-link-audit",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO": "/VERBOSE:LIB /MAP:\"${sourceDir}/build/windows-release-link-audit/canary-link-audit.map\""
+      }
     }
   ],
   "buildPresets": [
@@ -277,6 +288,10 @@
     {
       "name": "macos-release-metrics",
       "configurePreset": "macos-release-metrics"
+    },
+    {
+      "name": "windows-release-link-audit",
+      "configurePreset": "windows-release-link-audit"
     }
   ],
   "testPresets": [

--- a/tools/link-audit/extract-link-audit-evidence.ps1
+++ b/tools/link-audit/extract-link-audit-evidence.ps1
@@ -7,7 +7,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-if (-not (Test-Path $InputDir)) {
+if (-not (Test-Path $InputDir -PathType Container)) {
     throw "Input directory not found: $InputDir. Pass -InputDir with the directory that contains the link audit artifacts."
 }
 
@@ -19,6 +19,7 @@ if (-not $OutputDir) {
 
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 $OutputDir = (Resolve-Path -LiteralPath $OutputDir).Path
+$OutputDirWithSeparator = $OutputDir.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
 
 $Patterns = "link.exe|/VERBOSE:LIB|/MAP|LINK_LIBRARIES|libcrypto|libssl|libcurl|mariadbclient|lua51|libprotobuf|libprotobuf-lite|libprotoc|absl_|fmt|spdlog|pugixml|argon2|zs\.lib|bcrypt|ncrypt|crypt32|ws2_32|Searching|Found|Loaded|Referenced in|Processed|LNK"
 
@@ -32,12 +33,12 @@ if ($VcpkgInstalled) {
 # 1) Extract interesting lines from existing logs, if any
 $LogFiles = Get-ChildItem $InputDir -Recurse -File -Include "*.log","*.txt" -ErrorAction SilentlyContinue |
     Where-Object {
-        $_.FullName -notmatch "\\link-audit-extract\\"
+        -not $_.FullName.StartsWith($OutputDirWithSeparator, [System.StringComparison]::InvariantCultureIgnoreCase)
     }
 
 if ($LogFiles) {
     Select-String -Path $LogFiles.FullName -Pattern $Patterns -CaseSensitive:$false |
-        Set-Content (Join-Path $OutputDir "existing-logs-interesting-lines.txt")
+        Set-Content (Join-Path $OutputDir "existing-logs-interesting-lines.txt") -Encoding utf8
 
     Write-Host "OK: existing-logs-interesting-lines.txt"
 } else {
@@ -54,13 +55,13 @@ if ($Map) {
     Write-Host "Map: $($Map.FullName)"
 
     Select-String $Map.FullName -Pattern "libcrypto|libssl|libcurl|mariadbclient|libprotobuf|libprotobuf-lite|libprotoc|absl_|fmt|spdlog|pugixml|argon2|zs\.lib" -CaseSensitive:$false |
-        Set-Content (Join-Path $OutputDir "map-libs.txt")
+        Set-Content (Join-Path $OutputDir "map-libs.txt") -Encoding utf8
 
     Select-String $Map.FullName -Pattern "libcrypto|libssl|BN_|RSA_|EVP_|PEM_|BIO_|SSL_|ERR_|CRYPTO_|SHA|HMAC|RAND_|AES_|X509_|OPENSSL_" -CaseSensitive:$false |
-        Set-Content (Join-Path $OutputDir "map-openssl-symbols.txt")
+        Set-Content (Join-Path $OutputDir "map-openssl-symbols.txt") -Encoding utf8
 
     Select-String $Map.FullName -Pattern "libprotobuf|libprotobuf-lite|libprotoc|MessageLite|protobuf" -CaseSensitive:$false |
-        Set-Content (Join-Path $OutputDir "map-protobuf-symbols.txt")
+        Set-Content (Join-Path $OutputDir "map-protobuf-symbols.txt") -Encoding utf8
 
     Write-Host "OK: map-libs.txt"
     Write-Host "OK: map-openssl-symbols.txt"
@@ -74,7 +75,7 @@ $LinkMetadataFiles = Get-ChildItem $InputDir -Recurse -File -Include "*.rsp","*.
 
 if ($LinkMetadataFiles) {
     Select-String -Path $LinkMetadataFiles.FullName -Pattern $Patterns -CaseSensitive:$false |
-        Set-Content (Join-Path $OutputDir "link-metadata-interesting-lines.txt")
+        Set-Content (Join-Path $OutputDir "link-metadata-interesting-lines.txt") -Encoding utf8
 
     Write-Host "OK: link-metadata-interesting-lines.txt"
 } else {
@@ -87,19 +88,19 @@ Get-ChildItem $InputDir -Recurse -File -Include "canary.exe","canary.pdb","*.map
     Sort-Object MB -Descending |
     Format-Table -AutoSize |
     Out-String |
-    Set-Content (Join-Path $OutputDir "artifact-sizes.txt")
+    Set-Content (Join-Path $OutputDir "artifact-sizes.txt") -Encoding utf8
 
 Write-Host "OK: artifact-sizes.txt"
 
 # 5) Largest files from the installed vcpkg tree
-if ($VcpkgInstalled -and (Test-Path $VcpkgInstalled)) {
+if ($VcpkgInstalled -and (Test-Path $VcpkgInstalled -PathType Container)) {
     Get-ChildItem $VcpkgInstalled -Recurse -File -Include "*.lib","*.exe","*.pdb" -ErrorAction SilentlyContinue |
         Select-Object FullName, @{Name="MB";Expression={[math]::Round($_.Length / 1MB, 2)}} |
         Sort-Object MB -Descending |
         Select-Object -First 100 |
         Format-Table -AutoSize |
         Out-String |
-        Set-Content (Join-Path $OutputDir "vcpkg-largest-files.txt")
+        Set-Content (Join-Path $OutputDir "vcpkg-largest-files.txt") -Encoding utf8
 
     Write-Host "OK: vcpkg-largest-files.txt"
 } elseif ($VcpkgInstalled) {

--- a/tools/link-audit/extract-link-audit-evidence.ps1
+++ b/tools/link-audit/extract-link-audit-evidence.ps1
@@ -1,0 +1,114 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InputDir,
+    [string]$OutputDir,
+    [string]$VcpkgInstalled
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $InputDir)) {
+    throw "Input directory not found: $InputDir. Pass -InputDir with the directory that contains the link audit artifacts."
+}
+
+$InputDir = (Resolve-Path -LiteralPath $InputDir).Path
+
+if (-not $OutputDir) {
+    $OutputDir = Join-Path $InputDir "link-audit-extract"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$OutputDir = (Resolve-Path -LiteralPath $OutputDir).Path
+
+$Patterns = "link.exe|/VERBOSE:LIB|/MAP|LINK_LIBRARIES|libcrypto|libssl|libcurl|mariadbclient|lua51|libprotobuf|libprotobuf-lite|libprotoc|absl_|fmt|spdlog|pugixml|argon2|zs\.lib|bcrypt|ncrypt|crypt32|ws2_32|Searching|Found|Loaded|Referenced in|Processed|LNK"
+
+Write-Host "InputDir: $InputDir"
+Write-Host "OutputDir: $OutputDir"
+
+if ($VcpkgInstalled) {
+    Write-Host "VcpkgInstalled: $VcpkgInstalled"
+}
+
+# 1) Extract interesting lines from existing logs, if any
+$LogFiles = Get-ChildItem $InputDir -Recurse -File -Include "*.log","*.txt" -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.FullName -notmatch "\\link-audit-extract\\"
+    }
+
+if ($LogFiles) {
+    Select-String -Path $LogFiles.FullName -Pattern $Patterns -CaseSensitive:$false |
+        Set-Content (Join-Path $OutputDir "existing-logs-interesting-lines.txt")
+
+    Write-Host "OK: existing-logs-interesting-lines.txt"
+} else {
+    Write-Host "SKIP: no .log/.txt files found to extract"
+}
+
+# 2) Locate and extract .map data
+$MapFiles = Get-ChildItem $InputDir -Recurse -File -Filter "*.map" -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending
+
+$Map = $MapFiles | Select-Object -First 1
+
+if ($Map) {
+    Write-Host "Map: $($Map.FullName)"
+
+    Select-String $Map.FullName -Pattern "libcrypto|libssl|libcurl|mariadbclient|libprotobuf|libprotobuf-lite|libprotoc|absl_|fmt|spdlog|pugixml|argon2|zs\.lib" -CaseSensitive:$false |
+        Set-Content (Join-Path $OutputDir "map-libs.txt")
+
+    Select-String $Map.FullName -Pattern "libcrypto|libssl|BN_|RSA_|EVP_|PEM_|BIO_|SSL_|ERR_|CRYPTO_|SHA|HMAC|RAND_|AES_|X509_|OPENSSL_" -CaseSensitive:$false |
+        Set-Content (Join-Path $OutputDir "map-openssl-symbols.txt")
+
+    Select-String $Map.FullName -Pattern "libprotobuf|libprotobuf-lite|libprotoc|MessageLite|protobuf" -CaseSensitive:$false |
+        Set-Content (Join-Path $OutputDir "map-protobuf-symbols.txt")
+
+    Write-Host "OK: map-libs.txt"
+    Write-Host "OK: map-openssl-symbols.txt"
+    Write-Host "OK: map-protobuf-symbols.txt"
+} else {
+    Write-Host "SKIP: no .map file found"
+}
+
+# 3) Locate response files / tlog / link command, if present
+$LinkMetadataFiles = Get-ChildItem $InputDir -Recurse -File -Include "*.rsp","*.tlog","link.txt" -ErrorAction SilentlyContinue
+
+if ($LinkMetadataFiles) {
+    Select-String -Path $LinkMetadataFiles.FullName -Pattern $Patterns -CaseSensitive:$false |
+        Set-Content (Join-Path $OutputDir "link-metadata-interesting-lines.txt")
+
+    Write-Host "OK: link-metadata-interesting-lines.txt"
+} else {
+    Write-Host "SKIP: no .rsp/.tlog/link.txt files found"
+}
+
+# 4) Final artifact sizes
+Get-ChildItem $InputDir -Recurse -File -Include "canary.exe","canary.pdb","*.map" -ErrorAction SilentlyContinue |
+    Select-Object FullName, @{Name="MB";Expression={[math]::Round($_.Length / 1MB, 2)}}, LastWriteTime |
+    Sort-Object MB -Descending |
+    Format-Table -AutoSize |
+    Out-String |
+    Set-Content (Join-Path $OutputDir "artifact-sizes.txt")
+
+Write-Host "OK: artifact-sizes.txt"
+
+# 5) Largest files from the installed vcpkg tree
+if ($VcpkgInstalled -and (Test-Path $VcpkgInstalled)) {
+    Get-ChildItem $VcpkgInstalled -Recurse -File -Include "*.lib","*.exe","*.pdb" -ErrorAction SilentlyContinue |
+        Select-Object FullName, @{Name="MB";Expression={[math]::Round($_.Length / 1MB, 2)}} |
+        Sort-Object MB -Descending |
+        Select-Object -First 100 |
+        Format-Table -AutoSize |
+        Out-String |
+        Set-Content (Join-Path $OutputDir "vcpkg-largest-files.txt")
+
+    Write-Host "OK: vcpkg-largest-files.txt"
+} elseif ($VcpkgInstalled) {
+    Write-Host "SKIP: vcpkg_installed not found at $VcpkgInstalled"
+} else {
+    Write-Host "SKIP: no vcpkg_installed path provided"
+}
+
+Write-Host ""
+Write-Host "Extraction complete."
+Write-Host "Generated files in:"
+Write-Host $OutputDir


### PR DESCRIPTION
Add a CMake configure/build preset (windows-release-link-audit) that enables compile_commands and sets linker flags (/VERBOSE:LIB and /MAP) to produce link diagnostics and a .map file for Windows Release builds. Also add a new PowerShell helper tools/link-audit/extract-link-audit-evidence.ps1 that scans a build output directory and extracts relevant link-audit information (interesting log lines, map-based library/symbol matches, response/tlog/link command lines, artifact sizes, and largest files from a vcpkg installed tree).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows build preset that produces verbose linker output and generates a linker map file for diagnostic builds.
  * Added a link-audit extraction utility that collects and summarizes linker logs, map/symbol data, link metadata, and artifact size reports to an output directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->