### PR TITLE
fix: correct paralyze walk exhaust

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2933,6 +2933,17 @@ void Player::setWalkExhaust(int64_t value) {
 	lastWalking = OTSYS_TIME() + value;
 }
 
+void Player::updateParalyzeWalkExhaust() {
+	if (!hasCondition(CONDITION_PARALYZE)) {
+		return;
+	}
+
+	const int32_t walkDelay = getWalkDelay();
+	if (walkDelay > 0) {
+		setWalkExhaust(walkDelay);
+	}
+}
+
 const std::map<uint8_t, OpenContainer> &Player::getOpenContainers() const {
 	return openContainers;
 }
@@ -5930,6 +5941,10 @@ void Player::updateItemsLight(bool internal /*=false*/) {
 void Player::onAddCondition(ConditionType_t type) {
 	Creature::onAddCondition(type);
 
+	if (type == CONDITION_PARALYZE) {
+		updateParalyzeWalkExhaust();
+	}
+
 	if (type == CONDITION_OUTFIT && isMounted()) {
 		dismount();
 		wasMounted = true;
@@ -5959,6 +5974,10 @@ void Player::onCleanseCondition(ConditionType_t type) const {
 }
 
 void Player::onAddCombatCondition(ConditionType_t type) {
+	if (type == CONDITION_PARALYZE) {
+		updateParalyzeWalkExhaust();
+	}
+
 	if (IsConditionSuppressible(type)) {
 		updateLastConditionTime(type);
 	}
@@ -11488,6 +11507,10 @@ void Player::onCreatureMove(const std::shared_ptr<Creature> &creature, const std
 
 	if (creature != getPlayer()) {
 		return;
+	}
+
+	if (!teleport && oldPos.z == newPos.z) {
+		updateParalyzeWalkExhaust();
 	}
 
 	if (tradeState != TRADE_TRANSFER) {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1167,6 +1167,7 @@ public:
 	bool walkExhausted() const;
 
 	void setWalkExhaust(int64_t value);
+	void updateParalyzeWalkExhaust();
 
 	const std::map<uint8_t, OpenContainer> &getOpenContainers() const;
 

--- a/tests/unit/players/CMakeLists.txt
+++ b/tests/unit/players/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(components)
+add_subdirectory(condition)
 add_subdirectory(imbuements)

--- a/tests/unit/players/condition/CMakeLists.txt
+++ b/tests/unit/players/condition/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(
+    canary_ut
+    PRIVATE player_paralyze_walk_exhaust_test.cpp
+)

--- a/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
+++ b/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
@@ -1,0 +1,106 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "creatures/combat/condition.hpp"
+#include "creatures/players/player.hpp"
+#include "items/tile.hpp"
+
+#include "lib/logging/in_memory_logger.hpp"
+
+class PlayerParalyzeWalkExhaustTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		InMemoryLogger::install(injector);
+		DI::setTestContainer(&injector);
+	}
+
+	static std::shared_ptr<Condition> createParalyzeCondition(ConditionId_t conditionId = CONDITIONID_DEFAULT) {
+		auto condition = Condition::createCondition(conditionId, CONDITION_PARALYZE, 5000, -1000);
+		EXPECT_NE(nullptr, condition);
+		return condition;
+	}
+
+	static std::shared_ptr<Player> createPlayerAt(const std::shared_ptr<Tile> &tile) {
+		auto player = std::make_shared<Player>();
+		player->setParent(tile);
+		return player;
+	}
+
+	static void triggerBaseDiagonalStep(const std::shared_ptr<Player> &player, const std::shared_ptr<Tile> &oldTile, const std::shared_ptr<Tile> &newTile) {
+		player->Creature::onCreatureMove(player, newTile, newTile->getPosition(), oldTile, oldTile->getPosition(), false);
+	}
+
+	static void triggerPlayerDiagonalStep(const std::shared_ptr<Player> &player, const std::shared_ptr<Tile> &oldTile, const std::shared_ptr<Tile> &newTile) {
+		player->onCreatureMove(player, newTile, newTile->getPosition(), oldTile, oldTile->getPosition(), false);
+	}
+
+	static void expireWalkExhaust(const std::shared_ptr<Player> &player) {
+		player->setWalkExhaust(-1);
+	}
+
+private:
+	inline static di::extension::injector<> injector {};
+};
+
+TEST_F(PlayerParalyzeWalkExhaustTest, IdleParalyzeDoesNotBlockPlayerActions) {
+	auto oldTile = std::make_shared<DynamicTile>(Position(100, 100, 7));
+	auto player = createPlayerAt(oldTile);
+
+	ASSERT_TRUE(player->addCondition(createParalyzeCondition()));
+
+	EXPECT_FALSE(player->walkExhausted());
+}
+
+TEST_F(PlayerParalyzeWalkExhaustTest, ParalyzedDiagonalMovementBlocksActionsDuringWalkDelay) {
+	auto oldTile = std::make_shared<DynamicTile>(Position(100, 100, 7));
+	auto newTile = std::make_shared<DynamicTile>(Position(101, 101, 7));
+	auto player = createPlayerAt(oldTile);
+
+	ASSERT_TRUE(player->addCondition(createParalyzeCondition()));
+	EXPECT_FALSE(player->walkExhausted());
+
+	triggerPlayerDiagonalStep(player, oldTile, newTile);
+
+	EXPECT_TRUE(player->walkExhausted());
+
+	expireWalkExhaust(player);
+	EXPECT_FALSE(player->walkExhausted());
+}
+
+TEST_F(PlayerParalyzeWalkExhaustTest, ParalyzeAppliedDuringActiveStepBlocksActionsDuringWalkDelay) {
+	auto oldTile = std::make_shared<DynamicTile>(Position(100, 100, 7));
+	auto newTile = std::make_shared<DynamicTile>(Position(101, 101, 7));
+	auto player = createPlayerAt(oldTile);
+
+	triggerBaseDiagonalStep(player, oldTile, newTile);
+	ASSERT_TRUE(player->addCondition(createParalyzeCondition()));
+
+	EXPECT_TRUE(player->walkExhausted());
+
+	expireWalkExhaust(player);
+	EXPECT_FALSE(player->walkExhausted());
+}
+
+TEST_F(PlayerParalyzeWalkExhaustTest, CombatParalyzeRefreshDuringActiveStepBlocksActionsDuringWalkDelay) {
+	auto oldTile = std::make_shared<DynamicTile>(Position(100, 100, 7));
+	auto newTile = std::make_shared<DynamicTile>(Position(101, 101, 7));
+	auto player = createPlayerAt(oldTile);
+
+	ASSERT_TRUE(player->addCombatCondition(createParalyzeCondition(CONDITIONID_COMBAT)));
+	expireWalkExhaust(player);
+	EXPECT_FALSE(player->walkExhausted());
+
+	triggerBaseDiagonalStep(player, oldTile, newTile);
+	ASSERT_TRUE(player->addCombatCondition(createParalyzeCondition(CONDITIONID_COMBAT)));
+
+	EXPECT_TRUE(player->walkExhausted());
+
+	expireWalkExhaust(player);
+	EXPECT_FALSE(player->walkExhausted());
+}

--- a/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
+++ b/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
@@ -10,14 +10,12 @@
 #include "creatures/combat/condition.hpp"
 #include "creatures/players/player.hpp"
 #include "items/tile.hpp"
-
-#include "lib/logging/in_memory_logger.hpp"
+#include "utils/tools.hpp"
 
 class PlayerParalyzeWalkExhaustTest : public ::testing::Test {
 protected:
-	static void SetUpTestSuite() {
-		InMemoryLogger::install(injector);
-		DI::setTestContainer(&injector);
+	void SetUp() override {
+		UPDATE_OTSYS_TIME();
 	}
 
 	static std::shared_ptr<Condition> createParalyzeCondition(ConditionId_t conditionId = CONDITIONID_DEFAULT) {
@@ -43,9 +41,6 @@ protected:
 	static void expireWalkExhaust(const std::shared_ptr<Player> &player) {
 		player->setWalkExhaust(-1);
 	}
-
-private:
-	inline static di::extension::injector<> injector {};
 };
 
 TEST_F(PlayerParalyzeWalkExhaustTest, IdleParalyzeDoesNotBlockPlayerActions) {

--- a/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
+++ b/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
@@ -93,6 +93,8 @@ TEST_F(PlayerParalyzeWalkExhaustTest, CombatParalyzeRefreshDuringActiveStepBlock
 	auto player = createPlayerAt(oldTile);
 
 	ASSERT_TRUE(player->addCombatCondition(createParalyzeCondition(CONDITIONID_COMBAT)));
+	EXPECT_FALSE(player->walkExhausted()); // idle combat paralyze must not block
+
 	expireWalkExhaust(player);
 	EXPECT_FALSE(player->walkExhausted());
 

--- a/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
+++ b/tests/unit/players/condition/player_paralyze_walk_exhaust_test.cpp
@@ -12,6 +12,24 @@
 #include "items/tile.hpp"
 #include "utils/tools.hpp"
 
+namespace {
+	class TestParalyzeCondition final : public Condition {
+	public:
+		explicit TestParalyzeCondition(ConditionId_t conditionId, int32_t ticks = 5000) :
+			Condition(conditionId, CONDITION_PARALYZE, ticks) { }
+
+		void endCondition(std::shared_ptr<Creature>) override { }
+
+		void addCondition(std::shared_ptr<Creature>, std::shared_ptr<Condition> condition) override {
+			setTicks(condition->getTicks());
+		}
+
+		std::shared_ptr<Condition> clone() const override {
+			return std::make_shared<TestParalyzeCondition>(getId(), getTicks());
+		}
+	};
+}
+
 class PlayerParalyzeWalkExhaustTest : public ::testing::Test {
 protected:
 	void SetUp() override {
@@ -19,7 +37,7 @@ protected:
 	}
 
 	static std::shared_ptr<Condition> createParalyzeCondition(ConditionId_t conditionId = CONDITIONID_DEFAULT) {
-		auto condition = Condition::createCondition(conditionId, CONDITION_PARALYZE, 5000, -1000);
+		auto condition = std::make_shared<TestParalyzeCondition>(conditionId);
 		EXPECT_NE(nullptr, condition);
 		return condition;
 	}


### PR DESCRIPTION
## Summary

This PR fixes the paralyze movement exhaust bug where a paralyzed player could still use potion, rune, spell, or item actions during an active movement window.

The issue is not that `CONDITION_PARALYZE` should block actions by itself. The problem happens when paralyze interacts with the current walk delay created by movement between SQMs, especially diagonal movement where the step duration is longer.

Fixes #604.

## Technical Context

Canary already had the expected action-blocking path through `Player::walkExhausted()`, and several gameplay flows already check it before allowing actions such as item use, rune use, potion use, and spell casting.

The problem was that `Player::walkExhausted()` depends on `lastWalking`, but `lastWalking` was not being synchronized when paralyze interacted with an active movement window.

The relevant gameplay chain is:

```text
paralyze reduces speed
↓
step duration increases
↓
if the player is inside an active movement window, walkDelay becomes relevant
↓
potion/rune/spell/item actions should respect Player::walkExhausted()
```

Diagonal movement makes the bug easier to reproduce because diagonal steps use `WALK_DIAGONAL_EXTRA_COST`, increasing the movement window.

## Player Movement Exhaust Fix

Added a centralized `Player::updateParalyzeWalkExhaust()` helper to synchronize `lastWalking` when:

- the player has `CONDITION_PARALYZE`;
- there is an active `getWalkDelay()` window.

The helper is triggered when:

- a paralyzed player moves to another SQM;
- `CONDITION_PARALYZE` is added;
- combat paralyze is added or refreshed.

This covers both important cases:

```text
player is already paralyzed
↓
player moves to another SQM
↓
walk exhaust is synchronized
```

and:

```text
player is already inside a movement window
↓
monster or player applies paralyze
↓
paralyze changes speed and affects walkDelay
↓
walk exhaust is synchronized
```

## Gameplay Behavior

This PR intentionally keeps paralyze from blocking actions by itself.

Expected behavior after this change:

- A player who is paralyzed but idle can still use potion/spell normally, unless blocked by another existing cooldown.
- A player who is paralyzed and inside an active movement window cannot use potion/rune/spell/item actions until the walk delay ends.
- After the movement window ends, actions work normally again even if the player is still paralyzed.

## Example Scenario

Scenario that should block:

```text
X X X
X B X
A X X
```

Player A pushes paralyzed player B diagonally:

```text
X X B
X X X
A X X
```

While B is inside the diagonal movement window, B should not be able to use potion, rune, spell, or item actions.

After the walk delay ends, B should be able to use actions normally again.

## Scope Notice

This PR is intentionally scoped to player action exhaust.

It does not change monster combat behavior, monster spell timing, push rules, or generic `ConditionSpeed` behavior.

Monsters use a different combat flow based on attack and defense ticks, while this bug is specifically about player actions being allowed during a paralyze movement window.

## Test Plan

- [ ] Apply paralyze to a player while the player is idle and confirm potion/spell still works outside any movement window.
- [ ] Apply paralyze to a player, move the player diagonally, and confirm potion/rune/spell/item actions are blocked during the active walk delay.
- [ ] Push a paralyzed player diagonally and confirm actions are blocked during the movement window.
- [ ] Confirm actions work again after the walk delay ends, even if the player is still paralyzed.
- [ ] Start a diagonal movement and apply paralyze during the step window, then confirm potion/rune/spell/item actions are blocked until the movement window ends.
- [ ] Confirm cardinal movement still behaves normally, with a shorter movement window than diagonal movement.
- [ ] Confirm a paralyzed idle player is not blocked just because `CONDITION_PARALYZE` is active.
- [ ] Confirm existing action cooldowns and normal potion/rune/spell exhaust behavior still work as before.
- [ ] Confirm push behavior still respects `getWalkDelay()` / `isPushable()` and is not changed directly by this PR.

## Testing Environment

- Server version: Canary - Version 3.4.2
- OS: Windows 11
- Client: [15.00.249ccc](https://github.com/dudantas/tibia-client/releases/tag/15.00.249ccc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paralyzed players now have walk exhaustion recalculated immediately when paralysis is applied and during normal (non-teleport) movement on the same level, preventing incorrect walk cooldowns.

* **Tests**
  * Added unit tests validating walk-exhaustion across idle, movement-triggered, and combat-applied paralysis scenarios, including behavior during active steps and manual expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->