### PR TITLE
fix(crash): null checks to prevent null derefs

### DIFF
--- a/data-otservbr-global/scripts/quests/soul_war/soul_war_mechanics.lua
+++ b/data-otservbr-global/scripts/quests/soul_war/soul_war_mechanics.lua
@@ -65,7 +65,7 @@ soulCageDeath:register()
 local fourthTaintBossesDeath = CreatureEvent("FourthTaintBossesPrepareDeath")
 
 function fourthTaintBossesDeath.onPrepareDeath(creature, killer, realDamage)
-	if not creature or not killer:getPlayer() then
+	if not creature or not killer or not killer:getPlayer() then
 		return true
 	end
 

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -94,16 +94,15 @@ uint8_t Party::getUniqueVocationsCount() const {
 }
 
 void Party::disband() {
-	const auto &currentLeader = getLeader();
-	if (currentLeader) {
-		if (!g_events().eventPartyOnDisband(getParty())) {
-			return;
-		}
-
-		if (!g_callbacks().checkCallback(EventCallback_t::partyOnDisband, getParty())) {
-			return;
-		}
+	if (!g_events().eventPartyOnDisband(getParty())) {
+		return;
 	}
+
+	if (!g_callbacks().checkCallback(EventCallback_t::partyOnDisband, getParty())) {
+		return;
+	}
+
+	const auto &currentLeader = getLeader();
 
 	m_leader.reset();
 	m_mantraHolder.reset();
@@ -120,7 +119,9 @@ void Party::disband() {
 
 	for (const auto &invitee : getInvitees()) {
 		invitee->removePartyInvitation(getParty());
-		currentLeader->sendCreatureShield(invitee);
+		if (currentLeader) {
+			currentLeader->sendCreatureShield(invitee);
+		}
 	}
 	inviteList.clear();
 
@@ -139,8 +140,10 @@ void Party::disband() {
 			otherMember->sendCreatureSkull(member);
 		}
 
-		member->sendCreatureSkull(currentLeader);
-		currentLeader->sendCreatureSkull(member);
+		if (currentLeader) {
+			member->sendCreatureSkull(currentLeader);
+			currentLeader->sendCreatureSkull(member);
+		}
 		g_game().updatePlayerHelpers(member);
 	}
 	memberList.clear();

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -118,6 +118,10 @@ void Party::disband() {
 	}
 
 	for (const auto &invitee : getInvitees()) {
+		if (!invitee) {
+			continue;
+		}
+
 		invitee->removePartyInvitation(getParty());
 		if (currentLeader) {
 			currentLeader->sendCreatureShield(invitee);
@@ -127,6 +131,10 @@ void Party::disband() {
 
 	const auto &members = getMembers();
 	for (const auto &member : members) {
+		if (!member) {
+			continue;
+		}
+
 		member->resetBuff(BUFF_MANTRA);
 		member->setParty(nullptr);
 		member->sendClosePrivate(CHANNEL_PARTY);
@@ -134,9 +142,17 @@ void Party::disband() {
 	}
 
 	for (const auto &member : members) {
+		if (!member) {
+			continue;
+		}
+
 		g_game().updatePlayerShield(member);
 
 		for (const auto &otherMember : members) {
+			if (!otherMember) {
+				continue;
+			}
+
 			otherMember->sendCreatureSkull(member);
 		}
 

--- a/src/creatures/players/grouping/party.cpp
+++ b/src/creatures/players/grouping/party.cpp
@@ -46,10 +46,15 @@ std::shared_ptr<Player> Party::getMantraHolder() const {
 
 std::vector<std::shared_ptr<Player>> Party::getPlayers() const {
 	std::vector<std::shared_ptr<Player>> players;
-	for (auto &member : memberList) {
-		players.push_back(member);
+	players.reserve(memberList.size() + 1);
+	for (const auto &member : memberList) {
+		if (member) {
+			players.push_back(member);
+		}
 	}
-	players.push_back(getLeader());
+	if (const auto &leader = getLeader()) {
+		players.push_back(leader);
+	}
 	return players;
 }
 
@@ -89,29 +94,29 @@ uint8_t Party::getUniqueVocationsCount() const {
 }
 
 void Party::disband() {
-	if (!g_events().eventPartyOnDisband(getParty())) {
-		return;
-	}
-
-	if (!g_callbacks().checkCallback(EventCallback_t::partyOnDisband, getParty())) {
-		return;
-	}
-
 	const auto &currentLeader = getLeader();
-	if (!currentLeader) {
-		return;
+	if (currentLeader) {
+		if (!g_events().eventPartyOnDisband(getParty())) {
+			return;
+		}
+
+		if (!g_callbacks().checkCallback(EventCallback_t::partyOnDisband, getParty())) {
+			return;
+		}
 	}
 
 	m_leader.reset();
 	m_mantraHolder.reset();
 
-	currentLeader->resetBuff(BUFF_MANTRA);
-	currentLeader->setParty(nullptr);
-	currentLeader->sendClosePrivate(CHANNEL_PARTY);
-	g_game().updatePlayerShield(currentLeader);
-	g_game().updatePlayerHelpers(currentLeader);
-	currentLeader->sendCreatureSkull(currentLeader);
-	currentLeader->sendTextMessage(MESSAGE_PARTY_MANAGEMENT, "Your party has been disbanded.");
+	if (currentLeader) {
+		currentLeader->resetBuff(BUFF_MANTRA);
+		currentLeader->setParty(nullptr);
+		currentLeader->sendClosePrivate(CHANNEL_PARTY);
+		g_game().updatePlayerShield(currentLeader);
+		g_game().updatePlayerHelpers(currentLeader);
+		currentLeader->sendCreatureSkull(currentLeader);
+		currentLeader->sendTextMessage(MESSAGE_PARTY_MANAGEMENT, "Your party has been disbanded.");
+	}
 
 	for (const auto &invitee : getInvitees()) {
 		invitee->removePartyInvitation(getParty());

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -12544,7 +12544,7 @@ void Player::healFromHarmony(uint8_t charges /* = 1 */) {
 	// Check if the player is in a party
 	if (const auto &party = getParty()) {
 		for (const auto &partyMember : party->getPlayers()) {
-			if (!partyMember) {
+			if (!partyMember || partyMember->isRemoved() || partyMember->isDead()) {
 				continue;
 			}
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -12544,6 +12544,10 @@ void Player::healFromHarmony(uint8_t charges /* = 1 */) {
 	// Check if the player is in a party
 	if (const auto &party = getParty()) {
 		for (const auto &partyMember : party->getPlayers()) {
+			if (!partyMember) {
+				continue;
+			}
+
 			// Skip healing self during the search
 			if (this == partyMember.get()) {
 				continue;

--- a/tests/unit/players/CMakeLists.txt
+++ b/tests/unit/players/CMakeLists.txt
@@ -4,6 +4,5 @@ add_subdirectory(imbuements)
 
 target_sources(
     canary_ut
-    PRIVATE forge_test.cpp
-            party_test.cpp
+    PRIVATE forge_test.cpp party_test.cpp
 )

--- a/tests/unit/players/CMakeLists.txt
+++ b/tests/unit/players/CMakeLists.txt
@@ -5,4 +5,5 @@ add_subdirectory(imbuements)
 target_sources(
     canary_ut
     PRIVATE forge_test.cpp
+            party_test.cpp
 )

--- a/tests/unit/players/party_test.cpp
+++ b/tests/unit/players/party_test.cpp
@@ -1,0 +1,63 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include <gtest/gtest.h>
+
+#define private public
+#include "creatures/players/grouping/party.hpp"
+#undef private
+
+#include "creatures/players/player.hpp"
+#include "lib/di/container.hpp"
+#include "lib/logging/in_memory_logger.hpp"
+
+class PartyTest : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		InMemoryLogger::install(injector_);
+		DI::setTestContainer(&injector_);
+	}
+
+	static void TearDownTestSuite() {
+		if (DI::getTestContainer() == &injector_) {
+			DI::setTestContainer(nullptr);
+		}
+	}
+
+private:
+	inline static di::extension::injector<> injector_ {};
+};
+
+TEST_F(PartyTest, GetPlayersAndDisbandHandleNullEntries) {
+	auto party = std::make_shared<Party>();
+	auto leader = std::make_shared<Player>();
+	auto member = std::make_shared<Player>();
+	auto invitee = std::make_shared<Player>();
+
+	party->m_leader = leader;
+	leader->setParty(party);
+	member->setParty(party);
+
+	party->memberList.push_back(nullptr);
+	party->memberList.push_back(member);
+	party->inviteList.push_back(nullptr);
+	party->inviteList.push_back(invitee);
+
+	const auto players = party->getPlayers();
+	ASSERT_EQ(players.size(), 2U);
+	EXPECT_EQ(players[0], member);
+	EXPECT_EQ(players[1], leader);
+
+	EXPECT_NO_THROW(party->disband());
+	EXPECT_EQ(party->getLeader(), nullptr);
+	EXPECT_EQ(party->getMemberCount(), 0U);
+	EXPECT_EQ(party->getInvitationCount(), 0U);
+	EXPECT_EQ(leader->getParty(), nullptr);
+	EXPECT_EQ(member->getParty(), nullptr);
+}


### PR DESCRIPTION
Prevent potential crashes by adding safety checks: in soul_war_mechanics.lua, ensure 'killer' is not nil before calling killer:getPlayer(); in player.cpp, skip null partyMember entries in Player::healFromHarmony loop to avoid dereferencing null pointers when iterating party members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes in certain boss encounters by strengthening death-handling nil checks.
  * Fixed party healing to skip invalid or dead members when selecting targets.
  * Improved party management to remove null entries and ensure leader-specific cleanup only runs when a leader exists.
* **Tests**
  * Added unit tests validating party member filtering and proper disband behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->