### PR TITLE
fix: add optional stack to influenced monsters

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -898,8 +898,11 @@ function SetInfluenced(monsterType, monster, player, influencedLevel)
 			Game.removeInfluencedMonster(influencedMonster:getId())
 		end
 	end
-	Game.addInfluencedMonster(monster)
-	monster:setForgeStack(influencedLevel)
+	if not Game.addInfluencedMonster(monster, influencedLevel) then
+		player:sendCancelMessage("Could not add influenced monster.")
+		return false
+	end
+	return true
 end
 
 function ReloadDataEvent(cid)

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2687,7 +2687,7 @@ void Monster::applyStacks() {
 	health = newHealth;
 }
 
-void Monster::configureForgeSystem() {
+void Monster::configureForgeSystem(uint16_t stack /* = 0 */) {
 	if (!canBeForgeMonster()) {
 		return;
 	}
@@ -2697,7 +2697,9 @@ void Monster::configureForgeSystem() {
 		setIcon("forge", CreatureIcon(CreatureIconModifications_t::Fiendish, 0 /* don't show stacks on fiends */));
 		g_game().updateCreatureIcon(static_self_cast<Monster>());
 	} else if (monsterForgeClassification == ForgeClassifications_t::FORGE_INFLUENCED_MONSTER) {
-		auto stack = static_cast<uint16_t>(normal_random(1, 5));
+		if (stack == 0) {
+			stack = static_cast<uint16_t>(normal_random(1, 5));
+		}
 		setForgeStack(stack);
 		setIcon("forge", CreatureIcon(CreatureIconModifications_t::Influenced, stack));
 		g_game().updateCreatureIcon(static_self_cast<Monster>());

--- a/src/creatures/monsters/monster.hpp
+++ b/src/creatures/monsters/monster.hpp
@@ -194,7 +194,7 @@ public:
 
 	void applyStacks();
 
-	void configureForgeSystem();
+	void configureForgeSystem(uint16_t stack = 0);
 
 	bool canBeForgeMonster() const;
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -11196,15 +11196,17 @@ bool Game::addInfluencedMonster(const std::shared_ptr<Monster> &monster, uint16_
 			return getMonsterByID(monsterId) == nullptr;
 		});
 
+		const auto monsterId = monster->getID();
+		const bool alreadyInfluenced = influencedMonsters.contains(monsterId);
 		if (auto maxInfluencedMonsters = static_cast<uint32_t>(g_configManager().getNumber(FORGE_INFLUENCED_CREATURES_LIMIT));
 		    // If condition
-		    (influencedMonsters.size() + 1) > maxInfluencedMonsters) {
+		    !alreadyInfluenced && (influencedMonsters.size() + 1) > maxInfluencedMonsters) {
 			return false;
 		}
 
 		monster->setMonsterForgeClassification(ForgeClassifications_t::FORGE_INFLUENCED_MONSTER);
 		monster->configureForgeSystem(stack);
-		influencedMonsters.emplace(monster->getID());
+		influencedMonsters.emplace(monsterId);
 		return true;
 	}
 	return false;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -11190,8 +11190,12 @@ void Game::checkForgeEventId(uint32_t monsterId) {
 	}
 }
 
