### PR TITLE
ci(deploy-neep): tee log on remote, fetch tail via second SSH

### DIFF
--- a/.github/workflows/deploy-neep.yml
+++ b/.github/workflows/deploy-neep.yml
@@ -120,10 +120,10 @@ jobs:
           password: ${{ secrets.NEEP_PASS }}
           timeout: 300s
           command_timeout: 30m
-          capture_stdout: true
           script: |
             set -euo pipefail
-            exec 2>&1
+            : > /tmp/canary-deploy.log
+            exec > >(tee /tmp/canary-deploy.log) 2>&1
 
             CANARY_DIR=/opt/canary
             VCPKG_DIR="$HOME/vcpkg"
@@ -483,25 +483,23 @@ jobs:
             echo "DEPLOY_SUCCESS=true"
 
       # ---------------------------------------------------------
-      # Truncate captured remote output for use in PR comments.
-      # GitHub comment body limit is ~65k chars; keep the tail.
+      # On failure, fetch the tail of the remote deploy log over a
+      # second SSH session. This keeps the captured output small
+      # (well under ARG_MAX and under GitHub's ~65k comment limit)
+      # without piping the full multi-MB build log through env vars.
       # ---------------------------------------------------------
-      - name: Truncate remote output for comment
-        if: always()
-        id: trim_output
-        env:
-          REMOTE_LOG: ${{ steps.remote.outputs.stdout }}
-        run: |
-          {
-            echo "log<<__END_LOG__"
-            if [ -n "$REMOTE_LOG" ]; then
-              printf '%s' "$REMOTE_LOG" | tail -c 50000
-              echo
-            else
-              echo "(remote step produced no captured output)"
-            fi
-            echo "__END_LOG__"
-          } >> "$GITHUB_OUTPUT"
+      - name: Fetch remote deploy log tail
+        if: always() && steps.remote.outcome != 'success' && steps.setup.outputs.has_pr == 'true'
+        id: fetch_log
+        uses: appleboy/ssh-action@91f3272fc5907f4699dcf59761eb622a07342f5a
+        with:
+          host: ${{ secrets.NEEP_HOST }}
+          username: root
+          password: ${{ secrets.NEEP_PASS }}
+          timeout: 60s
+          command_timeout: 60s
+          capture_stdout: true
+          script: tail -c 50000 /tmp/canary-deploy.log 2>/dev/null || echo "(no deploy log on remote)"
 
       # ---------------------------------------------------------
       # Success or failure comment
@@ -530,7 +528,7 @@ jobs:
             <details><summary>Click to expand</summary>
 
             ````
-            ${{ steps.trim_output.outputs.log }}
+            ${{ steps.fetch_log.outputs.stdout }}
             ````
 
             </details>

--- a/.github/workflows/deploy-neep.yml
+++ b/.github/workflows/deploy-neep.yml
@@ -135,37 +135,37 @@ jobs:
             export VCPKG_ROOT="$VCPKG_DIR"
             export PATH="$VCPKG_DIR:$PATH"
 
-            echo "=== [1/7] Checkout da branch: $BRANCH ==="
+            echo "=== [1/7] Checking out branch: $BRANCH ==="
             cd "$CANARY_DIR"
             git fetch origin
             git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
             git reset --hard "origin/$BRANCH"
             git clean -fdx --exclude=build --exclude=config.lua
 
-            echo "=== [2/7] Atualizando vcpkg ==="
+            echo "=== [2/7] Updating vcpkg ==="
             if [ ! -d "$VCPKG_DIR/.git" ]; then
-              echo "ERRO: $VCPKG_DIR não é um clone git do vcpkg"
+              echo "ERROR: $VCPKG_DIR is not a git clone of vcpkg"
               exit 1
             fi
             git -C "$VCPKG_DIR" fetch --tags origin
             git -C "$VCPKG_DIR" reset --hard origin/master
             "$VCPKG_DIR/bootstrap-vcpkg.sh" -disableMetrics
 
-            echo "=== [3/7] Preparando build ==="
+            echo "=== [3/7] Preparing build ==="
             if [ "$IS_CLEAN" = "true" ]; then
-              echo "Comando '/deploy clean' detectado. Apagando $BUILD_DIR..."
+              echo "'/deploy clean' command detected. Removing $BUILD_DIR..."
               rm -rf "$BUILD_DIR"
             else
-              echo "Reaproveitando $BUILD_DIR se existir..."
+              echo "Reusing $BUILD_DIR if it exists..."
             fi
 
-            echo "=== [4/7] Configurando CMake ==="
+            echo "=== [4/7] Configuring CMake ==="
             cmake --preset "$BUILD_PRESET" -DTOGGLE_BIN_FOLDER=ON
 
-            echo "=== [5/7] Compilando ==="
+            echo "=== [5/7] Compiling ==="
             cmake --build --preset "$BUILD_PRESET"
 
