### PR TITLE
fix: reduce autoloot lag during mass corpse quick-loot

### DIFF
--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -725,11 +725,8 @@ bool Creature::dropCorpse(const std::shared_ptr<Creature> &lastHitCreature, cons
 				std::vector<Direction> dirList;
 				auto isReachable = g_game().map.getPathMatching(player->getPosition(), dirList, FrozenPathingConditionCall(corpse->getPosition()), fpp);
 
-				if (player->checkAutoLoot(monster->isRewardBoss()) && isReachable) {
-					g_dispatcher().addEvent([player, corpseContainer, corpsePosition = corpse->getPosition()] {
-						g_game().playerQuickLootCorpse(player, corpseContainer, corpsePosition);
-					},
-					                        "Game::playerQuickLootCorpse");
+				if (monster && player->checkAutoLoot(monster->isRewardBoss()) && isReachable) {
+					g_game().schedulePlayerAutoLootCorpse(player, corpseContainer, corpse->getPosition());
 				}
 
 				corpse->sendUpdateToClient(player);

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -39,6 +39,9 @@
 
 #include "game/scheduling/save_manager.hpp"
 #include "game/scheduling/task.hpp"
+
+#include <cassert>
+#include <limits>
 #include "grouping/familiars.hpp"
 #include "grouping/guild.hpp"
 #include "io/iobestiary.hpp"
@@ -2230,6 +2233,10 @@ void Player::sendPingBack() const {
 }
 
 void Player::sendStats() {
+	if (deferQuickLootStats()) {
+		return;
+	}
+
 	if (client) {
 		client->sendStats();
 		lastStatsTrainingTime = getOfflineTrainingTime() / 60 / 1000;
@@ -8610,6 +8617,111 @@ void Player::closeAllExternalContainers() {
 	}
 }
 
+Player::QuickLootClientRefreshGuard::QuickLootClientRefreshGuard(Player &player) :
+	player(player) {
+	player.beginQuickLootClientRefresh();
+}
+
+Player::QuickLootClientRefreshGuard::~QuickLootClientRefreshGuard() {
+	player.flushQuickLootClientRefresh();
+}
+
+void Player::beginQuickLootClientRefresh() {
+	assert(quickLootClientRefreshDepth < std::numeric_limits<uint16_t>::max());
+	++quickLootClientRefreshDepth;
+}
+
+void Player::flushQuickLootClientRefresh() {
+	if (quickLootClientRefreshDepth == 0) {
+		return;
+	}
+
+	--quickLootClientRefreshDepth;
+	if (quickLootClientRefreshDepth != 0) {
+		return;
+	}
+
+	auto dirtyContainers = std::move(quickLootDirtyContainers);
+	auto dirtyInventorySlots = std::move(quickLootDirtyInventorySlots);
+	const bool shouldSendInventoryIds = quickLootInventoryIdsDirty;
+	const bool shouldSendStats = quickLootStatsDirty;
+
+	quickLootDirtyContainers.clear();
+	quickLootDirtyInventorySlots.clear();
+	quickLootInventoryIdsDirty = false;
+	quickLootStatsDirty = false;
+
+	for (const auto &container : dirtyContainers) {
+		onSendContainer(container);
+	}
+
+	for (const Slots_t slot : dirtyInventorySlots) {
+		sendInventoryItem(slot, getInventoryItem(slot));
+	}
+
+	if (shouldSendInventoryIds) {
+		sendInventoryIds();
+	}
+
+	if (shouldSendStats) {
+		sendStats();
+	}
+}
+
+bool Player::deferQuickLootContainerRefresh(const std::shared_ptr<Container> &container) {
+	if (quickLootClientRefreshDepth == 0 || !container) {
+		return false;
+	}
+
+	if (std::ranges::find(quickLootDirtyContainers, container) == quickLootDirtyContainers.end()) {
+		quickLootDirtyContainers.push_back(container);
+	}
+
+	return true;
+}
+
+bool Player::deferQuickLootInventoryItem(Slots_t slot) const {
+	if (quickLootClientRefreshDepth == 0) {
+		return false;
+	}
+
+	if (std::ranges::find(quickLootDirtyInventorySlots, slot) == quickLootDirtyInventorySlots.end()) {
+		quickLootDirtyInventorySlots.push_back(slot);
+	}
+
+	return true;
+}
+
+bool Player::deferQuickLootInventoryIds() const {
+	if (quickLootClientRefreshDepth == 0) {
+		return false;
+	}
+
+	quickLootInventoryIdsDirty = true;
+	return true;
+}
+
+bool Player::deferQuickLootStats() const {
+	if (quickLootClientRefreshDepth == 0) {
+		return false;
+	}
+
+	quickLootStatsDirty = true;
+	return true;
+}
+
+uint16_t Player::getDeferredQuickLootContainerFirstIndex(uint16_t firstIndex, uint32_t size, uint16_t pageSize) {
+	if (size == 0 || pageSize == 0) {
+		return 0;
+	}
+
+	if (firstIndex > 0 && firstIndex >= size - 1) {
+		return firstIndex > pageSize ? static_cast<uint16_t>(firstIndex - pageSize) : 0;
+	}
+
+	return firstIndex;
+}
+
 // container
 
 void Player::sendAddContainerItem(const std::shared_ptr<Container> &container, std::shared_ptr<Item> item) {
@@ -8618,6 +8730,10 @@ void Player::sendAddContainerItem(const std::shared_ptr<Container> &container, s
 	}
 
 	if (!container) {
+		return;
+	}
+
+	if (deferQuickLootContainerRefresh(container)) {
 		return;
 	}
 
@@ -8648,6 +8764,10 @@ void Player::sendUpdateContainerItem(const std::shared_ptr<Container> &container
 		return;
 	}
 
+	if (deferQuickLootContainerRefresh(container)) {
+		return;
+	}
+
 	for (const auto &[containerId, containerInfo] : openContainers) {
 		if (containerInfo.container != container) {
 			continue;
@@ -8672,6 +8792,21 @@ void Player::sendRemoveContainerItem(const std::shared_ptr<Container> &container
 	}
 
 	if (!container) {
+		return;
+	}
+
+	if (quickLootClientRefreshDepth != 0) {
+		for (auto &entry : openContainers) {
+			auto &containerInfo = entry.second;
+			if (containerInfo.container != container) {
+				continue;
+			}
+
+			uint16_t &firstIndex = containerInfo.index;
+			firstIndex = getDeferredQuickLootContainerFirstIndex(firstIndex, container->size(), container->capacity());
+		}
+
+		deferQuickLootContainerRefresh(container);
 		return;
 	}
 
@@ -8736,12 +8871,20 @@ void Player::sendCoinBalance() const {
 }
 
 void Player::sendInventoryItem(Slots_t slot, const std::shared_ptr<Item> &item) const {
+	if (deferQuickLootInventoryItem(slot)) {
+		return;
+	}
+
 	if (client) {
 		client->sendInventoryItem(slot, item);
 	}
 }
 
 void Player::sendInventoryIds() const {
+	if (deferQuickLootInventoryIds()) {
+		return;
+	}
+
 	if (client) {
 		client->sendInventoryIds();
 	}
@@ -11721,6 +11864,10 @@ void Player::onCloseContainer(const std::shared_ptr<Container> &container) {
 
 void Player::onSendContainer(const std::shared_ptr<Container> &container) {
 	if (!client || !container) {
+		return;
+	}
+
+	if (deferQuickLootContainerRefresh(container)) {
 		return;
 	}
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1952,7 +1952,7 @@ private:
 		bool missedSomething = false;
 		bool capacityBlocked = false;
 		bool hasNotEnoughRoomCategory = false;
-		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t{};
+		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t {};
 	};
 
 	struct PendingAutoLootCorpse {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -938,6 +938,13 @@ public:
 
 	// container
 	void closeAllExternalContainers();
+	/**
+	 * @brief Calculates the first visible index after a deferred quick-loot container shrink.
+	 *
+	 * The helper keeps page-collapse behavior testable without forcing tests/unit to build a
+	 * full Player, Container, client protocol or item registry runtime.
+	 */
+	static uint16_t getDeferredQuickLootContainerFirstIndex(uint16_t firstIndex, uint32_t size, uint16_t pageSize);
 	// container
 	void sendAddContainerItem(const std::shared_ptr<Container> &container, std::shared_ptr<Item> item);
 	void sendUpdateContainerItem(const std::shared_ptr<Container> &container, uint16_t slot, const std::shared_ptr<Item> &newItem);
@@ -1890,7 +1897,82 @@ private:
 	PlayerStorage m_storage;
 	PlayerForgeHistory m_forgeHistoryPlayer;
 
+	/**
+	 * @brief Starts deferring quick-loot client refreshes until the matching flush call.
+	 */
+	void beginQuickLootClientRefresh();
+	/**
+	 * @brief Flushes deferred quick-loot container, inventory and stats refreshes when the outermost guard ends.
+	 */
+	void flushQuickLootClientRefresh();
+	/**
+	 * @brief Defers a full container refresh while quick-loot refresh batching is active.
+	 * @return True when the refresh was deferred, false when it must be sent immediately.
+	 */
+	bool deferQuickLootContainerRefresh(const std::shared_ptr<Container> &container);
+	/**
+	 * @brief Defers an inventory slot refresh while quick-loot refresh batching is active.
+	 * @return True when the refresh was deferred, false when it must be sent immediately.
+	 */
+	bool deferQuickLootInventoryItem(Slots_t slot) const;
+	/**
+	 * @brief Defers the inventory id refresh while quick-loot refresh batching is active.
+	 * @return True when the refresh was deferred, false when it must be sent immediately.
+	 */
+	bool deferQuickLootInventoryIds() const;
+	/**
+	 * @brief Defers the stats refresh while quick-loot refresh batching is active.
+	 * @return True when the refresh was deferred, false when it must be sent immediately.
+	 */
+	bool deferQuickLootStats() const;
+
+	/**
+	 * @brief RAII guard that pairs beginQuickLootClientRefresh and flushQuickLootClientRefresh.
+	 *
+	 * The guard only controls client refresh deferral. It does not acquire quickLootMutex; callers
+	 * must use the same PlayerLock/action locking rules as the surrounding quick-loot flow.
+	 */
+	class QuickLootClientRefreshGuard {
+	public:
+		explicit QuickLootClientRefreshGuard(Player &player);
+		~QuickLootClientRefreshGuard();
+
+		QuickLootClientRefreshGuard(const QuickLootClientRefreshGuard &) = delete;
+		QuickLootClientRefreshGuard &operator=(const QuickLootClientRefreshGuard &) = delete;
+		QuickLootClientRefreshGuard(QuickLootClientRefreshGuard &&) = delete;
+		QuickLootClientRefreshGuard &operator=(QuickLootClientRefreshGuard &&) = delete;
+
+	private:
+		Player &player;
+	};
+
+	struct AutoLootMessageState {
+		bool pending = false;
+		bool lootedSomething = false;
+		bool missedSomething = false;
+		bool capacityBlocked = false;
+		bool hasNotEnoughRoomCategory = false;
+		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t{};
+	};
+
+	struct PendingAutoLootCorpse {
+		std::shared_ptr<Container> corpse;
+		Position position;
+	};
+
+	// quickLootMutex/PlayerLock protects queued auto-loot corpse scheduling and message state.
+	// Client refresh deferral queues are dispatcher-thread batching state; QuickLootClientRefreshGuard
+	// controls their depth/flush lifecycle but deliberately does not acquire this mutex.
 	std::mutex quickLootMutex;
+	std::vector<PendingAutoLootCorpse> pendingAutoLootCorpses;
+	std::vector<std::shared_ptr<Container>> quickLootDirtyContainers;
+	// These mutable members are deferred client refresh queues updated from const send* methods.
+	mutable std::vector<Slots_t> quickLootDirtyInventorySlots;
+	mutable bool quickLootInventoryIdsDirty = false;
+	mutable bool quickLootStatsDirty = false;
+	uint16_t quickLootClientRefreshDepth = 0;
+	bool autoLootCorpseEventScheduled = false;
+	AutoLootMessageState autoLootMessageState;
 
 	std::shared_ptr<Account> account;
 	bool online = true;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -3029,7 +3029,8 @@ void Game::schedulePendingPlayerAutoLootCorpses(const std::shared_ptr<Player> &p
 		}
 
 		g_game().playerAutoLootCorpses(currentPlayer);
-	}, "Game::playerAutoLootCorpses");
+	},
+	                        "Game::playerAutoLootCorpses");
 }
 
 void Game::schedulePlayerAutoLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position) {
@@ -3297,7 +3298,7 @@ Game::QuickLootResult Game::playerQuickLootCorpseInternal(const std::shared_ptr<
 
 	if (shouldNotifyCapacity) {
 		ss.str(std::string());
-		ss << getAutoLootBatchFailureMessage(true, false, ObjectCategory_t{});
+		ss << getAutoLootBatchFailureMessage(true, false, ObjectCategory_t {});
 	} else if (shouldNotifyNotEnoughRoom != OBJECTCATEGORY_NONE) {
 		ss.str(std::string());
 		ss << getAutoLootBatchFailureMessage(false, true, shouldNotifyNotEnoughRoom);
@@ -6177,7 +6178,6 @@ namespace {
 		const auto reward = player->getReward(rewardId, false);
 		return reward ? reward->getContainer() : nullptr;
 	}
-
 
 	void sendNearbyQuickLootSummary(const std::shared_ptr<Player> &player, bool anyCorpseFound, uint32_t corpsesLooted) {
 		if (!player) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -2977,9 +2977,173 @@ ReturnValue Game::internalTeleport(const std::shared_ptr<Thing> &thing, const Po
 	return RETURNVALUE_NOTPOSSIBLE;
 }
 
+size_t Game::resolveAutoLootCorpseBatchSize(size_t pendingCorpses, int32_t configuredMaxCorpses) {
+	if (pendingCorpses == 0) {
+		return 0;
+	}
+
+	const int32_t clampedMaxCorpses = std::max<int32_t>(1, configuredMaxCorpses);
+	const auto maxQuickLootCorpses = static_cast<size_t>(clampedMaxCorpses);
+	return std::min(pendingCorpses, maxQuickLootCorpses);
+}
+
+std::string Game::getAutoLootBatchSummaryMessage(bool lootedSomething, bool missedSomething) {
+	if (lootedSomething && !missedSomething) {
+		return "You looted everything.";
+	}
+
+	if (lootedSomething) {
+		return "You looted some of the loot.";
+	}
+
+	if (missedSomething) {
+		return "You looted none of the loot.";
+	}
+
+	return "No loot.";
+}
+
+std::string Game::getAutoLootBatchFailureMessage(bool capacityBlocked, bool hasNotEnoughRoomCategory, ObjectCategory_t notEnoughRoomCategory) {
+	if (capacityBlocked) {
+		return "Attention! The loot you are trying to pick up is too heavy for you to carry.";
+	}
+
+	if (hasNotEnoughRoomCategory) {
+		return fmt::format("Attention! The container assigned to category {} is full.", getObjectCategoryName(notEnoughRoomCategory));
+	}
+
+	return {};
+}
+
+void Game::schedulePendingPlayerAutoLootCorpses(const std::shared_ptr<Player> &player) {
+	if (!player || player->autoLootCorpseEventScheduled || player->pendingAutoLootCorpses.empty()) {
+		return;
+	}
+
+	player->autoLootCorpseEventScheduled = true;
+	const uint32_t playerId = player->getID();
+	g_dispatcher().addEvent([playerId] {
+		const auto currentPlayer = g_game().getPlayerByID(playerId);
+		if (!currentPlayer) {
+			return;
+		}
+
+		g_game().playerAutoLootCorpses(currentPlayer);
+	}, "Game::playerAutoLootCorpses");
+}
+
+void Game::schedulePlayerAutoLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position) {
+	if (!player || !corpse || !player->isPremium()) {
+		return;
+	}
+
+	Player::PlayerLock lock(player);
+	if (player->pendingAutoLootCorpses.empty() && !player->autoLootCorpseEventScheduled) {
+		player->autoLootMessageState = {};
+	}
+
+	player->pendingAutoLootCorpses.push_back(Player::PendingAutoLootCorpse { corpse, position });
+	schedulePendingPlayerAutoLootCorpses(player);
+}
+
+void Game::playerAutoLootCorpses(const std::shared_ptr<Player> &player) {
+	if (!player) {
+		return;
+	}
+
+	Player::PlayerLock lock(player);
+	player->autoLootCorpseEventScheduled = false;
+	const auto batchSize = resolveAutoLootCorpseBatchSize(
+		player->pendingAutoLootCorpses.size(),
+		g_configManager().getNumber(QUICK_LOOT_MAX_CORPSES)
+	);
+	if (batchSize == 0) {
+		return;
+	}
+
+	std::vector<Player::PendingAutoLootCorpse> autoLootCorpses;
+	autoLootCorpses.reserve(batchSize);
+	for (size_t i = 0; i < batchSize; ++i) {
+		autoLootCorpses.emplace_back(std::move(player->pendingAutoLootCorpses[i]));
+	}
+	player->pendingAutoLootCorpses.erase(player->pendingAutoLootCorpses.begin(), player->pendingAutoLootCorpses.begin() + batchSize);
+
+	{
+		Player::QuickLootClientRefreshGuard refreshGuard(*player);
+		for (const auto &pendingCorpse : autoLootCorpses) {
+			const auto &corpse = pendingCorpse.corpse;
+			const auto &tile = corpse ? corpse->getTile() : nullptr;
+			if (!corpse || corpse->isRemoved() || !tile || corpse->getParent() != tile || tile->getPosition() != pendingCorpse.position) {
+				continue;
+			}
+
+			std::shared_ptr<Container> lootContainer = corpse;
+			if (corpse->isRewardCorpse()) {
+				const auto rewardId = corpse->getAttribute<time_t>(ItemAttribute_t::DATE);
+				const auto reward = player->getReward(rewardId, false);
+				lootContainer = reward ? reward->getContainer() : nullptr;
+			}
+			if (!lootContainer) {
+				continue;
+			}
+
+			const auto result = playerQuickLootCorpseInternal(player, lootContainer, pendingCorpse.position, false);
+			corpse->sendUpdateToClient(player);
+			if (!result.hasResult) {
+				continue;
+			}
+
+			player->autoLootMessageState.pending = true;
+			player->autoLootMessageState.lootedSomething = player->autoLootMessageState.lootedSomething || result.lootedSomething;
+			player->autoLootMessageState.missedSomething = player->autoLootMessageState.missedSomething || result.missedSomething;
+			player->autoLootMessageState.capacityBlocked = player->autoLootMessageState.capacityBlocked || result.capacityBlocked;
+			if (!player->autoLootMessageState.hasNotEnoughRoomCategory && result.hasNotEnoughRoomCategory) {
+				player->autoLootMessageState.hasNotEnoughRoomCategory = true;
+				player->autoLootMessageState.notEnoughRoomCategory = result.notEnoughRoomCategory;
+			}
+		}
+	}
+
+	if (player->pendingAutoLootCorpses.empty()) {
+		sendPlayerAutoLootSummary(player);
+		return;
+	}
+
+	schedulePendingPlayerAutoLootCorpses(player);
+}
+
+void Game::sendPlayerAutoLootSummary(const std::shared_ptr<Player> &player) {
+	if (!player || !player->autoLootMessageState.pending) {
+		return;
+	}
+
+	const auto failureMessage = getAutoLootBatchFailureMessage(player->autoLootMessageState.capacityBlocked, player->autoLootMessageState.hasNotEnoughRoomCategory, player->autoLootMessageState.notEnoughRoomCategory);
+	player->sendTextMessage(MESSAGE_STATUS, getAutoLootBatchSummaryMessage(player->autoLootMessageState.lootedSomething, player->autoLootMessageState.missedSomething));
+	if (!failureMessage.empty()) {
+		if (player->lastQuickLootNotification + 15000 < OTSYS_TIME()) {
+			player->sendTextMessage(MESSAGE_GAME_HIGHLIGHT, failureMessage);
+		} else {
+			player->sendTextMessage(MESSAGE_EVENT_ADVANCE, failureMessage);
+		}
+
+		player->lastQuickLootNotification = OTSYS_TIME();
+	}
+
+	player->autoLootMessageState = {};
+}
+
 void Game::playerQuickLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position) {
 	if (!player || !corpse) {
 		return;
+	}
+
+	Player::QuickLootClientRefreshGuard refreshGuard(*player);
+	playerQuickLootCorpseInternal(player, corpse, position, true);
+}
+
+Game::QuickLootResult Game::playerQuickLootCorpseInternal(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position, bool sendResultMessage) {
+	if (!player || !corpse) {
+		return {};
 	}
 
 	std::vector<std::shared_ptr<Item>> itemList;
@@ -3059,72 +3223,86 @@ void Game::playerQuickLootCorpse(const std::shared_ptr<Player> &player, const st
 		corpse->clearLootHighlight(player);
 	}
 
-	std::stringstream ss;
-	if (totalLootedGold != 0 || missedAnyGold || totalLootedItems != 0 || missedAnyItem) {
-		bool lootedAllGold = totalLootedGold != 0 && !missedAnyGold;
-		bool lootedAllItems = totalLootedItems != 0 && !missedAnyItem;
-		if (lootedAllGold) {
-			if (totalLootedItems != 0 || missedAnyItem) {
-				ss << "You looted the complete " << totalLootedGold << " gold";
+	QuickLootResult result;
+	result.hasResult = totalLootedGold != 0 || missedAnyGold || totalLootedItems != 0 || missedAnyItem;
+	result.lootedSomething = totalLootedGold != 0 || totalLootedItems != 0;
+	result.missedSomething = missedAnyGold || missedAnyItem;
+	result.capacityBlocked = shouldNotifyCapacity;
+	result.hasNotEnoughRoomCategory = shouldNotifyNotEnoughRoom != OBJECTCATEGORY_NONE;
+	result.notEnoughRoomCategory = shouldNotifyNotEnoughRoom;
 
-				if (lootedAllItems) {
-					ss << " and all dropped items";
-				} else if (totalLootedItems != 0) {
-					ss << ", but you only looted some of the items";
+	std::stringstream ss;
+	if (sendResultMessage) {
+		if (totalLootedGold != 0 || missedAnyGold || totalLootedItems != 0 || missedAnyItem) {
+			bool lootedAllGold = totalLootedGold != 0 && !missedAnyGold;
+			bool lootedAllItems = totalLootedItems != 0 && !missedAnyItem;
+			if (lootedAllGold) {
+				if (totalLootedItems != 0 || missedAnyItem) {
+					ss << "You looted the complete " << totalLootedGold << " gold";
+
+					if (lootedAllItems) {
+						ss << " and all dropped items";
+					} else if (totalLootedItems != 0) {
+						ss << ", but you only looted some of the items";
+					} else if (missedAnyItem) {
+						ss << " but none of the dropped items";
+					}
+				} else {
+					ss << "You looted " << totalLootedGold << " gold";
+				}
+			} else if (lootedAllItems) {
+				if (totalLootedItems == 1) {
+					ss << "You looted 1 item";
+				} else if (totalLootedGold != 0 || missedAnyGold) {
+					ss << "You looted all of the dropped items";
+				} else {
+					ss << "You looted all items";
+				}
+
+				if (totalLootedGold != 0) {
+					ss << ", but you only looted " << totalLootedGold << " of the dropped gold";
+				} else if (missedAnyGold) {
+					ss << " but none of the dropped gold";
+				}
+			} else if (totalLootedGold != 0) {
+				ss << "You only looted " << totalLootedGold << " of the dropped gold";
+				if (totalLootedItems != 0) {
+					ss << " and some of the dropped items";
 				} else if (missedAnyItem) {
 					ss << " but none of the dropped items";
 				}
-			} else {
-				ss << "You looted " << totalLootedGold << " gold";
-			}
-		} else if (lootedAllItems) {
-			if (totalLootedItems == 1) {
-				ss << "You looted 1 item";
-			} else if (totalLootedGold != 0 || missedAnyGold) {
-				ss << "You looted all of the dropped items";
-			} else {
-				ss << "You looted all items";
-			}
-
-			if (totalLootedGold != 0) {
-				ss << ", but you only looted " << totalLootedGold << " of the dropped gold";
+			} else if (totalLootedItems != 0) {
+				ss << "You looted some of the dropped items";
+				if (missedAnyGold) {
+					ss << " but none of the dropped gold";
+				}
 			} else if (missedAnyGold) {
-				ss << " but none of the dropped gold";
-			}
-		} else if (totalLootedGold != 0) {
-			ss << "You only looted " << totalLootedGold << " of the dropped gold";
-			if (totalLootedItems != 0) {
-				ss << " and some of the dropped items";
+				ss << "You looted none of the dropped gold";
+				if (missedAnyItem) {
+					ss << " and none of the items";
+				}
 			} else if (missedAnyItem) {
-				ss << " but none of the dropped items";
+				ss << "You looted none of the dropped items";
 			}
-		} else if (totalLootedItems != 0) {
-			ss << "You looted some of the dropped items";
-			if (missedAnyGold) {
-				ss << " but none of the dropped gold";
-			}
-		} else if (missedAnyGold) {
-			ss << "You looted none of the dropped gold";
-			if (missedAnyItem) {
-				ss << " and none of the items";
-			}
-		} else if (missedAnyItem) {
-			ss << "You looted none of the dropped items";
+		} else {
+			ss << "No loot";
 		}
-	} else {
-		ss << "No loot";
+		ss << ".";
+		player->sendTextMessage(MESSAGE_STATUS, ss.str());
 	}
-	ss << ".";
-	player->sendTextMessage(MESSAGE_STATUS, ss.str());
+
+	if (!sendResultMessage) {
+		return result;
+	}
 
 	if (shouldNotifyCapacity) {
 		ss.str(std::string());
-		ss << "Attention! The loot you are trying to pick up is too heavy for you to carry.";
+		ss << getAutoLootBatchFailureMessage(true, false, ObjectCategory_t{});
 	} else if (shouldNotifyNotEnoughRoom != OBJECTCATEGORY_NONE) {
 		ss.str(std::string());
-		ss << "Attention! The container assigned to category " << getObjectCategoryName(shouldNotifyNotEnoughRoom) << " is full.";
+		ss << getAutoLootBatchFailureMessage(false, true, shouldNotifyNotEnoughRoom);
 	} else {
-		return;
+		return result;
 	}
 
 	if (player->lastQuickLootNotification + 15000 < OTSYS_TIME()) {
@@ -3133,9 +3311,8 @@ void Game::playerQuickLootCorpse(const std::shared_ptr<Player> &player, const st
 		player->sendTextMessage(MESSAGE_EVENT_ADVANCE, ss.str());
 	}
 
-	corpse->sendUpdateToClient(player);
-
 	player->lastQuickLootNotification = OTSYS_TIME();
+	return result;
 }
 
 std::shared_ptr<Container> Game::findManagedContainer(const std::shared_ptr<Player> &player, bool &fallbackConsumed, ObjectCategory_t category, bool isLootContainer) {
@@ -5836,6 +6013,7 @@ void Game::playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t item
 				playerQuickLootCorpse(player, corpse, corpse->getPosition());
 			} else {
 				playerLootAllCorpses(player, pos, lootAllCorpses);
+				return;
 			}
 		}
 	}
@@ -5853,7 +6031,9 @@ void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Pos
 		}
 
 		const TileItemVector* itemVector = tile->getItemList();
-		uint16_t corpses = 0;
+		Player::QuickLootClientRefreshGuard refreshGuard(*player);
+		uint16_t processedCorpses = 0;
+		uint16_t lootedCorpses = 0;
 		for (auto &tileItem : *itemVector) {
 			if (!tileItem) {
 				continue;
@@ -5872,17 +6052,31 @@ void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Pos
 				continue;
 			}
 
-			corpses++;
-			playerQuickLootCorpse(player, tileCorpse, tileCorpse->getPosition());
-			if (corpses >= maxQuickLootCorpses) {
+			std::shared_ptr<Container> lootContainer = tileCorpse;
+			if (tileCorpse->isRewardCorpse()) {
+				const auto rewardId = tileCorpse->getAttribute<time_t>(ItemAttribute_t::DATE);
+				const auto reward = player->getReward(rewardId, false);
+				lootContainer = reward ? reward->getContainer() : nullptr;
+			}
+			if (!lootContainer) {
+				continue;
+			}
+
+			const auto result = playerQuickLootCorpseInternal(player, lootContainer, tileCorpse->getPosition(), true);
+			tileCorpse->sendUpdateToClient(player);
+			++processedCorpses;
+			if (result.lootedSomething) {
+				++lootedCorpses;
+			}
+			if (processedCorpses >= maxQuickLootCorpses) {
 				break;
 			}
 		}
 
-		if (corpses > 0) {
-			if (corpses > 1) {
+		if (lootedCorpses > 0) {
+			if (lootedCorpses > 1) {
 				std::stringstream string;
-				string << "You looted " << corpses << " corpses.";
+				string << "You looted " << lootedCorpses << " corpses.";
 				player->sendTextMessage(MESSAGE_LOOT, string.str());
 			}
 
@@ -5984,32 +6178,6 @@ namespace {
 		return reward ? reward->getContainer() : nullptr;
 	}
 
-	struct NearbyQuickLootOutcome {
-		bool foundCorpse = false;
-		bool looted = false;
-	};
-
-	NearbyQuickLootOutcome tryNearbyQuickLootCorpse(Game &game, const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse) {
-		if (!isNearbyLootableCorpse(player, corpse)) {
-			return {};
-		}
-
-		NearbyQuickLootOutcome outcome;
-		outcome.foundCorpse = true;
-
-		const auto lootContainer = resolveNearbyLootContainer(player, corpse);
-		const auto lootSnapshotBefore = captureNearbyQuickLootSnapshot(player, lootContainer);
-		if (!lootSnapshotBefore.hasLoot()) {
-			return outcome;
-		}
-
-		game.playerQuickLootCorpse(player, lootContainer, corpse->getPosition());
-		if (lootContainer != corpse) {
-			corpse->sendUpdateToClient(player);
-		}
-		outcome.looted = captureNearbyQuickLootSnapshot(player, lootContainer) != lootSnapshotBefore;
-		return outcome;
-	}
 
 	void sendNearbyQuickLootSummary(const std::shared_ptr<Player> &player, bool anyCorpseFound, uint32_t corpsesLooted) {
 		if (!player) {
@@ -6058,6 +6226,8 @@ void Game::playerLootNearby(uint32_t playerId) {
 
 	const auto maxQuickLootCorpses = static_cast<uint32_t>(std::max<int32_t>(1, g_configManager().getNumber(QUICK_LOOT_MAX_CORPSES)));
 	const Position &playerPos = player->getPosition();
+	Player::QuickLootClientRefreshGuard refreshGuard(*player);
+	uint32_t processedCorpses = 0;
 	uint32_t corpsesLooted = 0;
 	bool anyCorpseFound = false;
 
@@ -6069,20 +6239,33 @@ void Game::playerLootNearby(uint32_t playerId) {
 			}
 
 			for (const auto &tileItem : *itemVector) {
-				const auto outcome = tryNearbyQuickLootCorpse(*this, player, tileItem ? tileItem->getContainer() : nullptr);
-				anyCorpseFound = anyCorpseFound || outcome.foundCorpse;
-				corpsesLooted += outcome.looted ? 1U : 0U;
-				if (corpsesLooted >= maxQuickLootCorpses) {
+				const auto corpse = tileItem ? tileItem->getContainer() : nullptr;
+				if (!isNearbyLootableCorpse(player, corpse)) {
+					continue;
+				}
+
+				anyCorpseFound = true;
+				const auto lootContainer = resolveNearbyLootContainer(player, corpse);
+				const auto lootSnapshotBefore = captureNearbyQuickLootSnapshot(player, lootContainer);
+				if (!lootSnapshotBefore.hasLoot()) {
+					continue;
+				}
+
+				const auto result = playerQuickLootCorpseInternal(player, lootContainer, corpse->getPosition(), true);
+				corpse->sendUpdateToClient(player);
+				++processedCorpses;
+				corpsesLooted += result.lootedSomething ? 1U : 0U;
+				if (processedCorpses >= maxQuickLootCorpses) {
 					break;
 				}
 			}
 
-			if (corpsesLooted >= maxQuickLootCorpses) {
+			if (processedCorpses >= maxQuickLootCorpses) {
 				break;
 			}
 		}
 
-		if (corpsesLooted >= maxQuickLootCorpses) {
+		if (processedCorpses >= maxQuickLootCorpses) {
 			break;
 		}
 	}

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -371,7 +371,37 @@ public:
 	void playerSetFightModes(uint32_t playerId, FightMode_t fightMode, bool chaseMode, bool secureMode);
 	void playerLookAt(uint32_t playerId, uint16_t itemId, const Position &pos, uint8_t stackPos);
 	void playerLookInBattleList(uint32_t playerId, uint32_t creatureId);
+	/**
+	 * @brief Queues a corpse for automatic quick-loot processing by the owning player.
+	 *
+	 * The queued corpses are drained in bounded batches to avoid one dispatcher task per corpse
+	 * and to keep client refreshes aggregated during burst auto-loot scenarios.
+	 */
+	void schedulePlayerAutoLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position);
 	void playerQuickLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position);
+	/**
+	 * @brief Calculates how many pending auto-loot corpses may be processed in one drain pass.
+	 *
+	 * @param pendingCorpses Number of queued corpses waiting for automatic quick-loot. When this
+	 * value is zero, the function returns zero immediately regardless of configuration.
+	 * @param configuredMaxCorpses Configured maximum from quickLootMaxCorpses. When corpses are
+	 * pending, values less than one are intentionally clamped to one before conversion to size_t so
+	 * a bad config cannot create an empty drain loop or an unsigned overflow.
+	 * @return Zero when no corpses are pending; otherwise the bounded batch size, clamped to at
+	 * least one for invalid non-positive configuration values.
+	 */
+	static size_t resolveAutoLootCorpseBatchSize(size_t pendingCorpses, int32_t configuredMaxCorpses);
+	/**
+	 * @brief Builds the loot-neutral summary message emitted after an automatic quick-loot batch finishes.
+	 *
+	 * @return A player-facing summary describing whether the batch looted everything, some loot,
+	 * none of the loot, or had no loot to collect.
+	 */
+	static std::string getAutoLootBatchSummaryMessage(bool lootedSomething, bool missedSomething);
+	/**
+	 * @brief Builds the single warning message emitted after an automatic quick-loot batch hits capacity or container limits.
+	 */
+	static std::string getAutoLootBatchFailureMessage(bool capacityBlocked, bool hasNotEnoughRoomCategory, ObjectCategory_t notEnoughRoomCategory);
 	void playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem = nullptr, bool lootAllCorpses = false, bool autoLoot = false);
 	void playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool lootAllCorpses);
 	void playerLootNearby(uint32_t playerId);
@@ -771,6 +801,19 @@ private:
 	 * @return True if fallback logic was handled, false otherwise.
 	 */
 	bool handleFallbackLogic(const std::shared_ptr<Player> &player, std::shared_ptr<Container> &lootContainer, ContainerIterator &containerIterator, const bool &fallbackConsumed);
+	void schedulePendingPlayerAutoLootCorpses(const std::shared_ptr<Player> &player);
+	void playerAutoLootCorpses(const std::shared_ptr<Player> &player);
+	struct QuickLootResult {
+		bool hasResult = false;
+		bool lootedSomething = false;
+		bool missedSomething = false;
+		bool capacityBlocked = false;
+		bool hasNotEnoughRoomCategory = false;
+		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t{};
+	};
+
+	void sendPlayerAutoLootSummary(const std::shared_ptr<Player> &player);
+	QuickLootResult playerQuickLootCorpseInternal(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position, bool sendResultMessage = true);
 
 	/**
 	 * @brief Processes the movement or addition of an item to a loot container.

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -809,7 +809,7 @@ private:
 		bool missedSomething = false;
 		bool capacityBlocked = false;
 		bool hasNotEnoughRoomCategory = false;
-		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t{};
+		ObjectCategory_t notEnoughRoomCategory = ObjectCategory_t {};
 	};
 
 	void sendPlayerAutoLootSummary(const std::shared_ptr<Player> &player);

--- a/tests/unit/game/CMakeLists.txt
+++ b/tests/unit/game/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
     canary_ut
     PRIVATE events_scheduler_test.cpp
             highscores_test.cpp
-            random_mount_test.cpp
             player_stats_test.cpp
+            quickloot_auto_batch_test.cpp
+            random_mount_test.cpp
 )

--- a/tests/unit/game/quickloot_auto_batch_test.cpp
+++ b/tests/unit/game/quickloot_auto_batch_test.cpp
@@ -1,0 +1,109 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019–present OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "creatures/players/player.hpp"
+#include "enums/object_category.hpp"
+#include "game/game.hpp"
+
+TEST(QuickLootAutoBatchSizeTest, EmptyPendingCorpsesProduceEmptyBatch) {
+	EXPECT_EQ(0, Game::resolveAutoLootCorpseBatchSize(0, 30));
+}
+
+TEST(QuickLootAutoBatchSizeTest, NonPositiveConfigStillProcessesOneCorpsePerRound) {
+	EXPECT_EQ(1, Game::resolveAutoLootCorpseBatchSize(42, 0));
+	EXPECT_EQ(1, Game::resolveAutoLootCorpseBatchSize(42, -5));
+}
+
+TEST(QuickLootAutoBatchSizeTest, ZeroPendingTakesPrecedenceOverNonPositiveConfig) {
+	EXPECT_EQ(0, Game::resolveAutoLootCorpseBatchSize(0, 0));
+	EXPECT_EQ(0, Game::resolveAutoLootCorpseBatchSize(0, -5));
+}
+
+TEST(QuickLootAutoBatchSizeTest, BatchIsLimitedByConfiguredMaximum) {
+	EXPECT_EQ(30, Game::resolveAutoLootCorpseBatchSize(42, 30));
+}
+
+TEST(QuickLootAutoBatchSizeTest, OversizedPendingIsBoundedByConfiguredMaximum) {
+	EXPECT_EQ(30, Game::resolveAutoLootCorpseBatchSize(std::numeric_limits<size_t>::max(), 30));
+}
+
+TEST(QuickLootAutoBatchSizeTest, BatchDoesNotExceedPendingCorpses) {
+	EXPECT_EQ(12, Game::resolveAutoLootCorpseBatchSize(12, 30));
+}
+
+TEST(QuickLootAutoBatchMessageTest, SuccessfulAutoLootBatchUsesSingleSummaryMessage) {
+	EXPECT_EQ("You looted everything.", Game::getAutoLootBatchSummaryMessage(true, false));
+}
+
+TEST(QuickLootAutoBatchMessageTest, PartialAutoLootBatchDoesNotClaimFullSuccess) {
+	EXPECT_EQ("You looted some of the loot.", Game::getAutoLootBatchSummaryMessage(true, true));
+	EXPECT_EQ("You looted none of the loot.", Game::getAutoLootBatchSummaryMessage(false, true));
+}
+
+TEST(QuickLootAutoBatchMessageTest, SummaryHelperCanRepresentNoLoot) {
+	EXPECT_EQ("No loot.", Game::getAutoLootBatchSummaryMessage(false, false));
+}
+
+TEST(QuickLootAutoBatchMessageTest, CapacityFailureUsesSingleBatchWarning) {
+	EXPECT_EQ(
+		"Attention! The loot you are trying to pick up is too heavy for you to carry.",
+		Game::getAutoLootBatchFailureMessage(true, false, ObjectCategory_t{})
+	);
+}
+
+TEST(QuickLootAutoBatchMessageTest, FullContainerFailureUsesSingleBatchWarning) {
+	EXPECT_EQ(
+		"Attention! The container assigned to category Unassigned Loot is full.",
+		Game::getAutoLootBatchFailureMessage(false, true, OBJECTCATEGORY_DEFAULT)
+	);
+}
+
+TEST(QuickLootAutoBatchMessageTest, NoFailureProducesNoBatchWarning) {
+	EXPECT_TRUE(Game::getAutoLootBatchFailureMessage(false, false, OBJECTCATEGORY_DEFAULT).empty());
+}
+
+TEST(QuickLootDeferredPageCollapseTest, KeepsCurrentIndexWhenPageStillExists) {
+	EXPECT_EQ(20, Player::getDeferredQuickLootContainerFirstIndex(20, 100, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, EmptyContainerRewindsToStart) {
+	EXPECT_EQ(0, Player::getDeferredQuickLootContainerFirstIndex(20, 0, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, PageSizeBoundaryRewindsToStart) {
+	EXPECT_EQ(0, Player::getDeferredQuickLootContainerFirstIndex(20, 20, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, MultiPageShrinkRewindsOnePage) {
+	EXPECT_EQ(40, Player::getDeferredQuickLootContainerFirstIndex(60, 55, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, CurrentIndexBeyondItemCountRewindsOnePageFromCurrentOffset) {
+	EXPECT_EQ(40, Player::getDeferredQuickLootContainerFirstIndex(60, 30, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, UnalignedCurrentIndexIsPreservedWhenPageStillExists) {
+	EXPECT_EQ(25, Player::getDeferredQuickLootContainerFirstIndex(25, 50, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, LastItemOnCurrentPageRewindsLikeLiveRemovePath) {
+	EXPECT_EQ(0, Player::getDeferredQuickLootContainerFirstIndex(20, 21, 20));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, ZeroPageSizeWithItemsRewindsToStart) {
+	EXPECT_EQ(0, Player::getDeferredQuickLootContainerFirstIndex(20, 30, 0));
+}
+
+TEST(QuickLootDeferredPageCollapseTest, ZeroPageSizeRewindsToStart) {
+	EXPECT_EQ(0, Player::getDeferredQuickLootContainerFirstIndex(20, 0, 0));
+}

--- a/tests/unit/game/quickloot_auto_batch_test.cpp
+++ b/tests/unit/game/quickloot_auto_batch_test.cpp
@@ -57,7 +57,7 @@ TEST(QuickLootAutoBatchMessageTest, SummaryHelperCanRepresentNoLoot) {
 TEST(QuickLootAutoBatchMessageTest, CapacityFailureUsesSingleBatchWarning) {
 	EXPECT_EQ(
 		"Attention! The loot you are trying to pick up is too heavy for you to carry.",
-		Game::getAutoLootBatchFailureMessage(true, false, ObjectCategory_t{})
+		Game::getAutoLootBatchFailureMessage(true, false, ObjectCategory_t {})
 	);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes quick loot/autoloot performance spikes when many monsters die at the same time.

The previous flow could process each autoloot corpse separately, causing repeated dispatcher tasks, container refreshes, inventory/stat updates, and result messages. This was easier to notice when the loot pouch/backpack/managed loot container was open.

This PR updates quick loot/autoloot to batch pending corpses per player, limit each drain by `quickLootMaxCorpses`, defer client refreshes during the batch, and send aggregated result/warning messages.

Fixes: #3287 and #3467

## Quick Loot / Autoloot Batching

Automatic quick loot now queues pending corpses per player and drains them in bounded batches.

This reduces burst pressure from:

```text
N corpses -> N dispatcher tasks -> repeated client refresh/message updates
```

to:

```text
N corpses -> bounded batch processing -> coalesced client refresh/message updates
```

Queued corpses are revalidated before processing, and reward corpses are resolved to their reward container while preserving corpse refresh behavior.

## Client Refresh Handling

Container, inventory, and stat refreshes are deferred during quick loot batches and flushed once after the batch.

This reduces packet/update spam when many corpses are looted while a loot container is open.

## Result Messages

Autoloot batch results are summarized into a single message.

Capacity and container-full warnings are also aggregated, avoiding repeated warning spam during mass loot bursts.

## Test Plan

- [ ] Enable autoloot.
- [ ] Open the loot pouch/backpack/managed loot container.
- [ ] Spawn 30+ monsters around the player.
- [ ] Kill them at the same time with an area spell or admin command.
- [ ] Confirm movement/input does not noticeably freeze after the kill.
- [ ] Repeat with the loot container closed and compare behavior.
- [ ] Repeat with autoloot disabled and compare behavior.

## Testing Environment

- Server: Canary - Version 3.4.2
- OS: Windows 11
- Client: [15.00.249ccc](https://github.com/dudantas/tibia-client/releases/tag/15.00.249ccc)