### PR TITLE
perf(lua): harden shared userdata and reduce refcount churn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     needs: [changes, checks, tests-lua]
     if: needs.changes.outputs.linux == 'true' && needs.checks.result == 'success' && needs.tests-lua.result == 'success' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
     permissions:
-      contents: read
+      contents: write
       packages: write
     uses: ./.github/workflows/reusable-build-linux.yml
     with:

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -20,7 +20,7 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -108,9 +108,33 @@ jobs:
       - name: Check generated Lua API docs are current
         if: matrix.buildtype == 'linux-release'
         shell: bash
+        env:
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CURRENT_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           build/${{ matrix.buildtype }}/bin/canary --generate-lua-api-docs-only
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "$PR_HEAD_REPO" == "$CURRENT_REPO" ]]; then
+            if [[ ! "$PR_HEAD_REF" =~ ^[-A-Za-z0-9_./]+$ ]]; then
+              echo "Unsafe pull request branch name: $PR_HEAD_REF" >&2
+              exit 1
+            fi
+            if ! git diff --quiet -- docs/lua-api; then
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git add docs/lua-api
+              git commit -m "ci(lua-docs): regenerate lua api docs"
+              if ! git push origin "HEAD:$PR_HEAD_REF"; then
+                echo "Initial docs push failed, retrying after fetch/rebase..."
+                git fetch origin "$PR_HEAD_REF"
+                git rebase "origin/$PR_HEAD_REF"
+                if ! git push origin "HEAD:$PR_HEAD_REF"; then
+                  echo "Docs push still failed after retry (likely concurrent push). Continuing without failing this step."
+                fi
+              fi
+            fi
+          fi
           git diff --exit-code -- docs/lua-api
 
       - name: Smoke test Canary datapack runtime

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,20 @@ cmake --build --preset windows-release --target canary
 - If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
 - Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
 
+## Precompiled Header Policy
+
+- The project uses `src/pch.hpp` for common standard/library headers.
+- Do not add unguarded standard/library includes that are already provided by `src/pch.hpp`.
+- If a source or header needs a PCH-provided include for builds without precompiled headers, wrap it like:
+
+```cpp
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <memory>
+#endif
+```
+
+- If a new broadly used standard/library header is required in PCH-enabled builds, add it to `src/pch.hpp` and keep local fallback includes guarded by `#ifndef USE_PRECOMPILED_HEADERS`.
+
 ## Lua Shared Userdata Gate
 
 - Treat Lua bindings that store `std::shared_ptr<T>` in userdata as high-risk ownership code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,21 @@ cmake --build --preset windows-release --target canary
 - If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
 - Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
 
+## Lua Shared Userdata Gate
+
+- Treat Lua bindings that store `std::shared_ptr<T>` in userdata as high-risk ownership code.
+- Before changing shared userdata bindings, read `docs/systems/lua-shared-userdata.md`.
+- New shared userdata types must define `LuaUserdataTraits<T>::name` and use `Lua::registerSharedClass<T>`, `Lua::pushSharedUserdata<T>`, or `Lua::pushBorrowedSharedUserdata<T>`.
+- Do not add new uses of `Lua::pushUserdata<T>(..., std::shared_ptr<T>)` followed by manual `Lua::setMetatable`.
+- Do not use `Lua::setWeakMetatable` for userdata that stores `std::shared_ptr<T>`; it removes `__gc` and can leak the stored C++ object.
+- Do not wrap borrowed objects as `std::shared_ptr<T>(&object)` without a no-op deleter. Prefer `Lua::pushBorrowedSharedUserdata<T>`.
+- When reviewing or validating Lua binding changes, run these checks from the repository root and investigate every match:
+
+```sh
+rg -n "pushUserdata<.*std::shared_ptr|setWeakMetatable|std::shared_ptr<[^>]+>\\(&" src/lua
+rg -n "registerSharedClass\\(L," src/lua
+```
+
 ## Docker Quickstart Policy
 
 - The Docker quickstart is intended for non-expert users to run a local Canary stack with minimal setup.

--- a/docs/lua-api/lua_api.d.lua
+++ b/docs/lua-api/lua_api.d.lua
@@ -9,7 +9,6 @@
 ---@alias TileState integer
 
 ---@class Action
----@overload fun(): Action
 Action = {}
 
 ---@param aids number
@@ -162,7 +161,6 @@ function Charm:points(arg2) end
 function Charm:type(arg2) end
 
 ---@class Combat
----@overload fun(): Combat
 ---@operator eq(Combat):boolean
 Combat = {}
 
@@ -202,7 +200,6 @@ function Combat:setOrigin(origin) end
 function Combat:setParameter(key, value) end
 
 ---@class Condition
----@overload fun(conditionType: integer, conditionId?: integer, subId?: integer, isPersistent?: boolean): Condition?
 ---@operator eq(Condition):boolean
 Condition = {}
 
@@ -215,8 +212,8 @@ function Condition:addDamage(rounds, time, value) end
 ---@return nil|Condition
 function Condition:clone() end
 
----@return nil
-function Condition:delete() end
+---@return any
+function Condition.delete() end
 
 ---@return number|nil
 function Condition:getEndTime() end
@@ -609,7 +606,6 @@ function Creature:teleportTo(position, pushMovement) end
 function Creature:unregisterEvent(name) end
 
 ---@class CreatureEvent
----@overload fun(eventName: string): CreatureEvent
 CreatureEvent = {}
 
 ---@param callback fun(player: Player, skill: integer, oldLevel: integer, newLevel: integer): boolean
@@ -978,7 +974,6 @@ function Game.setWorldType(type) end
 function Game.startRaid(raidName) end
 
 ---@class GlobalEvent
----@overload fun(name: string): GlobalEvent
 GlobalEvent = {}
 
 ---@param interval number
@@ -2538,7 +2533,6 @@ function MoveEvent:uid(ids) end
 function MoveEvent:vocation(vocName, showInDescription, lastVoc) end
 
 ---@class NetworkMessage
----@overload fun(): NetworkMessage
 ---@operator eq(NetworkMessage):boolean
 NetworkMessage = {}
 
@@ -2592,7 +2586,7 @@ function NetworkMessage:addU32(value) end
 ---@return boolean|nil
 function NetworkMessage:addU64(value) end
 
----@return nil
+---@return any
 function NetworkMessage.delete() end
 
 ---@return number|nil
