### PR TITLE
improve: pagination in sendForgeHistory

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6056,24 +6056,24 @@ void ProtocolGame::sendForgeResult(ForgeAction_t actionType, uint16_t leftItemId
 }
 
 void ProtocolGame::sendForgeHistory(uint8_t page) {
-	page = page + 1;
+	static constexpr size_t entriesPerPage = 9;
+	const auto requestedPage = static_cast<size_t>(page) + 1;
 	const auto &historyVector = player->forgeHistory().get();
-	auto historyVectorLen = historyVector.size();
+	const auto historyVectorLen = historyVector.size();
 
 	uint16_t currentPage = 1;
 	uint16_t lastPage = 1;
-	uint16_t pageFirstEntry = 0;
-	uint16_t pageLastEntry = 0;
 
 	std::vector<ForgeHistory> historyPerPage;
 	if (historyVectorLen > 0) {
-		lastPage = std::clamp<uint16_t>(std::floor((historyVectorLen - 1) / 9) + 1, 0, std::numeric_limits<uint16_t>::max());
-		currentPage = (lastPage < page) ? lastPage : page;
+		const auto lastPageCount = ((historyVectorLen - 1) / entriesPerPage) + 1;
+		lastPage = static_cast<uint16_t>(std::min<size_t>(lastPageCount, std::numeric_limits<uint16_t>::max()));
+		currentPage = static_cast<uint16_t>(std::min(requestedPage, static_cast<size_t>(lastPage)));
 
-		pageFirstEntry = std::clamp<uint16_t>(historyVectorLen - (currentPage - 1) * 9, 0, std::numeric_limits<uint16_t>::max());
-		pageLastEntry = historyVectorLen > currentPage * 9 ? std::clamp<uint16_t>(historyVectorLen - currentPage * 9, 0, std::numeric_limits<uint16_t>::max()) : 0;
+		const auto pageFirstEntry = historyVectorLen - (static_cast<size_t>(currentPage) - 1) * entriesPerPage;
+		const auto pageLastEntry = historyVectorLen > static_cast<size_t>(currentPage) * entriesPerPage ? historyVectorLen - static_cast<size_t>(currentPage) * entriesPerPage : 0;
 
-		for (uint16_t entry = pageFirstEntry; entry > pageLastEntry; --entry) {
+		for (auto entry = pageFirstEntry; entry > pageLastEntry; --entry) {
 			[[maybe_unused]] auto &history_ref = historyPerPage.emplace_back(historyVector[entry - 1]);
 		}
 	}


### PR DESCRIPTION
This pull request refactors the pagination logic in the `sendForgeHistory` method to improve clarity and robustness. The update introduces clearer variable naming, removes redundant variables, and ensures that page calculations are safer and easier to understand.

Pagination logic improvements in `sendForgeHistory`:

* Replaced magic numbers with a named constant `entriesPerPage` for clarity and maintainability.
* Simplified and clarified page calculation by introducing `requestedPage` and using `std::min` for bounds checking, making the logic more robust.
* Removed unnecessary variables (`pageFirstEntry`, `pageLastEntry` as `uint16_t`) and replaced them with local scoped variables using `size_t` for safer index calculations.
* Updated the loop to use the new variable types and improved range calculation, reducing risk of overflow or underflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized forge history pagination logic for improved performance and reliability when navigating historical forge records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->