### PR TITLE
fix: validate exiva options packet parsing

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4373,7 +4373,7 @@ void Game::playerMoveUpContainer(uint32_t playerId, uint8_t cid) {
 }
 
 void Game::playerUpdateContainer(uint32_t playerId, uint8_t cid) {
-	const auto &player = getPlayerByID(playerId);
+	const auto &player = getPlayerByGUID(playerId);
 	if (!player) {
 		return;
 	}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4373,7 +4373,7 @@ void Game::playerMoveUpContainer(uint32_t playerId, uint8_t cid) {
 }
 
 void Game::playerUpdateContainer(uint32_t playerId, uint8_t cid) {
-	const auto &player = getPlayerByGUID(playerId);
+	const auto &player = getPlayerByID(playerId);
 	if (!player) {
 		return;
 	}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -65,6 +65,12 @@
 // Very useful to send the total amount in certain bytes in the ProtocolGame class
 namespace {
 	constexpr uint64_t PARTY_ANALYZER_THROTTLE_MS = 1000;
+	constexpr size_t UPDATE_CONTAINER_PAYLOAD_SIZE = 1;
+
+	size_t getUnreadBytes(const NetworkMessage &msg) {
+		const auto consumedBytes = static_cast<size_t>(msg.getBufferPosition() - NetworkMessage::INITIAL_BUFFER_POSITION);
+		return msg.getLength() > consumedBytes ? msg.getLength() - consumedBytes : 0;
+	}
 
 	template <typename T>
 	uint16_t getVectorIterationIncreaseCount(T &vector) {
@@ -1367,7 +1373,9 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage &msg, uint8_t recvby
 		case 0xC9: /* update tile */
 			break;
 		case 0xCA:
-			if (!oldProtocol && g_game().getWorldType() == WORLD_TYPE_NO_PVP) {
+			if (getUnreadBytes(msg) == UPDATE_CONTAINER_PAYLOAD_SIZE) {
+				parseUpdateContainer(msg);
+			} else if (!oldProtocol && g_game().getWorldType() == WORLD_TYPE_NO_PVP) {
 				parseExivaRestrictions(msg);
 			}
 			break;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -65,10 +65,11 @@
 // Very useful to send the total amount in certain bytes in the ProtocolGame class
 namespace {
 	constexpr uint64_t PARTY_ANALYZER_THROTTLE_MS = 1000;
-	constexpr size_t UPDATE_CONTAINER_PAYLOAD_SIZE = 1;
+	constexpr size_t EXIVA_RESTRICTIONS_MIN_PAYLOAD_SIZE = 6 + (sizeof(uint16_t) * 4);
 
 	size_t getUnreadBytes(const NetworkMessage &msg) {
-		const auto consumedBytes = static_cast<size_t>(msg.getBufferPosition() - NetworkMessage::INITIAL_BUFFER_POSITION);
+		const auto bufferPosition = msg.getBufferPosition();
+		const auto consumedBytes = bufferPosition >= NetworkMessage::INITIAL_BUFFER_POSITION ? bufferPosition - NetworkMessage::INITIAL_BUFFER_POSITION : 0;
 		return msg.getLength() > consumedBytes ? msg.getLength() - consumedBytes : 0;
 	}
 
@@ -1372,13 +1373,13 @@ void ProtocolGame::parsePacketFromDispatcher(NetworkMessage &msg, uint8_t recvby
 			break;
 		case 0xC9: /* update tile */
 			break;
-		case 0xCA:
-			if (getUnreadBytes(msg) == UPDATE_CONTAINER_PAYLOAD_SIZE) {
-				parseUpdateContainer(msg);
-			} else if (!oldProtocol && g_game().getWorldType() == WORLD_TYPE_NO_PVP) {
+		case 0xCA: {
+			const auto unreadBytes = getUnreadBytes(msg);
+			if (!oldProtocol && g_game().getWorldType() == WORLD_TYPE_NO_PVP && unreadBytes >= EXIVA_RESTRICTIONS_MIN_PAYLOAD_SIZE) {
 				parseExivaRestrictions(msg);
 			}
 			break;
+		}
 		case 0xCB:
 			parseBrowseField(msg);
 			break;


### PR DESCRIPTION
## Summary

Updates opcode `0xCA` handling to keep it aligned with TibiaAPI's `UpdateExivaOptions` packet model.

- validates the unread payload size before parsing Exiva restriction data
- guards unread-byte calculation when the network message buffer position is before the initial payload offset

## Validation

- `git diff --check`
- Build not run by request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server stability by adding validation checks to network message processing, ensuring messages meet size requirements before being handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->