-bool Game::addInfluencedMonster(const std::shared_ptr<Monster> &monster) {
+bool Game::addInfluencedMonster(const std::shared_ptr<Monster> &monster, uint16_t stack /* = 0 */) {
 	if (monster && monster->canBeForgeMonster()) {
+		std::erase_if(influencedMonsters, [this](const auto monsterId) {
+			return getMonsterByID(monsterId) == nullptr;
+		});
+
 		if (auto maxInfluencedMonsters = static_cast<uint32_t>(g_configManager().getNumber(FORGE_INFLUENCED_CREATURES_LIMIT));
 		    // If condition
 		    (influencedMonsters.size() + 1) > maxInfluencedMonsters) {
@@ -11199,7 +11203,7 @@ bool Game::addInfluencedMonster(const std::shared_ptr<Monster> &monster) {
 		}
 
 		monster->setMonsterForgeClassification(ForgeClassifications_t::FORGE_INFLUENCED_MONSTER);
-		monster->configureForgeSystem();
+		monster->configureForgeSystem(stack);
 		influencedMonsters.emplace(monster->getID());
 		return true;
 	}

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -648,7 +648,7 @@ public:
 	uint32_t makeFiendishMonster(uint32_t forgeableMonsterId = 0, bool createForgeableMonsters = false);
 	uint32_t makeInfluencedMonster();
 
-	bool addInfluencedMonster(const std::shared_ptr<Monster> &monster);
+	bool addInfluencedMonster(const std::shared_ptr<Monster> &monster, uint16_t stack = 0);
 	void sendUpdateCreature(const std::shared_ptr<Creature> &creature);
 	std::shared_ptr<Item> wrapItem(const std::shared_ptr<Item> &item, const std::shared_ptr<House> &house);
 

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -811,7 +811,8 @@ int GameFunctions::luaGameGetNormalizedGuildName(lua_State* L) {
 }
 
 int GameFunctions::luaGameAddInfluencedMonster(lua_State* L) {
-	// Game.addInfluencedMonster(monster)
+	// Game.addInfluencedMonster(monster[, stack])
+	const auto stack = Lua::getNumber<uint16_t>(L, 2, 0);
 	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
@@ -819,7 +820,7 @@ int GameFunctions::luaGameAddInfluencedMonster(lua_State* L) {
 		return 0;
 	}
 
-	lua_pushboolean(L, g_game().addInfluencedMonster(monster));
+	lua_pushboolean(L, g_game().addInfluencedMonster(monster, stack));
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -564,10 +564,11 @@ int MonsterFunctions::luaMonsterConfigureForgeSystem(lua_State* L) {
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
 		Lua::pushBoolean(L, false);
-		return 0;
+		return 1;
 	}
 
 	monster->configureForgeSystem(stack);
+	Lua::pushBoolean(L, true);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -558,7 +558,8 @@ int MonsterFunctions::luaMonsterSetForgeStack(lua_State* L) {
 }
 
 int MonsterFunctions::luaMonsterConfigureForgeSystem(lua_State* L) {
-	// monster:configureForgeSystem()
+	// monster:configureForgeSystem([stack])
+	const auto stack = Lua::getNumber<uint16_t>(L, 2, 0);
 	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (!monster) {
 		Lua::reportErrorFunc(Lua::getErrorDesc(LUA_ERROR_MONSTER_NOT_FOUND));
@@ -566,7 +567,7 @@ int MonsterFunctions::luaMonsterConfigureForgeSystem(lua_State* L) {
 		return 0;
 	}
 
-	monster->configureForgeSystem();
+	monster->configureForgeSystem(stack);
 	return 1;
 }
 


### PR DESCRIPTION
This pull request refactors and extends the forge system for influenced monsters, allowing the stack value to be explicitly set when adding or configuring an influenced monster. It updates both C++ and Lua interfaces to support this functionality, improving control over monster stack assignment and ensuring better cleanup of invalid influenced monsters.

**Forge system enhancements:**

* The `addInfluencedMonster` method now accepts an optional `stack` parameter, allowing explicit control over the influenced stack value when adding a monster. [[1]](diffhunk://#diff-cb32d05a9040ef81bfaa73bf11966d4f226fc4b81a83c7b9127ed60c9b2d66f0L11193-R11206) [[2]](diffhunk://#diff-8bf7970f43d75c050de68678612b371232affd1bd3f4a85141f8eaf7014d21fdL651-R651) [[3]](diffhunk://#diff-4b0271c0241ad6ee0e73874c62cf7ce7756ba40d24251182ca1bb85281b3f2f8L814-R823)
* The `configureForgeSystem` method in `Monster` now takes an optional `stack` parameter, using it if provided or generating a random stack otherwise. [[1]](diffhunk://#diff-7bd0c5453d083e53b9e581c6230bf61b7c0a094f663771d6788ec5ebb07fc8aaL2690-R2690) [[2]](diffhunk://#diff-7bd0c5453d083e53b9e581c6230bf61b7c0a094f663771d6788ec5ebb07fc8aaL2700-R2702) [[3]](diffhunk://#diff-bde6e7baf1e071d5b9d08925b2966a9062a03de9443654e6e9391b72eddfc8ceL197-R197) [[4]](diffhunk://#diff-e5ec2d7bfe2c514e66fba7cf6302836004c4e4bcdd836fbd8431abb4dab5cc90L561-R570)

**Lua and scripting API updates:**

* Lua bindings for both `Game.addInfluencedMonster` and `monster:configureForgeSystem` now accept an optional stack argument, aligning scripting capabilities with the new C++ interface. [[1]](diffhunk://#diff-4b0271c0241ad6ee0e73874c62cf7ce7756ba40d24251182ca1bb85281b3f2f8L814-R823) [[2]](diffhunk://#diff-e5ec2d7bfe2c514e66fba7cf6302836004c4e4bcdd836fbd8431abb4dab5cc90L561-R570)

**Logic and cleanup improvements:**

* The `addInfluencedMonster` method now removes invalid (non-existent) monster IDs from the influenced monsters set before adding a new one, ensuring accurate tracking.

**Behavioral change in monster influence:**

* The `SetInfluenced` Lua function now checks the result of `Game.addInfluencedMonster` and sends a cancel message to the player if adding fails, returning a boolean status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More precise control over influenced monsters’ forge stack when spawned.
  * Game now cleans up stale influenced-monster records to improve stability.
  * Adding influenced monsters includes failure handling to prevent invalid additions.
  * Scripting/console calls can optionally specify forge stack when configuring influenced monsters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->