### PR TITLE
fix: race conditions in attack check scheduling

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -148,6 +148,13 @@ void Creature::checkCreatureAttack(bool now) {
 		return;
 	}
 
+	// Player attack checks are debounced in Player::requestAttackCheck()
+	// to avoid duplicate/stale dispatcher events when targets change rapidly.
+	if (const auto &player = getPlayer()) {
+		player->requestAttackCheck();
+		return;
+	}
+
 	g_dispatcher().addEvent([self = std::weak_ptr<Creature>(getCreature())] {
 		if (const auto &creature = self.lock()) {
 			creature->checkCreatureAttack(true);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5847,7 +5847,8 @@ void Player::requestAttackCheck() {
 			player->m_hasPendingAttackCheck = false;
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5856,7 +5856,8 @@ void Player::requestAttackCheck(uint32_t delay) {
 			player->m_hasPendingAttackCheck = false;
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck");
+		"Player::requestAttackCheck"
+	);
 
 	if (m_pendingAttackCheckEventId == 0) {
 		m_hasPendingAttackCheck = false;

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5812,12 +5812,21 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		requestAttackCheck();
+		uint32_t delay = 0;
+		if (lastAttack != 0) {
+			const uint32_t elapsed = OTSYS_TIME() - lastAttack;
+			const uint32_t attackSpeed = getAttackSpeed();
+			if (elapsed < attackSpeed) {
+				delay = std::max<uint32_t>(SCHEDULER_MINTICKS, attackSpeed - elapsed);
+			}
+		}
+
+		requestAttackCheck(delay);
 	}
 	return true;
 }
 
-void Player::requestAttackCheck() {
+void Player::requestAttackCheck(uint32_t delay) {
 	if (!getAttackedCreature()) {
 		return;
 	}
@@ -5831,24 +5840,27 @@ void Player::requestAttackCheck() {
 	m_hasPendingAttackCheck = true;
 	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
 	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
-		0,
+		delay,
 		[weakPlayer, generation] {
 			const auto &player = weakPlayer.lock();
 			if (!player) {
 				return;
 			}
 
-			player->m_pendingAttackCheckEventId = 0;
 			// Drop stale callbacks from older generations or already-cleared state.
 			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
 				return;
 			}
 
+			player->m_pendingAttackCheckEventId = 0;
 			player->m_hasPendingAttackCheck = false;
 			player->checkCreatureAttack(true);
 		},
-		"Player::requestAttackCheck"
-	);
+		"Player::requestAttackCheck");
+
+	if (m_pendingAttackCheckEventId == 0) {
+		m_hasPendingAttackCheck = false;
+	}
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3754,10 +3754,15 @@ void Player::doAttacking(uint32_t interval) {
 			result = Weapon::useFist(static_self_cast<Player>(), attackedCreature);
 		}
 
+		const uint32_t generation = m_attackCheckGeneration;
 		const auto &task = createPlayerTask(
-			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Creature>(getCreature())] {
-				if (const auto &creature = self.lock()) {
-					creature->checkCreatureAttack(true);
+			std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [self = std::weak_ptr<Player>(getPlayer()), generation] {
+				if (const auto &player = self.lock()) {
+					if (generation != player->m_attackCheckGeneration) {
+						return;
+					}
+
+					player->checkCreatureAttack(true);
 				} }, __FUNCTION__
 		);
 
@@ -5785,6 +5790,13 @@ bool Player::setFollowCreature(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
+	++m_attackCheckGeneration;
+	if (m_pendingAttackCheckEventId != 0) {
+		g_dispatcher().stopEvent(m_pendingAttackCheckEventId);
+		m_pendingAttackCheckEventId = 0;
+	}
+	m_hasPendingAttackCheck = false;
+
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
 		return false;
@@ -5800,9 +5812,42 @@ bool Player::setAttackedCreature(const std::shared_ptr<Creature> &creature) {
 	}
 
 	if (creature) {
-		checkCreatureAttack();
+		requestAttackCheck();
 	}
 	return true;
+}
+
+void Player::requestAttackCheck() {
+	if (!getAttackedCreature()) {
+		return;
+	}
+
+	// Debounce: one pending attack-check event per player at a time.
+	if (m_pendingAttackCheckEventId != 0 || m_hasPendingAttackCheck) {
+		return;
+	}
+
+	const uint32_t generation = m_attackCheckGeneration;
+	m_hasPendingAttackCheck = true;
+	const auto weakPlayer = std::weak_ptr<Player>(getPlayer());
+	m_pendingAttackCheckEventId = g_dispatcher().scheduleEvent(
+		0,
+		[weakPlayer, generation] {
+			const auto &player = weakPlayer.lock();
+			if (!player) {
+				return;
+			}
+
+			player->m_pendingAttackCheckEventId = 0;
+			// Drop stale callbacks from older generations or already-cleared state.
+			if (!player->m_hasPendingAttackCheck || generation != player->m_attackCheckGeneration) {
+				return;
+			}
+
+			player->m_hasPendingAttackCheck = false;
+			player->checkCreatureAttack(true);
+		},
+		"Player::requestAttackCheck");
 }
 
 void Player::goToFollowCreature() {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -720,7 +720,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
-	void requestAttackCheck();
+	void requestAttackCheck(uint32_t delay = 0);
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -720,6 +720,7 @@ public:
 	void setFaction(Faction_t factionId);
 	// combat functions
 	bool setAttackedCreature(const std::shared_ptr<Creature> &creature) override;
+	void requestAttackCheck();
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -1808,6 +1809,9 @@ private:
 	mutable int64_t m_lastImbuementTrackerUpdate = 0;
 	mutable bool m_hasPendingImbuementTrackerUpdate = false;
 	mutable uint64_t m_pendingImbuementTrackerEventId = 0;
+	uint64_t m_pendingAttackCheckEventId = 0;
+	uint32_t m_attackCheckGeneration = 0;
+	bool m_hasPendingAttackCheck = false;
 	bool shouldForceLogout = true;
 	bool connProtected = false;
 


### PR DESCRIPTION
The goal here is to avoid scheduling duplicate attack checks and stop stale tasks from running...
Now, every time the target changes, it bumps a generation counter m_attackCheckGeneration and resets the pending state, so only the latest generation’s task can run. This reduces duplicate work and avoids race conditions when targets change quickly or attacks start/stop.

Prevent duplicate or stale scheduled attack checks when a Player begins or stops being attacked to avoid redundant work and race conditions.
Ensure only the most recent pending atack scheduler task executes for a given player generation.

- Improved creature attack mechanics stability by implementing proper event tracking and cancellation, preventing duplicate and lingering attack checks during combat interactions.
- Strengthened player combat state management to ensure attack checks are properly cleaned up when the combat target changes or combat ends.
- Enhanced overall reliability of creature combat states through better lifecycle management of attack events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combat handling to debounce and coalesce attack checks, preventing duplicate or stale attack events when rapidly switching targets.
  * Ensures only one pending attack-check is scheduled per player, reducing redundant work and race conditions.
  * Uses delayed/suppressed re-checks to improve combat stability and responsiveness for players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->