### PR TITLE
ci(deploy-neep): update vcpkg, capture full build output, modernize script

### DIFF
--- a/.github/workflows/deploy-neep.yml
+++ b/.github/workflows/deploy-neep.yml
@@ -166,8 +166,23 @@ jobs:
             cmake --build --preset "$BUILD_PRESET"
 
             echo "=== [6/7] Deploy do binário ==="
-            systemctl stop canary 2>/dev/null || true
+            stopped_canary=false
+            restore_canary() {
+              if [ "$stopped_canary" = "true" ]; then
+                systemctl start canary || true
+              fi
+            }
+            trap restore_canary EXIT
+
+            if systemctl is-active --quiet canary; then
+              systemctl stop canary
+              stopped_canary=true
+            fi
             sleep 3
+            if systemctl is-active --quiet canary; then
+              echo "ERRO: serviço canary ainda está rodando após o stop!"
+              exit 1
+            fi
             install -m 0755 "$BUILD_DIR/bin/canary" "$CANARY_DIR/canary"
 
             ESCAPED_BRANCH="$(printf '%s\n' "$BRANCH" | sed 's/[\/&]/\\&/g')"
@@ -463,6 +478,7 @@ jobs:
               systemctl status canary --no-pager || true
               exit 1
             fi
+            trap - EXIT
 
             echo "DEPLOY_SUCCESS=true"
 

--- a/.github/workflows/deploy-neep.yml
+++ b/.github/workflows/deploy-neep.yml
@@ -6,6 +6,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: deploy-neep
+  cancel-in-progress: false
+
 jobs:
   deploy:
     if: |
@@ -116,47 +120,63 @@ jobs:
           password: ${{ secrets.NEEP_PASS }}
           timeout: 300s
           command_timeout: 30m
+          capture_stdout: true
           script: |
-            set -e
+            set -euo pipefail
+            exec 2>&1
 
+            CANARY_DIR=/opt/canary
+            VCPKG_DIR="$HOME/vcpkg"
+            BUILD_PRESET=linux-release
+            BUILD_DIR="$CANARY_DIR/build/$BUILD_PRESET"
             BRANCH="${{ steps.setup.outputs.name }}"
             IS_CLEAN="${{ steps.setup.outputs.is_clean }}"
 
-            echo "=== [1/6] Checkout da branch: $BRANCH ==="
-            cd /opt/canary
+            export VCPKG_ROOT="$VCPKG_DIR"
+            export PATH="$VCPKG_DIR:$PATH"
+
+            echo "=== [1/7] Checkout da branch: $BRANCH ==="
+            cd "$CANARY_DIR"
             git fetch origin
             git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
             git reset --hard "origin/$BRANCH"
             git clean -fdx --exclude=build --exclude=config.lua
 
-            echo "=== [2/6] Preparando build ==="
-            if [ "$IS_CLEAN" = "true" ]; then
-              echo "Comando '/deploy clean' detectado. Apagando diretório build atual..."
-              rm -rf build
-            else
-              echo "Reaproveitando diretório build se existir..."
+            echo "=== [2/7] Atualizando vcpkg ==="
+            if [ ! -d "$VCPKG_DIR/.git" ]; then
+              echo "ERRO: $VCPKG_DIR não é um clone git do vcpkg"
+              exit 1
             fi
-            
-            mkdir -p build
-            cd build
+            git -C "$VCPKG_DIR" fetch --tags origin
+            git -C "$VCPKG_DIR" reset --hard origin/master
+            "$VCPKG_DIR/bootstrap-vcpkg.sh" -disableMetrics
 
-            echo "=== [3/6] Configurando CMake ==="
-            cmake -DCMAKE_TOOLCHAIN_FILE=~/vcpkg/scripts/buildsystems/vcpkg.cmake .. --preset linux-release -DTOGGLE_BIN_FOLDER=ON
+            echo "=== [3/7] Preparando build ==="
+            if [ "$IS_CLEAN" = "true" ]; then
+              echo "Comando '/deploy clean' detectado. Apagando $BUILD_DIR..."
+              rm -rf "$BUILD_DIR"
+            else
+              echo "Reaproveitando $BUILD_DIR se existir..."
+            fi
 
