### PR TITLE
fix(account): support sha256 session ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,29 @@
 - Do not mix unrelated changes in the same commit unless the user explicitly asks for a single combined commit.
 - Before amending or rebasing commits that may already be pushed, check the remote state and prefer `--force-with-lease` when a rewrite is explicitly approved.
 
+## Build Policy
+
+- Compile when the change is critical, complex, or likely to break compilation. For small documentation, script, or clearly non-build-affecting changes, avoid builds unless they add real validation value.
+- When compiling, prioritize the correct known workflow below instead of guessing commands or creating new build trees, to avoid wasting time on environment or cache mistakes.
+- Before building on Windows, inspect the repository build entry points instead of guessing:
+  - Check `CMakePresets.json` and `CMakeLists.txt`.
+  - Check whether Visual Studio solutions exist, such as `vcproj/*.sln` or generated `build/**/*.sln`.
+  - Check whether a CMake cache already exists under `build/<preset>`.
+- Prefer the CMake preset workflow over Visual Studio solution builds unless the user explicitly asks for the solution path or the preset is unusable.
+- Prefer the release preset for normal local validation because it uses the intended cache and unity settings. The default Windows server build path is:
+
+```bat
+cmake --preset windows-release
+cmake --build --preset windows-release --target canary
+```
+
+- On Windows, prefer running the CMake commands from the Visual Studio Developer Command Prompt or Developer PowerShell. That environment is the expected reliable build environment because it already prepares the MSVC compiler, Windows SDK, CMake tools, Ninja, and the required environment variables.
+- If the shell is not already a Visual Studio developer environment, initialize it with `VsDevCmd.bat` before configuring or building. `cl.exe` and Ninja must be available in `PATH` before running CMake.
+- If Ninja is not in `PATH`, use the Ninja bundled with the Visual Studio CMake tools instead of changing generators or creating another build tree.
+- Treat these files/directories as signs of an active CMake/Ninja cache: `CMakeCache.txt`, `CMakeFiles/`, `build.ninja`, `.ninja_deps`, `.ninja_log`, `cmake_install.cmake`, `compile_commands.json`, `vcpkg-manifest-install.log`, and `VSInheritEnvironments.txt`.
+- If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
+- Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
+
 ## PR Communication Policy
 
 - Do not post any PR comments/reviews automatically.

--- a/src/account/account_repository_db.cpp
+++ b/src/account/account_repository_db.cpp
@@ -37,16 +37,17 @@ bool AccountRepositoryDB::loadByEmailOrName(bool oldProtocol, const std::string 
 };
 
 bool AccountRepositoryDB::loadBySession(const std::string &sessionKey, std::unique_ptr<AccountInfo> &acc) {
-	const auto escapedSessionKey = g_database().escapeString(sessionKey);
+	const auto escapedSessionId = g_database().escapeString(transformToSHA256(sessionKey));
 	const auto escapedLegacySessionId = g_database().escapeString(transformToSHA1(sessionKey));
 	auto query = fmt::format(
 		"SELECT `accounts`.`id`, `type`, `premdays`, `lastday`, `creation`, `premdays_purchased`, `account_sessions`.`expires` "
 		"FROM `accounts` "
 		"INNER JOIN `account_sessions` ON `account_sessions`.`account_id` = `accounts`.`id` "
-		"WHERE `account_sessions`.`id` IN (SHA2({}, 256), {}) "
-		"ORDER BY CHAR_LENGTH(`account_sessions`.`id`) DESC LIMIT 1",
-		escapedSessionKey,
-		escapedLegacySessionId
+		"WHERE `account_sessions`.`id` IN ({}, {}) "
+		"ORDER BY CASE `account_sessions`.`id` WHEN {} THEN 0 ELSE 1 END LIMIT 1",
+		escapedSessionId,
+		escapedLegacySessionId,
+		escapedSessionId
 	);
 	return load(query, acc);
 };

