### PR TITLE
fix(container): preserve managed loot batch refresh

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -8923,8 +8923,7 @@ void Player::sendBatchUpdateContainer(Container* container, bool hasParent) {
 			continue;
 		}
 
-		auto sharedContainer = containerInfo.container;
-		client->sendContainer(cid, sharedContainer, hasParent, containerInfo.index);
+		client->sendContainer(cid, containerInfo.container, hasParent, containerInfo.index);
 		g_logger().debug("Player::sendBatchUpdateContainer - Sent batch update for container {} to player {}.", cid, getName());
 	}
 }

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -8924,7 +8924,6 @@ void Player::sendBatchUpdateContainer(Container* container, bool hasParent) {
 		}
 
 		auto sharedContainer = containerInfo.container;
-		checkLootContainers(sharedContainer);
 		client->sendContainer(cid, sharedContainer, hasParent, containerInfo.index);
 		g_logger().debug("Player::sendBatchUpdateContainer - Sent batch update for container {} to player {}.", cid, getName());
 	}


### PR DESCRIPTION
This pull request makes a small change to the `Player::sendBatchUpdateContainer` method by removing a call to `checkLootContainers`. This likely streamlines the container update process and prevents unnecessary checks when sending batch updates.

Related to: https://github.com/opentibiabr/canary/pull/3701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to container update handling with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->