### PR TITLE
feat(net): accept IPv6 clients via dual-stack listener

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -57,6 +57,10 @@ cleanProtectionZones = false
 -- NOTE: maxPlayers set to 0 means no limit
 -- NOTE: MaxPacketsPerSeconds if you change you will be subject to bugs by WPE, keep the default value of 25,
 -- It's recommended to use a range like min 50 in this function, otherwise you will be disconnected after equipping two-handed distance weapons.
+-- NOTE: The server listens on a dual-stack IPv6 socket and accepts both IPv4 and IPv6 clients
+-- on the same ports. The 'ip' value is announced to the client in the character list and is
+-- used as the bind address when bindOnlyGlobalAddress is true; it may be an IPv4 literal
+-- (e.g. "127.0.0.1"), an IPv6 literal (e.g. "::1"), or a hostname that resolves on the client side.
 ip = "127.0.0.1"
 allowOldProtocol = false
 bindOnlyGlobalAddress = false

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -9873,6 +9873,10 @@ uint32_t Player::getIP() const {
 	return client ? client->getIP() : 0;
 }
 
+std::string Player::getIPString() const {
+	return client ? client->getIPString() : std::string {};
+}
+
 void Player::reloadTaskSlot(PreySlot_t slotid) {
 	if (g_configManager().getBoolean(TASK_HUNTING_ENABLED) && client) {
 		client->sendTaskHuntingData(getTaskHuntingSlotById(slotid));

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -446,6 +446,7 @@ public:
 	void disconnect() const;
 
 	uint32_t getIP() const;
+	std::string getIPString() const;
 
 	bool isDisconnected() const {
 		return getIP() == 0;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9428,7 +9428,7 @@ void Game::playerDebugAssert(uint32_t playerId, const std::string &assertLine, c
 	// TODO: move debug assertions to database
 	FILE* file = fopen("client_assertions.txt", "a");
 	if (file) {
-		fprintf(file, "----- %s - %s (%s) -----\n", formatDate(time(nullptr)).c_str(), player->getName().c_str(), convertIPToString(player->getIP()).c_str());
+		fprintf(file, "----- %s - %s (%s) -----\n", formatDate(time(nullptr)).c_str(), player->getName().c_str(), player->getIPString().c_str());
 		fprintf(file, "%s\n%s\n%s\n%s\n", assertLine.c_str(), date.c_str(), description.c_str(), comment.c_str());
 		fclose(file);
 	}

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -21,7 +21,7 @@
 #include "enums/account_type.hpp"
 #include "enums/account_errors.hpp"
 
-bool IOLoginData::gameWorldAuthentication(const std::string &accountDescriptor, const std::string &password, std::string &characterName, uint32_t &accountId, bool oldProtocol, const uint32_t ip) {
+bool IOLoginData::gameWorldAuthentication(const std::string &accountDescriptor, const std::string &password, std::string &characterName, uint32_t &accountId, bool oldProtocol, const std::string &ipString) {
 	Account account(accountDescriptor);
 	account.setProtocolCompat(oldProtocol);
 
@@ -41,7 +41,7 @@ bool IOLoginData::gameWorldAuthentication(const std::string &accountDescriptor, 
 	}
 
 	if (!g_accountRepository().getCharacterByAccountIdAndName(account.getID(), characterName)) {
-		g_logger().warn("IP [{}] trying to connect into another account character", convertIPToString(ip));
+		g_logger().warn("IP [{}] trying to connect into another account character", ipString);
 		return false;
 	}
 

--- a/src/io/iologindata.hpp
+++ b/src/io/iologindata.hpp
@@ -20,7 +20,7 @@ using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
 
 class IOLoginData {
 public:
-	static bool gameWorldAuthentication(const std::string &accountDescriptor, const std::string &sessionOrPassword, std::string &characterName, uint32_t &accountId, bool oldProcotol, const uint32_t ip);
+	static bool gameWorldAuthentication(const std::string &accountDescriptor, const std::string &sessionOrPassword, std::string &characterName, uint32_t &accountId, bool oldProcotol, const std::string &ipString);
 	static uint8_t getAccountType(uint32_t accountId);
 	static bool loadPlayerById(const std::shared_ptr<Player> &player, uint32_t id, bool disableIrrelevantInfo = true);
 	static bool loadPlayerByName(const std::shared_ptr<Player> &player, const std::string &name, bool disableIrrelevantInfo = true);

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -51,6 +51,7 @@ void PlayerFunctions::init(lua_State* L) {
 
 	Lua::registerMethod(L, "Player", "getGuid", PlayerFunctions::luaPlayerGetGuid);
 	Lua::registerMethod(L, "Player", "getIp", PlayerFunctions::luaPlayerGetIp);
+	Lua::registerMethod(L, "Player", "getIpString", PlayerFunctions::luaPlayerGetIpString);
 	Lua::registerMethod(L, "Player", "getAccountId", PlayerFunctions::luaPlayerGetAccountId);
 	Lua::registerMethod(L, "Player", "getLastLoginSaved", PlayerFunctions::luaPlayerGetLastLoginSaved);
 	Lua::registerMethod(L, "Player", "getLastLogout", PlayerFunctions::luaPlayerGetLastLogout);
@@ -687,6 +688,17 @@ int PlayerFunctions::luaPlayerGetIp(lua_State* L) {
 	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
 		lua_pushnumber(L, player->getIP());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int PlayerFunctions::luaPlayerGetIpString(lua_State* L) {
+	// player:getIpString()
+	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
+	if (player) {
+		Lua::pushString(L, player->getIPString());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -34,6 +34,7 @@ class PlayerFunctions {
 
 	static int luaPlayerGetGuid(lua_State* L);
 	static int luaPlayerGetIp(lua_State* L);
+	static int luaPlayerGetIpString(lua_State* L);
 	static int luaPlayerGetAccountId(lua_State* L);
 	static int luaPlayerGetLastLoginSaved(lua_State* L);
 	static int luaPlayerGetLastLogout(lua_State* L);

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -199,7 +199,7 @@ void Connection::parseHeader(const std::error_code &error) {
 
 	uint32_t timePassed = std::max<uint32_t>(1, (time(nullptr) - timeConnected) + 1);
 	if ((++packetsSent / timePassed) > static_cast<uint32_t>(g_configManager().getNumber(MAX_PACKETS_PER_SECOND))) {
-		g_logger().warn("[Connection::parseHeader] - {} disconnected for exceeding packet per second limit.", convertIPToString(getIP()));
+		g_logger().warn("[Connection::parseHeader] - {} disconnected for exceeding packet per second limit.", getIPString());
 		close();
 		return;
 	}
@@ -353,20 +353,62 @@ void Connection::internalWorker() {
 	internalSend(outputMessage);
 }
 
-uint32_t Connection::getIP() {
-	std::scoped_lock lock(connectionLock);
+void Connection::resolveRemoteAddress() {
+	if (addressResolved) {
+		return;
+	}
+	addressResolved = true;
 
-	if (ip == 1) {
-		std::error_code error;
-		asio::ip::tcp::endpoint endpoint = socket.remote_endpoint(error);
-		if (error) {
-			g_logger().error("[Connection::getIP] - Failed to get remote endpoint: {}", error.message());
-			ip = 0;
-		} else {
-			ip = htonl(endpoint.address().to_v4().to_uint());
+	std::error_code error;
+	const asio::ip::tcp::endpoint endpoint = socket.remote_endpoint(error);
+	if (error) {
+		g_logger().error("[Connection::resolveRemoteAddress] - Failed to get remote endpoint: {}", error.message());
+		ip = 0;
+		return;
+	}
+
+	asio::ip::address address = endpoint.address();
+	// Dual-stack listeners report IPv4 peers as v4-mapped IPv6. Unmap so the
+	// legacy 32-bit IP path keeps working unchanged for the IPv4 majority.
+	if (address.is_v6()) {
+		const auto v6 = address.to_v6();
+		if (v6.is_v4_mapped()) {
+			address = v6.to_v4();
 		}
 	}
+
+	ipString = address.to_string();
+
+	if (address.is_v4()) {
+		ip = htonl(address.to_v4().to_uint());
+		return;
+	}
+
+	// Pure IPv6 peer: fold the 128-bit address into a 32-bit value so existing
+	// uint32_t consumers (rate-limit buckets, lua scripts, lastip column) keep
+	// functioning. The hash is not unique across the v6 space — proper IPv6 ban
+	// and persistence require schema-level changes tracked as a follow-up.
+	const auto bytes = address.to_v6().to_bytes();
+	uint32_t hash = 0;
+	for (size_t i = 0; i + 4 <= bytes.size(); i += 4) {
+		uint32_t chunk = 0;
+		std::memcpy(&chunk, &bytes[i], sizeof(chunk));
+		hash ^= chunk;
+	}
+	// Reserve 0 (unknown) and 1 (unresolved sentinel) so callers can keep using them.
+	ip = (hash == 0 || hash == 1) ? 2 : hash;
+}
+
+uint32_t Connection::getIP() {
+	std::scoped_lock lock(connectionLock);
+	resolveRemoteAddress();
 	return ip;
+}
+
+const std::string &Connection::getIPString() {
+	std::scoped_lock lock(connectionLock);
+	resolveRemoteAddress();
+	return ipString;
 }
 
 void Connection::internalSend(const OutputMessage_ptr &outputMessage) {
@@ -412,9 +454,9 @@ void Connection::handleTimeout(ConnectionWeak_ptr connectionWeak, const std::err
 
 	if (auto connection = connectionWeak.lock()) {
 		if (!error) {
-			g_logger().debug("Connection Timeout, IP: {}", convertIPToString(connection->getIP()));
+			g_logger().debug("Connection Timeout, IP: {}", connection->getIPString());
 		} else {
-			g_logger().debug("Connection Timeout or error: {}, IP: {}", error.message(), convertIPToString(connection->getIP()));
+			g_logger().debug("Connection Timeout or error: {}, IP: {}", error.message(), connection->getIPString());
 		}
 		connection->close(FORCE_CLOSE);
 	}

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -69,8 +69,11 @@ public:
 	void send(const OutputMessage_ptr &outputMessage);
 
 	uint32_t getIP();
+	const std::string &getIPString();
 
 private:
+	void resolveRemoteAddress();
+
 	void parseProxyIdentification(const std::error_code &error);
 	void parseHeader(const std::error_code &error);
 	void parsePacket(const std::error_code &error);
@@ -104,6 +107,8 @@ private:
 	std::time_t timeConnected = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 	uint32_t packetsSent = 0;
 	uint32_t ip = 1;
+	std::string ipString;
+	bool addressResolved = false;
 
 	std::underlying_type_t<ConnectionState_t> connectionState = CONNECTION_STATE_OPEN;
 	bool receivedFirst = false;

--- a/src/server/network/protocol/protocol.cpp
+++ b/src/server/network/protocol/protocol.cpp
@@ -256,6 +256,14 @@ uint32_t Protocol::getIP() const {
 	return 0;
 }
 
+std::string Protocol::getIPString() const {
+	if (const auto protocolConnection = getConnection()) {
+		return protocolConnection->getIPString();
+	}
+
+	return {};
+}
+
 bool Protocol::compression(OutputMessage &outputMessage) const {
 	if (checksumMethod != CHECKSUM_METHOD_SEQUENCE) {
 		return false;

--- a/src/server/network/protocol/protocol.hpp
+++ b/src/server/network/protocol/protocol.hpp
@@ -42,6 +42,7 @@ public:
 	Connection_ptr getConnection() const;
 
 	uint32_t getIP() const;
+	std::string getIPString() const;
 
 	// Use this function for autosend messages only
 	OutputMessage_ptr getOutputBuffer(int32_t size);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -938,7 +938,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg) {
 	}
 
 	uint32_t accountId;
-	if (!IOLoginData::gameWorldAuthentication(accountDescriptor, password, characterName, accountId, oldProtocol, getIP())) {
+	if (!IOLoginData::gameWorldAuthentication(accountDescriptor, password, characterName, accountId, oldProtocol, getIPString())) {
 		ss.str(std::string());
 		if (authType == "session") {
 			ss << "Your session has expired. Please log in again.";

--- a/src/server/network/protocol/protocolstatus.cpp
+++ b/src/server/network/protocol/protocolstatus.cpp
@@ -26,8 +26,8 @@ const uint64_t ProtocolStatus::start = OTSYS_TIME(true);
 void ProtocolStatus::onRecvFirstMessage(NetworkMessage &msg) {
 	const uint32_t ip = getIP();
 	if (ip != 0x0100007F) {
-		const std::string ipStr = convertIPToString(ip);
-		if (ipStr != g_configManager().getString(IP)) {
+		const std::string ipStr = getIPString();
+		if (ipStr != g_configManager().getString(IP) && ipStr != "::1") {
 			const auto it = ipConnectMap.find(ip);
 			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_configManager().getNumber(STATUSQUERY_TIMEOUT)))) {
 				disconnect();

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -152,11 +152,33 @@ void ServicePort::open(uint16_t port) {
 	pendingStart = false;
 
 	try {
+		// Dual-stack IPv6 listener: accepts both IPv4 (as v4-mapped) and IPv6 clients
+		// on a single socket. Falling back to IPv4 only if the platform refuses v6_only=false
+		// keeps the server reachable on environments where IPv6 is disabled at the OS level.
+		asio::ip::tcp::endpoint endpoint;
 		if (g_configManager().getBoolean(BIND_ONLY_GLOBAL_ADDRESS)) {
-			acceptor = std::make_unique<asio::ip::tcp::acceptor>(io_service, asio::ip::tcp::endpoint(asio::ip::address(asio::ip::address_v4::from_string(g_configManager().getString(IP))), serverPort));
+			std::error_code parseError;
+			const auto configured = asio::ip::make_address(g_configManager().getString(IP), parseError);
+			if (parseError) {
+				throw std::system_error(parseError, "invalid 'ip' config value");
+			}
+			endpoint = asio::ip::tcp::endpoint(configured, serverPort);
 		} else {
-			acceptor = std::make_unique<asio::ip::tcp::acceptor>(io_service, asio::ip::tcp::endpoint(asio::ip::address(asio::ip::address_v4(INADDR_ANY)), serverPort));
+			endpoint = asio::ip::tcp::endpoint(asio::ip::tcp::v6(), serverPort);
 		}
+
+		acceptor = std::make_unique<asio::ip::tcp::acceptor>(io_service);
+		acceptor->open(endpoint.protocol());
+		acceptor->set_option(asio::ip::tcp::acceptor::reuse_address(true));
+		if (endpoint.protocol() == asio::ip::tcp::v6()) {
+			std::error_code v6Error;
+			acceptor->set_option(asio::ip::v6_only(false), v6Error);
+			if (v6Error) {
+				g_logger().warn("[ServicePort::open] - Could not enable dual-stack on IPv6 socket: {}", v6Error.message());
+			}
+		}
+		acceptor->bind(endpoint);
+		acceptor->listen();
 
 		acceptor->set_option(asio::ip::tcp::no_delay(true));
 


### PR DESCRIPTION
Closes #3959

🤖 Beats opened an enhancement and went to do something more fun. My turn.

## Feature

**Summary:** The server now accepts IPv6 client connections on the same ports it serves IPv4. A client running on a v6-only network (or a dual-stack client that prefers v6) can establish a TCP session, complete login and play.

**Approach:** Open the acceptor as `tcp::v6()` with `v6_only=false` so a single socket handles both stacks. IPv4 peers arrive as v4-mapped IPv6 and are unmapped at `Connection::resolveRemoteAddress`, which preserves the existing 32-bit uint IP path used by rate-limiting, `players.lastip`, `ip_bans`, and the lua `player:getIp()` API. Pure IPv6 peers are folded into a 32-bit hash for the same legacy slot, and a parallel `getIPString()` API exposes the canonical address for logs, debug dumps and a new `player:getIpString()` lua binding.

**Files touched:**
- `src/server/server.cpp` — acceptor opens v6, sets `v6_only(false)`; `bindOnlyGlobalAddress` parses any v4/v6 literal via `asio::ip::make_address`.
- `src/server/network/connection/connection.{hpp,cpp}` — resolve remote endpoint once, unmap v4-mapped, fold pure v6 into 32 bits, store canonical string, expose `getIPString()`. Two log statements switched to it.
- `src/server/network/protocol/protocol.{hpp,cpp}` — forward `getIPString()`.
- `src/server/network/protocol/protocolgame.cpp` — auth failure logs use the string IP.
- `src/server/network/protocol/protocolstatus.cpp` — status rate-limiter compares against `getIPString()` and skips `::1` alongside the v4 loopback fast path.
- `src/io/iologindata.{hpp,cpp}` — `gameWorldAuthentication` takes the IP as `const std::string&` for its warning log.
- `src/creatures/players/player.{hpp,cpp}` — add `getIPString()` forwarder.
- `src/lua/functions/creatures/player/player_functions.{hpp,cpp}` — register `Player:getIpString()`.
- `src/game/game.cpp` — client-assertion dump uses the string IP.
- `config.lua.dist` — note that the listener is dual-stack and that `ip` accepts v4/v6 literals or hostnames.

**Reused helpers / patterns:**
- `asio::ip::make_address` and `asio::ip::v6_only` from the bundled asio (already in pch via `asio.hpp`).
- `Lua::pushString` for the new binding, matching every other Player string accessor in `player_functions.cpp`.

## Design notes

- **Single-socket dual-stack over two acceptors.** Most modern asio servers do this and it keeps `ServiceManager`'s `flat_hash_map<uint16_t, ServicePort_ptr>` keyed on port alone (used by `ServiceManager::add` to colocate Login/Game on `:7171`). Two acceptors would require keying on `(port, family)` and break that contract for zero observable benefit on platforms that handle dual-stack natively.
- **Unmapping v4-mapped at the connection layer, not deeper.** Everything downstream — `Ban::acceptConnection`, `IOBan::isIpBanned`, `players.lastip`, `player:getIp()` — keeps its `uint32_t` contract. This avoids a sweeping change to schema, lua API, and ~30 callsites for what the issue literally asks ("players can connect via IPv6"). The cost is that pure IPv6 peers share a hashed 32-bit slot, so two distinct v6 addresses *can* collide on a ban or rate-limit bucket; collisions are improbable for non-adversarial traffic.
- **Side-channel string API instead of replacing `getIP()`.** `getIPString()` exists alongside `getIP()` so v6 peers get correct values in logs, `client_assertions.txt`, the GM `/info` command via the new lua method, etc., without churning every numeric callsite. `Game.convertIpToString` (pure-lua, in `data/libs/functions/game.lua`) is left as-is — it operates on the legacy numeric IP and remains useful for v4. Scripts that want v6-correct output should switch to `player:getIpString()`.
- **Hash sentinels.** `getIP() == 0` is the existing "unknown / disconnected" marker (`Player::isDisconnected`) and `ip == 1` is the unresolved sentinel inside `Connection`. The v6 fold reserves both: a hash of 0 or 1 is bumped to 2 so neither contract leaks.
- **`bindOnlyGlobalAddress` with v4 IP stays v4-only.** Operators who pinned the bind to a specific v4 address explicitly chose that; we don't second-guess it. To bind to a specific v6 address, set `ip` to the v6 literal.

**How to verify manually:**
1. Default config (`bindOnlyGlobalAddress = false`): start server, `netstat -an` shows the acceptor on `tcp6 :::7171 / :::7172`. Connect a v4 client (existing Tibia client to `127.0.0.1`) — login flow, character list, in-game look-IP all work and `players.lastip` stores the v4 numeric form.
2. Connect from `::1` (e.g. `nc -6 ::1 7171`): connection is accepted; `Connection Timeout` log line reports `::1`; `Player:getIpString()` returns `::1`; `Player:getIp()` returns a stable non-zero 32-bit hash.
3. Set `ip = "::"` and `bindOnlyGlobalAddress = true`: server binds dual-stack and accepts both v4-mapped and pure v6 peers. Set `ip = "127.0.0.1"` with the same flag: server binds v4-only as before — no regression.
4. Trigger the "wrong account" warning (login with mismatched character): log line shows the real `ipString` instead of `0.0.0.0`-style garbage for a v6 peer.

**Out of scope / follow-ups:**
- **Native v6 storage for bans and `lastip`.** Requires migrating `ip_bans.ip` and `players.lastip` to `VARBINARY(16)` (or `VARCHAR(45)`), updating `IOBan::isIpBanned` to key on the full address, and changing the lua `db.storeQuery(... ip_bans ...)` callers (`data/scripts/talkactions/god/ip_ban.lua`). Worth its own issue — it touches schema, lua scripts, and the `player:getIp()` lua API contract.
- **IPv6 subnet masking in `Game.getPlayersByIPAddress`** (`data/libs/functions/game.lua`) — currently `bit.band` over a 32-bit value; meaningless for pure v6.
- **`ConnectionManager` could expose remote address strings for the `/online` panel** — small ergonomic win, not requested here.

---

*Opened as **draft** by the bot. Review carefully before marking ready.*