--- a/src/account/account_repository_db.cpp
+++ b/src/account/account_repository_db.cpp
@@ -37,12 +37,16 @@ bool AccountRepositoryDB::loadByEmailOrName(bool oldProtocol, const std::string 
 };
 
 bool AccountRepositoryDB::loadBySession(const std::string &sessionKey, std::unique_ptr<AccountInfo> &acc) {
+	const auto escapedSessionKey = g_database().escapeString(sessionKey);
+	const auto escapedLegacySessionId = g_database().escapeString(transformToSHA1(sessionKey));
 	auto query = fmt::format(
 		"SELECT `accounts`.`id`, `type`, `premdays`, `lastday`, `creation`, `premdays_purchased`, `account_sessions`.`expires` "
 		"FROM `accounts` "
 		"INNER JOIN `account_sessions` ON `account_sessions`.`account_id` = `accounts`.`id` "
-		"WHERE `account_sessions`.`id` = {}",
-		g_database().escapeString(transformToSHA1(sessionKey))
+		"WHERE `account_sessions`.`id` IN (SHA2({}, 256), {}) "
+		"ORDER BY CHAR_LENGTH(`account_sessions`.`id`) DESC LIMIT 1",
+		escapedSessionKey,
+		escapedLegacySessionId
 	);
 	return load(query, acc);
 };

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -23,7 +23,29 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <array>
+	#include <cstddef>
+	#include <cstdint>
+	#include <span>
+	#include <string_view>
 #endif