-            echo "=== [4/6] Compilando ==="
-            cmake --build linux-release
+            echo "=== [4/7] Configurando CMake ==="
+            cmake --preset "$BUILD_PRESET" -DTOGGLE_BIN_FOLDER=ON
 
-            echo "=== [5/6] Deploy do binário ==="
-            (systemctl stop canary 2>/dev/null || true) && sleep 3
+            echo "=== [5/7] Compilando ==="
+            cmake --build --preset "$BUILD_PRESET"
 
-            cp linux-release/bin/canary /opt/canary/canary
-            chmod +x /opt/canary/canary
+            echo "=== [6/7] Deploy do binário ==="
+            systemctl stop canary 2>/dev/null || true
+            sleep 3
+            install -m 0755 "$BUILD_DIR/bin/canary" "$CANARY_DIR/canary"
 
             ESCAPED_BRANCH="$(printf '%s\n' "$BRANCH" | sed 's/[\/&]/\\&/g')"
-            sed -i "s/^serverMotd = \".*\"/serverMotd = \"Welcome to the Canary Test Server! Currently running branch: $ESCAPED_BRANCH\"/" /opt/canary/config.lua
+            sed -i "s/^serverMotd = \".*\"/serverMotd = \"Welcome to the Canary Test Server! Currently running branch: $ESCAPED_BRANCH\"/" "$CANARY_DIR/config.lua"
 
-            echo "Atualizando /opt/canary/data/stages.lua"
-            cat << 'EOF' > /opt/canary/data/stages.lua
+            echo "=== [7/7] Atualizando configs e iniciando serviço ==="
+
+            echo "Atualizando $CANARY_DIR/data/stages.lua"
+            cat << 'EOF' > "$CANARY_DIR/data/stages.lua"
             -- Minlevel and multiplier are MANDATORY
             -- Maxlevel is OPTIONAL, but is considered infinite by default
             -- Create a stage with minlevel 1 and no maxlevel to disable stages
@@ -282,8 +302,8 @@ jobs:
             }
             EOF
 
-            echo "Atualizando /opt/canary/data/XML/vocations.xml"
-            cat << 'EOF' > /opt/canary/data/XML/vocations.xml
+            echo "Atualizando $CANARY_DIR/data/XML/vocations.xml"
+            cat << 'EOF' > "$CANARY_DIR/data/XML/vocations.xml"
             <?xml version="1.0" encoding="UTF-8"?>
             <vocations>
             	<vocation id="0" clientid="0" baseid="0" name="None" description="none" magicshield="0" gaincap="10" gainhp="5" gainmana="5" gainhpticks="4000" gainhpamount="5" gainmanaticks="4000" gainmanaamount="5" manamultiplier="4.0" attackspeed="2000" basespeed="110" soulmax="100" gainsoulticks="120000" fromvoc="0">
@@ -436,7 +456,6 @@ jobs:
             </vocations>
             EOF
 
-            echo "=== [6/6] Iniciando serviço ==="
             systemctl start canary
             sleep 3
             if ! systemctl is-active --quiet canary; then
@@ -446,6 +465,27 @@ jobs:
             fi
 
             echo "DEPLOY_SUCCESS=true"
+
+      # ---------------------------------------------------------
+      # Truncate captured remote output for use in PR comments.
+      # GitHub comment body limit is ~65k chars; keep the tail.
+      # ---------------------------------------------------------
+      - name: Truncate remote output for comment
+        if: always()
+        id: trim_output
+        env:
+          REMOTE_LOG: ${{ steps.remote.outputs.stdout }}
+        run: |
+          {
+            echo "log<<__END_LOG__"
+            if [ -n "$REMOTE_LOG" ]; then
+              printf '%s' "$REMOTE_LOG" | tail -c 50000
+              echo
+            else
+              echo "(remote step produced no captured output)"
+            fi
+            echo "__END_LOG__"
+          } >> "$GITHUB_OUTPUT"
 
       # ---------------------------------------------------------
       # Success or failure comment
@@ -469,10 +509,16 @@ jobs:
           body: |
             ❌ **Deploy failed!**
             **Branch:** `${{ steps.setup.outputs.name }}`