-            echo "=== [6/7] Deploy do binário ==="
+            echo "=== [6/7] Deploying binary ==="
             stopped_canary=false
             restore_canary() {
               if [ "$stopped_canary" = "true" ]; then
@@ -180,7 +180,7 @@ jobs:
             fi
             sleep 3
             if systemctl is-active --quiet canary; then
-              echo "ERRO: serviço canary ainda está rodando após o stop!"
+              echo "ERROR: canary service is still running after stop!"
               exit 1
             fi
             install -m 0755 "$BUILD_DIR/bin/canary" "$CANARY_DIR/canary"
@@ -188,9 +188,9 @@ jobs:
             ESCAPED_BRANCH="$(printf '%s\n' "$BRANCH" | sed 's/[\/&]/\\&/g')"
             sed -i "s/^serverMotd = \".*\"/serverMotd = \"Welcome to the Canary Test Server! Currently running branch: $ESCAPED_BRANCH\"/" "$CANARY_DIR/config.lua"
 
-            echo "=== [7/7] Atualizando configs e iniciando serviço ==="
+            echo "=== [7/7] Updating configs and starting service ==="
 
-            echo "Atualizando $CANARY_DIR/data/stages.lua"
+            echo "Updating $CANARY_DIR/data/stages.lua"
             cat << 'EOF' > "$CANARY_DIR/data/stages.lua"
             -- Minlevel and multiplier are MANDATORY
             -- Maxlevel is OPTIONAL, but is considered infinite by default
@@ -317,7 +317,7 @@ jobs:
             }
             EOF
 
-            echo "Atualizando $CANARY_DIR/data/XML/vocations.xml"
+            echo "Updating $CANARY_DIR/data/XML/vocations.xml"
             cat << 'EOF' > "$CANARY_DIR/data/XML/vocations.xml"
             <?xml version="1.0" encoding="UTF-8"?>
             <vocations>
@@ -474,7 +474,7 @@ jobs:
             systemctl start canary
             sleep 3
             if ! systemctl is-active --quiet canary; then
-              echo "ERRO: serviço canary não está rodando após o start!"
+              echo "ERROR: canary service is not running after start!"
               systemctl status canary --no-pager || true
               exit 1
             fi


### PR DESCRIPTION
# Description

Follow-up to [#3951](https://github.com/opentibiabr/canary/pull/3951). The deploy ran successfully on the remote in [#3940 (comment)](https://github.com/opentibiabr/canary/pull/3940#issuecomment-4413060513), but the workflow itself failed at the `Truncate remote output for comment` step:

```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/canary/canary'. Argument list too long
```

Two issues showed up in the captured log:

1. **Argument list too long (`E2BIG`)** — we passed `${{ steps.remote.outputs.stdout }}` (multi-MB build log) as an env var to the truncate step's bash. Linux's `ARG_MAX` is ~2 MB and the env block counts toward it, so `execve` failed before bash even ran.
2. **Every line was duplicated** in the captured output (e.g. `=== [6/7] Deploy do binário ===` printed twice, success banner printed twice). The combination of `appleboy/ssh-action`'s `capture_stdout: true` plus our `exec 2>&1` was double-capturing each line, inflating the size.

## Behaviour
### **Actual**

- Successful deploy still marks the workflow as failed because the truncate step crashes on the env-var size.
- Captured stdout is duplicated, doubling the volume that gets piped through the runner.

### **Expected**

- Workflow status reflects the actual deploy outcome.
- Failure comments still get the tail of the build log without funneling the entire log through a runner env var.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- Drop `capture_stdout: true` from the deploy SSH step — we no longer rely on the action capturing the full log.
- Tee remote output to `/tmp/canary-deploy.log` on the VPS (`exec > >(tee /tmp/canary-deploy.log) 2>&1`) so the log lives on disk regardless of how the action captures.
- Replace the `Truncate remote output for comment` runner step with a small **second** SSH step `Fetch remote deploy log tail` that runs `tail -c 50000 /tmp/canary-deploy.log` with `capture_stdout: true`. The captured output is bounded to ~50 KB — comfortably under both `ARG_MAX` and GitHub's ~65 K comment-body limit.
- The fetch step only runs on failure (`steps.remote.outcome != 'success'`), so successful deploys don't pay for an extra SSH session.
- Failure comment now reads from `${{ steps.fetch_log.outputs.stdout }}`.

## How Has This Been Tested

- [ ] `/deploy` on a passing branch — verify the workflow now exits clean (no truncate-step crash) and the success comment is unchanged.
- [ ] `/deploy` on a deliberately broken branch — verify the failure comment contains the tail of the build log and is no longer duplicated.

**Test Configuration**:

  - Server Version: any
  - Client: n/a (CI workflow)
  - Operating System: Ubuntu (runner) + remote VPS

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment failure reporting by persistently capturing full remote output and including the last ~50KB of that log in failure notifications for easier troubleshooting.
  * Clarified various remote progress and error messages (including Portuguese→English updates) to make deployment feedback more readable, without changing deployment control flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3952)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->