### PR TITLE
ci(deploy-neep): fetch fork PR heads via refs/pull/<N>/head

### DIFF
--- a/.github/workflows/deploy-neep.yml
+++ b/.github/workflows/deploy-neep.yml
@@ -131,6 +131,8 @@ jobs:
             BUILD_DIR="$CANARY_DIR/build/$BUILD_PRESET"
             BRANCH="${{ steps.setup.outputs.name }}"
             IS_CLEAN="${{ steps.setup.outputs.is_clean }}"
+            HAS_PR="${{ steps.setup.outputs.has_pr }}"
+            PR_NUMBER="${{ steps.setup.outputs.pr_number }}"
 
             export VCPKG_ROOT="$VCPKG_DIR"
             export PATH="$VCPKG_DIR:$PATH"
@@ -138,8 +140,16 @@ jobs:
             echo "=== [1/7] Checking out branch: $BRANCH ==="
             cd "$CANARY_DIR"
             git fetch origin
-            git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
-            git reset --hard "origin/$BRANCH"
+            if [ "$HAS_PR" = "true" ] && [ -n "$PR_NUMBER" ]; then
+              # PR head may live in a fork; use the GitHub PR ref so this works
+              # for both same-repo and fork PRs.
+              git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pr/${PR_NUMBER}"
+              git checkout -B "$BRANCH" "refs/remotes/pr/${PR_NUMBER}"
+              git reset --hard "refs/remotes/pr/${PR_NUMBER}"
+            else
+              git checkout "$BRANCH" 2>/dev/null || git checkout -b "$BRANCH"
+              git reset --hard "origin/$BRANCH"
+            fi
             git clean -fdx --exclude=build --exclude=config.lua
 
             echo "=== [2/7] Updating vcpkg ==="


### PR DESCRIPTION
# Description

Follow-up to [#3951](https://github.com/opentibiabr/canary/pull/3951) and [#3952](https://github.com/opentibiabr/canary/pull/3952). The deploy on [#3945 (comment)](https://github.com/opentibiabr/canary/pull/3945#issuecomment-4413128685) failed at `[1/7] Checking out branch` because the PR's head branch `Add-linux-release-arm-CMake-preset` only exists in the contributor's fork:

```
=== [1/7] Checking out branch: Add-linux-release-arm-CMake-preset ===
From https://github.com/opentibiabr/canary
   6dd0bd534..85c2475aa  main       -> origin/main
Switched to a new branch 'Add-linux-release-arm-CMake-preset'
fatal: ambiguous argument 'origin/Add-linux-release-arm-CMake-preset': unknown revision or path not in the working tree.
```

The script ran `git fetch origin` (upstream `opentibiabr/canary`) followed by `git reset --hard origin/$BRANCH`, which can't resolve a fork's branch.

GitHub maintains a `refs/pull/<N>/head` ref on the upstream repo for **every** PR — same-repo or fork — so we can fetch and reset against that ref instead.

## Behaviour
### **Actual**

`/deploy` on a PR opened from a fork aborts at the checkout step.

### **Expected**

`/deploy` works for both same-repo and fork PRs.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- New shell vars `HAS_PR` and `PR_NUMBER` plumbed into the remote script from `steps.setup.outputs`.
- Checkout block now branches:
  - **PR context** (`HAS_PR=true` and `PR_NUMBER` set): `git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pr/${PR_NUMBER}"`, then `git checkout -B "$BRANCH" "refs/remotes/pr/${PR_NUMBER}"`, then `git reset --hard "refs/remotes/pr/${PR_NUMBER}"`. Works for fork PRs and same-repo PRs alike.
  - **No PR context** (`workflow_dispatch` on a known branch): unchanged — `git checkout "$BRANCH" || git checkout -b "$BRANCH"` then `git reset --hard "origin/$BRANCH"`.
- The `$BRANCH` name is still used as the local branch name on the VPS and in the MOTD.

Security note: the existing `author_association` gate (`OWNER`/`MEMBER`/`COLLABORATOR` only) still applies, so only trusted maintainers can trigger a fork-code deploy via `/deploy`.

## How Has This Been Tested

- [ ] `/deploy` on a same-repo PR — verify checkout still works through the new PR-ref path.
- [ ] `/deploy` on a fork PR — verify the deploy proceeds past the checkout step (the original symptom).
- [ ] `workflow_dispatch` on a non-PR branch — verify the fallback path still works.

**Test Configuration**:

  - Server Version: any
  - Client: n/a (CI workflow)
  - Operating System: Ubuntu (runner) + remote VPS

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works

## Notes for reviewers

A separate, **cosmetic** issue is still visible in the same comment: every block of output is duplicated (e.g. the `=== [1/7] ...` block, and even drone-ssh's own `✅ Successfully executed commands to all hosts.` banner). The drone-ssh banner is emitted locally by `appleboy/ssh-action`, not by our remote script — its appearance in `outputs.stdout` confirms the duplication is in the action's `capture_stdout` mechanism rather than in our log file. Worth addressing as a follow-up; not in scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to enable triggering deployments for pull requests via issue comments, including support for pull requests from forked repositories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3953)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->