-            **Error output:**
-            ```
-            ${{ steps.remote.outputs.stderr }}
-            ```
+            **Last build output (tail, max 50KB):**
+
+            <details><summary>Click to expand</summary>
+
+            ````
+            ${{ steps.trim_output.outputs.log }}
+            ````
+
+            </details>
+
             *(Triggered by @${{ steps.setup.outputs.actor }})*
 
       # ---------------------------------------------------------


### PR DESCRIPTION
# Description

Hardens the `Deploy to Neep Host` workflow used by `/deploy` PR comments. The previous version was producing empty failure comments (e.g. [#3940 (comment)](https://github.com/opentibiabr/canary/pull/3940#issuecomment-4412957579)) and relied on the VPS keeping its `~/vcpkg` checkout up to date by hand — which has been failing builds.

## Behaviour
### **Actual**

- Failure comment renders the boilerplate but the error block is blank (`${{ steps.remote.outputs.stderr }}` does not exist on `appleboy/ssh-action@v1.2.3`).
- Builds fail because the VPS `~/vcpkg` tree is stale relative to the project's required baseline.
- Two parallel `/deploy` calls race over `/opt/canary`.

### **Expected**

- Failure comment includes the tail of the actual remote build log.
- Each deploy refreshes `~/vcpkg` (fetch + reset to `origin/master` + bootstrap) before configure.
- Concurrent `/deploy` invocations are serialized.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- **Capture full output** — `capture_stdout: true` on the SSH action, plus `set -euo pipefail` and `exec 2>&1` in the remote script so stderr from `cmake`/`git`/`systemctl` lands in the captured stdout.
- **Update vcpkg before build** — new `[2/7] Atualizando vcpkg` step: validates `~/vcpkg` is a git checkout, fetches with tags, hard-resets to `origin/master`, and re-bootstraps with `-disableMetrics`.
- **Truncate output for PR comment** — new `Truncate remote output for comment` step keeps the last 50 KB (`tail -c 50000`) so the body fits under GitHub's ~65 K char limit. Failure comment uses `<details>` + 4-backtick fences so triple backticks inside the log don't break markdown.
- **Concurrency** — workflow-level `concurrency: { group: deploy-neep, cancel-in-progress: false }`. One deploy at a time on the VPS, no mid-build cancellation.
- **Cleaner CMake invocation** — runs `cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON` from the project root and `cmake --build --preset linux-release`. Drops the redundant `-DCMAKE_TOOLCHAIN_FILE=...` (the preset already sets it via `$env{VCPKG_ROOT}`) and the confusing `cd build && cmake .. --preset` pattern.
- **Centralized paths** — `CANARY_DIR`, `VCPKG_DIR`, `BUILD_PRESET`, `BUILD_DIR` defined at the top of the remote script. `export VCPKG_ROOT="$VCPKG_DIR"` so the preset's toolchain resolution works.
- **`install -m 0755`** in place of `cp` + `chmod`.

## How Has This Been Tested

- [ ] `/deploy` on a passing branch — verify success comment renders unchanged.
- [ ] `/deploy` on a deliberately broken branch — verify failure comment now contains the build log tail.
- [ ] `/deploy clean` — verify `$BUILD_DIR` is wiped and rebuilt from scratch.
- [ ] Two concurrent `/deploy` comments — verify only one runs at a time.

**Test Configuration**:

  - Server Version: any
  - Client: n/a (CI workflow)
  - Operating System: Ubuntu (runner) + remote VPS

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

## Notes for reviewers

- The vcpkg branch is hard-coded to `master` (matches `microsoft/vcpkg` upstream default). If the VPS's `~/vcpkg` tracks a different remote/branch, that step will reset it. Worth a quick `git -C ~/vcpkg remote -v` sanity check on the VPS.
- The vcpkg binary cache (`$VCPKG_ROOT/binary-cache`) is preserved — only the ports tree is updated, so unchanged packages don't rebuild.
- The two large heredocs (`stages.lua`, `vocations.xml`) are kept in-place. Moving them to `.github/deploy/test-server/` would make the workflow ~280 lines shorter; happy to do as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Serialized deployments to avoid overlapping runs and improve reliability.
  * Safer, staged deployment flow with build, install, service restart, and optional clean step.
* **Bug Fixes / Diagnostics**
  * Captures and truncates remote deployment logs, including a tail in failure comments for clearer error reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3951)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->