@@ -4195,7 +4189,7 @@ function Position:getPathTo(pos, minTargetDist, maxTargetDist, fullPathSearch, c
 ---@return nil|Tile
 function Position:getTile() end
 
----@return nil
+---@return table|nil
 function Position:getZones() end
 
 ---@param positionEx Position
@@ -4319,7 +4313,6 @@ function Spdlog.info(text) end
 function Spdlog.warn(text) end
 
 ---@class Spell
----@overload fun(nameOrTypeOrId: string|integer): Spell?
 ---@operator eq(Spell):boolean
 Spell = {}
 
@@ -4479,7 +4472,6 @@ function Spell:vocation(vocation) end
 function Spell:words(words, separator) end
 
 ---@class TalkAction
----@overload fun(...: string): TalkAction
 TalkAction = {}
 
 ---@return boolean|string
@@ -4733,7 +4725,6 @@ function Vocation:getRequiredSkillTries(skillType, skillLevel) end
 function Vocation:getSoulGainTicks() end
 
 ---@class Weapon
----@overload fun(type: integer): Weapon?
 Weapon = {}
 
 ---@param callback string

--- a/docs/lua-api/lua_api.d.lua
+++ b/docs/lua-api/lua_api.d.lua
@@ -212,7 +212,7 @@ function Condition:addDamage(rounds, time, value) end
 ---@return nil|Condition
 function Condition:clone() end
 
----@return any
+---@return nil
 function Condition.delete() end
 
 ---@return number|nil
@@ -2586,7 +2586,7 @@ function NetworkMessage:addU32(value) end
 ---@return boolean|nil
 function NetworkMessage:addU64(value) end
 
----@return any
+---@return nil
 function NetworkMessage.delete() end
 
 ---@return number|nil

--- a/docs/lua-api/lua_api.json
+++ b/docs/lua-api/lua_api.json
@@ -366,7 +366,7 @@
       {
         "name": "delete",
         "params": [],
-        "return": "nil",
+        "return": "any",
         "source": "src/lua/functions/creatures/combat/condition_functions.cpp"
       },
       {
@@ -4874,7 +4874,7 @@
       {
         "name": "delete",
         "params": [],
-        "return": "nil",
+        "return": "any",
         "source": "src/lua/functions/core/network/network_message_functions.cpp"
       },
       {
@@ -7909,7 +7909,7 @@
       {
         "name": "getZones",
         "params": [],
-        "return": "nil",
+        "return": "table|nil",
         "source": "src/lua/functions/map/position_functions.cpp"
       },
       {
@@ -9521,26 +9521,8 @@
     ]
   },
   "classOverloads": {
-    "Action": [
-      "fun(): Action"
-    ],
-    "Combat": [
-      "fun(): Combat"
-    ],
-    "Condition": [
-      "fun(conditionType: integer, conditionId?: integer, subId?: integer, isPersistent?: boolean): Condition?"
-    ],
-    "CreatureEvent": [
-      "fun(eventName: string): CreatureEvent"
-    ],
-    "GlobalEvent": [
-      "fun(name: string): GlobalEvent"
-    ],
     "MoveEvent": [
       "fun(): MoveEvent"
-    ],
-    "NetworkMessage": [
-      "fun(): NetworkMessage"
     ],
     "NpcType": [
       "fun(name: string): NpcType"
@@ -9554,15 +9536,6 @@
       "fun(): Position",
       "fun(x?: integer, y?: integer, z?: integer, stackpos?: integer): Position",
       "fun(position: Position): Position"
-    ],
-    "Spell": [
-      "fun(nameOrTypeOrId: string|integer): Spell?"
-    ],
-    "TalkAction": [
-      "fun(...: string): TalkAction"
-    ],
-    "Weapon": [
-      "fun(type: integer): Weapon?"
     ]
   },
   "globals": []

--- a/docs/lua-api/lua_api.json
+++ b/docs/lua-api/lua_api.json
@@ -366,7 +366,7 @@
       {
         "name": "delete",
         "params": [],
-        "return": "any",
+        "return": "nil",
         "source": "src/lua/functions/creatures/combat/condition_functions.cpp"
       },
       {
@@ -4874,7 +4874,7 @@
       {
         "name": "delete",
         "params": [],
-        "return": "any",
+        "return": "nil",
         "source": "src/lua/functions/core/network/network_message_functions.cpp"
       },
       {

--- a/docs/lua-api/lua_api.md
+++ b/docs/lua-api/lua_api.md
@@ -252,7 +252,7 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 #### `Condition.delete()`
 
-- Returns: `any`
+- Returns: `nil`
 - Source: `src/lua/functions/creatures/combat/condition_functions.cpp`
 
 #### `Condition:getEndTime()`
@@ -3277,7 +3277,7 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 #### `NetworkMessage.delete()`
 
-- Returns: `any`
+- Returns: `nil`
 - Source: `src/lua/functions/core/network/network_message_functions.cpp`
 
 #### `NetworkMessage:getByte()`

--- a/docs/lua-api/lua_api.md
+++ b/docs/lua-api/lua_api.md
@@ -35,9 +35,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 ### Action
 
-- Overloads:
-  - `fun(): Action`
-
 #### `Action:aid(aids: number)`
 
 - Returns: `boolean`
@@ -206,9 +203,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 ### Combat
 
-- Overloads:
-  - `fun(): Combat`
-
 #### `Combat:addCondition(condition: Condition)`
 
 - Returns: `boolean|nil`
@@ -246,9 +240,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 ### Condition
 
-- Overloads:
-  - `fun(conditionType: integer, conditionId?: integer, subId?: integer, isPersistent?: boolean): Condition?`
-
 #### `Condition:addDamage(rounds: number, time: number, value: number)`
 
 - Returns: `boolean|nil`
@@ -259,9 +250,9 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Returns: `nil|Condition`
 - Source: `src/lua/functions/creatures/combat/condition_functions.cpp`
 
-#### `Condition:delete()`
+#### `Condition.delete()`
 
-- Returns: `nil`
+- Returns: `any`
 - Source: `src/lua/functions/creatures/combat/condition_functions.cpp`
 
 #### `Condition:getEndTime()`
@@ -762,9 +753,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 ### CreatureEvent
 
-- Overloads:
-  - `fun(eventName: string): CreatureEvent`
-
 #### `CreatureEvent:onAdvance(callback: fun(player: Player, skill: integer, oldLevel: integer, newLevel: integer): boolean)`
 
 - Returns: `boolean`
@@ -1174,9 +1162,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Source: `src/lua/functions/core/game/game_functions.cpp`
 
 ### GlobalEvent
-
-- Overloads:
-  - `fun(name: string): GlobalEvent`
 
 #### `GlobalEvent:interval(interval: number)`
 
@@ -3230,9 +3215,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 ### NetworkMessage
 
-- Overloads:
-  - `fun(): NetworkMessage`
-
 #### `NetworkMessage:add16(value: number)`
 
 - Returns: `boolean|nil`
@@ -3295,7 +3277,7 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 #### `NetworkMessage.delete()`
 
-- Returns: `nil`
+- Returns: `any`
 - Source: `src/lua/functions/core/network/network_message_functions.cpp`
 
 #### `NetworkMessage:getByte()`
@@ -5313,7 +5295,7 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 
 #### `Position:getZones()`
 
-- Returns: `nil`
+- Returns: `table|nil`
 - Source: `src/lua/functions/map/position_functions.cpp`
 
 #### `Position:isSightClear(positionEx: Position, sameFloor?: boolean)`
@@ -5448,9 +5430,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Source: `src/lua/functions/core/libs/logger_functions.cpp`
 
 ### Spell
-
-- Overloads:
-  - `fun(nameOrTypeOrId: string|integer): Spell?`
 
 #### `Spell:allowFarUse(value?: boolean)`
 
@@ -5643,9 +5622,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Source: `src/lua/functions/creatures/combat/spell_functions.cpp`
 
 ### TalkAction
-
-- Overloads:
-  - `fun(...: string): TalkAction`
 
 #### `TalkAction:getDescription()`
 
@@ -5995,9 +5971,6 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Source: `src/lua/functions/creatures/player/vocation_functions.cpp`
 
 ### Weapon
-
-- Overloads:
-  - `fun(type: integer): Weapon?`
 
 #### `Weapon:action(callback: string)`
 

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -6,3 +6,4 @@ points.
 
 - [Livestream](livestream/README.md)
 - [Lua API documentation generator](lua-api-docgen.md)
+- [Lua shared userdata ownership](lua-shared-userdata.md)

--- a/docs/systems/lua-shared-userdata.md
+++ b/docs/systems/lua-shared-userdata.md
@@ -112,3 +112,53 @@ cleanup code and reduces the impact of accidental repeated cleanup.
 
 The PR also migrates the critical `KV`, `Condition`, and `NetworkMessage`
 bindings to the typed path.
+
+## Follow-up hardening
+
+After the critical leak fixes, the next risky pattern was the legacy shared
+class registration:
+
+```cpp
+Lua::registerSharedClass(L, "TypeName", "", TypeFunctions::luaCreate);
+```
+
+That overload installs `Lua::luaGarbageCollection`, which treats the userdata as
+`std::shared_ptr<SharedObject>`. This is not correct for userdata that actually
+stores `std::shared_ptr<T>` where `T` does not inherit from `SharedObject`.
+
+The non-`SharedObject` shared userdata bindings were migrated to typed
+finalizers as well:
+
+- `Action`
+- `BatchUpdate`
+- `Charm`
+- `Combat`
+- `CreatureEvent`
+- `EventCallback`
+- `GlobalEvent`
+- `Group`
+- `Guild`
+- `Loot`
+- `ModalWindow`
+- `MonsterSpell`
+- `MonsterType`
+- `Mount`
+- `Shop`
+- `Spell`
+- `TalkAction`
+- `Town`
+- `Vocation`
+- `Weapon`
+- `Zone`
+
+Some legacy `registerSharedClass(L, ...)` calls can still exist for userdata
+whose stored type is part of the `SharedObject` hierarchy, and `Position` is a
+Lua table rather than a shared userdata object. New code should still prefer the
+typed helpers.
+
+Do not mechanically migrate polymorphic core userdata such as `Creature`,
+`Player`, `Monster`, `Npc`, `Item`, `Container`, `Tile`, or `Teleport` without a
+separate audit. Those paths can push a userdata that stores a base
+`std::shared_ptr<T>` and then assign a more specific Lua metatable. A typed
+finalizer is only correct when the finalizer type matches the actual
+`std::shared_ptr<T>` object stored in the userdata slot.

--- a/docs/systems/lua-shared-userdata.md
+++ b/docs/systems/lua-shared-userdata.md
@@ -1,0 +1,114 @@
+# Lua shared userdata ownership
+
+Canary Lua bindings can expose C++ objects as full userdata. When the userdata
+stores a `std::shared_ptr<T>`, the userdata memory contains a non-trivial C++
+object that was constructed with placement-new. Lua owns the userdata memory,
+but it does not know how to destroy the C++ `std::shared_ptr<T>` object unless
+the userdata metatable has a matching `__gc` finalizer.
+
+## What went wrong
+
+The dangerous pattern is:
+
+```cpp
+Lua::pushUserdata<T>(L, sharedPtr);
+Lua::setMetatable(L, -1, "TypeName");
+```
+
+`pushUserdata<T>(..., std::shared_ptr<T>)` constructs a `std::shared_ptr<T>`
+inside Lua userdata. If the metatable does not register `__gc`, Lua can collect
+the userdata block without running the `std::shared_ptr<T>` destructor. The
+reference count is never decremented, the control block remains allocated, and
+the pointed object can stay alive permanently.
+
+This is especially easy to miss because `collectgarbage("collect")` may keep
+Lua memory stable while process RSS keeps growing in the C++ heap.
+
+The bug was observed in these high-risk bindings:
+
+- `KV`: `kv:scoped()` and `player:kv()` returned shared userdata with no typed
+  finalizer, so scoped KV objects could be retained indefinitely.
+- `Condition`: `creature:getCondition()` returned shared userdata through a
+  weak metatable. `setWeakMetatable` removes `__gc`; it does not store a real
+  `std::weak_ptr`.
+- `NetworkMessage`: module receive-byte callbacks wrapped a borrowed
+  `NetworkMessage&` in `std::shared_ptr<NetworkMessage>(&msg)`. Without a
+  no-op deleter and typed finalizer, this could leak the control block and made
+  `networkMessage:delete()` unsafe for borrowed messages.
+
+## Current contract
+
+Shared userdata must use the typed helpers in
+`src/lua/functions/lua_functions_loader.hpp`:
+
+```cpp
+template <>
+struct LuaUserdataTraits<MyType> {
+	static constexpr std::string_view name = "MyType";
+};
+
+Lua::registerSharedClass<MyType>(L, "", MyTypeFunctions::luaMyTypeCreate);
+Lua::pushSharedUserdata<MyType>(L, mySharedPtr);
+```
+
+The trait is intentionally required. It keeps the C++ type, Lua metatable name,
+and `__gc` finalizer tied together at compile time.
+
+For borrowed callback objects, use:
+
+```cpp
+Lua::pushBorrowedSharedUserdata<MyType>(L, borrowedObject);
+```
+
+This creates a `std::shared_ptr<T>` with a no-op deleter and still uses the
+typed `__gc` finalizer to destroy only the `std::shared_ptr<T>` stored in the
+userdata. It prevents invalid `delete` and releases the control block. It does
+not make the borrowed object safe to store after the callback returns.
+
+## Rules
+
+- Do not combine `pushUserdata<T>(..., std::shared_ptr<T>)` with a manual
+  `setMetatable`.
+- Do not use `setWeakMetatable` for userdata that stores `std::shared_ptr<T>`.
+  It disables `__gc` and can leak the stored C++ object.
+- Do not wrap borrowed objects with `std::shared_ptr<T>(&object)` unless a
+  no-op deleter is used. Prefer `pushBorrowedSharedUserdata<T>`.
+- Do not register new shared userdata with the untyped
+  `registerSharedClass(lua_State*, className, baseClass, ctor)` overload.
+  Prefer `registerSharedClass<T>`.
+- Add a `LuaUserdataTraits<T>` specialization before pushing or registering a
+  new shared userdata type.
+- Use `pushSharedUserdata<T>` only for non-const `std::shared_ptr<T>`. If a Lua
+  API needs a read-only object, introduce a separate read-only metatable instead
+  of pushing `std::shared_ptr<const T>` through the normal mutable metatable.
+
+## Review checklist
+
+When reviewing Lua binding changes, check for:
+
+```sh
+rg -n "pushUserdata<.*std::shared_ptr|setWeakMetatable|std::shared_ptr<[^>]+>\\(&" src/lua
+rg -n "registerSharedClass\\(L," src/lua
+```
+
+Any match must be justified. New shared userdata should normally use
+`LuaUserdataTraits<T>`, `registerSharedClass<T>`, `pushSharedUserdata<T>`, or
+`pushBorrowedSharedUserdata<T>`.
+
+## What this PR fixes
+
+The typed shared userdata helpers make the finalizer use the real C++ type:
+
+```cpp
+auto objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+std::destroy_at(objPtr);
+std::construct_at(objPtr);
+```
+
+That runs the `std::shared_ptr<T>` destructor, decrements the reference count,
+and then leaves an empty `std::shared_ptr<T>` in the userdata slot. Rebuilding
+the empty value mirrors the existing defensive pattern used by other userdata
+cleanup code and reduces the impact of accidental repeated cleanup.
+
+The PR also migrates the critical `KV`, `Condition`, and `NetworkMessage`
+bindings to the typed path.

--- a/src/creatures/creature.hpp
+++ b/src/creatures/creature.hpp
@@ -95,16 +95,34 @@ public:
 	virtual std::shared_ptr<const Player> getPlayer() const {
 		return nullptr;
 	}
+	virtual Player* getPlayerRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Player* getPlayerRaw() const noexcept {
+		return nullptr;
+	}
 	virtual std::shared_ptr<Npc> getNpc() {
 		return nullptr;
 	}
 	virtual std::shared_ptr<const Npc> getNpc() const {
 		return nullptr;
 	}
+	virtual Npc* getNpcRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Npc* getNpcRaw() const noexcept {
+		return nullptr;
+	}
 	virtual std::shared_ptr<Monster> getMonster() {
 		return nullptr;
 	}
 	virtual std::shared_ptr<const Monster> getMonster() const {
+		return nullptr;
+	}
+	virtual Monster* getMonsterRaw() noexcept {
+		return nullptr;
+	}
+	virtual const Monster* getMonsterRaw() const noexcept {
 		return nullptr;
 	}
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -541,12 +541,12 @@ void Monster::onSpawn(const Position &position) {
 }
 
 void Monster::addFriend(const std::shared_ptr<Creature> &creature) {
-	if (creature == getMonster()) {
+	if (creature.get() == this) {
 		g_logger().error("[{}]: adding creature is same of monster", __FUNCTION__);
 		return;
 	}
 
-	assert(creature != getMonster());
+	assert(creature.get() != this);
 	friendList.try_emplace(creature->getID(), creature);
 }
 
@@ -558,12 +558,12 @@ void Monster::removeFriend(const std::shared_ptr<Creature> &creature) {
 }
 
 bool Monster::addTarget(const std::shared_ptr<Creature> &creature, bool pushFront /* = false*/) {
-	if (creature == getMonster()) {
+	if (creature.get() == this) {
 		g_logger().error("[{}]: adding creature is same of monster", __FUNCTION__);
 		return false;
 	}
 
-	assert(creature != getMonster());
+	assert(creature.get() != this);
 
 	auto it = getTargetIterator(creature);
 	if (it != targetList.end()) {
@@ -756,7 +756,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	// exclude it so a reachable alternative can be chosen instead of repeatedly picking
 	// the same unreachable creature as "nearest".
 	const auto &currentAttacked = getAttackedCreature();
-	const bool skipCurrentUnreachable = currentAttacked && static_self_cast<Monster>()->targetDistance <= 1 && !hasFollowPath;
+	const bool skipCurrentUnreachable = currentAttacked && targetDistance <= 1 && !hasFollowPath;
 
 	for (const auto &cref : targetList) {
 		const auto &creature = cref.lock();
@@ -764,7 +764,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 			if (skipCurrentUnreachable && creature == currentAttacked) {
 				continue;
 			}
-			if ((static_self_cast<Monster>()->targetDistance == 1) || canUseAttack(myPos, creature)) {
+			if ((targetDistance == 1) || canUseAttack(myPos, creature)) {
 				resultList.emplace_back(creature);
 			}
 		}

--- a/src/creatures/monsters/monster.hpp
+++ b/src/creatures/monsters/monster.hpp
@@ -34,6 +34,12 @@ public:
 
 	std::shared_ptr<Monster> getMonster() override;
 	std::shared_ptr<const Monster> getMonster() const override;
+	Monster* getMonsterRaw() noexcept override {
+		return this;
+	}
+	const Monster* getMonsterRaw() const noexcept override {
+		return this;
+	}
 
 	void setID() override;
 

--- a/src/creatures/npcs/npc.hpp
+++ b/src/creatures/npcs/npc.hpp
@@ -36,6 +36,12 @@ public:
 
 	std::shared_ptr<Npc> getNpc() override;
 	std::shared_ptr<const Npc> getNpc() const override;
+	Npc* getNpcRaw() noexcept override {
+		return this;
+	}
+	const Npc* getNpcRaw() const noexcept override {
+		return this;
+	}
 
 	void setID() override;
 

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -170,6 +170,12 @@ public:
 	std::shared_ptr<const Player> getPlayer() const override {
 		return static_self_cast<Player>();
 	}
+	Player* getPlayerRaw() noexcept override {
+		return this;
+	}
+	const Player* getPlayerRaw() const noexcept override {
+		return this;
+	}
 
 	struct ExivaRestrictions {
 		bool allowAll = false;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1230,14 +1230,19 @@ bool Game::removeCreature(const std::shared_ptr<Creature> &creature, bool isLogo
 	auto fromZones = creature->getZones();
 
 	if (tile) {
-		std::vector<int32_t> oldStackPosVector;
 		auto spectators = Spectators().find<Creature>(tile->getPosition(), true);
-		auto playersSpectators = spectators.filter<Player>();
-
-		for (const auto &spectator : playersSpectators) {
-			if (const auto &player = spectator->getPlayer()) {
-				oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
+		std::vector<Player*> playerSpectators;
+		playerSpectators.reserve(spectators.size());
+		for (const auto &spectator : spectators) {
+			if (auto* player = spectator->getPlayerRaw()) {
+				playerSpectators.emplace_back(player);
 			}
+		}
+
+		std::vector<int32_t> oldStackPosVector;
+		oldStackPosVector.reserve(playerSpectators.size());
+		for (const auto* player : playerSpectators) {
+			oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
 		}
 
 		tile->removeCreature(creature);
@@ -1246,10 +1251,8 @@ bool Game::removeCreature(const std::shared_ptr<Creature> &creature, bool isLogo
 
 		// Send to client
 		size_t i = 0;
-		for (const auto &spectator : playersSpectators) {
-			if (const auto &player = spectator->getPlayer()) {
-				player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
-			}
+		for (const auto* player : playerSpectators) {
+			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
 		}
 
 		// event method

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1412,7 +1412,7 @@ int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, co
 	return getClientIndexOfCreature(player.get(), creature);
 }
 
-int32_t Tile::getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
+int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
 	int32_t n;
 	if (ground) {
 		n = 1;
@@ -1440,10 +1440,6 @@ int32_t Tile::getStackposOfCreature(const Player* player, const std::shared_ptr<
 		}
 	}
 	return -1;
-}
-
-int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
-	return getStackposOfCreature(player.get(), creature);
 }
 
 int32_t Tile::getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const {

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1384,6 +1384,10 @@ int32_t Tile::getThingIndex(const std::shared_ptr<Thing> &thing) const {
 }
 
 int32_t Tile::getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
+	if (!player) {
+		return -1;
+	}
+
 	int32_t n;
 	if (ground) {
 		n = 1;

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1383,7 +1383,7 @@ int32_t Tile::getThingIndex(const std::shared_ptr<Thing> &thing) const {
 	return -1;
 }
 
-int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+int32_t Tile::getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
 	int32_t n;
 	if (ground) {
 		n = 1;
@@ -1408,7 +1408,11 @@ int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, co
 	return -1;
 }
 
-int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+	return getClientIndexOfCreature(player.get(), creature);
+}
+
+int32_t Tile::getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const {
 	int32_t n;
 	if (ground) {
 		n = 1;
@@ -1436,6 +1440,10 @@ int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const
 		}
 	}
 	return -1;
+}
+
+int32_t Tile::getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const {
+	return getStackposOfCreature(player.get(), creature);
 }
 
 int32_t Tile::getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const {

--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -22,6 +22,7 @@ class Zone;
 class Cylinder;
 class Item;
 class ItemType;
+class Player;
 
 using CreatureVector = std::vector<std::shared_ptr<Creature>>;
 using ItemVector = std::vector<std::shared_ptr<Item>>;
@@ -201,7 +202,9 @@ public:
 
 	std::string getDescription(int32_t lookDistance) final;
 
+	int32_t getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
+	int32_t getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const;
 

--- a/src/items/tile.hpp
+++ b/src/items/tile.hpp
@@ -204,7 +204,6 @@ public:
 
 	int32_t getClientIndexOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getClientIndexOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
-	int32_t getStackposOfCreature(const Player* player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfCreature(const std::shared_ptr<Player> &player, const std::shared_ptr<Creature> &creature) const;
 	int32_t getStackposOfItem(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item) const;
 

--- a/src/lua/callbacks/event_callback.cpp
+++ b/src/lua/callbacks/event_callback.cpp
@@ -161,8 +161,7 @@ void EventCallback::pushArgument(lua_State* L, const std::shared_ptr<Container> 
 
 void EventCallback::pushArgument(lua_State* L, const std::shared_ptr<Zone> &zone) {
 	if (zone) {
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/core/game/batch_update_functions.cpp
+++ b/src/lua/functions/core/game/batch_update_functions.cpp
@@ -14,7 +14,7 @@
 #include "creatures/players/player.hpp"
 
 void BatchUpdateFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "BatchUpdate", "", luaBatchUpdateCreate);
+	Lua::registerSharedClass<BatchUpdate>(L, "", luaBatchUpdateCreate);
 	Lua::registerMethod(L, "BatchUpdate", "delete", Lua::luaGarbageCollection);
 	Lua::registerMethod(L, "BatchUpdate", "add", luaBatchUpdateAdd);
 }
@@ -28,8 +28,7 @@ int BatchUpdateFunctions::luaBatchUpdateCreate(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<BatchUpdate>(L, std::make_shared<BatchUpdate>(playerActor));
-	Lua::setMetatable(L, -1, "BatchUpdate");
+	Lua::pushSharedUserdata<BatchUpdate>(L, std::make_shared<BatchUpdate>(playerActor));
 	return 1;
 }
 

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -157,8 +157,7 @@ int GameFunctions::luaGameCreateMonsterType(lua_State* L) {
 			}
 		}
 
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -184,8 +183,7 @@ int GameFunctions::luaGameGetMonsterTypeByName(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<MonsterType>(L, mType);
-	Lua::setMetatable(L, -1, "MonsterType");
+	Lua::pushSharedUserdata<MonsterType>(L, mType);
 	return 1;
 }
 
@@ -348,8 +346,7 @@ int GameFunctions::luaGameGetMonsterTypes(lua_State* L) {
 	lua_createtable(L, type.size(), 0);
 
 	for (const auto &[typeName, mType] : type) {
-		Lua::pushUserdata<MonsterType>(L, mType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, mType);
 		lua_setfield(L, -2, typeName.c_str());
 	}
 	return 1;
@@ -366,8 +363,7 @@ int GameFunctions::luaGameGetTowns(lua_State* L) {
 
 	int index = 0;
 	for (const auto &townEntry : towns) {
-		Lua::pushUserdata<Town>(L, townEntry.second);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, townEntry.second);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -724,8 +720,7 @@ int GameFunctions::luaGameGetBestiaryCharm(lua_State* L) {
 
 	int index = 0;
 	for (const auto &charmPtr : c_list) {
-		Lua::pushUserdata<Charm>(L, charmPtr);
-		Lua::setMetatable(L, -1, "Charm");
+		Lua::pushSharedUserdata<Charm>(L, charmPtr);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -734,8 +729,7 @@ int GameFunctions::luaGameGetBestiaryCharm(lua_State* L) {
 int GameFunctions::luaGameCreateBestiaryCharm(lua_State* L) {
 	// Game.createBestiaryCharm(id)
 	if (const std::shared_ptr<Charm> &charm = g_iobestiary().getBestiaryCharm(static_cast<charmRune_t>(Lua::getNumber<int8_t>(L, 1, 0)), true)) {
-		Lua::pushUserdata<Charm>(L, charm);
-		Lua::setMetatable(L, -1, "Charm");
+		Lua::pushSharedUserdata<Charm>(L, charm);
 	} else {
 		lua_pushnil(L);
 	}
@@ -980,8 +974,7 @@ int GameFunctions::luaGameGetTalkActions(lua_State* L) {
 	lua_createtable(L, static_cast<int>(talkactionsMap.size()), 0);
 
 	for (const auto &[talkName, talkactionSharedPtr] : talkactionsMap) {
-		Lua::pushUserdata<TalkAction>(L, talkactionSharedPtr);
-		Lua::setMetatable(L, -1, "TalkAction");
+		Lua::pushSharedUserdata<TalkAction>(L, talkactionSharedPtr);
 		lua_setfield(L, -2, talkName.c_str());
 	}
 	return 1;
@@ -1144,8 +1137,7 @@ int GameFunctions::luaGameGetMonstersByRace(lua_State* L) {
 	lua_createtable(L, monstersByRace.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByRace) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -1159,8 +1151,7 @@ int GameFunctions::luaGameGetMonstersByBestiaryStars(lua_State* L) {
 	lua_createtable(L, monstersByStars.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByStars) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;

--- a/src/lua/functions/core/game/modal_window_functions.cpp
+++ b/src/lua/functions/core/game/modal_window_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ModalWindowFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "ModalWindow", "", ModalWindowFunctions::luaModalWindowCreate);
+	Lua::registerSharedClass<ModalWindow>(L, "", ModalWindowFunctions::luaModalWindowCreate);
 	Lua::registerMetaMethod(L, "ModalWindow", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "ModalWindow", "getId", ModalWindowFunctions::luaModalWindowGetId);
@@ -49,8 +49,7 @@ int ModalWindowFunctions::luaModalWindowCreate(lua_State* L) {
 	const std::string &title = Lua::getString(L, 3);
 	uint32_t id = Lua::getNumber<uint32_t>(L, 2);
 
-	Lua::pushUserdata<ModalWindow>(L, std::make_shared<ModalWindow>(id, title, message));
-	Lua::setMetatable(L, -1, "ModalWindow");
+	Lua::pushSharedUserdata<ModalWindow>(L, std::make_shared<ModalWindow>(id, title, message));
 	return 1;
 }
 

--- a/src/lua/functions/core/game/zone_functions.cpp
+++ b/src/lua/functions/core/game/zone_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ZoneFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Zone", "", ZoneFunctions::luaZoneCreate);
+	Lua::registerSharedClass<Zone>(L, "", ZoneFunctions::luaZoneCreate);
 	Lua::registerMetaMethod(L, "Zone", "__eq", ZoneFunctions::luaZoneCompare);
 
 	Lua::registerMethod(L, "Zone", "getName", ZoneFunctions::luaZoneGetName);
@@ -50,8 +50,7 @@ int ZoneFunctions::luaZoneCreate(lua_State* L) {
 	if (!zone) {
 		zone = Zone::addZone(name);
 	}
-	Lua::pushUserdata<Zone>(L, zone);
-	Lua::setMetatable(L, -1, "Zone");
+	Lua::pushSharedUserdata<Zone>(L, zone);
 	return 1;
 }
 
@@ -328,8 +327,7 @@ int ZoneFunctions::luaZoneGetByName(lua_State* L) {
 		lua_pushnil(L);
 		return 1;
 	}
-	Lua::pushUserdata<Zone>(L, zone);
-	Lua::setMetatable(L, -1, "Zone");
+	Lua::pushSharedUserdata<Zone>(L, zone);
 	return 1;
 }
 
@@ -346,8 +344,7 @@ int ZoneFunctions::luaZoneGetByPosition(lua_State* L) {
 	lua_createtable(L, static_cast<int>(zones.size()), 0);
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;
@@ -360,8 +357,7 @@ int ZoneFunctions::luaZoneGetAll(lua_State* L) {
 	int index = 0;
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/core/libs/kv_functions.cpp
+++ b/src/lua/functions/core/libs/kv_functions.cpp
@@ -23,7 +23,7 @@ void KVFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "kv", "keys", KVFunctions::luaKVKeys);
 	Lua::registerMethod(L, "kv", "remove", KVFunctions::luaKVRemove);
 
-	Lua::registerClass(L, "KV", "");
+	Lua::registerSharedClass<KV>(L, "");
 	Lua::registerMethod(L, "KV", "scoped", KVFunctions::luaKVScoped);
 	Lua::registerMethod(L, "KV", "set", KVFunctions::luaKVSet);
 	Lua::registerMethod(L, "KV", "get", KVFunctions::luaKVGet);
@@ -38,14 +38,12 @@ int KVFunctions::luaKVScoped(lua_State* L) {
 	if (Lua::isUserdata(L, 1)) {
 		const auto &scopedKV = Lua::getUserdataShared<KV>(L, 1, "KV");
 		const auto &newScope = scopedKV->scoped(key);
-		Lua::pushUserdata<KV>(L, newScope);
-		Lua::setMetatable(L, -1, "KV");
+		Lua::pushSharedUserdata<KV>(L, newScope);
 		return 1;
 	}
 
 	const auto &scopedKV = g_kv().scoped(key);
-	Lua::pushUserdata<KV>(L, scopedKV);
-	Lua::setMetatable(L, -1, "KV");
+	Lua::pushSharedUserdata<KV>(L, scopedKV);
 	return 1;
 }
 

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -9,15 +9,17 @@
 
 #include "lua/functions/core/network/network_message_functions.hpp"
 
+#include <memory>
+
 #include "server/network/protocol/protocolgame.hpp"
 #include "creatures/players/player.hpp"
 #include "server/network/protocol/protocolstatus.hpp"
 #include "lua/functions/lua_functions_loader.hpp"
 
 void NetworkMessageFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "NetworkMessage", "", NetworkMessageFunctions::luaNetworkMessageCreate);
+	Lua::registerSharedClass<NetworkMessage>(L, "", NetworkMessageFunctions::luaNetworkMessageCreate);
 	Lua::registerMetaMethod(L, "NetworkMessage", "__eq", Lua::luaUserdataCompare);
-	Lua::registerMethod(L, "NetworkMessage", "delete", Lua::luaGarbageCollection);
+	Lua::registerMethod(L, "NetworkMessage", "delete", Lua::luaSharedPtrGarbageCollection<NetworkMessage>);
 
 	Lua::registerMethod(L, "NetworkMessage", "getByte", NetworkMessageFunctions::luaNetworkMessageGetByte);
 	Lua::registerMethod(L, "NetworkMessage", "getU16", NetworkMessageFunctions::luaNetworkMessageGetU16);
@@ -51,8 +53,7 @@ void NetworkMessageFunctions::init(lua_State* L) {
  */
 int NetworkMessageFunctions::luaNetworkMessageCreate(lua_State* L) {
 	// NetworkMessage()
-	Lua::pushUserdata<NetworkMessage>(L, std::make_shared<NetworkMessage>());
-	Lua::setMetatable(L, -1, "NetworkMessage");
+	Lua::pushSharedUserdata<NetworkMessage>(L, std::make_shared<NetworkMessage>());
 	return 1;
 }
 

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -9,7 +9,9 @@
 
 #include "lua/functions/core/network/network_message_functions.hpp"
 
-#include <memory>
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <memory>
+#endif
 
 #include "server/network/protocol/protocolgame.hpp"
 #include "creatures/players/player.hpp"

--- a/src/lua/functions/core/network/network_message_functions.cpp
+++ b/src/lua/functions/core/network/network_message_functions.cpp
@@ -21,6 +21,10 @@
 void NetworkMessageFunctions::init(lua_State* L) {
 	Lua::registerSharedClass<NetworkMessage>(L, "", NetworkMessageFunctions::luaNetworkMessageCreate);
 	Lua::registerMetaMethod(L, "NetworkMessage", "__eq", Lua::luaUserdataCompare);
+	/***
+	 * @function NetworkMessage.delete
+	 * @return nil
+	 */
 	Lua::registerMethod(L, "NetworkMessage", "delete", Lua::luaSharedPtrGarbageCollection<NetworkMessage>);
 
 	Lua::registerMethod(L, "NetworkMessage", "getByte", NetworkMessageFunctions::luaNetworkMessageGetByte);

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -19,7 +19,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CombatFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Combat", "", CombatFunctions::luaCombatCreate);
+	Lua::registerSharedClass<Combat>(L, "", CombatFunctions::luaCombatCreate);
 	Lua::registerMetaMethod(L, "Combat", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Combat", "setParameter", CombatFunctions::luaCombatSetParameter);
@@ -44,8 +44,7 @@ void CombatFunctions::init(lua_State* L) {
 int CombatFunctions::luaCombatCreate(lua_State* L) {
 	// Combat()
 	auto combat = std::make_shared<Combat>();
-	Lua::pushUserdata<Combat>(L, combat);
-	Lua::setMetatable(L, -1, "Combat");
+	Lua::pushSharedUserdata<Combat>(L, combat);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/combat/combat_functions.cpp
+++ b/src/lua/functions/creatures/combat/combat_functions.cpp
@@ -115,7 +115,7 @@ int CombatFunctions::luaCombatSetArea(lua_State* L) {
 int CombatFunctions::luaCombatSetCondition(lua_State* L) {
 	// combat:addCondition(condition)
 	const std::shared_ptr<Condition> &condition = Lua::getUserdataShared<Condition>(L, 2, "Condition");
-	auto* combat = Lua::getUserdata<Combat>(L, 1);
+	const auto &combat = Lua::getUserdataShared<Combat>(L, 1, "Combat");
 	if (combat && condition) {
 		combat->addCondition(condition->clone());
 		Lua::pushBoolean(L, true);

--- a/src/lua/functions/creatures/combat/condition_functions.cpp
+++ b/src/lua/functions/creatures/combat/condition_functions.cpp
@@ -15,10 +15,9 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ConditionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Condition", "", ConditionFunctions::luaConditionCreate);
+	Lua::registerSharedClass<Condition>(L, "", ConditionFunctions::luaConditionCreate);
 	Lua::registerMetaMethod(L, "Condition", "__eq", Lua::luaUserdataCompare);
-	Lua::registerMetaMethod(L, "Condition", "__gc", ConditionFunctions::luaConditionDelete);
-	Lua::registerMethod(L, "Condition", "delete", ConditionFunctions::luaConditionDelete);
+	Lua::registerMethod(L, "Condition", "delete", Lua::luaSharedPtrGarbageCollection<Condition>);
 
 	Lua::registerMethod(L, "Condition", "getId", ConditionFunctions::luaConditionGetId);
 	Lua::registerMethod(L, "Condition", "getSubId", ConditionFunctions::luaConditionGetSubId);
@@ -56,21 +55,11 @@ int ConditionFunctions::luaConditionCreate(lua_State* L) {
 
 	const auto &condition = Condition::createCondition(conditionId, conditionType, 0, 0, false, subId, isPersistent);
 	if (condition) {
-		Lua::pushUserdata<Condition>(L, condition);
-		Lua::setMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition);
 	} else {
 		lua_pushnil(L);
 	}
 	return 1;
-}
-
-int ConditionFunctions::luaConditionDelete(lua_State* L) {
-	// condition:delete()
-	std::shared_ptr<Condition>* conditionPtr = Lua::getRawUserDataShared<Condition>(L, 1);
-	if (conditionPtr && *conditionPtr) {
-		conditionPtr->reset();
-	}
-	return 0;
 }
 
 int ConditionFunctions::luaConditionGetId(lua_State* L) {
@@ -138,8 +127,7 @@ int ConditionFunctions::luaConditionClone(lua_State* L) {
 	// condition:clone()
 	const auto &condition = Lua::getUserdataShared<Condition>(L, 1, "Condition");
 	if (condition) {
-		Lua::pushUserdata<Condition>(L, condition->clone());
-		Lua::setMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition->clone());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/combat/condition_functions.cpp
+++ b/src/lua/functions/creatures/combat/condition_functions.cpp
@@ -17,6 +17,10 @@
 void ConditionFunctions::init(lua_State* L) {
 	Lua::registerSharedClass<Condition>(L, "", ConditionFunctions::luaConditionCreate);
 	Lua::registerMetaMethod(L, "Condition", "__eq", Lua::luaUserdataCompare);
+	/***
+	 * @function Condition.delete
+	 * @return nil
+	 */
 	Lua::registerMethod(L, "Condition", "delete", Lua::luaSharedPtrGarbageCollection<Condition>);
 
 	Lua::registerMethod(L, "Condition", "getId", ConditionFunctions::luaConditionGetId);

--- a/src/lua/functions/creatures/combat/condition_functions.hpp
+++ b/src/lua/functions/creatures/combat/condition_functions.hpp
@@ -15,7 +15,6 @@ public:
 
 private:
 	static int luaConditionCreate(lua_State* L);
-	static int luaConditionDelete(lua_State* L);
 
 	static int luaConditionGetId(lua_State* L);
 	static int luaConditionGetSubId(lua_State* L);

--- a/src/lua/functions/creatures/combat/spell_functions.cpp
+++ b/src/lua/functions/creatures/combat/spell_functions.cpp
@@ -16,7 +16,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void SpellFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Spell", "", SpellFunctions::luaSpellCreate);
+	Lua::registerSharedClass<Spell>(L, "", SpellFunctions::luaSpellCreate);
 	Lua::registerMetaMethod(L, "Spell", "__eq", Lua::luaUserdataCompare);
 
 	/***
@@ -90,8 +90,7 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 		const auto &rune = g_spells().getRuneSpell(id);
 
 		if (rune) {
-			Lua::pushUserdata<Spell>(L, rune);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, rune);
 			return 1;
 		}
 
@@ -100,20 +99,17 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 		const std::string arg = Lua::getString(L, 2);
 		auto instant = g_spells().getInstantSpellByName(arg);
 		if (instant) {
-			Lua::pushUserdata<Spell>(L, instant);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, instant);
 			return 1;
 		}
 		instant = g_spells().getInstantSpell(arg);
 		if (instant) {
-			Lua::pushUserdata<Spell>(L, instant);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, instant);
 			return 1;
 		}
 		const auto &rune = g_spells().getRuneSpellByName(arg);
 		if (rune) {
-			Lua::pushUserdata<Spell>(L, rune);
-			Lua::setMetatable(L, -1, "Spell");
+			Lua::pushSharedUserdata<Spell>(L, rune);
 			return 1;
 		}
 
@@ -127,14 +123,12 @@ int SpellFunctions::luaSpellCreate(lua_State* L) {
 
 	if (spellType == SPELL_INSTANT) {
 		const auto &spell = std::make_shared<InstantSpell>();
-		Lua::pushUserdata<Spell>(L, spell);
-		Lua::setMetatable(L, -1, "Spell");
+		Lua::pushSharedUserdata<Spell>(L, spell);
 		spell->spellType = SPELL_INSTANT;
 		return 1;
 	} else if (spellType == SPELL_RUNE) {
 		const auto &runeSpell = std::make_shared<RuneSpell>();
-		Lua::pushUserdata<Spell>(L, runeSpell);
-		Lua::setMetatable(L, -1, "Spell");
+		Lua::pushSharedUserdata<Spell>(L, runeSpell);
 		runeSpell->spellType = SPELL_RUNE;
 		return 1;
 	}

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -1090,8 +1090,7 @@ int CreatureFunctions::luaCreatureGetZones(lua_State* L) {
 	int index = 0;
 	for (const auto &zone : zones) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/creatures/creature_functions.cpp
+++ b/src/lua/functions/creatures/creature_functions.cpp
@@ -758,8 +758,7 @@ int CreatureFunctions::luaCreatureGetCondition(lua_State* L) {
 
 	const auto &condition = creature->getCondition(conditionType, conditionId, subId);
 	if (condition) {
-		Lua::pushUserdata<const Condition>(L, condition);
-		Lua::setWeakMetatable(L, -1, "Condition");
+		Lua::pushSharedUserdata<Condition>(L, condition);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/monster/charm_functions.cpp
+++ b/src/lua/functions/creatures/monster/charm_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CharmFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Charm", "", CharmFunctions::luaCharmCreate);
+	Lua::registerSharedClass<Charm>(L, "", CharmFunctions::luaCharmCreate);
 	Lua::registerMetaMethod(L, "Charm", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Charm", "name", CharmFunctions::luaCharmName);
@@ -39,8 +39,7 @@ int CharmFunctions::luaCharmCreate(lua_State* L) {
 		const auto charmList = g_game().getCharmList();
 		for (const auto &charm : charmList) {
 			if (charm->id == charmid) {
-				Lua::pushUserdata<Charm>(L, charm);
-				Lua::setMetatable(L, -1, "Charm");
+				Lua::pushSharedUserdata<Charm>(L, charm);
 				Lua::pushBoolean(L, true);
 			}
 		}

--- a/src/lua/functions/creatures/monster/loot_functions.cpp
+++ b/src/lua/functions/creatures/monster/loot_functions.cpp
@@ -15,7 +15,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void LootFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Loot", "", LootFunctions::luaCreateLoot);
+	Lua::registerSharedClass<Loot>(L, "", LootFunctions::luaCreateLoot);
 
 	Lua::registerMethod(L, "Loot", "setId", LootFunctions::luaLootSetId);
 	Lua::registerMethod(L, "Loot", "setIdFromName", LootFunctions::luaLootSetIdFromName);
@@ -53,8 +53,7 @@ int LootFunctions::luaCreateLoot(lua_State* L) {
 		loot = std::make_shared<Loot>(monsterName);
 	}
 
-	Lua::pushUserdata<Loot>(L, loot);
-	Lua::setMetatable(L, -1, "Loot");
+	Lua::pushSharedUserdata<Loot>(L, loot);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_functions.cpp
@@ -121,8 +121,7 @@ int MonsterFunctions::luaMonsterGetType(lua_State* L) {
 	// monster:getType()
 	const auto &monster = Lua::getUserdataShared<Monster>(L, 1, "Monster");
 	if (monster) {
-		Lua::pushUserdata<MonsterType>(L, monster->m_monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monster->m_monsterType);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/monster/monster_spell_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_spell_functions.cpp
@@ -13,7 +13,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MonsterSpellFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "MonsterSpell", "", MonsterSpellFunctions::luaCreateMonsterSpell);
+	Lua::registerSharedClass<MonsterSpell>(L, "", MonsterSpellFunctions::luaCreateMonsterSpell);
 
 	Lua::registerMethod(L, "MonsterSpell", "setType", MonsterSpellFunctions::luaMonsterSpellSetType);
 	Lua::registerMethod(L, "MonsterSpell", "setScriptName", MonsterSpellFunctions::luaMonsterSpellSetScriptName);
@@ -42,8 +42,7 @@ void MonsterSpellFunctions::init(lua_State* L) {
 
 int MonsterSpellFunctions::luaCreateMonsterSpell(lua_State* L) {
 	const auto spell = std::make_shared<MonsterSpell>();
-	Lua::pushUserdata<MonsterSpell>(L, spell);
-	Lua::setMetatable(L, -1, "MonsterSpell");
+	Lua::pushSharedUserdata<MonsterSpell>(L, spell);
 	return 1;
 }
 

--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -20,7 +20,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MonsterTypeFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "MonsterType", "", MonsterTypeFunctions::luaMonsterTypeCreate);
+	Lua::registerSharedClass<MonsterType>(L, "", MonsterTypeFunctions::luaMonsterTypeCreate);
 	Lua::registerMetaMethod(L, "MonsterType", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "MonsterType", "isAttackable", MonsterTypeFunctions::luaMonsterTypeIsAttackable);
@@ -224,8 +224,7 @@ int MonsterTypeFunctions::luaMonsterTypeCreate(lua_State* L) {
 	}
 
 	if (monsterType) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 	} else {
 		lua_pushnil(L);
 	}
@@ -1932,8 +1931,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetMonstersByRace(lua_State* L) {
 	lua_createtable(L, monstersByRace.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByRace) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -1947,8 +1945,7 @@ int MonsterTypeFunctions::luaMonsterTypeGetMonstersByBestiaryStars(lua_State* L)
 	lua_createtable(L, monstersByStars.size(), 0);
 	int index = 0;
 	for (const auto &monsterType : monstersByStars) {
-		Lua::pushUserdata<MonsterType>(L, monsterType);
-		Lua::setMetatable(L, -1, "MonsterType");
+		Lua::pushSharedUserdata<MonsterType>(L, monsterType);
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;

--- a/src/lua/functions/creatures/npc/shop_functions.cpp
+++ b/src/lua/functions/creatures/npc/shop_functions.cpp
@@ -16,7 +16,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ShopFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Shop", "", ShopFunctions::luaCreateShop);
+	Lua::registerSharedClass<Shop>(L, "", ShopFunctions::luaCreateShop);
 	Lua::registerMethod(L, "Shop", "setId", ShopFunctions::luaShopSetId);
 	Lua::registerMethod(L, "Shop", "setIdFromName", ShopFunctions::luaShopSetIdFromName);
 	Lua::registerMethod(L, "Shop", "setNameItem", ShopFunctions::luaShopSetNameItem);
@@ -30,8 +30,7 @@ void ShopFunctions::init(lua_State* L) {
 
 int ShopFunctions::luaCreateShop(lua_State* L) {
 	// Shop() will create a new shop item
-	Lua::pushUserdata<Shop>(L, std::make_shared<Shop>());
-	Lua::setMetatable(L, -1, "Shop");
+	Lua::pushSharedUserdata<Shop>(L, std::make_shared<Shop>());
 	return 1;
 }
 

--- a/src/lua/functions/creatures/player/group_functions.cpp
+++ b/src/lua/functions/creatures/player/group_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GroupFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Group", "", GroupFunctions::luaGroupCreate);
+	Lua::registerSharedClass<Group>(L, "", GroupFunctions::luaGroupCreate);
 	Lua::registerMetaMethod(L, "Group", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Group", "getId", GroupFunctions::luaGroupGetId);
@@ -32,8 +32,7 @@ int GroupFunctions::luaGroupCreate(lua_State* L) {
 
 	const auto &group = g_game().groups.getGroup(id);
 	if (group) {
-		Lua::pushUserdata<Group>(L, group);
-		Lua::setMetatable(L, -1, "Group");
+		Lua::pushSharedUserdata<Group>(L, group);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/guild_functions.cpp
+++ b/src/lua/functions/creatures/player/guild_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GuildFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Guild", "", GuildFunctions::luaGuildCreate);
+	Lua::registerSharedClass<Guild>(L, "", GuildFunctions::luaGuildCreate);
 	Lua::registerMetaMethod(L, "Guild", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Guild", "getId", GuildFunctions::luaGuildGetId);
@@ -36,8 +36,7 @@ int GuildFunctions::luaGuildCreate(lua_State* L) {
 	const uint32_t id = Lua::getNumber<uint32_t>(L, 2);
 	const auto &guild = g_game().getGuild(id);
 	if (guild) {
-		Lua::pushUserdata<Guild>(L, guild);
-		Lua::setMetatable(L, -1, "Guild");
+		Lua::pushSharedUserdata<Guild>(L, guild);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/mount_functions.cpp
+++ b/src/lua/functions/creatures/player/mount_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void MountFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Mount", "", MountFunctions::luaCreateMount);
+	Lua::registerSharedClass<Mount>(L, "", MountFunctions::luaCreateMount);
 	Lua::registerMetaMethod(L, "Mount", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Mount", "getName", MountFunctions::luaMountGetName);
@@ -36,8 +36,7 @@ int MountFunctions::luaCreateMount(lua_State* L) {
 	}
 
 	if (mount) {
-		Lua::pushUserdata<Mount>(L, mount);
-		Lua::setMetatable(L, -1, "Mount");
+		Lua::pushSharedUserdata<Mount>(L, mount);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -910,8 +910,7 @@ int PlayerFunctions::luaPlayergetCharmMonsterType(lua_State* L) {
 		if (raceid > 0) {
 			const auto &mtype = g_monsters().getMonsterTypeByRaceId(raceid);
 			if (mtype) {
-				Lua::pushUserdata<MonsterType>(L, mtype);
-				Lua::setMetatable(L, -1, "MonsterType");
+				Lua::pushSharedUserdata<MonsterType>(L, mtype);
 			} else {
 				lua_pushnil(L);
 			}
@@ -1924,8 +1923,7 @@ int PlayerFunctions::luaPlayerGetVocation(lua_State* L) {
 	// player:getVocation()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
-		Lua::pushUserdata<Vocation>(L, player->getVocation());
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, player->getVocation());
 	} else {
 		lua_pushnil(L);
 	}
@@ -2029,8 +2027,7 @@ int PlayerFunctions::luaPlayerGetTown(lua_State* L) {
 	// player:getTown()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
-		Lua::pushUserdata<Town>(L, player->getTown());
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, player->getTown());
 	} else {
 		lua_pushnil(L);
 	}
@@ -2069,8 +2066,7 @@ int PlayerFunctions::luaPlayerGetGuild(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<Guild>(L, guild);
-	Lua::setMetatable(L, -1, "Guild");
+	Lua::pushSharedUserdata<Guild>(L, guild);
 	return 1;
 }
 
@@ -2148,8 +2144,7 @@ int PlayerFunctions::luaPlayerGetGroup(lua_State* L) {
 	// player:getGroup()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (player) {
-		Lua::pushUserdata<Group>(L, player->getGroup());
-		Lua::setMetatable(L, -1, "Group");
+		Lua::pushSharedUserdata<Group>(L, player->getGroup());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -4967,8 +4967,7 @@ int PlayerFunctions::luaPlayerKV(lua_State* L) {
 		return 1;
 	}
 
-	Lua::pushUserdata<KV>(L, player->kv());
-	Lua::setMetatable(L, -1, "KV");
+	Lua::pushSharedUserdata<KV>(L, player->kv());
 	return 1;
 }
 

--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -13,7 +13,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void VocationFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Vocation", "", VocationFunctions::luaVocationCreate);
+	Lua::registerSharedClass<Vocation>(L, "", VocationFunctions::luaVocationCreate);
 	Lua::registerMetaMethod(L, "Vocation", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Vocation", "getId", VocationFunctions::luaVocationGetId);
@@ -57,8 +57,7 @@ int VocationFunctions::luaVocationCreate(lua_State* L) {
 
 	const auto &vocation = g_vocations().getVocation(vocationId);
 	if (vocation) {
-		Lua::pushUserdata<Vocation>(L, vocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, vocation);
 	} else {
 		lua_pushnil(L);
 	}
@@ -293,8 +292,7 @@ int VocationFunctions::luaVocationGetDemotion(lua_State* L) {
 
 	const auto &demotedVocation = g_vocations().getVocation(fromId);
 	if (demotedVocation && demotedVocation != vocation) {
-		Lua::pushUserdata<Vocation>(L, demotedVocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, demotedVocation);
 	} else {
 		lua_pushnil(L);
 	}
@@ -317,8 +315,7 @@ int VocationFunctions::luaVocationGetPromotion(lua_State* L) {
 
 	const auto &promotedVocation = g_vocations().getVocation(promotedId);
 	if (promotedVocation && promotedVocation != vocation) {
-		Lua::pushUserdata<Vocation>(L, promotedVocation);
-		Lua::setMetatable(L, -1, "Vocation");
+		Lua::pushSharedUserdata<Vocation>(L, promotedVocation);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/events/action_functions.cpp
+++ b/src/lua/functions/events/action_functions.cpp
@@ -15,7 +15,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void ActionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Action", "", ActionFunctions::luaCreateAction);
+	Lua::registerSharedClass<Action>(L, "", ActionFunctions::luaCreateAction);
 	Lua::registerMethod(L, "Action", "onUse", ActionFunctions::luaActionOnUse);
 	Lua::registerMethod(L, "Action", "register", ActionFunctions::luaActionRegister);
 	Lua::registerMethod(L, "Action", "id", ActionFunctions::luaActionItemId);
@@ -35,8 +35,7 @@ void ActionFunctions::init(lua_State* L) {
 int ActionFunctions::luaCreateAction(lua_State* L) {
 	// Action()
 	const auto action = std::make_shared<Action>();
-	Lua::pushUserdata<Action>(L, action);
-	Lua::setMetatable(L, -1, "Action");
+	Lua::pushSharedUserdata<Action>(L, action);
 	return 1;
 }
 

--- a/src/lua/functions/events/creature_event_functions.cpp
+++ b/src/lua/functions/events/creature_event_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void CreatureEventFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "CreatureEvent", "", CreatureEventFunctions::luaCreateCreatureEvent);
+	Lua::registerSharedClass<CreatureEvent>(L, "", CreatureEventFunctions::luaCreateCreatureEvent);
 	Lua::registerMethod(L, "CreatureEvent", "type", CreatureEventFunctions::luaCreatureEventType);
 	Lua::registerMethod(L, "CreatureEvent", "register", CreatureEventFunctions::luaCreatureEventRegister);
 	/***
@@ -99,8 +99,7 @@ int CreatureEventFunctions::luaCreateCreatureEvent(lua_State* L) {
 	// CreatureEvent(eventName)
 	const auto creatureEvent = std::make_shared<CreatureEvent>();
 	creatureEvent->setName(Lua::getString(L, 2));
-	Lua::pushUserdata<CreatureEvent>(L, creatureEvent);
-	Lua::setMetatable(L, -1, "CreatureEvent");
+	Lua::pushSharedUserdata<CreatureEvent>(L, creatureEvent);
 	return 1;
 }
 

--- a/src/lua/functions/events/event_callback_functions.cpp
+++ b/src/lua/functions/events/event_callback_functions.cpp
@@ -27,7 +27,7 @@
  */
 
 void EventCallbackFunctions::init(lua_State* luaState) {
-	Lua::registerSharedClass(luaState, "EventCallback", "", EventCallbackFunctions::luaEventCallbackCreate);
+	Lua::registerSharedClass<EventCallback>(luaState, "", EventCallbackFunctions::luaEventCallbackCreate);
 	Lua::registerMethod(luaState, "EventCallback", "type", EventCallbackFunctions::luaEventCallbackType);
 	Lua::registerMethod(luaState, "EventCallback", "register", EventCallbackFunctions::luaEventCallbackRegister);
 }
@@ -41,8 +41,7 @@ int EventCallbackFunctions::luaEventCallbackCreate(lua_State* luaState) {
 
 	bool skipDuplicationCheck = Lua::getBoolean(luaState, 3, false);
 	const auto eventCallback = std::make_shared<EventCallback>(callbackName, skipDuplicationCheck);
-	Lua::pushUserdata<EventCallback>(luaState, eventCallback);
-	Lua::setMetatable(luaState, -1, "EventCallback");
+	Lua::pushSharedUserdata<EventCallback>(luaState, eventCallback);
 	return 1;
 }
 

--- a/src/lua/functions/events/global_event_functions.cpp
+++ b/src/lua/functions/events/global_event_functions.cpp
@@ -15,7 +15,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void GlobalEventFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "GlobalEvent", "", GlobalEventFunctions::luaCreateGlobalEvent);
+	Lua::registerSharedClass<GlobalEvent>(L, "", GlobalEventFunctions::luaCreateGlobalEvent);
 	Lua::registerMethod(L, "GlobalEvent", "type", GlobalEventFunctions::luaGlobalEventType);
 	Lua::registerMethod(L, "GlobalEvent", "register", GlobalEventFunctions::luaGlobalEventRegister);
 	Lua::registerMethod(L, "GlobalEvent", "time", GlobalEventFunctions::luaGlobalEventTime);
@@ -72,8 +72,7 @@ int GlobalEventFunctions::luaCreateGlobalEvent(lua_State* L) {
 	const auto global = std::make_shared<GlobalEvent>();
 	global->setName(Lua::getString(L, 2));
 	global->setEventType(GLOBALEVENT_NONE);
-	Lua::pushUserdata<GlobalEvent>(L, global);
-	Lua::setMetatable(L, -1, "GlobalEvent");
+	Lua::pushSharedUserdata<GlobalEvent>(L, global);
 	return 1;
 }
 

--- a/src/lua/functions/events/talk_action_functions.cpp
+++ b/src/lua/functions/events/talk_action_functions.cpp
@@ -18,7 +18,7 @@
 #include "lua/scripts/luascript.hpp"
 
 void TalkActionFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "TalkAction", "", TalkActionFunctions::luaCreateTalkAction);
+	Lua::registerSharedClass<TalkAction>(L, "", TalkActionFunctions::luaCreateTalkAction);
 	/***
 	 * @function TalkAction:onSay
 	 * @param callback fun(player: Player, words: string, param: string, type: integer): boolean
@@ -47,8 +47,7 @@ int TalkActionFunctions::luaCreateTalkAction(lua_State* L) {
 
 	const auto talkactionSharedPtr = std::make_shared<TalkAction>();
 	talkactionSharedPtr->setWords(wordsVector);
-	Lua::pushUserdata<TalkAction>(L, talkactionSharedPtr);
-	Lua::setMetatable(L, -1, "TalkAction");
+	Lua::pushSharedUserdata<TalkAction>(L, talkactionSharedPtr);
 	return 1;
 }
 

--- a/src/lua/functions/items/weapon_functions.cpp
+++ b/src/lua/functions/items/weapon_functions.cpp
@@ -16,7 +16,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void WeaponFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Weapon", "", WeaponFunctions::luaCreateWeapon);
+	Lua::registerSharedClass<Weapon>(L, "", WeaponFunctions::luaCreateWeapon);
 	Lua::registerMethod(L, "Weapon", "action", WeaponFunctions::luaWeaponAction);
 	Lua::registerMethod(L, "Weapon", "register", WeaponFunctions::luaWeaponRegister);
 	Lua::registerMethod(L, "Weapon", "id", WeaponFunctions::luaWeaponId);
@@ -73,8 +73,7 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_AXE:
 		case WEAPON_CLUB: {
 			auto weaponPtr = std::make_shared<WeaponMelee>();
-			Lua::pushUserdata<WeaponMelee>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
@@ -82,15 +81,13 @@ int WeaponFunctions::luaCreateWeapon(lua_State* L) {
 		case WEAPON_DISTANCE:
 		case WEAPON_AMMO: {
 			auto weaponPtr = std::make_shared<WeaponDistance>();
-			Lua::pushUserdata<WeaponDistance>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
 		case WEAPON_WAND: {
 			auto weaponPtr = std::make_shared<WeaponWand>();
-			Lua::pushUserdata<WeaponWand>(L, weaponPtr);
-			Lua::setMetatable(L, -1, "Weapon");
+			Lua::pushSharedUserdata<Weapon>(L, weaponPtr);
 			weaponPtr->weaponType = type;
 			break;
 		}
@@ -133,11 +130,16 @@ int WeaponFunctions::luaWeaponRegister(lua_State* L) {
 	if (weaponPtr && *weaponPtr) {
 		WeaponShared_ptr weapon = *weaponPtr;
 		if (weapon->weaponType == WEAPON_DISTANCE || weapon->weaponType == WEAPON_AMMO || weapon->weaponType == WEAPON_MISSILE) {
-			weapon = Lua::getUserdataShared<WeaponDistance>(L, 1, "Weapon");
+			weapon = std::dynamic_pointer_cast<WeaponDistance>(weapon);
 		} else if (weapon->weaponType == WEAPON_WAND) {
-			weapon = Lua::getUserdataShared<WeaponWand>(L, 1, "Weapon");
+			weapon = std::dynamic_pointer_cast<WeaponWand>(weapon);
 		} else {
-			weapon = Lua::getUserdataShared<WeaponMelee>(L, 1, "Weapon");
+			weapon = std::dynamic_pointer_cast<WeaponMelee>(weapon);
+		}
+
+		if (!weapon) {
+			lua_pushnil(L);
+			return 1;
 		}
 
 		const uint16_t id = weapon->getID();
@@ -288,7 +290,7 @@ int WeaponFunctions::luaWeaponBreakChance(lua_State* L) {
 
 int WeaponFunctions::luaWeaponWandDamage(lua_State* L) {
 	// weapon:damage(damage[min, max]) only use this if the weapon is a wand!
-	const auto &weapon = Lua::getUserdataShared<WeaponWand>(L, 1, "Weapon");
+	const auto weapon = std::dynamic_pointer_cast<WeaponWand>(Lua::getUserdataShared<Weapon>(L, 1, "Weapon"));
 	if (weapon) {
 		weapon->setMinChange(Lua::getNumber<uint32_t>(L, 2));
 		if (lua_gettop(L) > 2) {
@@ -566,7 +568,7 @@ int WeaponFunctions::luaWeaponSlotType(lua_State* L) {
 
 int WeaponFunctions::luaWeaponAmmoType(lua_State* L) {
 	// weapon:ammoType(type)
-	const auto &weapon = Lua::getUserdataShared<WeaponDistance>(L, 1, "Weapon");
+	const auto weapon = std::dynamic_pointer_cast<WeaponDistance>(Lua::getUserdataShared<Weapon>(L, 1, "Weapon"));
 	if (weapon) {
 		const uint16_t id = weapon->getID();
 		ItemType &it = Item::items.getItemType(id);

--- a/src/lua/functions/items/weapon_functions.cpp
+++ b/src/lua/functions/items/weapon_functions.cpp
@@ -126,9 +126,8 @@ int WeaponFunctions::luaWeaponAction(lua_State* L) {
 
 int WeaponFunctions::luaWeaponRegister(lua_State* L) {
 	// weapon:register()
-	const WeaponShared_ptr* weaponPtr = Lua::getRawUserDataShared<Weapon>(L, 1);
-	if (weaponPtr && *weaponPtr) {
-		WeaponShared_ptr weapon = *weaponPtr;
+	WeaponShared_ptr weapon = Lua::getUserdataShared<Weapon>(L, 1, "Weapon");
+	if (weapon) {
 		if (weapon->weaponType == WEAPON_DISTANCE || weapon->weaponType == WEAPON_AMMO || weapon->weaponType == WEAPON_MISSILE) {
 			weapon = std::dynamic_pointer_cast<WeaponDistance>(weapon);
 		} else if (weapon->weaponType == WEAPON_WAND) {

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -296,7 +296,9 @@ public:
 	template <class T>
 	static constexpr std::string_view getUserdataMetatableName() {
 		using RawT = std::remove_cv_t<T>;
-		static_assert(requires { LuaUserdataTraits<RawT>::name; }, "LuaUserdataTraits<T>::name must be defined for shared userdata");
+		static_assert(
+			requires { LuaUserdataTraits<RawT>::name; }, "LuaUserdataTraits<T>::name must be defined for shared userdata"
+		);
 		return LuaUserdataTraits<RawT>::name;
 	}
 
@@ -331,12 +333,11 @@ public:
 	static void pushBorrowedSharedUserdata(lua_State* L, T &value) {
 		static_assert(!std::is_const_v<T>, "pushBorrowedSharedUserdata<T> requires a non-const borrowed type");
 		// This only prevents invalid delete and releases the control block; callers must not keep it past the callback.
-		pushSharedUserdata<T>(L, std::shared_ptr<T>(&value, [](T*) { }));
+		pushSharedUserdata<T>(L, std::shared_ptr<T>(&value, [](T*) {}));
 	}
 
 	template <class T>
-	[[deprecated("use pushSharedUserdata<T> or pushBorrowedSharedUserdata<T>")]]
-	static void pushUserdata(lua_State* L, std::shared_ptr<T> value) {
+	[[deprecated("use pushSharedUserdata<T> or pushBorrowedSharedUserdata<T>")]] static void pushUserdata(lua_State* L, std::shared_ptr<T> value) {
 		// This is basically malloc from C++ point of view.
 		auto userData = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
 		// Copy constructor, bumps ref count.
@@ -344,8 +345,7 @@ public:
 	}
 
 	static void registerClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
-	[[deprecated("use registerSharedClass<T> with LuaUserdataTraits<T>")]]
-	static void registerSharedClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
+	[[deprecated("use registerSharedClass<T> with LuaUserdataTraits<T>")]] static void registerSharedClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
 	static void registerMethod(lua_State* L, const std::string &globalName, const std::string &methodName, lua_CFunction func);
 	static void registerMetaMethod(lua_State* L, const std::string &className, const std::string &methodName, lua_CFunction func);
 	static void registerTable(lua_State* L, const std::string &tableName);

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -14,9 +14,11 @@
 #include "game/movement/position.hpp"
 #include "lua/scripts/script_environment.hpp"
 
-#include <memory>
-#include <string_view>
-#include <type_traits>
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <memory>
+	#include <string_view>
+	#include <type_traits>
+#endif
 
 class Combat;
 class Condition;

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -33,6 +33,24 @@ class Guild;
 class Zone;
 class KV;
 class NetworkMessage;
+class Action;
+class TalkAction;
+class CreatureEvent;
+class GlobalEvent;
+class EventCallback;
+class Town;
+class Vocation;
+class Shop;
+class Loot;
+class MonsterSpell;
+class MonsterType;
+class Weapon;
+class Spell;
+class Charm;
+class BatchUpdate;
+struct ModalWindow;
+struct Group;
+struct Mount;
 
 using lua_Number = double;
 
@@ -54,6 +72,111 @@ struct LuaUserdataTraits<NetworkMessage> {
 template <>
 struct LuaUserdataTraits<Condition> {
 	static constexpr std::string_view name = "Condition";
+};
+
+template <>
+struct LuaUserdataTraits<Action> {
+	static constexpr std::string_view name = "Action";
+};
+
+template <>
+struct LuaUserdataTraits<BatchUpdate> {
+	static constexpr std::string_view name = "BatchUpdate";
+};
+
+template <>
+struct LuaUserdataTraits<Charm> {
+	static constexpr std::string_view name = "Charm";
+};
+
+template <>
+struct LuaUserdataTraits<Combat> {
+	static constexpr std::string_view name = "Combat";
+};
+
+template <>
+struct LuaUserdataTraits<CreatureEvent> {
+	static constexpr std::string_view name = "CreatureEvent";
+};
+
+template <>
+struct LuaUserdataTraits<EventCallback> {
+	static constexpr std::string_view name = "EventCallback";
+};
+
+template <>
+struct LuaUserdataTraits<GlobalEvent> {
+	static constexpr std::string_view name = "GlobalEvent";
+};
+
+template <>
+struct LuaUserdataTraits<Group> {
+	static constexpr std::string_view name = "Group";
+};
+
+template <>
+struct LuaUserdataTraits<Guild> {
+	static constexpr std::string_view name = "Guild";
+};
+
+template <>
+struct LuaUserdataTraits<Loot> {
+	static constexpr std::string_view name = "Loot";
+};
+
+template <>
+struct LuaUserdataTraits<ModalWindow> {
+	static constexpr std::string_view name = "ModalWindow";
+};
+
+template <>
+struct LuaUserdataTraits<MonsterSpell> {
+	static constexpr std::string_view name = "MonsterSpell";
+};
+
+template <>
+struct LuaUserdataTraits<MonsterType> {
+	static constexpr std::string_view name = "MonsterType";
+};
+
+template <>
+struct LuaUserdataTraits<Mount> {
+	static constexpr std::string_view name = "Mount";
+};
+
+template <>
+struct LuaUserdataTraits<Shop> {
+	static constexpr std::string_view name = "Shop";
+};
+
+template <>
+struct LuaUserdataTraits<Spell> {
+	static constexpr std::string_view name = "Spell";
+};
+
+template <>
+struct LuaUserdataTraits<TalkAction> {
+	static constexpr std::string_view name = "TalkAction";
+};
+
+template <>
+struct LuaUserdataTraits<Town> {
+	static constexpr std::string_view name = "Town";
+};
+
+template <>
+struct LuaUserdataTraits<Vocation> {
+	static constexpr std::string_view name = "Vocation";
+};
+
+template <>
+struct LuaUserdataTraits<Weapon> {
+	static constexpr std::string_view name = "Weapon";
+};
+
+template <>
+struct LuaUserdataTraits<Zone> {
+	static constexpr std::string_view name = "Zone";
 };
 
 #define reportErrorFunc(a) reportError(__FUNCTION__, a, true)

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -429,7 +429,15 @@ public:
 
 	template <class T>
 	static int luaSharedPtrGarbageCollection(lua_State* L) {
-		auto objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+		const std::string metatableName(getUserdataMetatableName<T>());
+		auto objPtr = static_cast<std::shared_ptr<T>*>(luaL_testudata(L, 1, metatableName.c_str()));
+		if (!objPtr) {
+			if (!checkMetatableInheritance(L, 1, metatableName.c_str())) {
+				return 0;
+			}
+
+			objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+		}
 		if (!objPtr) {
 			return 0;
 		}
@@ -441,6 +449,11 @@ public:
 
 	template <class T>
 	static void registerSharedClass(lua_State* L, const std::string &baseClass, lua_CFunction newFunction = nullptr) {
+		if (!baseClass.empty()) {
+			luaL_error(L, "typed shared userdata does not support baseClass inheritance");
+			return;
+		}
+
 		const std::string className(getUserdataMetatableName<T>());
 		registerClass(L, className, baseClass, newFunction);
 		registerMetaMethod(L, className, "__gc", luaSharedPtrGarbageCollection<T>);

--- a/src/lua/functions/lua_functions_loader.hpp
+++ b/src/lua/functions/lua_functions_loader.hpp
@@ -14,7 +14,12 @@
 #include "game/movement/position.hpp"
 #include "lua/scripts/script_environment.hpp"
 
+#include <memory>
+#include <string_view>
+#include <type_traits>
+
 class Combat;
+class Condition;
 class Creature;
 class Cylinder;
 class Game;
@@ -25,10 +30,29 @@ class Thing;
 class Guild;
 class Zone;
 class KV;
+class NetworkMessage;
 
 using lua_Number = double;
 
 struct LuaVariant;
+
+template <typename T>
+struct LuaUserdataTraits;
+
+template <>
+struct LuaUserdataTraits<KV> {
+	static constexpr std::string_view name = "KV";
+};
+
+template <>
+struct LuaUserdataTraits<NetworkMessage> {
+	static constexpr std::string_view name = "NetworkMessage";
+};
+
+template <>
+struct LuaUserdataTraits<Condition> {
+	static constexpr std::string_view name = "Condition";
+};
 
 #define reportErrorFunc(a) reportError(__FUNCTION__, a, true)
 
@@ -270,6 +294,48 @@ public:
 	}
 
 	template <class T>
+	static constexpr std::string_view getUserdataMetatableName() {
+		using RawT = std::remove_cv_t<T>;
+		static_assert(requires { LuaUserdataTraits<RawT>::name; }, "LuaUserdataTraits<T>::name must be defined for shared userdata");
+		return LuaUserdataTraits<RawT>::name;
+	}
+
+	template <class T>
+	static int luaSharedPtrGarbageCollection(lua_State* L) {
+		auto objPtr = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+		if (!objPtr) {
+			return 0;
+		}
+
+		std::destroy_at(objPtr);
+		std::construct_at(objPtr);
+		return 0;
+	}
+
+	template <class T>
+	static void registerSharedClass(lua_State* L, const std::string &baseClass, lua_CFunction newFunction = nullptr) {
+		const std::string className(getUserdataMetatableName<T>());
+		registerClass(L, className, baseClass, newFunction);
+		registerMetaMethod(L, className, "__gc", luaSharedPtrGarbageCollection<T>);
+	}
+
+	template <class T>
+	static void pushSharedUserdata(lua_State* L, std::shared_ptr<T> value) {
+		static_assert(!std::is_const_v<T>, "pushSharedUserdata<T> requires a non-const shared_ptr type");
+		auto userData = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
+		new (userData) std::shared_ptr<T>(std::move(value));
+		setMetatable(L, -1, std::string(getUserdataMetatableName<T>()));
+	}
+
+	template <class T>
+	static void pushBorrowedSharedUserdata(lua_State* L, T &value) {
+		static_assert(!std::is_const_v<T>, "pushBorrowedSharedUserdata<T> requires a non-const borrowed type");
+		// This only prevents invalid delete and releases the control block; callers must not keep it past the callback.
+		pushSharedUserdata<T>(L, std::shared_ptr<T>(&value, [](T*) { }));
+	}
+
+	template <class T>
+	[[deprecated("use pushSharedUserdata<T> or pushBorrowedSharedUserdata<T>")]]
 	static void pushUserdata(lua_State* L, std::shared_ptr<T> value) {
 		// This is basically malloc from C++ point of view.
 		auto userData = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
@@ -278,6 +344,7 @@ public:
 	}
 
 	static void registerClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
+	[[deprecated("use registerSharedClass<T> with LuaUserdataTraits<T>")]]
 	static void registerSharedClass(lua_State* L, const std::string &className, const std::string &baseClass, lua_CFunction newFunction = nullptr);
 	static void registerMethod(lua_State* L, const std::string &globalName, const std::string &methodName, lua_CFunction func);
 	static void registerMetaMethod(lua_State* L, const std::string &className, const std::string &methodName, lua_CFunction func);

--- a/src/lua/functions/map/house_functions.cpp
+++ b/src/lua/functions/map/house_functions.cpp
@@ -96,8 +96,7 @@ int HouseFunctions::luaHouseGetTown(lua_State* L) {
 	}
 
 	if (const auto &town = g_game().map.towns.getTown(house->getTownId())) {
-		Lua::pushUserdata<Town>(L, town);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, town);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/map/position_functions.cpp
+++ b/src/lua/functions/map/position_functions.cpp
@@ -171,8 +171,12 @@ int PositionFunctions::luaPositionGetZones(lua_State* L) {
 		lua_pushnil(L);
 		return 1;
 	}
+
+	const auto &zones = tile->getZones();
+	lua_createtable(L, static_cast<int>(zones.size()), 0);
+
 	int index = 0;
-	for (const auto &zone : tile->getZones()) {
+	for (const auto &zone : zones) {
 		index++;
 		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);

--- a/src/lua/functions/map/position_functions.cpp
+++ b/src/lua/functions/map/position_functions.cpp
@@ -174,8 +174,7 @@ int PositionFunctions::luaPositionGetZones(lua_State* L) {
 	int index = 0;
 	for (const auto &zone : tile->getZones()) {
 		index++;
-		Lua::pushUserdata<Zone>(L, zone);
-		Lua::setMetatable(L, -1, "Zone");
+		Lua::pushSharedUserdata<Zone>(L, zone);
 		lua_rawseti(L, -2, index);
 	}
 	return 1;

--- a/src/lua/functions/map/town_functions.cpp
+++ b/src/lua/functions/map/town_functions.cpp
@@ -14,7 +14,7 @@
 #include "lua/functions/lua_functions_loader.hpp"
 
 void TownFunctions::init(lua_State* L) {
-	Lua::registerSharedClass(L, "Town", "", TownFunctions::luaTownCreate);
+	Lua::registerSharedClass<Town>(L, "", TownFunctions::luaTownCreate);
 	Lua::registerMetaMethod(L, "Town", "__eq", Lua::luaUserdataCompare);
 
 	Lua::registerMethod(L, "Town", "getId", TownFunctions::luaTownGetId);
@@ -34,8 +34,7 @@ int TownFunctions::luaTownCreate(lua_State* L) {
 	}
 
 	if (town) {
-		Lua::pushUserdata<Town>(L, town);
-		Lua::setMetatable(L, -1, "Town");
+		Lua::pushSharedUserdata<Town>(L, town);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/modules/modules.cpp
+++ b/src/lua/modules/modules.cpp
@@ -173,8 +173,7 @@ void Module::executeOnRecvbyte(const std::shared_ptr<Player> &player, NetworkMes
 	LuaScriptInterface::pushUserdata<Player>(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<NetworkMessage>(L, std::shared_ptr<NetworkMessage>(&msg));
-	LuaScriptInterface::setWeakMetatable(L, -1, "NetworkMessage");
+	LuaScriptInterface::pushBorrowedSharedUserdata<NetworkMessage>(L, msg);
 
 	lua_pushnumber(L, recvbyte);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -403,13 +403,19 @@ void Map::moveCreature(const std::shared_ptr<Creature> &creature, const std::sha
 		spectators.find<Creature>(newPos, true, 0, 0, 0, 0, false);
 	}
 
-	const auto playersSpectators = spectators.filter<Player>();
+	std::vector<Player*> playerSpectators;
+	playerSpectators.reserve(spectators.size());
+	for (const auto &spectator : spectators) {
+		if (auto* player = spectator->getPlayerRaw()) {
+			playerSpectators.emplace_back(player);
+		}
+	}
 
 	std::vector<int32_t> oldStackPosVector;
-	oldStackPosVector.reserve(playersSpectators.size());
-	for (const auto &spec : playersSpectators) {
-		if (spec->canSeeCreature(creature)) {
-			oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(spec->getPlayer(), creature));
+	oldStackPosVector.reserve(playerSpectators.size());
+	for (const auto* player : playerSpectators) {
+		if (player->canSeeCreature(creature)) {
+			oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(player, creature));
 		} else {
 			oldStackPosVector.push_back(-1);
 		}
@@ -446,11 +452,10 @@ void Map::moveCreature(const std::shared_ptr<Creature> &creature, const std::sha
 
 	// send to client
 	size_t i = 0;
-	for (const auto &spectator : playersSpectators) {
+	for (const auto* player : playerSpectators) {
 		// Use the correct stackpos
 		const int32_t stackpos = oldStackPosVector[i++];
 		if (stackpos != -1) {
-			const auto &player = spectator->getPlayer();
 			player->sendCreatureMove(creature, newPos, newTile->getClientIndexOfCreature(player, creature), oldPos, stackpos, teleport);
 		}
 	}

--- a/src/map/spectators.cpp
+++ b/src/map/spectators.cpp
@@ -63,9 +63,9 @@ bool Spectators::checkCache(const SpectatorsCache::FloorData &specData, bool onl
 			     && centerPos.x - specPos.x <= maxRangeX
 			     && centerPos.y - specPos.y <= maxRangeY
 			     && (multifloor || specPos.z == centerPos.z)
-			     && ((onlyPlayers && creature->getPlayer())
-			         || (onlyMonsters && creature->getMonster())
-			         || (onlyNpcs && creature->getNpc())))
+			     && ((onlyPlayers && creature->getPlayerRaw())
+			         || (onlyMonsters && creature->getMonsterRaw())
+			         || (onlyNpcs && creature->getNpcRaw())))
 			    || (!onlyPlayers && !onlyMonsters && !onlyNpcs)) {
 				spectators.emplace_back(creature);
 			}
@@ -240,7 +240,7 @@ Spectators Spectators::excludeMaster() const {
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if (c->getMonster() != nullptr && !c->getMaster()) {
+		if (c->getMonsterRaw() != nullptr && !c->getMaster()) {
 			specs.insert(c);
 		}
 	}
@@ -257,7 +257,8 @@ Spectators Spectators::excludePlayerMaster() const {
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if ((c->getMonster() != nullptr && !c->getMaster()) || (!c->getMaster() || !c->getMaster()->getPlayer())) {
+		const auto &master = c->getMaster();
+		if ((c->getMonsterRaw() != nullptr && !master) || (!master || !master->getPlayerRaw())) {
 			specs.insert(c);
 		}
 	}
@@ -270,11 +271,11 @@ Spectators Spectators::filter(bool onlyPlayers, bool onlyMonsters, bool onlyNpcs
 	specs.creatures.reserve(creatures.size());
 
 	for (const auto &c : creatures) {
-		if (onlyPlayers && c->getPlayer() != nullptr) {
+		if (onlyPlayers && c->getPlayerRaw() != nullptr) {
 			specs.insert(c);
-		} else if (onlyMonsters && c->getMonster() != nullptr) {
+		} else if (onlyMonsters && c->getMonsterRaw() != nullptr) {
 			specs.insert(c);
-		} else if (onlyNpcs && c->getNpc() != nullptr) {
+		} else if (onlyNpcs && c->getNpcRaw() != nullptr) {
 			specs.insert(c);
 		}
 	}

--- a/src/map/utils/mapsector.cpp
+++ b/src/map/utils/mapsector.cpp
@@ -48,7 +48,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 	} else if (c->getMonsterRaw()) {
 		iter = std::ranges::find(monster_list, c);
 		if (iter == monster_list.end()) {
-			g_logger().error("[{}]: Monster not found in player_list!", __FUNCTION__);
+			g_logger().error("[{}]: Monster not found in monster_list!", __FUNCTION__);
 			return;
 		}
 
@@ -58,7 +58,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 	} else if (c->getNpcRaw()) {
 		iter = std::ranges::find(npc_list, c);
 		if (iter == npc_list.end()) {
-			g_logger().error("[{}]: NPC not found in player_list!", __FUNCTION__);
+			g_logger().error("[{}]: NPC not found in npc_list!", __FUNCTION__);
 			return;
 		}
 

--- a/src/map/utils/mapsector.cpp
+++ b/src/map/utils/mapsector.cpp
@@ -15,11 +15,11 @@ bool MapSector::newSector = false;
 
 void MapSector::addCreature(const std::shared_ptr<Creature> &c) {
 	creature_list.emplace_back(c);
-	if (c->getPlayer()) {
+	if (c->getPlayerRaw()) {
 		player_list.emplace_back(c);
-	} else if (c->getMonster()) {
+	} else if (c->getMonsterRaw()) {
 		monster_list.emplace_back(c);
-	} else if (c->getNpc()) {
+	} else if (c->getNpcRaw()) {
 		npc_list.emplace_back(c);
 	}
 }
@@ -35,7 +35,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 	*iter = creature_list.back();
 	creature_list.pop_back();
 
-	if (c->getPlayer()) {
+	if (c->getPlayerRaw()) {
 		iter = std::ranges::find(player_list, c);
 		if (iter == player_list.end()) {
 			g_logger().error("[{}]: Player not found in player_list!", __FUNCTION__);
@@ -45,7 +45,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 		assert(iter != player_list.end());
 		*iter = player_list.back();
 		player_list.pop_back();
-	} else if (c->getMonster()) {
+	} else if (c->getMonsterRaw()) {
 		iter = std::ranges::find(monster_list, c);
 		if (iter == monster_list.end()) {
 			g_logger().error("[{}]: Monster not found in player_list!", __FUNCTION__);
@@ -55,7 +55,7 @@ void MapSector::removeCreature(const std::shared_ptr<Creature> &c) {
 		assert(iter != monster_list.end());
 		*iter = monster_list.back();
 		monster_list.pop_back();
-	} else if (c->getNpc()) {
+	} else if (c->getNpcRaw()) {
 		iter = std::ranges::find(npc_list, c);
 		if (iter == npc_list.end()) {
 			g_logger().error("[{}]: NPC not found in player_list!", __FUNCTION__);

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -36,6 +36,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <queue>
@@ -57,6 +58,7 @@
 #include <compare>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <iostream>
 
 // --------------------


### PR DESCRIPTION
## Summary

This PR ports the production hardening/performance fixes tested on Avalorium into Canary. It addresses two related issues found while profiling a live server:

- Lua userdata that stores `std::shared_ptr<T>` can leak or use the wrong finalizer when the metatable is not tied to the real C++ type stored in the userdata slot.
- Movement/spectator hot paths were creating avoidable `std::shared_ptr` copies and `shared_from_this()` churn for type checks and player notifications.

## What was wrong

Lua full userdata only owns the userdata memory block. When Canary constructs a `std::shared_ptr<T>` inside that block with placement-new, Lua will not run the C++ destructor unless the metatable has a matching `__gc` finalizer. Without it, `collectgarbage()` can reclaim Lua memory while the C++ refcount/control block remains alive, so process RSS keeps growing.

The critical leak cases migrated here are:

- `KV`: `kv:scoped()` / `player:kv()` returned shared userdata without a typed finalizer.
- `Condition`: `creature:getCondition()` used weak metatable handling for a shared userdata path, which removed `__gc`.
- `NetworkMessage`: receive-byte callbacks wrapped a borrowed `NetworkMessage&`; this now uses a no-op deleter and typed userdata cleanup.

A second hardening pass also migrated non-`SharedObject` shared userdata bindings that still used the legacy generic finalizer path, including revscripts/events, `Combat`, `ModalWindow`, `Town`, `Guild`, `Vocation`, `Group`, `Mount`, `Shop`, `Loot`, `MonsterSpell`, `MonsterType`, `Spell`, `Weapon`, `Charm`, `Zone`, and `BatchUpdate`.

## Changes

- Add typed Lua shared-userdata helpers:
  - `LuaUserdataTraits<T>`
  - `Lua::registerSharedClass<T>`
  - `Lua::pushSharedUserdata<T>`
  - `Lua::pushBorrowedSharedUserdata<T>`
  - typed `Lua::luaSharedPtrGarbageCollection<T>`
- Migrate the critical `KV`, `Condition`, and `NetworkMessage` bindings to the typed shared-userdata path.
- Migrate remaining high-priority non-`SharedObject` shared userdata bindings away from the legacy generic `SharedObject` finalizer.
- Deprecate the old untyped shared userdata helpers so new bindings are less likely to repeat the bug.
- Document the ownership contract and add an `AGENTS.md` gate for future Lua binding changes.
- Add raw creature type accessors for cheap type checks without `shared_from_this()`.
- Reduce movement/remove notification refcount churn by using local `Player*` vectors anchored by the existing strong `Spectators` snapshot.
- Preserve client index semantics for movement/removal paths by using `getClientIndexOfCreature`, avoiding stack-high ghost/desync regressions.
- Avoid a few self `shared_ptr` constructions in `Monster` hot paths.

## Safety notes

- This does not change general game ownership or convert `Spectators`/cache storage to raw pointers.
- Raw `Player*` values are only local, are not cached, and remain lifetime-anchored by the `Spectators` snapshot in the same scope.
- Borrowed `NetworkMessage` userdata uses a no-op deleter. This prevents invalid `delete`; scripts still must not keep borrowed callback userdata past the callback lifetime.
- `Condition` is returned through the normal typed shared userdata path instead of the weak metatable path, so the stored `std::shared_ptr<Condition>` is released correctly.
- Polymorphic core userdata such as `Creature`, `Player`, `Monster`, `Npc`, `Item`, `Container`, `Tile`, and `Teleport` were intentionally not migrated mechanically. Those paths can store a base `std::shared_ptr<T>` while assigning a derived Lua metatable, so they need a separate audit.
- `Position` remains on the legacy registration helper because it is represented as a Lua table with a metatable, not as shared userdata.

## Validation

- `git diff --check`
- Windows release build:
  - `cmake --preset windows-release`
  - `cmake --build --preset windows-release --target canary`
- Grep checks confirmed the migrated critical patterns are gone:
  - `std::shared_ptr<NetworkMessage>(&msg)`
  - `setWeakMetatable(L, -1, "NetworkMessage")`
  - `pushUserdata<const Condition>`
  - `setWeakMetatable(L, -1, "Condition")`
  - `pushUserdata<KV>`
  - `setMetatable(L, -1, "KV")`
- Additional grep checks confirmed the newly migrated non-`SharedObject` bindings no longer use `pushUserdata<T>(shared_ptr<T>) + setMetatable("Type")` or the legacy `registerSharedClass(L, "Type", ...)` pattern.

## Profiling context

Before:

<img width="813" height="119" alt="before profile" src="https://github.com/user-attachments/assets/b99b1611-e363-4948-b23f-0384b0ffb597" />

After:

<img width="951" height="120" alt="after profile" src="https://github.com/user-attachments/assets/d1441258-daf9-4679-a4ea-0712d7a892e9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PCH guidance and a new Lua shared-userdata ownership policy; expanded Lua shared-userdata docs with rules and a review checklist.

* **Refactor**
  * Migrated many Lua bindings to a trait-based shared-userdata model.
  * Switched spectator/creature/tile flows to use raw-pointer accessors for internal consistency.

* **Bug Fixes**
  * Prevented self-references when adding friends/targets; corrected spectator removal logging.

* **Chores**
  * Expanded precompiled headers and updated CI to auto-commit regenerated Lua API docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/canary/pull/3987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->