### PR TITLE
fix: move canary from cwd instead of build

### DIFF
--- a/recompile.sh
+++ b/recompile.sh
@@ -144,9 +144,9 @@ setup_canary() {
 
 move_executable() {
 	local executable_name="canary"
-	if [[ -e "$executable_name" ]]; then
+	if [[ -f "$executable_name" ]]; then
 		info "Saving previous build as ${executable_name}.old"
-		mv "$executable_name" "${executable_name}.old"
+		mv -f "$executable_name" "${executable_name}.old"
 	fi
 }
 

--- a/recompile.sh
+++ b/recompile.sh
@@ -144,9 +144,9 @@ setup_canary() {
 
 move_executable() {
 	local executable_name="canary"
-	if [[ -e "build/$executable_name" ]]; then
+	if [[ -e "$executable_name" ]]; then
 		info "Saving previous build as ${executable_name}.old"
-		mv "build/$executable_name" "build/${executable_name}.old"
+		mv "$executable_name" "${executable_name}.old"
 	fi
 }
 


### PR DESCRIPTION
# Description

eng:
Create a backup of the executable before recompiling using recompile.sh.
The current script is looking for the canary executable in the build folder. But in reality, it should be looking in the root folder.

pt-br:
O script estava procurando o executavel do canary na pasta build, mas na realidade o executavel esta na pasta raiz, entao o backup nunca era feito.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

**Test Configuration**:

  - Server Version: Main
  - Client: 15.11
  - Operating System: Ubuntu 

## Checklist

  - [x] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build script to operate on the top-level build artifact instead of a subdirectory, improving artifact handling.
  * Script now logs the previous artifact location and creates a local ".old" backup of the previous executable to preserve prior builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->