+
+namespace {
+std::string bytesToHex(std::span<const std::byte> bytes) {
+	static constexpr std::array<char, 16> hexDigits = {
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+	};
+
+	std::string hex(bytes.size() * 2, '\0');
+	for (size_t i = 0; i < bytes.size(); ++i) {
+		const auto byte = static_cast<uint8_t>(bytes[i]);
+		const auto offset = i * 2;
+		hex[offset] = hexDigits[byte >> 4];
+		hex[offset + 1] = hexDigits[byte & 0x0F];
+	}
+	return hex;
+}
+}
 
 void printXMLError(const std::string &where, const std::string &fileName, const pugi::xml_parse_result &result) {
 	g_logger().error("[{}] Failed to load {}: {}", where, fileName, result.description());
@@ -200,32 +222,21 @@ std::string transformToSHA1(const std::string &input) {
 
 	processSHA1MessageBlock(messageBlock, H);
 
-	char hexstring[41];
-	static constexpr char hexDigits[] = { "0123456789abcdef" };
-	for (int hashByte = 20; --hashByte >= 0;) {
+	std::array<std::byte, 20> hash {};
+	for (size_t hashByte = hash.size(); hashByte-- > 0;) {
 		const uint8_t byte = H[hashByte >> 2] >> (((3 - hashByte) & 3) << 3);
-		index = hashByte << 1;
-		hexstring[index] = hexDigits[byte >> 4];
-		hexstring[index + 1] = hexDigits[byte & 15];
+		hash[hashByte] = static_cast<std::byte>(byte);
 	}
-	return std::string(hexstring, 40);
+	return bytesToHex(hash);
 }
 
-std::string transformToSHA256(const std::string &input) {
-	std::array<unsigned char, 32> hash {};
-	if (mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), hash.data(), 0) != 0) {
+std::string transformToSHA256(std::string_view input) {
+	std::array<std::byte, 32> hash {};
+	if (mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), reinterpret_cast<unsigned char*>(hash.data()), 0) != 0) {
 		return {};
 	}
 
-	char hexstring[65];
-	static constexpr char hexDigits[] = { "0123456789abcdef" };
-	for (size_t i = 0; i < hash.size(); ++i) {
-		const auto byte = hash[i];
-		const auto offset = i * 2;
-		hexstring[offset] = hexDigits[byte >> 4];
-		hexstring[offset + 1] = hexDigits[byte & 15];
-	}
-	return std::string(hexstring, 64);
+	return bytesToHex(hash);
 }
 
 uint16_t getStashSize(const std::map<uint16_t, uint32_t> &itemList) {

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -30,21 +30,21 @@
 #endif
 
 namespace {
-std::string bytesToHex(std::span<const std::byte> bytes) {
-	static constexpr std::array<char, 16> hexDigits = {
-		'0', '1', '2', '3', '4', '5', '6', '7',
-		'8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-	};
+	std::string bytesToHex(std::span<const std::byte> bytes) {
+		static constexpr std::array<char, 16> hexDigits = {
+			'0', '1', '2', '3', '4', '5', '6', '7',
+			'8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+		};
 
-	std::string hex(bytes.size() * 2, '\0');
-	for (size_t i = 0; i < bytes.size(); ++i) {
-		const auto byte = static_cast<uint8_t>(bytes[i]);
-		const auto offset = i * 2;
-		hex[offset] = hexDigits[byte >> 4];
-		hex[offset + 1] = hexDigits[byte & 0x0F];
+		std::string hex(bytes.size() * 2, '\0');
+		for (size_t i = 0; i < bytes.size(); ++i) {
+			const auto byte = static_cast<uint8_t>(bytes[i]);
+			const auto offset = i * 2;
+			hex[offset] = hexDigits[byte >> 4];
+			hex[offset + 1] = hexDigits[byte & 0x0F];
+		}
+		return hex;
 	}
-	return hex;
-}
 }
 
 void printXMLError(const std::string &where, const std::string &fileName, const pugi::xml_parse_result &result) {

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -45,7 +45,7 @@ namespace {
 		return hex;
 	}
 
-	std::span<unsigned char> asWritableUnsignedBytes(std::span<std::byte> bytes) {
+	[[nodiscard]] std::span<unsigned char> asWritableUnsignedBytes(std::span<std::byte> bytes) {
 		// mbedTLS exposes a C API that writes to unsigned char buffers.
 		return { reinterpret_cast<unsigned char*>(bytes.data()), bytes.size() }; // NOSONAR
 	}

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -38,12 +38,16 @@ namespace {
 
 		std::string hex(bytes.size() * 2, '\0');
 		for (size_t i = 0; i < bytes.size(); ++i) {
-			const auto byte = static_cast<uint8_t>(bytes[i]);
 			const auto offset = i * 2;
-			hex[offset] = hexDigits[byte >> 4];
-			hex[offset + 1] = hexDigits[byte & 0x0F];
+			hex[offset] = hexDigits[std::to_integer<size_t>(bytes[i] >> 4)];
+			hex[offset + 1] = hexDigits[std::to_integer<size_t>(bytes[i] & std::byte { 0x0F })];
 		}
 		return hex;
+	}
+
+	std::span<unsigned char> asWritableUnsignedBytes(std::span<std::byte> bytes) {
+		// mbedTLS exposes a C API that writes to unsigned char buffers.
+		return { reinterpret_cast<unsigned char*>(bytes.data()), bytes.size() }; // NOSONAR
 	}
 }
 
@@ -232,7 +236,8 @@ std::string transformToSHA1(const std::string &input) {
 
 std::string transformToSHA256(std::string_view input) {
 	std::array<std::byte, 32> hash {};
-	if (mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), reinterpret_cast<unsigned char*>(hash.data()), 0) != 0) {
+	const auto hashOutput = asWritableUnsignedBytes(hash);
+	if (mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), hashOutput.data(), 0) != 0) {
 		return {};
 	}
 

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -19,6 +19,11 @@
 
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
+#include "mbedtls/sha256.h"
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <array>
+#endif
 
 void printXMLError(const std::string &where, const std::string &fileName, const pugi::xml_parse_result &result) {
 	g_logger().error("[{}] Failed to load {}: {}", where, fileName, result.description());
@@ -204,6 +209,23 @@ std::string transformToSHA1(const std::string &input) {
 		hexstring[index + 1] = hexDigits[byte & 15];
 	}
 	return std::string(hexstring, 40);
+}
+
+std::string transformToSHA256(const std::string &input) {
+	std::array<unsigned char, 32> hash {};
+	if (mbedtls_sha256(reinterpret_cast<const unsigned char*>(input.data()), input.size(), hash.data(), 0) != 0) {
+		return {};
+	}
+
+	char hexstring[65];
+	static constexpr char hexDigits[] = { "0123456789abcdef" };
+	for (size_t i = 0; i < hash.size(); ++i) {
+		const auto byte = hash[i];
+		const auto offset = i * 2;
+		hexstring[offset] = hexDigits[byte >> 4];
+		hexstring[offset + 1] = hexDigits[byte & 15];
+	}
+	return std::string(hexstring, 64);
 }
 
 uint16_t getStashSize(const std::map<uint16_t, uint32_t> &itemList) {

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -40,6 +40,7 @@ enum PlayerSex_t : uint8_t;
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <random>
+	#include <string_view>
 #endif
 
 void printXMLError(const std::string &where, const std::string &fileName, const pugi::xml_parse_result &result);
@@ -48,7 +49,7 @@ void printXMLError(const std::string &where, const std::string &fileName, const 
 
 [[nodiscard]] std::string transformToSHA1(const std::string &input);
 
-[[nodiscard]] std::string transformToSHA256(const std::string &input);
+[[nodiscard]] std::string transformToSHA256(std::string_view input);
 
 [[nodiscard]] uint16_t getStashSize(const std::map<uint16_t, uint32_t> &itemList);
 

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -48,6 +48,8 @@ void printXMLError(const std::string &where, const std::string &fileName, const 
 
 [[nodiscard]] std::string transformToSHA1(const std::string &input);
 
+[[nodiscard]] std::string transformToSHA256(const std::string &input);
+
 [[nodiscard]] uint16_t getStashSize(const std::map<uint16_t, uint32_t> &itemList);
 
 [[nodiscard]] std::string generateToken(const std::string &secret, uint32_t ticks);

--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -135,8 +135,8 @@ namespace it_account_repo_db {
 			auto ids = getTestIds();
 			auto expectedLastDay = createAccount(db, ids);
 			ASSERT_TRUE(db.executeQuery(fmt::format(
-				"UPDATE `account_sessions` SET `id` = SHA2({}, 256) WHERE `account_id` = {}",
-				db.escapeString(ids.name),
+				"UPDATE `account_sessions` SET `id` = {} WHERE `account_id` = {}",
+				db.escapeString(transformToSHA256(ids.name)),
 				ids.id
 			)));
 
@@ -144,6 +144,25 @@ namespace it_account_repo_db {
 			ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
 			assertAccountLoad(*acc, ids, expectedLastDay);
 			EXPECT_EQ(1337, acc->sessionExpires);
+		})();
+	}
+
+	TEST_F(AccountRepositoryDBTest, LoadBySessionPrefersSHA256SessionId) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
+			AccountRepositoryDB accRepo {};
+			auto ids = getTestIds();
+			auto expectedLastDay = createAccount(db, ids);
+			ASSERT_TRUE(db.executeQuery(fmt::format(
+				"INSERT INTO `account_sessions` (`id`, `account_id`, `expires`) VALUES ({}, {}, 7331)",
+				db.escapeString(transformToSHA256(ids.name)),
+				ids.id
+			)));
+
+			auto acc = std::make_unique<AccountInfo>();
+			ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
+			assertAccountLoad(*acc, ids, expectedLastDay);
+			EXPECT_EQ(7331, acc->sessionExpires);
 		})();
 	}
 

--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -89,6 +89,14 @@ namespace it_account_repo_db {
 		EXPECT_NEAR(static_cast<double>(acc.creationTime), 42183281.0, 1.0);
 	}
 
+	inline void assertSessionLoad(const TestIds &ids, time_t expectedLastDay, int64_t expectedSessionExpires) {
+		AccountRepositoryDB accRepo {};
+		auto acc = std::make_unique<AccountInfo>();
+		ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
+		assertAccountLoad(*acc, ids, expectedLastDay);
+		EXPECT_EQ(expectedSessionExpires, acc->sessionExpires);
+	}
+
 	TEST_F(AccountRepositoryDBTest, LoadByID) {
 		auto &db = g_database();
 		databaseTest(db, [&db] {
@@ -131,7 +139,6 @@ namespace it_account_repo_db {
 	TEST_F(AccountRepositoryDBTest, LoadBySessionWithSHA256SessionId) {
 		auto &db = g_database();
 		databaseTest(db, [&db] {
-			AccountRepositoryDB accRepo {};
 			auto ids = getTestIds();
 			auto expectedLastDay = createAccount(db, ids);
 			ASSERT_TRUE(db.executeQuery(fmt::format(
@@ -139,18 +146,13 @@ namespace it_account_repo_db {
 				db.escapeString(transformToSHA256(ids.name)),
 				ids.id
 			)));
-
-			auto acc = std::make_unique<AccountInfo>();
-			ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
-			assertAccountLoad(*acc, ids, expectedLastDay);
-			EXPECT_EQ(1337, acc->sessionExpires);
+			assertSessionLoad(ids, expectedLastDay, 1337);
 		})();
 	}
 
 	TEST_F(AccountRepositoryDBTest, LoadBySessionPrefersSHA256SessionId) {
 		auto &db = g_database();
 		databaseTest(db, [&db] {
-			AccountRepositoryDB accRepo {};
 			auto ids = getTestIds();
 			auto expectedLastDay = createAccount(db, ids);
 			ASSERT_TRUE(db.executeQuery(fmt::format(
@@ -158,11 +160,7 @@ namespace it_account_repo_db {
 				db.escapeString(transformToSHA256(ids.name)),
 				ids.id
 			)));
-
-			auto acc = std::make_unique<AccountInfo>();
-			ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
-			assertAccountLoad(*acc, ids, expectedLastDay);
-			EXPECT_EQ(7331, acc->sessionExpires);
+			assertSessionLoad(ids, expectedLastDay, 7331);
 		})();
 	}
 

--- a/tests/integration/account/account_repository_db_it.cpp
+++ b/tests/integration/account/account_repository_db_it.cpp
@@ -128,6 +128,25 @@ namespace it_account_repo_db {
 		})();
 	}
 
+	TEST_F(AccountRepositoryDBTest, LoadBySessionWithSHA256SessionId) {
+		auto &db = g_database();
+		databaseTest(db, [&db] {
+			AccountRepositoryDB accRepo {};
+			auto ids = getTestIds();
+			auto expectedLastDay = createAccount(db, ids);
+			ASSERT_TRUE(db.executeQuery(fmt::format(
+				"UPDATE `account_sessions` SET `id` = SHA2({}, 256) WHERE `account_id` = {}",
+				db.escapeString(ids.name),
+				ids.id
+			)));
+
+			auto acc = std::make_unique<AccountInfo>();
+			ASSERT_TRUE(accRepo.loadBySession(ids.name, acc));
+			assertAccountLoad(*acc, ids, expectedLastDay);
+			EXPECT_EQ(1337, acc->sessionExpires);
+		})();
+	}
+
 	TEST_F(AccountRepositoryDBTest, PremiumDaysPurchasedSync) {
 		auto &db = g_database();
 		databaseTest(db, [&db] {

--- a/tests/unit/utils/string_functions_test.cpp
+++ b/tests/unit/utils/string_functions_test.cpp
@@ -44,3 +44,13 @@ INSTANTIATE_TEST_SUITE_P(
 		return fmt::format("Case{}", info.index);
 	}
 );
+
+TEST(HashFunctionsTest, TransformToSHA1MatchesCanonicalVectors) {
+	EXPECT_EQ("da39a3ee5e6b4b0d3255bfef95601890afd80709", transformToSHA1(""));
+	EXPECT_EQ("a9993e364706816aba3e25717850c26c9cd0d89d", transformToSHA1("abc"));
+}
+
+TEST(HashFunctionsTest, TransformToSHA256MatchesCanonicalVectors) {
+	EXPECT_EQ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", transformToSHA256(""));
+	EXPECT_EQ("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", transformToSHA256("abc"));
+}


### PR DESCRIPTION
This pull request updates the logic for loading accounts by session key to support both legacy SHA1 and new SHA256 session ID formats. It also adds an integration test to ensure the new SHA256 session ID logic works as expected.

**Session ID handling improvements:**

* Modified `AccountRepositoryDB::loadBySession` in `account_repository_db.cpp` to search for session IDs using both SHA256 (current) and SHA1 (legacy) hashes, ensuring backward compatibility and smoother migration to the new format. The query now checks for both formats and prefers the longer (SHA256) ID if both exist.

**Testing enhancements:**

* Added a new integration test `LoadBySessionWithSHA256SessionId` in `account_repository_db_it.cpp` to verify that accounts can be loaded using the SHA256 session ID, confirming the new logic works correctly.

Works with: https://github.com/opentibiabr/login-server/pull/32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session lookup now recognizes SHA-256 session identifiers and prefers them over legacy IDs while remaining backward compatible.

* **New Features**
  * Added a SHA-256 session identifier transformation utility used by session lookup.

* **Tests**
  * Added integration tests validating SHA-256 session handling and that SHA-256-backed sessions are selected when present.

* **Documentation**
  * Added build-policy guidance with CMake preset workflows and recovery/verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->