### PR TITLE
fix: GHA build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ cmake_minimum_required(
     FATAL_ERROR
 )
 
+if(POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
+if(POLICY CMP0179)
+    cmake_policy(SET CMP0179 NEW)
+endif()
+
 # VCPKG cmake
 # -DCMAKE_TOOLCHAIN_FILE=/opt/workspace/vcpkg/scripts/buildsystems/vcpkg.cmake
 # .. Needed libs are in file vcpkg.json Windows required libs: .\vcpkg install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,19 @@ cmake_minimum_required(
 )
 
 if(POLICY CMP0156)
-    cmake_policy(SET CMP0156 NEW)
+    cmake_policy(
+        SET
+        CMP0156
+        NEW
+    )
 endif()
 
 if(POLICY CMP0179)
-    cmake_policy(SET CMP0179 NEW)
+    cmake_policy(
+        SET
+        CMP0179
+        NEW
+    )
 endif()
 
 # VCPKG cmake

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -127,6 +127,8 @@ static constexpr uint8_t PLAYER_SOUND_HEALTH_CHANGE = 10;
 
 class Player final : public Creature, public Cylinder, public Bankable {
 public:
+	using Thing::getDepotChest;
+
 	class PlayerLock {
 	public:
 		explicit PlayerLock(const std::shared_ptr<Player> &p) :

--- a/vcproj/settings.props
+++ b/vcproj/settings.props
@@ -40,10 +40,6 @@
     <CANARY_RUNTIME_LIBRARY>MultiThreadedDLL</CANARY_RUNTIME_LIBRARY>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <CANARY_RUNTIME_LIBRARY>MultiThreadedDebugDLL</CANARY_RUNTIME_LIBRARY>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <CANARY_COMMON_LIBDEPS>
       $(CANARY_COMMON_LIBDEPS_BASE);


### PR DESCRIPTION
This pull request introduces some build configuration improvements and a minor code update. The main changes include setting new CMake policies for improved compatibility, updating build property settings, and exposing an inherited method in the `Player` class.

Build system improvements:

* Added checks and set CMake policies `CMP0156` and `CMP0179` to `NEW` in `CMakeLists.txt` to ensure compatibility with newer CMake versions.
* Removed the explicit setting of `MultiThreadedDebugDLL` for the `Debug|x64` configuration in `vcproj/settings.props`, likely to streamline or unify runtime library settings.

Codebase changes:

* Exposed the inherited `getDepotChest` method from `Thing` in the `Player` class by adding a `using` declaration in `player.hpp`, making it accessible directly from `Player` instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMake build policies (CMP0156, CMP0179) to use new behavior when available.
  * Adjusted Visual Studio build configuration by removing a Debug runtime library setting.

* **Refactor**
  * Exposed getDepotChest method on Player class for public access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->