### PR TITLE
fix: harden Game::updatePlayersOnline DB logic

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -12043,45 +12043,63 @@ void Game::updatePlayersOnline() const {
 	// Function to be executed within the transaction
 	auto updateOperation = [this]() {
 		const auto &m_players = getPlayers();
-		bool changesMade = false;
 
 		// g_metrics().addUpDownCounter("players_online", 1);
 		// g_metrics().addUpDownCounter("players_online", -1);
 
 		if (m_players.empty()) {
-			std::string query = "SELECT COUNT(*) AS count FROM players_online;";
-			auto result = g_database().storeQuery(query);
-			int count = result->getNumber<int>("count");
-			if (count > 0) {
-				g_database().executeQuery("DELETE FROM `players_online`;");
-				changesMade = true;
+			auto result = g_database().storeQuery("SELECT COUNT(*) AS count FROM players_online;");
+			if (!result) {
+				g_logger().error("[Game::updatePlayersOnline] Failed to count players_online records.");
+				return false;
 			}
-		} else {
-			// Insert the current players
-			DBInsert stmt("INSERT IGNORE INTO `players_online` (player_id) VALUES ");
-			for (const auto &[key, player] : m_players) {
-				std::ostringstream playerQuery;
-				playerQuery << "(" << player->getGUID() << ")";
-				stmt.addRow(playerQuery.str());
-			}
-			stmt.execute();
-			changesMade = true;
 
-			// Remove players who are no longer online
-			std::ostringstream cleanupQuery;
-			cleanupQuery << "DELETE FROM `players_online` WHERE `player_id` NOT IN (";
-			for (const auto &[key, player] : m_players) {
-				cleanupQuery << player->getGUID() << ",";
+			if (result->getNumber<int>("count") == 0) {
+				return true;
 			}
-			cleanupQuery.seekp(-1, std::ostringstream::cur); // Remove the last comma
-			cleanupQuery << ");";
-			g_database().executeQuery(cleanupQuery.str());
+
+			if (!g_database().executeQuery("DELETE FROM `players_online`;")) {
+				g_logger().error("[Game::updatePlayersOnline] Failed to clear players_online records.");
+				return false;
+			}
+
+			return true;
 		}
 
-		return changesMade;
+		// Insert the current players
+		DBInsert stmt("INSERT IGNORE INTO `players_online` (`player_id`) VALUES ");
+		std::vector<uint32_t> onlinePlayerIds;
+		onlinePlayerIds.reserve(m_players.size());
+
+		for (const auto &player : m_players | std::views::values) {
+			const auto playerGuid = player->getGUID();
+			if (!stmt.addRow(fmt::format("{}", playerGuid))) {
+				g_logger().error("[Game::updatePlayersOnline] Failed to add players_online insert row.");
+				return false;
+			}
+
+			onlinePlayerIds.emplace_back(playerGuid);
+		}
+
+		if (!stmt.execute()) {
+			g_logger().error("[Game::updatePlayersOnline] Failed to insert players_online records.");
+			return false;
+		}
+
+		// Remove players who are no longer online
+		const auto cleanupQuery = fmt::format(
+			"DELETE FROM `players_online` WHERE `player_id` NOT IN ({});",
+			fmt::join(onlinePlayerIds, ",")
+		);
+		if (!g_database().executeQuery(cleanupQuery)) {
+			g_logger().error("[Game::updatePlayersOnline] Failed to prune offline players_online records.");
+			return false;
+		}
+
+		return true;
 	};
 
-	const bool success = DBTransaction::executeWithinTransaction(updateOperation);
+	const bool success = DBTransaction::executeWithinTransactionRollbackOnFailure(updateOperation);
 	if (!success) {
 		g_logger().error("[Game::updatePlayersOnline] Failed to update players online.");
 	}


### PR DESCRIPTION
This pull request hardens `Game::updatePlayersOnline()` so the periodic `players_online` refresh no longer reports a false failure when the server has zero online players, while still surfacing real database failures.

## Context

This work follows the investigation and review discussion from #3904. That PR identified the idle-server log spam and the review discussion also highlighted the transaction-safety risk of returning `false` from `DBTransaction::executeWithinTransaction()` after partial writes.

Since the original author did not respond to the maintainer follow-up, this PR carries the same fix forward in a new branch and keeps the final scope limited to `src/game/game.cpp`.

## Changes

- Treat `0` online players with an already empty `players_online` table as a successful no-op.
- Keep real database read/write failures visible through explicit error logs.
- Use `DBTransaction::executeWithinTransactionRollbackOnFailure()` so callback failures roll back instead of committing partial updates.
- Check `DBInsert::addRow()` and `DBInsert::execute()` results.
- Build the cleanup query with `fmt::format` / `fmt::join` instead of manual comma handling.

## Validation

- `git diff --check`

No compile/build validation was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced online player status management with improved transaction handling and error recovery. The system now uses atomic transactions with automatic rollback on failures, ensuring greater reliability and data consistency when managing active player information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->