### PR TITLE
perf(database): per-thread mysql connections, async player load, thread-safe saves

### DIFF
--- a/docs/database-connection-model.md
+++ b/docs/database-connection-model.md
@@ -1,0 +1,253 @@
+# Per-Thread MySQL Connection Model
+
+This document describes the database concurrency rework done to fix mass-login
+stalls, why it was done this way, and the changes that build on top of it
+(asynchronous player load and thread-safe player save).
+
+> TL;DR: the server used a **single MySQL connection guarded by one global
+> mutex**, so *every* database query in the whole server ran one at a time. Under
+> mass login (hundreds/thousands of characters at once) the dispatcher (game-loop)
+> thread spent its time blocked on serialized DB I/O — the server "froze" with low
+> CPU. We replaced it with **one lazily-created MySQL connection per worker
+> thread**, made the query hot path **lock-free**, and moved the heavy player load
+> off the dispatcher thread.
+
+---
+
+## 1. The problem (before)
+
+`Database` was a singleton holding a single `MYSQL*` handle protected by a
+`std::recursive_mutex`:
+
+```cpp
+MYSQL* handle = nullptr;
+mutable std::recursive_mutex databaseLock;
+```
+
+Every `storeQuery` / `executeQuery` / `escapeBlob` acquired `databaseLock`. The
+consequences:
+
+- **No DB parallelism anywhere.** Two queries from two threads could never run
+  at the same time, even on a 12-core machine.
+- **The login path made it worse.** `ProtocolGame::login()` ran on the single
+  **dispatcher thread** (the game loop) and called `IOLoginData::loadPlayerById`,
+  which issues ~20 sequential SQL queries per character. With 500–1000 logins,
+  the dispatcher was stuck doing serialized I/O → the world stopped updating
+  (movement, combat, `SERVER_BEAT`) even though CPU was mostly idle.
+- A single global lock also meant InnoDB **deadlocks were impossible** — which
+  sounds nice, but it hid the fact that nothing was concurrent.
+
+## 2. The new model: one connection per worker thread
+
+`Database` no longer owns a single handle. Instead, each thread that touches the
+database gets **its own** `ConnectionContext`, created lazily on first use:
+
+```cpp
+struct ConnectionContext {
+    MYSQL* handle = nullptr;
+    uint64_t maxPacketSize = 1048576;
+    unsigned int lastErrno = 0;   // for transaction deadlock retry
+    ~ConnectionContext();         // mysql_close
+};
+```
+
+- A `thread_local ConnectionContext*` cache makes the hot path a pointer lookup
+  with **no locking**.
+- A central `std::vector<std::unique_ptr<ConnectionContext>>` owns the contexts
+  so they can all be closed at shutdown. A `std::mutex` guards this vector, but
+  it is only taken **once per thread** (when that thread opens its connection) —
+  never on the query hot path.
+- The connection parameters are captured once in `connect()` and reused to open
+  each new per-thread connection.
+
+```cpp
+Database::ConnectionContext &Database::getContext() const {
+    thread_local ConnectionContext* tlsContext = nullptr;
+    if (tlsContext != nullptr) {
+        return *tlsContext;          // hot path: no lock
+    }
+    // first query on this thread: create + register + establish (cold path)
+    ...
+}
+```
+
+### Why per-thread instead of an explicit acquire/release pool?
+
+The codebase already executes a unit of work (a player load, a player save, a
+whole transaction) **entirely on one thread**. With one connection per thread:
+
+- The public API (`Database::getInstance().storeQuery(...)`) is **unchanged** —
+  none of the ~150 call sites across ~27 files had to be touched.
+- **Transactions and `getLastInsertId()` keep connection affinity for free**: a
+  `BEGIN … COMMIT` runs on one thread, hence one connection.
+- No object needs to carry a "session"/connection handle around.
+
+An explicit `acquire/release` pool would have required threading a connection
+handle through transactions and `getLastInsertId`, touching many call sites — far
+more invasive for no real benefit here.
+
+## 3. Lock-free hot path
+
+Because a `ConnectionContext` belongs to exactly one thread (reached only through
+that thread's `thread_local` cache), **the handle needs no lock**: no other
+thread can ever touch it. `storeQuery` / `executeQuery` / `escapeBlob` simply use
+`getContext().handle` directly.
+
+The only remaining mutex (`connectionsMutex`) is **cold path**: it guards the
+registry vector during connection creation and shutdown, never during a query.
+
+## 4. Transactions and deadlock handling
+
+With real concurrency, two transactions can now run at the same time, so two
+things change:
+
+1. **No global lock to hold open across a transaction.** Previously
+   `beginTransaction` locked `databaseLock` and `commit`/`rollback` unlocked it.
+   Now a transaction runs entirely on its thread's connection; thread affinity
+   alone provides isolation. `beginTransaction/commit/rollback` operate on
+   `getContext()`.
+
+2. **InnoDB deadlocks / lock-wait timeouts are now possible** (`ER_LOCK_DEADLOCK`
+   = 1213, `ER_LOCK_WAIT_TIMEOUT` = 1205) — they were impossible under the old
+   global serialization. Without handling, a deadlock would turn into a *lost
+   save*. So:
+   - `ConnectionContext::lastErrno` records the error of the last failed query
+     (kept here, not read via `mysql_errno`, so it survives an intervening
+     rollback).
+   - `Database::lastQueryWasDeadlock()` reports whether it was 1213/1205.
+   - `DBTransaction::executeWithinTransaction[RollbackOnFailure]` now **retries
+     the whole transaction** up to `TRANSACTION_MAX_ATTEMPTS = 3` when a deadlock
+     is detected.
+
+## 5. MySQL client library initialization
+
+In a multi-threaded program, `mysql_library_init()` must run **once, before any
+thread opens a connection**. `mysql_init()` does this implicitly, but that
+implicit init is **not thread-safe** if two threads race on their first
+connection. We therefore call `mysql_library_init()` explicitly via
+`std::call_once` at the start of `connect()` (which runs single-threaded at
+startup), removing the race.
+
+Each per-thread connection also calls `mysql_thread_init()` when it is
+established (required by libmysqlclient for thread-local state).
+
+## 6. Query capture (record-replay) — used by saves
+
+`Database` gained a small **capture mode** used to make player saves thread-safe
+(see §8):
+
+```cpp
+void beginQueryCapture(std::vector<std::string>* buffer); // RAII: QueryCaptureScope
+void endQueryCapture();
+```
+
+While a capture is active on the calling thread, `executeQuery()` **appends** its
+SQL to the buffer and returns `true` *without executing*. `storeQuery()` is never
+captured. This lets a save be **serialized on the dispatcher** (reading the live
+`Player` consistently) and **replayed on a pool thread** (pure SQL, no player
+access).
+
+> Known limitation: an *incidental* `executeQuery` during a capture (only known
+> case: a KV cache eviction, `KVStore::processEvictions`) would also be captured.
+> It is rare (needs a new KV key during the build *and* the global KV cache at
+> `MAX_SIZE`) and bounded; future hardening is to route evictions asynchronously.
+
+## 7. Consumer: asynchronous player load (login)
+
+With per-thread connections in place, the heavy login load was moved **off the
+dispatcher thread**:
+
+- `ProtocolGame::login()` (dispatcher) runs the cheap checks + waiting list, then
+  `g_game().reserveLogin(guid)` and dispatches the heavy `loadPlayerById` to the
+  thread pool.
+- `loadPlayer`/`loadPlayerById` gained a `deferWorldData` flag. The audit found
+  that only **2 of ~27** load steps mutate shared global state and therefore are
+  unsafe to run on a pool thread:
+  - `loadPlayerGuild` → writes the global guild registry (`g_game().addGuild`)
+    and mutates a shared `Guild` object.
+  - `loadPlayerInitializeSystem` → via the wheel, mutates a shared `Party`.
+  When `deferWorldData == true`, these two (plus `updateSystem`/`exiva`, which
+  must run *after* `initializeSystem` so wheel bonuses are applied before stats
+  are recomputed) are **skipped** on the pool and run later on the dispatcher via
+  `IOLoginData::loadPlayerWorldData()`.
+- `ProtocolGame::finishLogin()` (dispatcher callback) runs `loadPlayerWorldData`,
+  the protection-zone check, `placeCreature`, `acceptPackets = true`, and
+  `releaseLogin` on **every** exit path (success, failure, dropped connection).
+- `Game::reserveLogin/releaseLogin/isLoginPending` (a dispatcher-only set, no
+  lock) reject a second concurrent login of the same character while its load is
+  in flight.
+
+Net effect: the ~20-query load no longer blocks the game loop, and N logins load
+in parallel across the pool (one connection each).
+
+## 8. Consumer: thread-safe player save
+
+The `SaveManager` already saved players on pool threads, but it **read the live
+`Player` on the pool while the dispatcher kept mutating it** — a data race (it
+could persist inconsistent state or crash). Fix (record-replay):
+
+- `IOLoginData::savePlayer` split into `buildPlayerSave` (serialize the player to
+  SQL — runs on the dispatcher, consistent read) and `flushPlayerSave` (execute
+  the SQL in a transaction — runs on the pool, touches no player).
+- The `players.save` flag is cached on the `Player` at login
+  (`Player::getSaveFlag`), so the build needs **no DB round-trip** and is pure
+  CPU.
+- Per-player saves are serialized/ordered via `m_flushInFlight` / `m_resavePending`
+  / `onPlayerFlushed` so an older flush can never overwrite a newer one.
+- `saveAll` was restructured into `buildAllPlayers` (dispatcher) +
+  `flushBuiltPlayers` / `saveGuildsMapAndKV` (pool); the global save now builds on
+  the dispatcher and only flushes on the pool.
+
+## 9. Observability (logs)
+
+The connection model emits these `info` logs:
+
+- `Database running in per-thread connection mode ...` — once, at startup.
+- `Database: opened MySQL connection #N (new worker thread reached the
+  database).` — each time a new thread opens its connection (lazy). The count is
+  bounded by the number of threads that touch the DB (≈ thread pool size + a
+  few), **not** per login. Watching these appear during a mass-login test shows
+  the parallelism ramping up.
+- `Database: closing N MySQL connection(s).` — at shutdown.
+
+Transaction deadlock retries log a `warn`. The existing
+`metrics::query_latency` / `metrics::lock_latency` counters remain useful for
+spotting whether the new bottleneck is the thread pool or the MySQL server.
+
+## 10. Trade-offs and limitations
+
+- **The bottleneck moves to the MySQL server and the thread-pool size.** Per-thread
+  connections remove the *global lock*, but throughput is now capped by (a) how
+  many worker threads exist and (b) what the MySQL server can sustain. For more
+  login parallelism, raise the worker count (see §11) and/or reduce the number of
+  queries per load.
+- **More real TCP connections to MySQL** — one per worker thread. Validate against
+  the server's `max_connections` (default 151). With a ~12-thread pool this is a
+  non-issue.
+- **`mysql_thread_end()` is not called per thread.** Pool threads are long-lived
+  and the process exits shortly after shutdown, so the tiny per-thread TLS leak is
+  negligible.
+- **`thread_local` assumes a single `Database` instance** (true in production via
+  DI). Test harnesses that create/destroy multiple `Database` instances on the
+  same thread should be aware of this.
+
+## 11. Tuning
+
+The number of parallel DB connections equals the number of worker threads that
+touch the database, which is driven by the thread pool size
+(`DEFAULT_NUMBER_OF_THREADS`, default 4; overridable). For mass-login workloads,
+increasing the pool size is the highest-leverage knob, bounded by CPU cores and
+MySQL `max_connections`.
+
+## 12. Changed files
+
+| File | Change |
+|------|--------|
+| `src/database/database.hpp` / `.cpp` | Per-thread `ConnectionContext`, lazy `getContext`, lock-free hot path, `mysql_library_init`, transaction deadlock retry, query capture, connection logs |
+| `src/creatures/players/player.hpp` | Cached `save` flag (`getSaveFlag`/`setSaveFlag`) |
+| `src/io/iologindata.hpp` / `.cpp` | `deferWorldData` param, `loadPlayerWorldData`, `buildPlayerSave`/`flushPlayerSave` split |
+| `src/io/functions/iologindata_load_player.cpp` / `.hpp` | `loadPlayerGuild` self-queries; cache `save` flag in `loadPlayerBasicInfo` |
+| `src/io/functions/iologindata_save_player.cpp` | `savePlayerFirst` reads cached `save` flag instead of a SELECT |
+| `src/server/network/protocol/protocolgame.hpp` / `.cpp` | `login()` dispatches load to the pool; `finishLogin()` continuation |
+| `src/game/game.hpp` / `.cpp` | `reserveLogin`/`releaseLogin`/`isLoginPending` |
+| `src/game/scheduling/save_manager.hpp` / `.cpp` | Build-on-dispatcher / flush-on-pool; per-player flush serialization; `saveAll` restructure |

--- a/docs/database-connection-model.md
+++ b/docs/database-connection-model.md
@@ -129,7 +129,9 @@ connection. We therefore call `mysql_library_init()` explicitly via
 startup), removing the race.
 
 Each per-thread connection also calls `mysql_thread_init()` when it is
-established (required by libmysqlclient for thread-local state).
+established (required by libmysqlclient for thread-local state), and a
+`thread_local` cleanup object calls `mysql_thread_end()` when the thread exits
+(on that same thread, as libmysqlclient requires).
 
 ## 6. Query capture (record-replay) — used by saves
 
@@ -224,9 +226,9 @@ spotting whether the new bottleneck is the thread pool or the MySQL server.
 - **More real TCP connections to MySQL** — one per worker thread. Validate against
   the server's `max_connections` (default 151). With a ~12-thread pool this is a
   non-issue.
-- **`mysql_thread_end()` is not called per thread.** Pool threads are long-lived
-  and the process exits shortly after shutdown, so the tiny per-thread TLS leak is
-  negligible.
+- **`mysql_thread_end()`** is called via a `thread_local` cleanup object when a
+  thread that opened a connection exits, releasing libmysqlclient's per-thread
+  TLS.
 - **`thread_local` assumes a single `Database` instance** (true in production via
   DI). Test harnesses that create/destroy multiple `Database` instances on the
   same thread should be aware of this.

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -391,6 +391,15 @@ public:
 	OperatingSystem_t getOperatingSystem() const;
 	void setOperatingSystem(OperatingSystem_t clientos);
 
+	// Whether the `players.save` column allows persisting full player data.
+	// Cached at login so the save build needs no DB round-trip. Defaults true.
+	bool getSaveFlag() const {
+		return m_saveFlag;
+	}
+	void setSaveFlag(bool value) {
+		m_saveFlag = value;
+	}
+
 	bool isOldProtocol() const;
 
 	uint32_t getProtocolVersion() const;
@@ -1826,6 +1835,7 @@ private:
 
 	PlayerSex_t sex = PLAYERSEX_FEMALE;
 	OperatingSystem_t operatingSystem = CLIENTOS_NONE;
+	bool m_saveFlag = true;
 	BlockType_t lastAttackBlockType = BLOCK_NONE;
 	TradeState_t tradeState = TRADE_NONE;
 	FightMode_t fightMode = FIGHTMODE_ATTACK;

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -131,7 +131,9 @@ bool Database::establishConnection(ConnectionContext &ctx) const {
 	// Each thread must initialize the MySQL client library's thread-local state,
 	// and release it when the thread exits (the thread_local destructor runs on
 	// this very thread, which is where mysql_thread_end() must be called).
-	(void)mysql_thread_init();
+	if (mysql_thread_init() != 0) {
+		g_logger().warn("mysql_thread_init() failed for a database worker thread");
+	}
 	static thread_local ThreadCleanup threadCleanup;
 
 	ctx.handle = mysql_init(nullptr);
@@ -357,7 +359,7 @@ bool Database::retryQuery(std::string_view query, int retries) {
 		retries--;
 	}
 	if (retries == 0) {
-		g_logger().error("Query {} failed after {} retries.", query, 10);
+		g_logger().error("Query {} failed, retries exhausted.", query);
 		return false;
 	}
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -19,6 +19,10 @@ namespace {
 	// it instead of executing. See Database::beginQueryCapture.
 	thread_local std::vector<std::string>* tlsQueryCapture = nullptr;
 
+	// Set once mysql_library_init() succeeds, so the matching mysql_library_end()
+	// runs exactly once on shutdown (and only if init actually happened).
+	std::atomic<bool> g_mysqlLibraryInitialized { false };
+
 	// Calls mysql_thread_end() when a thread that opened a connection exits, so
 	// libmysqlclient's thread-local state is released (no per-thread TLS leak).
 	struct ThreadCleanup {
@@ -38,10 +42,13 @@ Database::ConnectionContext::~ConnectionContext() {
 }
 
 void Database::beginQueryCapture(std::vector<std::string>* buffer) {
+	// Not reentrant: a nested capture would silently steal the outer buffer.
+	assert(tlsQueryCapture == nullptr && "nested query capture is not supported");
 	tlsQueryCapture = buffer;
 }
 
 void Database::endQueryCapture() {
+	assert(tlsQueryCapture != nullptr && "endQueryCapture without a matching begin");
 	tlsQueryCapture = nullptr;
 }
 
@@ -50,11 +57,21 @@ Database::~Database() {
 	// mysql_close. The pool threads are already joined by this point (the thread
 	// pool shuts down before the Database singleton is torn down), so no other
 	// thread can be using a context while we clear them.
-	std::scoped_lock lock { connectionsMutex };
-	if (!connections.empty()) {
-		g_logger().info("Database: closing {} MySQL connection(s).", connections.size());
+	{
+		std::scoped_lock lock { connectionsMutex };
+		if (!connections.empty()) {
+			g_logger().info("Database: closing {} MySQL connection(s).", connections.size());
+		}
+		connections.clear();
 	}
-	connections.clear();
+
+	// Pair mysql_library_init(): release the client library after every per-thread
+	// connection is closed (and each thread's mysql_thread_end() has run). The
+	// compare_exchange guarantees it runs at most once.
+	bool wasInitialized = true;
+	if (g_mysqlLibraryInitialized.compare_exchange_strong(wasInitialized, false)) {
+		mysql_library_end();
+	}
 }
 
 Database &Database::getInstance() {
@@ -75,6 +92,7 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 		if (mysql_library_init(0, nullptr, nullptr) != 0) {
 			g_logger().error("Failed to initialize the MySQL client library.");
 		} else {
+			g_mysqlLibraryInitialized.store(true);
 			g_logger().info("Database running in per-thread connection mode (one MySQL connection per worker thread).");
 		}
 	});
@@ -157,10 +175,12 @@ Database::ConnectionContext &Database::getContext() const {
 		connectionNumber = connections.size();
 	}
 
-	// Publish to the thread_local cache before establishing so the nested
-	// max_allowed_packet query reuses this very context.
-	tlsContext = contextPtr;
 	if (establishConnection(*contextPtr)) {
+		// Cache in the thread_local only on success: a failed open is not cached,
+		// so the next query on this thread retries with a fresh connection (e.g.
+		// if MySQL was briefly unreachable) instead of being stuck with a null
+		// handle forever.
+		tlsContext = contextPtr;
 		g_logger().info("Database: opened MySQL connection #{} (new worker thread reached the database).", connectionNumber);
 	} else {
 		g_logger().error("Database: failed to open MySQL connection #{} for a worker thread.", connectionNumber);

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -18,6 +18,14 @@ namespace {
 	// Per-thread query capture buffer. When non-null, executeQuery records into
 	// it instead of executing. See Database::beginQueryCapture.
 	thread_local std::vector<std::string>* tlsQueryCapture = nullptr;
+
+	// Calls mysql_thread_end() when a thread that opened a connection exits, so
+	// libmysqlclient's thread-local state is released (no per-thread TLS leak).
+	struct ThreadCleanup {
+		~ThreadCleanup() {
+			mysql_thread_end();
+		}
+	};
 }
 
 Database::ConnectionContext::~ConnectionContext() {
@@ -89,8 +97,11 @@ bool Database::establishConnection(ConnectionContext &ctx) const {
 		return false;
 	}
 
-	// Each thread must initialize the MySQL client library's thread-local state.
+	// Each thread must initialize the MySQL client library's thread-local state,
+	// and release it when the thread exits (the thread_local destructor runs on
+	// this very thread, which is where mysql_thread_end() must be called).
 	mysql_thread_init();
+	static thread_local ThreadCleanup threadCleanup;
 
 	ctx.handle = mysql_init(nullptr);
 	if (!ctx.handle) {
@@ -378,7 +389,12 @@ retry:
 }
 
 uint64_t Database::getLastInsertId() const {
-	return static_cast<uint64_t>(mysql_insert_id(getContext().handle));
+	auto &ctx = getContext();
+	if (!ctx.handle) {
+		g_logger().error("Database connection not established, cannot get last insert id!");
+		return 0;
+	}
+	return static_cast<uint64_t>(mysql_insert_id(ctx.handle));
 }
 
 uint64_t Database::getMaxPacketSize() const {
@@ -397,6 +413,10 @@ std::string Database::escapeString(const std::string &s) const {
 
 std::string Database::escapeBlob(const char* s, uint32_t length) const {
 	auto &ctx = getContext();
+	if (!ctx.handle) {
+		g_logger().error("Database connection not established, cannot escape blob!");
+		return "''";
+	}
 
 	size_t maxLength = (length * 2) + 1;
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -22,6 +22,9 @@ namespace {
 	// Calls mysql_thread_end() when a thread that opened a connection exits, so
 	// libmysqlclient's thread-local state is released (no per-thread TLS leak).
 	struct ThreadCleanup {
+		ThreadCleanup() = default;
+		ThreadCleanup(const ThreadCleanup &) = delete;
+		ThreadCleanup &operator=(const ThreadCleanup &) = delete;
 		~ThreadCleanup() {
 			mysql_thread_end();
 		}

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -19,10 +19,6 @@ namespace {
 	// it instead of executing. See Database::beginQueryCapture.
 	thread_local std::vector<std::string>* tlsQueryCapture = nullptr;
 
-	// Set once mysql_library_init() succeeds, so the matching mysql_library_end()
-	// runs exactly once on shutdown (and only if init actually happened).
-	std::atomic<bool> g_mysqlLibraryInitialized { false };
-
 	// Calls mysql_thread_end() when a thread that opened a connection exits, so
 	// libmysqlclient's thread-local state is released (no per-thread TLS leak).
 	struct ThreadCleanup {
@@ -66,10 +62,10 @@ Database::~Database() {
 	}
 
 	// Pair mysql_library_init(): release the client library after every per-thread
-	// connection is closed (and each thread's mysql_thread_end() has run). The
-	// compare_exchange guarantees it runs at most once.
-	bool wasInitialized = true;
-	if (g_mysqlLibraryInitialized.compare_exchange_strong(wasInitialized, false)) {
+	// connection is closed (and each thread's mysql_thread_end() has run). Only the
+	// instance that initialized the library (single-threaded at startup) does this.
+	if (m_libraryInitialized) {
+		m_libraryInitialized = false;
 		mysql_library_end();
 	}
 }
@@ -88,11 +84,11 @@ bool Database::connect(const std::string* host, const std::string* user, const s
 	// implicitly, but that implicit init is not thread-safe if two threads race
 	// to open their first connection — doing it here up front removes that risk.
 	static std::once_flag libraryInitFlag;
-	std::call_once(libraryInitFlag, []() {
+	std::call_once(libraryInitFlag, [this]() {
 		if (mysql_library_init(0, nullptr, nullptr) != 0) {
 			g_logger().error("Failed to initialize the MySQL client library.");
 		} else {
-			g_mysqlLibraryInitialized.store(true);
+			m_libraryInitialized = true;
 			g_logger().info("Database running in per-thread connection mode (one MySQL connection per worker thread).");
 		}
 	});

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -14,10 +14,36 @@
 #include "lib/metrics/metrics.hpp"
 #include "utils/tools.hpp"
 
-Database::~Database() {
+namespace {
+	// Per-thread query capture buffer. When non-null, executeQuery records into
+	// it instead of executing. See Database::beginQueryCapture.
+	thread_local std::vector<std::string>* tlsQueryCapture = nullptr;
+}
+
+Database::ConnectionContext::~ConnectionContext() {
 	if (handle != nullptr) {
 		mysql_close(handle);
 	}
+}
+
+void Database::beginQueryCapture(std::vector<std::string>* buffer) {
+	tlsQueryCapture = buffer;
+}
+
+void Database::endQueryCapture() {
+	tlsQueryCapture = nullptr;
+}
+
+Database::~Database() {
+	// Every per-thread connection is owned here; their destructors call
+	// mysql_close. The pool threads are already joined by this point (the thread
+	// pool shuts down before the Database singleton is torn down), so no other
+	// thread can be using a context while we clear them.
+	std::scoped_lock lock { connectionsMutex };
+	if (!connections.empty()) {
+		g_logger().info("Database: closing {} MySQL connection(s).", connections.size());
+	}
+	connections.clear();
 }
 
 Database &Database::getInstance() {
@@ -29,36 +55,103 @@ bool Database::connect() {
 }
 
 bool Database::connect(const std::string* host, const std::string* user, const std::string* password, const std::string* database, uint32_t port, const std::string* sock) {
-	// connection handle initialization
-	handle = mysql_init(nullptr);
-	if (!handle) {
-		g_logger().error("Failed to initialize MySQL connection handle.");
-		return false;
-	}
+	// Initialize the MySQL client library exactly once, on this (startup) thread,
+	// before any other thread opens its own connection. mysql_init() would do it
+	// implicitly, but that implicit init is not thread-safe if two threads race
+	// to open their first connection — doing it here up front removes that risk.
+	static std::once_flag libraryInitFlag;
+	std::call_once(libraryInitFlag, []() {
+		if (mysql_library_init(0, nullptr, nullptr) != 0) {
+			g_logger().error("Failed to initialize the MySQL client library.");
+		} else {
+			g_logger().info("Database running in per-thread connection mode (one MySQL connection per worker thread).");
+		}
+	});
 
 	if (host->empty() || user->empty() || password->empty() || database->empty() || port <= 0) {
 		g_logger().warn("MySQL host, user, password, database or port not provided");
 	}
 
-	// automatic reconnect
-	bool reconnect = true;
-	mysql_options(handle, MYSQL_OPT_RECONNECT, &reconnect);
+	// Capture the parameters once; every thread reuses them to open its own
+	// connection lazily on first query.
+	connectionParams = ConnectionParams {
+		*host, *user, *password, *database, *sock, port
+	};
 
-	// Remove ssl verification
-	bool ssl_enabled = false;
-	mysql_options(handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
+	// Establish the connection for the calling (startup) thread so credential
+	// errors surface immediately instead of on the first asynchronous query.
+	return getContext().handle != nullptr;
+}
 
-	// connects to database
-	if (!mysql_real_connect(handle, host->c_str(), user->c_str(), password->c_str(), database->c_str(), port, sock->c_str(), 0)) {
-		g_logger().error("MySQL Error Message: {}", mysql_error(handle));
+bool Database::establishConnection(ConnectionContext &ctx) const {
+	if (!connectionParams) {
+		g_logger().error("Database connection parameters not initialized!");
 		return false;
 	}
 
-	DBResult_ptr result = storeQuery("SHOW VARIABLES LIKE 'max_allowed_packet'");
-	if (result) {
-		maxPacketSize = result->getNumber<uint64_t>("Value");
+	// Each thread must initialize the MySQL client library's thread-local state.
+	mysql_thread_init();
+
+	ctx.handle = mysql_init(nullptr);
+	if (!ctx.handle) {
+		g_logger().error("Failed to initialize MySQL connection handle.");
+		return false;
+	}
+
+	// automatic reconnect
+	bool reconnect = true;
+	mysql_options(ctx.handle, MYSQL_OPT_RECONNECT, &reconnect);
+
+	// Remove ssl verification
+	bool ssl_enabled = false;
+	mysql_options(ctx.handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
+
+	const auto &p = *connectionParams;
+	if (!mysql_real_connect(ctx.handle, p.host.c_str(), p.user.c_str(), p.password.c_str(), p.database.c_str(), p.port, p.sock.empty() ? nullptr : p.sock.c_str(), 0)) {
+		g_logger().error("MySQL Error Message: {}", mysql_error(ctx.handle));
+		mysql_close(ctx.handle);
+		ctx.handle = nullptr;
+		return false;
+	}
+
+	// Query max_allowed_packet straight on this handle — we already hold it, and
+	// going through storeQuery() would just resolve back to this same context.
+	if (mysql_query(ctx.handle, "SHOW VARIABLES LIKE 'max_allowed_packet'") == 0) {
+		MYSQL_RES* res = mysql_store_result(ctx.handle);
+		if (res != nullptr) {
+			DBResult result(res);
+			if (result.hasNext()) {
+				ctx.maxPacketSize = result.getNumber<uint64_t>("Value");
+			}
+		}
 	}
 	return true;
+}
+
+Database::ConnectionContext &Database::getContext() const {
+	thread_local ConnectionContext* tlsContext = nullptr;
+	if (tlsContext != nullptr) {
+		return *tlsContext;
+	}
+
+	auto context = std::make_unique<ConnectionContext>();
+	ConnectionContext* contextPtr = context.get();
+	size_t connectionNumber = 0;
+	{
+		std::scoped_lock lock { connectionsMutex };
+		connections.emplace_back(std::move(context));
+		connectionNumber = connections.size();
+	}
+
+	// Publish to the thread_local cache before establishing so the nested
+	// max_allowed_packet query reuses this very context.
+	tlsContext = contextPtr;
+	if (establishConnection(*contextPtr)) {
+		g_logger().info("Database: opened MySQL connection #{} (new worker thread reached the database).", connectionNumber);
+	} else {
+		g_logger().error("Database: failed to open MySQL connection #{} for a worker thread.", connectionNumber);
+	}
+	return *contextPtr;
 }
 
 void Database::createDatabaseBackup(bool compress) const {
@@ -157,45 +250,48 @@ void Database::createDatabaseBackup(bool compress) const {
 	}
 }
 
+// A transaction runs entirely on the calling thread, hence entirely on that
+// thread's connection. Connection affinity alone provides exclusion, so there
+// is no global lock to hold between BEGIN and COMMIT/ROLLBACK anymore.
 bool Database::beginTransaction() {
-	if (!executeQuery("BEGIN")) {
-		return false;
-	}
-	metrics::lock_latency measureLock("database");
-	databaseLock.lock();
-	measureLock.stop();
+	// Clear any stale error from a previous transaction so the retry logic only
+	// reacts to a deadlock raised within this one.
+	getContext().lastErrno = 0;
+	return executeQuery("BEGIN");
+}
 
-	return true;
+bool Database::lastQueryWasDeadlock() const {
+	const auto errorCode = getContext().lastErrno;
+	// 1213 = ER_LOCK_DEADLOCK, 1205 = ER_LOCK_WAIT_TIMEOUT.
+	return errorCode == 1213 || errorCode == 1205;
 }
 
 bool Database::rollback() {
-	if (!handle) {
+	auto &ctx = getContext();
+	if (!ctx.handle) {
 		g_logger().error("Database not initialized!");
 		return false;
 	}
 
-	if (mysql_rollback(handle) != 0) {
-		g_logger().error("Message: {}", mysql_error(handle));
-		databaseLock.unlock();
+	if (mysql_rollback(ctx.handle) != 0) {
+		g_logger().error("Message: {}", mysql_error(ctx.handle));
 		return false;
 	}
 
-	databaseLock.unlock();
 	return true;
 }
 
 bool Database::commit() {
-	if (!handle) {
+	auto &ctx = getContext();
+	if (!ctx.handle) {
 		g_logger().error("Database not initialized!");
 		return false;
 	}
-	if (mysql_commit(handle) != 0) {
-		g_logger().error("Message: {}", mysql_error(handle));
-		databaseLock.unlock();
+	if (mysql_commit(ctx.handle) != 0) {
+		g_logger().error("Message: {}", mysql_error(ctx.handle));
 		return false;
 	}
 
-	databaseLock.unlock();
 	return true;
 }
 
@@ -204,10 +300,13 @@ bool Database::isRecoverableError(unsigned int error) {
 }
 
 bool Database::retryQuery(std::string_view query, int retries) {
-	while (retries > 0 && mysql_query(handle, query.data()) != 0) {
+	auto &ctx = getContext();
+	while (retries > 0 && mysql_query(ctx.handle, query.data()) != 0) {
+		const unsigned int errorCode = mysql_errno(ctx.handle);
 		g_logger().error("Query: {}", query.substr(0, 256));
-		g_logger().error("MySQL error [{}]: {}", mysql_errno(handle), mysql_error(handle));
-		if (!isRecoverableError(mysql_errno(handle))) {
+		g_logger().error("MySQL error [{}]: {}", errorCode, mysql_error(ctx.handle));
+		if (!isRecoverableError(errorCode)) {
+			ctx.lastErrno = errorCode;
 			return false;
 		}
 		std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -222,41 +321,44 @@ bool Database::retryQuery(std::string_view query, int retries) {
 }
 
 bool Database::executeQuery(std::string_view query) {
-	if (!handle) {
+	// Record-replay: during a capture (player save build on the dispatcher), defer
+	// the write by recording it; it will be replayed on a pool thread.
+	if (tlsQueryCapture != nullptr) {
+		tlsQueryCapture->emplace_back(query);
+		return true;
+	}
+
+	auto &ctx = getContext();
+	if (!ctx.handle) {
 		g_logger().error("Database not initialized!");
 		return false;
 	}
 
 	g_logger().trace("Executing Query: {}", query);
 
-	metrics::lock_latency measureLock("database");
-	std::scoped_lock lock { databaseLock };
-	measureLock.stop();
-
 	metrics::query_latency measure(query.substr(0, 50));
 	bool success = retryQuery(query, 10);
-	mysql_free_result(mysql_store_result(handle));
+	mysql_free_result(mysql_store_result(ctx.handle));
 
 	return success;
 }
 
 DBResult_ptr Database::storeQuery(std::string_view query) {
-	if (!handle) {
+	auto &ctx = getContext();
+	if (!ctx.handle) {
 		g_logger().error("Database not initialized!");
 		return nullptr;
 	}
 	g_logger().trace("Storing Query: {}", query);
 
-	metrics::lock_latency measureLock("database");
-	std::scoped_lock lock { databaseLock };
-	measureLock.stop();
-
 	metrics::query_latency measure(query.substr(0, 50));
 retry:
-	if (mysql_query(handle, query.data()) != 0) {
+	if (mysql_query(ctx.handle, query.data()) != 0) {
+		const unsigned int errorCode = mysql_errno(ctx.handle);
 		g_logger().error("Query: {}", query);
-		g_logger().error("Message: {}", mysql_error(handle));
-		if (!isRecoverableError(mysql_errno(handle))) {
+		g_logger().error("Message: {}", mysql_error(ctx.handle));
+		if (!isRecoverableError(errorCode)) {
+			ctx.lastErrno = errorCode;
 			return nullptr;
 		}
 		std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -264,7 +366,7 @@ retry:
 	}
 
 	// Retrieving results of query
-	MYSQL_RES* res = mysql_store_result(handle);
+	MYSQL_RES* res = mysql_store_result(ctx.handle);
 	if (res != nullptr) {
 		DBResult_ptr result = std::make_shared<DBResult>(res);
 		if (!result->hasNext()) {
@@ -273,6 +375,14 @@ retry:
 		return result;
 	}
 	return nullptr;
+}
+
+uint64_t Database::getLastInsertId() const {
+	return static_cast<uint64_t>(mysql_insert_id(getContext().handle));
+}
+
+uint64_t Database::getMaxPacketSize() const {
+	return getContext().maxPacketSize;
 }
 
 std::string Database::escapeString(const std::string &s) const {
@@ -286,9 +396,7 @@ std::string Database::escapeString(const std::string &s) const {
 }
 
 std::string Database::escapeBlob(const char* s, uint32_t length) const {
-	metrics::lock_latency measureLock("database");
-	std::scoped_lock lock { databaseLock };
-	measureLock.stop();
+	auto &ctx = getContext();
 
 	size_t maxLength = (length * 2) + 1;
 
@@ -298,7 +406,7 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const {
 
 	if (length != 0) {
 		std::string output(maxLength, '\0');
-		size_t escapedLength = mysql_real_escape_string(handle, &output[0], s, length);
+		size_t escapedLength = mysql_real_escape_string(ctx.handle, &output[0], s, length);
 		output.resize(escapedLength);
 		escaped.append(output);
 	}

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -100,7 +100,7 @@ bool Database::establishConnection(ConnectionContext &ctx) const {
 	// Each thread must initialize the MySQL client library's thread-local state,
 	// and release it when the thread exits (the thread_local destructor runs on
 	// this very thread, which is where mysql_thread_end() must be called).
-	mysql_thread_init();
+	(void)mysql_thread_init();
 	static thread_local ThreadCleanup threadCleanup;
 
 	ctx.handle = mysql_init(nullptr);
@@ -111,11 +111,11 @@ bool Database::establishConnection(ConnectionContext &ctx) const {
 
 	// automatic reconnect
 	bool reconnect = true;
-	mysql_options(ctx.handle, MYSQL_OPT_RECONNECT, &reconnect);
+	(void)mysql_options(ctx.handle, MYSQL_OPT_RECONNECT, &reconnect);
 
 	// Remove ssl verification
 	bool ssl_enabled = false;
-	mysql_options(ctx.handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
+	(void)mysql_options(ctx.handle, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &ssl_enabled);
 
 	const auto &p = *connectionParams;
 	if (!mysql_real_connect(ctx.handle, p.host.c_str(), p.user.c_str(), p.password.c_str(), p.database.c_str(), p.port, p.sock.empty() ? nullptr : p.sock.c_str(), 0)) {
@@ -150,7 +150,7 @@ Database::ConnectionContext &Database::getContext() const {
 	size_t connectionNumber = 0;
 	{
 		std::scoped_lock lock { connectionsMutex };
-		connections.emplace_back(std::move(context));
+		connections.push_back(std::move(context));
 		connectionNumber = connections.size();
 	}
 
@@ -335,7 +335,7 @@ bool Database::executeQuery(std::string_view query) {
 	// Record-replay: during a capture (player save build on the dispatcher), defer
 	// the write by recording it; it will be replayed on a pool thread.
 	if (tlsQueryCapture != nullptr) {
-		tlsQueryCapture->emplace_back(query);
+		tlsQueryCapture->push_back(std::string(query));
 		return true;
 	}
 
@@ -394,7 +394,7 @@ uint64_t Database::getLastInsertId() const {
 		g_logger().error("Database connection not established, cannot get last insert id!");
 		return 0;
 	}
-	return static_cast<uint64_t>(mysql_insert_id(ctx.handle));
+	return mysql_insert_id(ctx.handle);
 }
 
 uint64_t Database::getMaxPacketSize() const {

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -107,6 +107,11 @@ private:
 		// inspected by the transaction retry logic.
 		unsigned int lastErrno = 0;
 
+		ConnectionContext() = default;
+		// Owns the raw MYSQL* handle, so it is non-copyable/non-movable (always
+		// held inside a unique_ptr in the registry).
+		ConnectionContext(const ConnectionContext &) = delete;
+		ConnectionContext &operator=(const ConnectionContext &) = delete;
 		~ConnectionContext();
 	};
 

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -13,8 +13,11 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <mysql/mysql.h>
+	#include <memory>
 	#include <mutex>
+	#include <optional>
 	#include <utility>
+	#include <vector>
 #endif
 
 class DBResult;
@@ -63,17 +66,25 @@ public:
 
 	std::string escapeBlob(const char* s, uint32_t length) const;
 
-	uint64_t getLastInsertId() const {
-		return static_cast<uint64_t>(mysql_insert_id(handle));
-	}
+	uint64_t getLastInsertId() const;
 
 	static const char* getClientVersion() {
 		return mysql_get_client_info();
 	}
 
-	uint64_t getMaxPacketSize() const {
-		return maxPacketSize;
-	}
+	uint64_t getMaxPacketSize() const;
+
+	// True when the calling thread's last failed query was an InnoDB deadlock or
+	// lock-wait timeout — i.e. a transient error worth retrying the transaction.
+	[[nodiscard]] bool lastQueryWasDeadlock() const;
+
+	// Query capture (record-replay). While active on the calling thread,
+	// executeQuery() appends its SQL to `buffer` and returns true WITHOUT
+	// executing. This lets a player save be serialized on the dispatcher (reading
+	// the live Player consistently) and replayed on a pool thread. storeQuery()
+	// is never captured. Not reentrant per thread. Use QueryCaptureScope (below).
+	void beginQueryCapture(std::vector<std::string>* buffer);
+	void endQueryCapture();
 
 private:
 	bool beginTransaction();
@@ -82,14 +93,63 @@ private:
 
 	static bool isRecoverableError(unsigned int error);
 
-	MYSQL* handle = nullptr;
-	mutable std::recursive_mutex databaseLock;
-	uint64_t maxPacketSize = 1048576;
+	// State that must be private to each MySQL connection. A context belongs to a
+	// single thread (reached only through that thread's thread_local cache), so
+	// all queries from a given thread — and therefore a whole player load or
+	// transaction — share the same handle: getLastInsertId and BEGIN/COMMIT keep
+	// connection affinity for free, and the handle needs no lock because no other
+	// thread can ever touch it.
+	struct ConnectionContext {
+		MYSQL* handle = nullptr;
+		uint64_t maxPacketSize = 1048576;
+		// Error code of the last failed query on this connection. Kept here (not
+		// read via mysql_errno) so it survives an intervening rollback and can be
+		// inspected by the transaction retry logic.
+		unsigned int lastErrno = 0;
+
+		~ConnectionContext();
+	};
+
+	// Returns the calling thread's connection, establishing it lazily on first
+	// use from the parameters captured by connect(). Fast path is a thread_local
+	// pointer lookup with no locking.
+	ConnectionContext &getContext() const;
+	bool establishConnection(ConnectionContext &ctx) const;
+
+	// Connection parameters captured on the first connect(), reused to spin up a
+	// fresh connection for every thread that touches the database.
+	struct ConnectionParams {
+		std::string host;
+		std::string user;
+		std::string password;
+		std::string database;
+		std::string sock;
+		uint32_t port = 0;
+	};
+
+	mutable std::optional<ConnectionParams> connectionParams;
+	mutable std::mutex connectionsMutex;
+	mutable std::vector<std::unique_ptr<ConnectionContext>> connections;
 
 	friend class DBTransaction;
 };
 
 constexpr auto g_database = Database::getInstance;
+
+// RAII wrapper for Database query capture. While in scope, executeQuery() on the
+// calling thread records into `buffer` instead of executing.
+class QueryCaptureScope {
+public:
+	explicit QueryCaptureScope(std::vector<std::string> &buffer) {
+		Database::getInstance().beginQueryCapture(&buffer);
+	}
+	~QueryCaptureScope() {
+		Database::getInstance().endQueryCapture();
+	}
+
+	QueryCaptureScope(const QueryCaptureScope &) = delete;
+	QueryCaptureScope &operator=(const QueryCaptureScope &) = delete;
+};
 
 class DBResult {
 public:
@@ -230,53 +290,75 @@ public:
 	DBTransaction(const DBTransaction &&) = delete;
 	DBTransaction &operator=(const DBTransaction &&) = delete;
 
+	// Number of times a transaction is retried when it fails with a transient
+	// InnoDB deadlock / lock-wait timeout before giving up.
+	static constexpr uint8_t TRANSACTION_MAX_ATTEMPTS = 3;
+
 	template <typename Func>
 	static bool executeWithinTransaction(const Func &callback)
 		requires std::invocable<Func>
 	{
-		DBTransaction transaction;
-		try {
-			if (!transaction.begin()) {
-				g_logger().error("[{}] Failed to begin transaction", __FUNCTION__);
+		for (uint8_t attempt = 1; attempt <= TRANSACTION_MAX_ATTEMPTS; ++attempt) {
+			DBTransaction transaction;
+			try {
+				if (!transaction.begin()) {
+					g_logger().error("[{}] Failed to begin transaction", __FUNCTION__);
+					return false;
+				}
+
+				const bool result = callback();
+
+				if (!transaction.commit()) {
+					return false;
+				}
+
+				return result;
+			} catch (const std::exception &exception) {
+				transaction.rollback();
+				if (Database::getInstance().lastQueryWasDeadlock() && attempt < TRANSACTION_MAX_ATTEMPTS) {
+					g_logger().warn("[{}] Transaction hit a deadlock/lock timeout, retrying ({}/{})", __FUNCTION__, attempt, TRANSACTION_MAX_ATTEMPTS);
+					continue;
+				}
+				g_logger().error("[{}] Error occurred during transaction, error: {}", __FUNCTION__, exception.what());
 				return false;
 			}
-
-			const bool result = callback();
-
-			if (!transaction.commit()) {
-				return false;
-			}
-
-			return result;
-		} catch (const std::exception &exception) {
-			transaction.rollback();
-			g_logger().error("[{}] Error occurred during transaction, error: {}", __FUNCTION__, exception.what());
-			return false;
 		}
+		return false;
 	}
 
 	template <typename Func>
 	static bool executeWithinTransactionRollbackOnFailure(const Func &callback)
 		requires std::invocable<Func>
 	{
-		DBTransaction transaction;
-		try {
-			if (!transaction.begin()) {
-				g_logger().error("[{}] Failed to begin transaction", __FUNCTION__);
-				return false;
-			}
+		for (uint8_t attempt = 1; attempt <= TRANSACTION_MAX_ATTEMPTS; ++attempt) {
+			DBTransaction transaction;
+			try {
+				if (!transaction.begin()) {
+					g_logger().error("[{}] Failed to begin transaction", __FUNCTION__);
+					return false;
+				}
 
-			if (!callback()) {
+				if (!callback()) {
+					transaction.rollback();
+					if (Database::getInstance().lastQueryWasDeadlock() && attempt < TRANSACTION_MAX_ATTEMPTS) {
+						g_logger().warn("[{}] Transaction hit a deadlock/lock timeout, retrying ({}/{})", __FUNCTION__, attempt, TRANSACTION_MAX_ATTEMPTS);
+						continue;
+					}
+					return false;
+				}
+
+				return transaction.commit();
+			} catch (const std::exception &exception) {
 				transaction.rollback();
+				if (Database::getInstance().lastQueryWasDeadlock() && attempt < TRANSACTION_MAX_ATTEMPTS) {
+					g_logger().warn("[{}] Transaction hit a deadlock/lock timeout, retrying ({}/{})", __FUNCTION__, attempt, TRANSACTION_MAX_ATTEMPTS);
+					continue;
+				}
+				g_logger().error("[{}] Error occurred during transaction, error: {}", __FUNCTION__, exception.what());
 				return false;
 			}
-
-			return transaction.commit();
-		} catch (const std::exception &exception) {
-			transaction.rollback();
-			g_logger().error("[{}] Error occurred during transaction, error: {}", __FUNCTION__, exception.what());
-			return false;
 		}
+		return false;
 	}
 
 private:

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -13,6 +13,8 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <mysql/mysql.h>
+	#include <atomic>
+	#include <cassert>
 	#include <memory>
 	#include <mutex>
 	#include <optional>

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -13,7 +13,6 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <mysql/mysql.h>
-	#include <atomic>
 	#include <cassert>
 	#include <memory>
 	#include <mutex>
@@ -137,6 +136,10 @@ private:
 	mutable std::optional<ConnectionParams> connectionParams;
 	mutable std::mutex connectionsMutex;
 	mutable std::vector<std::unique_ptr<ConnectionContext>> connections;
+	// Set when this instance initialized the MySQL client library, so its
+	// destructor pairs the single mysql_library_end(). Set/read single-threaded
+	// (startup / shutdown), so no atomic is needed.
+	bool m_libraryInitialized = false;
 
 	friend class DBTransaction;
 };

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -11089,16 +11089,19 @@ void Game::addPlayer(const std::shared_ptr<Player> &player) {
 
 bool Game::reserveLogin(uint32_t guid) {
 	// Dispatcher-only: the insert is atomic relative to other logins because the
-	// dispatcher processes them serially. Returns false if a login for this
-	// character is already in flight.
+	// dispatcher processes them serially (m_pendingLogins is unsynchronized).
+	// Returns false if a login for this character is already in flight.
+	assert(DispatcherContext::isOn());
 	return m_pendingLogins.emplace(guid).second;
 }
 
 void Game::releaseLogin(uint32_t guid) {
+	assert(DispatcherContext::isOn());
 	m_pendingLogins.erase(guid);
 }
 
 bool Game::isLoginPending(uint32_t guid) const {
+	assert(DispatcherContext::isOn());
 	return m_pendingLogins.contains(guid);
 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -11087,6 +11087,21 @@ void Game::addPlayer(const std::shared_ptr<Player> &player) {
 	players[player->getID()] = player;
 }
 
+bool Game::reserveLogin(uint32_t guid) {
+	// Dispatcher-only: the insert is atomic relative to other logins because the
+	// dispatcher processes them serially. Returns false if a login for this
+	// character is already in flight.
+	return m_pendingLogins.emplace(guid).second;
+}
+
+void Game::releaseLogin(uint32_t guid) {
+	m_pendingLogins.erase(guid);
+}
+
+bool Game::isLoginPending(uint32_t guid) const {
+	return m_pendingLogins.contains(guid);
+}
+
 void Game::removePlayer(const std::shared_ptr<Player> &player) {
 	const std::string &lowercase_name = asLowerCaseString(player->getName());
 	mappedPlayerNames.erase(lowercase_name);

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -175,6 +175,14 @@ public:
 
 	std::vector<std::shared_ptr<Player>> getPlayersByAccount(const std::shared_ptr<Account> &acc, bool allowOffline = false);
 
+	// Logins in flight: a character whose data is being loaded on a pool thread
+	// but is not yet placed in the world. Used to reject a second concurrent
+	// login of the same character. MUST be called only from the dispatcher
+	// thread — it is serial there, so the set needs no lock.
+	bool reserveLogin(uint32_t guid);
+	void releaseLogin(uint32_t guid);
+	bool isLoginPending(uint32_t guid) const;
+
 	bool internalPlaceCreature(const std::shared_ptr<Creature> &creature, const Position &pos, bool extendedPos = false, bool forced = false, bool creatureCheck = false);
 
 	bool placeCreature(const std::shared_ptr<Creature> &creature, const Position &pos, bool extendedPos = false, bool force = false);
@@ -817,6 +825,8 @@ private:
 	phmap::flat_hash_map<std::string, HighscoreCacheEntry> highscoreCache;
 
 	std::unordered_map<std::string, std::weak_ptr<Player>> m_deadPlayers;
+	// Characters currently being loaded asynchronously (dispatcher-only, no lock).
+	phmap::flat_hash_set<uint32_t> m_pendingLogins;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Player>> players;
 	phmap::flat_hash_map<std::string, std::weak_ptr<Player>> mappedPlayerNames;
 	phmap::parallel_flat_hash_map<uint32_t, std::shared_ptr<Guild>> guilds;

--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -12,6 +12,7 @@
 #include "config/configmanager.hpp"
 #include "creatures/players/grouping/guild.hpp"
 #include "game/game.hpp"
+#include "game/scheduling/dispatcher.hpp"
 #include "io/ioguild.hpp"
 #include "io/iologindata.hpp"
 #include "kv/kv.hpp"
@@ -25,18 +26,12 @@ SaveManager &SaveManager::getInstance() {
 	return inject<SaveManager>();
 }
 
-void SaveManager::saveAll() {
-	Benchmark bm_saveAll;
-	logger.info("Saving server...");
-	Benchmark bm_players;
+SaveManager::PlayerSaveBatch SaveManager::buildAllPlayers() {
+	// Dispatcher thread: read (and adjust) live player state and serialize each
+	// player to SQL. CPU-only — no DB round-trips (the save build is captured).
 	const auto &players = game.getPlayers();
-	const bool savePlayersInParallel = threadPool.get_thread_count() > 1 && players.size() > 1;
-	std::vector<std::pair<std::future<void>, std::string>> pending;
-	logger.info("Saving {} players...", players.size());
-	if (savePlayersInParallel) {
-		pending.reserve(players.size());
-	}
-
+	PlayerSaveBatch built;
+	built.reserve(players.size());
 	for (const auto &[_, player] : players) {
 		if (player->isDead()) {
 			player->loginPosition = player->getTemplePosition();
@@ -44,25 +39,45 @@ void SaveManager::saveAll() {
 			player->loginPosition = player->getPosition();
 		}
 
-		if (savePlayersInParallel) {
-			auto fut = threadPool.submit_task([this, player] {
-				doSavePlayer(player);
+		auto queries = IOLoginData::buildPlayerSave(player);
+		if (!queries) {
+			logger.error("Failed to build save for player {}.", player->getName());
+			continue;
+		}
+		built.emplace_back(player->getName(), std::move(*queries));
+	}
+	return built;
+}
+
+void SaveManager::flushBuiltPlayers(PlayerSaveBatch &built) {
+	// Pool-safe: only executes the captured SQL, never touches a player.
+	Benchmark bm_players;
+	logger.info("Saving {} players...", built.size());
+	const bool flushInParallel = threadPool.get_thread_count() > 1 && built.size() > 1;
+
+	if (flushInParallel) {
+		std::vector<std::pair<std::future<void>, std::string>> pending;
+		pending.reserve(built.size());
+		for (auto &[name, queries] : built) {
+			auto fut = threadPool.submit_task([this, q = std::move(queries), name]() {
+				if (!IOLoginData::flushPlayerSave(q)) {
+					logger.error("Failed to save player {}.", name);
+				}
 			});
-			pending.emplace_back(std::move(fut), player->getName());
-		} else {
+			pending.emplace_back(std::move(fut), name);
+		}
+		for (auto &[future, name] : pending) {
 			try {
-				doSavePlayer(player);
+				future.get();
 			} catch (const std::exception &e) {
-				logger.error("Failed to save player {}: {}", player->getName(), e.what());
+				logger.error("Failed to save player {}: {}", name, e.what());
 			}
 		}
-	}
-
-	for (auto &[future, name] : pending) {
-		try {
-			future.get();
-		} catch (const std::exception &e) {
-			logger.error("Failed to save player {}: {}", name, e.what());
+	} else {
+		for (auto &[name, queries] : built) {
+			if (!IOLoginData::flushPlayerSave(queries)) {
+				logger.error("Failed to save player {}.", name);
+			}
 		}
 	}
 
@@ -72,7 +87,9 @@ void SaveManager::saveAll() {
 	} else {
 		logger.info("Players saved in {} milliseconds.", duration_players);
 	}
+}
 
+void SaveManager::saveGuildsMapAndKV() {
 	Benchmark bm_guilds;
 	const auto &guilds = game.getGuilds();
 	for (const auto &[_, guild] : guilds) {
@@ -87,6 +104,16 @@ void SaveManager::saveAll() {
 
 	saveMap();
 	saveKV();
+}
+
+void SaveManager::saveAll() {
+	// Synchronous full save (non-async path / shutdown): build then flush on the
+	// calling thread. Safe when run on the dispatcher.
+	Benchmark bm_saveAll;
+	logger.info("Saving server...");
+	auto built = buildAllPlayers();
+	flushBuiltPlayers(built);
+	saveGuildsMapAndKV();
 
 	double duration_saveAll = bm_saveAll.duration();
 	if (duration_saveAll > 1000.0) {
@@ -106,16 +133,32 @@ void SaveManager::scheduleAll() {
 		return;
 	}
 
-	threadPool.detach_task([this, scheduledAt]() {
+	// Build every player's save on the dispatcher (consistent, CPU-only read),
+	// then flush them plus guilds/map/kv on a pool thread so the save I/O does
+	// not block the game loop.
+	auto built = buildAllPlayers();
+
+	threadPool.detach_task([this, scheduledAt, built = std::move(built)]() mutable {
 		if (m_scheduledAt.load() != scheduledAt) {
 			logger.warn("Skipping save for server because another save has been scheduled.");
 			return;
 		}
-		saveAll();
+		Benchmark bm_saveAll;
+		logger.info("Saving server...");
+		flushBuiltPlayers(built);
+		saveGuildsMapAndKV();
+
+		double duration_saveAll = bm_saveAll.duration();
+		if (duration_saveAll > 1000.0) {
+			logger.info("Server saved in {:.2f} seconds.", duration_saveAll / 1000.0);
+		} else {
+			logger.info("Server saved in {} milliseconds.", duration_saveAll);
+		}
 	});
 }
 
 void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
+	// Runs on the dispatcher thread (called from game logic via savePlayer).
 	auto playerToSave = playerPtr.lock();
 	if (!playerToSave) {
 		logger.debug("Skipping save for player because player is no longer online.");
@@ -131,24 +174,53 @@ void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
 		return;
 	}
 
+	const uint32_t guid = playerToSave->getGUID();
+
+	// If a flush for this player is already running on a pool thread, do not build
+	// and dispatch a second one: two concurrent flushes could apply out of order
+	// and let an older one overwrite newer data. Mark it to be rebuilt once the
+	// in-flight flush finishes (onPlayerFlushed).
+	if (m_flushInFlight.contains(guid)) {
+		m_resavePending.insert(guid);
+		return;
+	}
+
+	// Build the save here, on the dispatcher — the owner of the player state — so
+	// the read is consistent. No PlayerLock needed: the dispatcher is serial, so
+	// nothing mutates the player during the build. This produces only SQL strings
+	// (no DB round-trips, since the `save` flag is cached on the player).
+	auto queries = IOLoginData::buildPlayerSave(playerToSave);
+	if (!queries) {
+		logger.error("Failed to build save for player {}.", playerToSave->getName());
+		return;
+	}
+
+	m_flushInFlight.insert(guid);
 	logger.debug("Scheduling player {} for saving.", playerToSave->getName());
-	auto scheduledAt = std::chrono::steady_clock::now();
-	m_playerMap[playerToSave->getGUID()] = scheduledAt;
-	threadPool.detach_task([this, playerPtr, scheduledAt]() {
-		auto player = playerPtr.lock();
-		if (!player) {
-			logger.debug("Skipping save for player because player is no longer online.");
-			return;
+	threadPool.detach_task([this, guid, name = playerToSave->getName(), q = std::move(*queries)]() {
+		// Pool thread: replay the captured SQL. Touches no player state.
+		if (!IOLoginData::flushPlayerSave(q)) {
+			logger.error("Failed to save player {}.", name);
 		}
-		if (m_playerMap[player->getGUID()] != scheduledAt) {
-			logger.warn("Skipping save for player because another save has been scheduled.");
-			return;
-		}
-		doSavePlayer(player);
+		g_dispatcher().addEvent([this, guid]() { onPlayerFlushed(guid); }, "SaveManager::onPlayerFlushed");
 	});
 }
 
+void SaveManager::onPlayerFlushed(uint32_t guid) {
+	// Dispatcher thread.
+	m_flushInFlight.erase(guid);
+	if (m_resavePending.erase(guid) > 0) {
+		// A save was requested while the previous flush was in flight; rebuild
+		// from the current (newer) player state.
+		if (const auto &player = g_game().getPlayerByID(guid)) {
+			schedulePlayer(player);
+		}
+	}
+}
+
 bool SaveManager::doSavePlayer(std::shared_ptr<Player> player) {
+	// Synchronous build+flush on the calling thread. Used for the non-async path
+	// and for offline/shutdown saves, where there is no concurrent mutation.
 	if (!player) {
 		logger.debug("Failed to save player because player is null.");
 		return false;
@@ -156,7 +228,6 @@ bool SaveManager::doSavePlayer(std::shared_ptr<Player> player) {
 
 	Benchmark bm_savePlayer;
 	Player::PlayerLock lock(player);
-	m_playerMap.erase(player->getGUID());
 	if (g_game().getGameState() == GAME_STATE_NORMAL) {
 		logger.debug("Saving player {}.", player->getName());
 	}

--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -176,15 +176,6 @@ void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
 
 	const uint32_t guid = playerToSave->getGUID();
 
-	// If a flush for this player is already running on a pool thread, do not build
-	// and dispatch a second one: two concurrent flushes could apply out of order
-	// and let an older one overwrite newer data. Mark it to be rebuilt once the
-	// in-flight flush finishes (onPlayerFlushed).
-	if (m_flushInFlight.contains(guid)) {
-		m_resavePending.insert(guid);
-		return;
-	}
-
 	// Build the save here, on the dispatcher — the owner of the player state — so
 	// the read is consistent. No PlayerLock needed: the dispatcher is serial, so
 	// nothing mutates the player during the build. This produces only SQL strings
@@ -192,6 +183,17 @@ void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
 	auto queries = IOLoginData::buildPlayerSave(playerToSave);
 	if (!queries) {
 		logger.error("Failed to build save for player {}.", playerToSave->getName());
+		return;
+	}
+
+	// If a flush for this player is already running on a pool thread, queue the
+	// freshly-built save to run after it finishes — running two concurrently
+	// could let an older one overwrite newer data. We store the built SQL (not
+	// just the guid) so the queued save survives even if the player object is
+	// destroyed before the in-flight flush completes (e.g. logout). Overwriting a
+	// previous pending entry is correct: only the latest state matters.
+	if (m_flushInFlight.contains(guid)) {
+		m_pendingFlushes[guid] = std::make_pair(playerToSave->getName(), std::move(*queries));
 		return;
 	}
 
@@ -207,15 +209,23 @@ void SaveManager::schedulePlayer(std::weak_ptr<Player> playerPtr) {
 }
 
 void SaveManager::onPlayerFlushed(uint32_t guid) {
-	// Dispatcher thread.
-	m_flushInFlight.erase(guid);
-	if (m_resavePending.erase(guid) > 0) {
-		// A save was requested while the previous flush was in flight; rebuild
-		// from the current (newer) player state.
-		if (const auto &player = g_game().getPlayerByID(guid)) {
-			schedulePlayer(player);
-		}
+	// Dispatcher thread. If a save was queued while this flush ran, dispatch the
+	// already-built queries directly — no player lookup, so the final save is
+	// never dropped. The guid stays in m_flushInFlight until nothing is pending.
+	auto it = m_pendingFlushes.find(guid);
+	if (it == m_pendingFlushes.end()) {
+		m_flushInFlight.erase(guid);
+		return;
 	}
+
+	auto [name, queries] = std::move(it->second);
+	m_pendingFlushes.erase(it);
+	threadPool.detach_task([this, guid, name, q = std::move(queries)]() {
+		if (!IOLoginData::flushPlayerSave(q)) {
+			logger.error("Failed to save player {}.", name);
+		}
+		g_dispatcher().addEvent([this, guid]() { onPlayerFlushed(guid); }, "SaveManager::onPlayerFlushed");
+	});
 }
 
 bool SaveManager::doSavePlayer(std::shared_ptr<Player> player) {

--- a/src/game/scheduling/save_manager.cpp
+++ b/src/game/scheduling/save_manager.cpp
@@ -133,27 +133,31 @@ void SaveManager::scheduleAll() {
 		return;
 	}
 
-	// Build every player's save on the dispatcher (consistent, CPU-only read),
-	// then flush them plus guilds/map/kv on a pool thread so the save I/O does
-	// not block the game loop.
-	auto built = buildAllPlayers();
+	// Route every online player through the per-player save path (schedulePlayer):
+	// it builds on the dispatcher and serializes flushes per guid via
+	// m_flushInFlight/m_pendingFlushes. This stops a full save from racing — and
+	// overwriting with an older snapshot — a concurrent per-player save of the
+	// same character, which a standalone batch flush would not coordinate with.
+	logger.info("Saving server...");
+	const auto &players = game.getPlayers();
+	logger.info("Saving {} players...", players.size());
+	for (const auto &[_, player] : players) {
+		if (player->isDead()) {
+			player->loginPosition = player->getTemplePosition();
+		} else if (player->loginPosition != player->getTemplePosition()) {
+			player->loginPosition = player->getPosition();
+		}
+		schedulePlayer(player);
+	}
 
-	threadPool.detach_task([this, scheduledAt, built = std::move(built)]() mutable {
+	// Guilds/map/kv don't participate in per-player ordering; flush them on a pool
+	// thread. m_scheduledAt dedups overlapping full saves.
+	threadPool.detach_task([this, scheduledAt]() {
 		if (m_scheduledAt.load() != scheduledAt) {
-			logger.warn("Skipping save for server because another save has been scheduled.");
+			logger.warn("Skipping guild/map/kv save because another save has been scheduled.");
 			return;
 		}
-		Benchmark bm_saveAll;
-		logger.info("Saving server...");
-		flushBuiltPlayers(built);
 		saveGuildsMapAndKV();
-
-		double duration_saveAll = bm_saveAll.duration();
-		if (duration_saveAll > 1000.0) {
-			logger.info("Server saved in {:.2f} seconds.", duration_saveAll / 1000.0);
-		} else {
-			logger.info("Server saved in {} milliseconds.", duration_saveAll);
-		}
 	});
 }
 

--- a/src/game/scheduling/save_manager.hpp
+++ b/src/game/scheduling/save_manager.hpp
@@ -54,12 +54,14 @@ private:
 
 	std::atomic<std::chrono::steady_clock::time_point> m_scheduledAt;
 	// Per-player async-save coordination (dispatcher-only, no lock): guids whose
-	// flush is currently running on a pool thread, and guids that were asked to
-	// save again while a flush was in flight (rebuilt once the flush completes).
-	// This keeps same-player flushes serial and ordered so an older flush can
-	// never overwrite a newer one.
+	// flush is currently running on a pool thread, and the already-built (name,
+	// SQL) of a save queued while a flush was in flight. Keeping same-player
+	// flushes serial and ordered means an older flush can never overwrite a newer
+	// one; storing the built SQL (instead of a guid to re-look-up) means the final
+	// save (e.g. on logout) is never dropped even if the player object is already
+	// gone when the in-flight flush completes.
 	phmap::flat_hash_set<uint32_t> m_flushInFlight;
-	phmap::flat_hash_set<uint32_t> m_resavePending;
+	phmap::flat_hash_map<uint32_t, std::pair<std::string, std::vector<std::string>>> m_pendingFlushes;
 
 	ThreadPool &threadPool;
 	KVStore &kv;

--- a/src/game/scheduling/save_manager.hpp
+++ b/src/game/scheduling/save_manager.hpp
@@ -38,9 +38,28 @@ private:
 
 	void schedulePlayer(std::weak_ptr<Player> player);
 	bool doSavePlayer(std::shared_ptr<Player> player);
+	// Dispatcher callback after a player's async flush finishes: clears the
+	// in-flight flag and rebuilds if another save was requested meanwhile.
+	void onPlayerFlushed(uint32_t guid);
+
+	// (name, captured SQL) pairs produced by the save build phase.
+	using PlayerSaveBatch = std::vector<std::pair<std::string, std::vector<std::string>>>;
+	// Builds save payloads for every online player. MUST run on the dispatcher —
+	// it reads (and adjusts loginPosition of) live player state.
+	PlayerSaveBatch buildAllPlayers();
+	// Executes the built payloads (in parallel when possible). Touches no player
+	// state, so it is safe on a pool thread.
+	void flushBuiltPlayers(PlayerSaveBatch &built);
+	void saveGuildsMapAndKV();
 
 	std::atomic<std::chrono::steady_clock::time_point> m_scheduledAt;
-	phmap::parallel_flat_hash_map<uint32_t, std::chrono::steady_clock::time_point> m_playerMap;
+	// Per-player async-save coordination (dispatcher-only, no lock): guids whose
+	// flush is currently running on a pool thread, and guids that were asked to
+	// save again while a flush was in flight (rebuilt once the flush completes).
+	// This keeps same-player flushes serial and ordered so an older flush can
+	// never overwrite a newer one.
+	phmap::flat_hash_set<uint32_t> m_flushInFlight;
+	phmap::flat_hash_set<uint32_t> m_resavePending;
 
 	ThreadPool &threadPool;
 	KVStore &kv;

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -144,6 +144,9 @@ bool IOLoginDataLoad::loadPlayerBasicInfo(const std::shared_ptr<Player> &player,
 	}
 	player->setGroup(group);
 
+	// Cache the `save` flag so the save path does not need a SELECT round-trip.
+	player->setSaveFlag(result->getNumber<uint16_t>("save") != 0);
+
 	player->setBankBalance(result->getNumber<uint64_t>("balance"));
 	player->quickLootFallbackToMainContainer = result->getNumber<bool>("quickloot_fallback");
 	player->setSex(static_cast<PlayerSex_t>(result->getNumber<uint16_t>("sex")));
@@ -390,15 +393,16 @@ void IOLoginDataLoad::loadPlayerKills(const std::shared_ptr<Player> &player, DBR
 	}
 }
 
-void IOLoginDataLoad::loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result) {
-	if (!result || !player) {
-		g_logger().warn("[{}] - Player or Result nullptr", __FUNCTION__);
+void IOLoginDataLoad::loadPlayerGuild(const std::shared_ptr<Player> &player) {
+	if (!player) {
+		g_logger().warn("[{}] - Player nullptr", __FUNCTION__);
 		return;
 	}
 
 	Database &db = Database::getInstance();
 	std::ostringstream query;
 	query << "SELECT `guild_id`, `rank_id`, `nick` FROM `guild_membership` WHERE `player_id` = " << player->getGUID();
+	DBResult_ptr result;
 	if ((result = db.storeQuery(query.str()))) {
 		auto guildId = result->getNumber<uint32_t>("guild_id");
 		auto playerRankId = result->getNumber<uint32_t>("rank_id");

--- a/src/io/functions/iologindata_load_player.hpp
+++ b/src/io/functions/iologindata_load_player.hpp
@@ -27,7 +27,7 @@ public:
 	static void loadPlayerSkullSystem(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static void loadPlayerSkill(const std::shared_ptr<Player> &player, const DBResult_ptr &result);
 	static void loadPlayerKills(const std::shared_ptr<Player> &player, DBResult_ptr result);
-	static void loadPlayerGuild(const std::shared_ptr<Player> &player, DBResult_ptr result);
+	static void loadPlayerGuild(const std::shared_ptr<Player> &player);
 	static void loadPlayerStashItems(const std::shared_ptr<Player> &player, DBResult_ptr result);
 	static void loadPlayerBestiaryCharms(const std::shared_ptr<Player> &player, DBResult_ptr result);
 	static void loadPlayerInstantSpellList(const std::shared_ptr<Player> &player, DBResult_ptr result);

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -173,15 +173,9 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	Database &db = Database::getInstance();
 
 	std::ostringstream query;
-	query << "SELECT `save` FROM `players` WHERE `id` = " << player->getGUID();
-	DBResult_ptr result = db.storeQuery(query.str());
-	if (!result) {
-		g_logger().warn("[IOLoginData::savePlayer] - Error for select result query from player: {}", player->getName());
-		return false;
-	}
-
-	if (result->getNumber<uint16_t>("save") == 0) {
-		query.str("");
+	// `save` flag is cached on the player at login (loadPlayerBasicInfo), so no
+	// SELECT is needed here — keeping the save build free of DB round-trips.
+	if (!player->getSaveFlag()) {
 		query << "UPDATE `players` SET `lastlogin` = " << player->lastLoginSaved << ", `lastip` = " << player->lastIP << " WHERE `id` = " << player->getGUID();
 		return db.executeQuery(query.str());
 	}

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -229,7 +229,10 @@ std::optional<std::vector<std::string>> IOLoginData::buildPlayerSave(const std::
 }
 
 bool IOLoginData::flushPlayerSave(const std::vector<std::string> &queries) {
-	return DBTransaction::executeWithinTransaction([&queries]() {
+	// RollbackOnFailure (not executeWithinTransaction): a failing query must roll
+	// the whole transaction back — otherwise a partial save would be committed —
+	// and the rollback is what lets the deadlock retry kick in.
+	return DBTransaction::executeWithinTransactionRollbackOnFailure([&queries]() {
 		Database &db = Database::getInstance();
 		for (const auto &query : queries) {
 			if (!db.executeQuery(query)) {

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -78,11 +78,11 @@ uint8_t IOLoginData::getAccountType(uint32_t accountId) {
 }
 
 // The boolean "disableIrrelevantInfo" will deactivate the loading of information that is not relevant to the preload, for example, forge, bosstiary, etc. None of this we need to access if the player is offline
-bool IOLoginData::loadPlayerById(const std::shared_ptr<Player> &player, uint32_t id, bool disableIrrelevantInfo /* = true*/) {
+bool IOLoginData::loadPlayerById(const std::shared_ptr<Player> &player, uint32_t id, bool disableIrrelevantInfo /* = true*/, bool deferWorldData /* = false */) {
 	Database &db = Database::getInstance();
 	std::ostringstream query;
 	query << "SELECT * FROM `players` WHERE `id` = " << id;
-	return loadPlayer(player, db.storeQuery(query.str()), disableIrrelevantInfo);
+	return loadPlayer(player, db.storeQuery(query.str()), disableIrrelevantInfo, deferWorldData);
 }
 
 bool IOLoginData::loadPlayerByName(const std::shared_ptr<Player> &player, const std::string &name, bool disableIrrelevantInfo /* = true*/) {
@@ -92,7 +92,7 @@ bool IOLoginData::loadPlayerByName(const std::shared_ptr<Player> &player, const 
 	return loadPlayer(player, db.storeQuery(query.str()), disableIrrelevantInfo);
 }
 
-bool IOLoginData::loadPlayer(const std::shared_ptr<Player> &player, const DBResult_ptr &result, bool disableIrrelevantInfo /* = false*/) {
+bool IOLoginData::loadPlayer(const std::shared_ptr<Player> &player, const DBResult_ptr &result, bool disableIrrelevantInfo /* = false*/, bool deferWorldData /* = false */) {
 	if (!result || !player) {
 		std::string nullptrType = !result ? "Result" : "Player";
 		g_logger().warn("[{}] - {} is nullptr", __FUNCTION__, nullptrType);
@@ -130,8 +130,11 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player> &player, const DBResu
 		// kills load
 		IOLoginDataLoad::loadPlayerKills(player, result);
 
-		// guild load
-		IOLoginDataLoad::loadPlayerGuild(player, result);
+		// guild load — skipped here when deferred (mutates global guild registry;
+		// must run on the dispatcher via loadPlayerWorldData).
+		if (!deferWorldData) {
+			IOLoginDataLoad::loadPlayerGuild(player);
+		}
 
 		// stash load items
 		IOLoginDataLoad::loadPlayerStashItems(player, result);
@@ -171,7 +174,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player> &player, const DBResu
 
 		if (!disableIrrelevantInfo) {
 			// Load additional data only if the player is online (e.g., forge, bosstiary)
-			loadOnlyDataForOnlinePlayer(player, result);
+			loadOnlyDataForOnlinePlayer(player, result, deferWorldData);
 		}
 
 		return true;
@@ -184,30 +187,71 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player> &player, const DBResu
 	}
 }
 
-void IOLoginData::loadOnlyDataForOnlinePlayer(const std::shared_ptr<Player> &player, const DBResult_ptr &result) {
+void IOLoginData::loadOnlyDataForOnlinePlayer(const std::shared_ptr<Player> &player, const DBResult_ptr &result, bool deferWorldData /* = false */) {
 	IOLoginDataLoad::loadPlayerForgeHistory(player);
 	IOLoginDataLoad::loadPlayerBosstiary(player, result);
+	// loadPlayerInitializeSystem mutates shared state (Party::m_mantraHolder via
+	// the wheel). When deferred, it — together with the two steps that must run
+	// after it (updateSystem recalculates base speed/weight from the wheel
+	// bonuses applied by initializeSystem; exiva restrictions) — runs on the
+	// dispatcher in loadPlayerWorldData, preserving the original order.
+	if (!deferWorldData) {
+		IOLoginDataLoad::loadPlayerInitializeSystem(player);
+		IOLoginDataLoad::loadPlayerUpdateSystem(player);
+		IOLoginDataLoad::loadPlayerExivaRestrictions(player);
+	}
+}
+
+void IOLoginData::loadPlayerWorldData(const std::shared_ptr<Player> &player) {
+	// Dispatcher-only: the load steps that touch shared global state, plus the
+	// steps that must run after initializeSystem (same order as the inline load).
+	IOLoginDataLoad::loadPlayerGuild(player);
 	IOLoginDataLoad::loadPlayerInitializeSystem(player);
 	IOLoginDataLoad::loadPlayerUpdateSystem(player);
 	IOLoginDataLoad::loadPlayerExivaRestrictions(player);
 }
 
-bool IOLoginData::savePlayer(const std::shared_ptr<Player> &player) {
+std::optional<std::vector<std::string>> IOLoginData::buildPlayerSave(const std::shared_ptr<Player> &player) {
+	std::vector<std::string> queries;
 	try {
-		bool success = DBTransaction::executeWithinTransaction([player]() {
-			return savePlayerGuard(player);
-		});
-
-		if (!success) {
-			g_logger().error("[{}] Error occurred saving player", __FUNCTION__);
+		// Capture every executeQuery issued by savePlayerGuard instead of running
+		// it. The player is read here, on the owning (dispatcher) thread, and the
+		// SQL is replayed later on a pool thread by flushPlayerSave.
+		QueryCaptureScope capture(queries);
+		if (!savePlayerGuard(player)) {
+			return std::nullopt;
 		}
-
-		return success;
 	} catch (const DatabaseException &e) {
 		g_logger().error("[{}] Exception occurred: {}", __FUNCTION__, e.what());
+		return std::nullopt;
+	}
+	return queries;
+}
+
+bool IOLoginData::flushPlayerSave(const std::vector<std::string> &queries) {
+	return DBTransaction::executeWithinTransaction([&queries]() {
+		Database &db = Database::getInstance();
+		for (const auto &query : queries) {
+			if (!db.executeQuery(query)) {
+				return false;
+			}
+		}
+		return true;
+	});
+}
+
+bool IOLoginData::savePlayer(const std::shared_ptr<Player> &player) {
+	auto queries = buildPlayerSave(player);
+	if (!queries) {
+		g_logger().error("[{}] Error occurred building player save", __FUNCTION__);
+		return false;
 	}
 
-	return false;
+	bool success = flushPlayerSave(*queries);
+	if (!success) {
+		g_logger().error("[{}] Error occurred saving player", __FUNCTION__);
+	}
+	return success;
 }
 
 bool IOLoginData::savePlayerGuard(const std::shared_ptr<Player> &player) {

--- a/src/io/iologindata.hpp
+++ b/src/io/iologindata.hpp
@@ -22,9 +22,18 @@ class IOLoginData {
 public:
 	static bool gameWorldAuthentication(const std::string &accountDescriptor, const std::string &sessionOrPassword, std::string &characterName, uint32_t &accountId, bool oldProcotol, const uint32_t ip);
 	static uint8_t getAccountType(uint32_t accountId);
-	static bool loadPlayerById(const std::shared_ptr<Player> &player, uint32_t id, bool disableIrrelevantInfo = true);
+	// deferWorldData: when true, skips the two load steps that mutate shared
+	// global state (guild registry + system initialization). Used by the async
+	// login path so the heavy load runs on a pool thread; the deferred steps are
+	// then run on the dispatcher via loadPlayerWorldData().
+	static bool loadPlayerById(const std::shared_ptr<Player> &player, uint32_t id, bool disableIrrelevantInfo = true, bool deferWorldData = false);
 	static bool loadPlayerByName(const std::shared_ptr<Player> &player, const std::string &name, bool disableIrrelevantInfo = true);
-	static bool loadPlayer(const std::shared_ptr<Player> &player, const std::shared_ptr<DBResult> &result, bool disableIrrelevantInfo = false);
+	static bool loadPlayer(const std::shared_ptr<Player> &player, const std::shared_ptr<DBResult> &result, bool disableIrrelevantInfo = false, bool deferWorldData = false);
+
+	// Runs the load steps that touch shared global state (guild registry, system
+	// initialization). MUST run on the dispatcher thread. Pairs with a load done
+	// with deferWorldData = true.
+	static void loadPlayerWorldData(const std::shared_ptr<Player> &player);
 
 	/**
 	 * @brief Loads data components that are only relevant when the player is online.
@@ -38,9 +47,19 @@ public:
 	 * @param player A shared pointer to the Player instance. Must not be nullptr.
 	 * @param result The database result containing the player's data.
 	 */
-	static void loadOnlyDataForOnlinePlayer(const std::shared_ptr<Player> &player, const std::shared_ptr<DBResult> &result);
+	static void loadOnlyDataForOnlinePlayer(const std::shared_ptr<Player> &player, const std::shared_ptr<DBResult> &result, bool deferWorldData = false);
 
 	static bool savePlayer(const std::shared_ptr<Player> &player);
+
+	// Thread-safe split of savePlayer (record-replay):
+	//  - buildPlayerSave: serializes the player into a list of SQL statements.
+	//    MUST run on the thread that owns the player state (the dispatcher),
+	//    reading it consistently. Returns nullopt on failure.
+	//  - flushPlayerSave: executes those statements in a transaction. Safe on a
+	//    pool thread — touches no player state.
+	// savePlayer() simply chains build+flush for synchronous callers.
+	static std::optional<std::vector<std::string>> buildPlayerSave(const std::shared_ptr<Player> &player);
+	static bool flushPlayerSave(const std::vector<std::string> &queries);
 
 	/**
 	 * @brief Saves data components that are only relevant when the player is online.

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -689,12 +689,18 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		g_threadPool().detach_task([self = getThis(), operatingSystem]() {
-			// pool thread — populates only self->player (not yet in the world, and
-			// protected from a concurrent login by the reservation above). The two
-			// load steps that touch shared global state are deferred to finishLogin.
-			const bool loaded = IOLoginData::loadPlayerById(self->player, self->player->getGUID(), false, true);
-			g_dispatcher().addEvent([self, loaded, operatingSystem]() { self->finishLogin(loaded, operatingSystem); }, "ProtocolGame::finishLogin");
+		// Capture the reserved guid and a local shared_ptr to the player here: if
+		// the client disconnects mid-load, release() may clear the `player` member,
+		// which would null-deref on the pool thread and lose the reserved guid.
+		const uint32_t reservedGuid = player->getGUID();
+		const auto loginPlayer = player;
+		g_threadPool().detach_task([self = getThis(), loginPlayer, reservedGuid, operatingSystem]() {
+			// pool thread — populates only loginPlayer (kept alive by this capture,
+			// not yet in the world, and protected from a concurrent login by the
+			// reservation above). The two load steps that touch shared global state
+			// are deferred to finishLogin.
+			const bool loaded = IOLoginData::loadPlayerById(loginPlayer, reservedGuid, false, true);
+			g_dispatcher().addEvent([self, reservedGuid, loaded, operatingSystem]() { self->finishLogin(reservedGuid, loaded, operatingSystem); }, "ProtocolGame::finishLogin");
 		});
 		return;
 	} else {
@@ -721,19 +727,20 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 	}
 }
 
-void ProtocolGame::finishLogin(bool loaded, OperatingSystem_t operatingSystem) {
-	// dispatcher thread — continuation after loadPlayerById ran on the pool.
-	const uint32_t guid = player ? player->getGUID() : 0;
+void ProtocolGame::finishLogin(uint32_t reservedGuid, bool loaded, OperatingSystem_t operatingSystem) {
+	// dispatcher thread — continuation after loadPlayerById ran on the pool. Use
+	// the captured reservedGuid (not player->getGUID()) so the reservation is
+	// always released even if the player member was cleared by a disconnect.
 
 	// The client may have dropped while we were loading; nothing was placed in
 	// the world yet, so just release the reservation and bail.
 	if (!player || isConnectionExpired()) {
-		g_game().releaseLogin(guid);
+		g_game().releaseLogin(reservedGuid);
 		return;
 	}
 
 	if (!loaded) {
-		g_game().releaseLogin(guid);
+		g_game().releaseLogin(reservedGuid);
 		disconnectClient("Your character could not be loaded, please contact an adminstrator.");
 		return;
 	}
@@ -757,14 +764,14 @@ void ProtocolGame::finishLogin(bool loaded, OperatingSystem_t operatingSystem) {
 			}
 		}
 		if (countOutsizePZ >= maxOutsizePZ) {
-			g_game().releaseLogin(guid);
+			g_game().releaseLogin(reservedGuid);
 			disconnectClient(fmt::format("You can only have {} character{} from your account outside of a protection zone.", maxOutsizePZ == 1 ? "one" : std::to_string(maxOutsizePZ), maxOutsizePZ > 1 ? "s" : ""));
 			return;
 		}
 	}
 
 	if (!g_game().placeCreature(player, player->getLoginPosition()) && !g_game().placeCreature(player, player->getTemplePosition(), false, true)) {
-		g_game().releaseLogin(guid);
+		g_game().releaseLogin(reservedGuid);
 		disconnectClient("Temple position is wrong. Please, contact the administrator.");
 		g_logger().warn("Player {} temple position is wrong", player->getName());
 		return;
@@ -775,7 +782,7 @@ void ProtocolGame::finishLogin(bool loaded, OperatingSystem_t operatingSystem) {
 	player->loginProtectionTime = OTSYS_TIME() + g_configManager().getNumber(LOGIN_PROTECTION_TIME);
 	acceptPackets = true;
 
-	g_game().releaseLogin(guid);
+	g_game().releaseLogin(reservedGuid);
 
 	OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
 	sendBosstiaryCooldownTimer();

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -34,6 +34,7 @@
 #include "game/game.hpp"
 #include "game/modal_window/modal_window.hpp"
 #include "game/scheduling/dispatcher.hpp"
+#include "lib/thread/thread_pool.hpp"
 #include "io/functions/iologindata_load_player.hpp"
 #include "io/io_bosstiary.hpp"
 #include "io/iobestiary.hpp"
@@ -679,40 +680,23 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 			return;
 		}
 
-		if (!IOLoginData::loadPlayerById(player, player->getGUID(), false)) {
-			disconnectClient("Your character could not be loaded, please contact an adminstrator.");
+		// The heavy character load (~20 queries) runs on a pool thread so it no
+		// longer blocks the dispatcher/game loop. Reserve the login first so a
+		// second concurrent attempt for the same character is rejected while the
+		// load is in flight; finishLogin (back on the dispatcher) releases it.
+		if (!g_game().reserveLogin(player->getGUID())) {
+			disconnectClient("You are already logging in.");
 			return;
 		}
 
-		player->setOperatingSystem(operatingSystem);
-
-		const auto tile = g_game().map.getOrCreateTile(player->getLoginPosition());
-		// moving from a pz tile to a non-pz tile
-		if (maxOnline > 1 && player->getAccountType() < ACCOUNT_TYPE_GAMEMASTER && !tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
-			auto maxOutsizePZ = g_configManager().getNumber(MAX_PLAYERS_OUTSIDE_PZ_PER_ACCOUNT);
-			auto accountPlayers = g_game().getPlayersByAccount(player->getAccount());
-			int countOutsizePZ = 0;
-			for (const auto &accountPlayer : accountPlayers) {
-				if (accountPlayer != player && accountPlayer->getTile() && !accountPlayer->getTile()->hasFlag(TILESTATE_PROTECTIONZONE)) {
-					++countOutsizePZ;
-				}
-			}
-			if (countOutsizePZ >= maxOutsizePZ) {
-				disconnectClient(fmt::format("You can only have {} character{} from your account outside of a protection zone.", maxOutsizePZ == 1 ? "one" : std::to_string(maxOutsizePZ), maxOutsizePZ > 1 ? "s" : ""));
-				return;
-			}
-		}
-
-		if (!g_game().placeCreature(player, player->getLoginPosition()) && !g_game().placeCreature(player, player->getTemplePosition(), false, true)) {
-			disconnectClient("Temple position is wrong. Please, contact the administrator.");
-			g_logger().warn("Player {} temple position is wrong", player->getName());
-			return;
-		}
-
-		player->lastIP = player->getIP();
-		player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
-		player->loginProtectionTime = OTSYS_TIME() + g_configManager().getNumber(LOGIN_PROTECTION_TIME);
-		acceptPackets = true;
+		g_threadPool().detach_task([self = getThis(), operatingSystem]() {
+			// pool thread — populates only self->player (not yet in the world, and
+			// protected from a concurrent login by the reservation above). The two
+			// load steps that touch shared global state are deferred to finishLogin.
+			const bool loaded = IOLoginData::loadPlayerById(self->player, self->player->getGUID(), false, true);
+			g_dispatcher().addEvent([self, loaded, operatingSystem]() { self->finishLogin(loaded, operatingSystem); }, "ProtocolGame::finishLogin");
+		});
+		return;
 	} else {
 		if (eventConnect != 0 || !g_configManager().getBoolean(REPLACE_KICK_ON_LOGIN)) {
 			// Already trying to connect
@@ -731,7 +715,68 @@ void ProtocolGame::login(const std::string &name, uint32_t accountId, OperatingS
 		} else {
 			connect(foundPlayer->getName(), operatingSystem);
 		}
+
+		OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
+		sendBosstiaryCooldownTimer();
 	}
+}
+
+void ProtocolGame::finishLogin(bool loaded, OperatingSystem_t operatingSystem) {
+	// dispatcher thread — continuation after loadPlayerById ran on the pool.
+	const uint32_t guid = player ? player->getGUID() : 0;
+
+	// The client may have dropped while we were loading; nothing was placed in
+	// the world yet, so just release the reservation and bail.
+	if (!player || isConnectionExpired()) {
+		g_game().releaseLogin(guid);
+		return;
+	}
+
+	if (!loaded) {
+		g_game().releaseLogin(guid);
+		disconnectClient("Your character could not be loaded, please contact an adminstrator.");
+		return;
+	}
+
+	// Deferred load steps that mutate shared global state (guild registry, system
+	// initialization) — safe here on the dispatcher.
+	IOLoginData::loadPlayerWorldData(player);
+
+	player->setOperatingSystem(operatingSystem);
+
+	const auto tile = g_game().map.getOrCreateTile(player->getLoginPosition());
+	auto maxOnline = g_configManager().getNumber(MAX_PLAYERS_PER_ACCOUNT);
+	// moving from a pz tile to a non-pz tile
+	if (maxOnline > 1 && player->getAccountType() < ACCOUNT_TYPE_GAMEMASTER && !tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		auto maxOutsizePZ = g_configManager().getNumber(MAX_PLAYERS_OUTSIDE_PZ_PER_ACCOUNT);
+		auto accountPlayers = g_game().getPlayersByAccount(player->getAccount());
+		int countOutsizePZ = 0;
+		for (const auto &accountPlayer : accountPlayers) {
+			if (accountPlayer != player && accountPlayer->getTile() && !accountPlayer->getTile()->hasFlag(TILESTATE_PROTECTIONZONE)) {
+				++countOutsizePZ;
+			}
+		}
+		if (countOutsizePZ >= maxOutsizePZ) {
+			g_game().releaseLogin(guid);
+			disconnectClient(fmt::format("You can only have {} character{} from your account outside of a protection zone.", maxOutsizePZ == 1 ? "one" : std::to_string(maxOutsizePZ), maxOutsizePZ > 1 ? "s" : ""));
+			return;
+		}
+	}
+
+	if (!g_game().placeCreature(player, player->getLoginPosition()) && !g_game().placeCreature(player, player->getTemplePosition(), false, true)) {
+		g_game().releaseLogin(guid);
+		disconnectClient("Temple position is wrong. Please, contact the administrator.");
+		g_logger().warn("Player {} temple position is wrong", player->getName());
+		return;
+	}
+
+	player->lastIP = player->getIP();
+	player->lastLoginSaved = std::max<time_t>(time(nullptr), player->lastLoginSaved + 1);
+	player->loginProtectionTime = OTSYS_TIME() + g_configManager().getNumber(LOGIN_PROTECTION_TIME);
+	acceptPackets = true;
+
+	g_game().releaseLogin(guid);
+
 	OutputMessagePool::getInstance().addProtocolToAutosend(shared_from_this());
 	sendBosstiaryCooldownTimer();
 }

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -109,8 +109,9 @@ public:
 
 	void login(const std::string &name, uint32_t accnumber, OperatingSystem_t operatingSystem);
 	// Dispatcher-thread continuation of login() after the heavy character load
-	// has run on a pool thread. `loaded` is the result of loadPlayerById.
-	void finishLogin(bool loaded, OperatingSystem_t operatingSystem);
+	// has run on a pool thread. `reservedGuid` is the login reservation to
+	// release; `loaded` is the result of loadPlayerById.
+	void finishLogin(uint32_t reservedGuid, bool loaded, OperatingSystem_t operatingSystem);
 	void logout(bool displayEffect, bool forced);
 
 	void AddItem(NetworkMessage &msg, const std::shared_ptr<Item> &item);

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -108,6 +108,9 @@ public:
 	explicit ProtocolGame(const Connection_ptr &initConnection);
 
 	void login(const std::string &name, uint32_t accnumber, OperatingSystem_t operatingSystem);
+	// Dispatcher-thread continuation of login() after the heavy character load
+	// has run on a pool thread. `loaded` is the result of loadPlayerById.
+	void finishLogin(bool loaded, OperatingSystem_t operatingSystem);
 	void logout(bool displayEffect, bool forced);
 
 	void AddItem(NetworkMessage &msg, const std::shared_ptr<Item> &item);


### PR DESCRIPTION
## Problem

Every DB query in the server went through a single `MYSQL*` handle behind one global `std::recursive_mutex` (`Database::databaseLock`), so all queries — from every thread — were serialized. `ProtocolGame::login()` runs on the dispatcher (game-loop) thread and calls `loadPlayerById`, which issues ~20 sequential queries per character. Under mass login the dispatcher sat blocked on serialized DB I/O and the whole world stopped updating (movement, combat, `SERVER_BEAT`) while CPU stayed mostly idle.

## What changed

### 1. One MySQL connection per worker thread (lock-free hot path)

`Database` no longer holds a single handle. Each thread that touches the DB gets its own `ConnectionContext` (handle + `maxPacketSize` + `lastErrno`), created lazily on first query and cached in a `thread_local` pointer. A registry vector owns the contexts for shutdown; its mutex is taken once per thread, never on the query path. Because a context belongs to a single thread, the handle needs no lock — `storeQuery`/`executeQuery`/`escapeBlob` use `getContext().handle` directly. Public `Database` API is unchanged (~150 call sites untouched); connection params are captured in `connect()` and reused for each new per-thread connection.

- `mysql_library_init()` is now called explicitly once (via `call_once` in `connect()`, single-threaded at startup) — `mysql_init()`'s implicit init is not thread-safe when two threads race their first connection. `mysql_thread_init()` per connection, and `mysql_thread_end()` via a `thread_local` cleanup on thread exit.
- Transactions keep connection affinity for free (a tx runs on one thread → one connection). With real concurrency, InnoDB deadlocks / lock-wait timeouts (1213/1205) become possible, so `DBTransaction::executeWithinTransaction*` now retries the whole transaction up to 3x.

### 2. Player load off the dispatcher (login)

`login()` runs the cheap checks + waiting list, reserves the login (`Game::reserveLogin`, a dispatcher-only set), then dispatches `loadPlayerById` to the thread pool. Audit found only **2 of ~27** load steps mutate shared global state and are unsafe on a pool thread:

- `loadPlayerGuild` → writes the global guild map and mutates a shared `Guild`.
- `loadPlayerInitializeSystem` → mutates a shared `Party` via the wheel.

These (plus `updateSystem`/`exiva`, which must run *after* `initializeSystem`) are skipped on the pool (`deferWorldData = true`) and run on the dispatcher in `finishLogin` via `loadPlayerWorldData`. `finishLogin` then does the PZ check, `placeCreature`, `acceptPackets`, and `releaseLogin` on every exit path.

### 3. Thread-safe player save

The save already ran on pool threads but read the live `Player` while the dispatcher mutated it — a data race. `savePlayer` is now split into `buildPlayerSave` (serialize the player to SQL — runs on the dispatcher, consistent read) and `flushPlayerSave` (execute the SQL in a transaction — pool). It uses a `Database` query-capture mode: during the build, `executeQuery` records SQL into a buffer instead of running it. The `players.save` flag is cached on the `Player` at login so the build needs no DB round-trip (pure CPU). Per-player flushes are serialized/ordered (`m_flushInFlight` / `m_pendingFlushes`) so an older flush can never overwrite a newer one, and a save queued behind an in-flight one keeps its built SQL so a final (logout) save is never dropped. `saveAll` builds on the dispatcher and flushes on the pool.

## Review notes

- **Bottleneck moves to MySQL + thread-pool size.** Per-thread connections remove the global lock; throughput is now bounded by worker count and the MySQL server. Highest-leverage knob: thread pool size (`DEFAULT_NUMBER_OF_THREADS`, default 4), bounded by MySQL `max_connections`. Reducing the ~20 queries/load is the next lever.
- **Load ordering change:** guild now loads *after* the pool steps instead of mid-sequence; the `initializeSystem → updateSystem → exiva` order is preserved. No load step reads `player->guild`, so this is safe — worth a second look.
- **Query-capture edge case:** an incidental `executeQuery` during a build (only known case: a KV cache eviction) would be captured into the save buffer. Rare and bounded; documented in [docs/database-connection-model.md](https://github.com/opentibiabr/canary/blob/beats/db-per-thread-connections/docs/database-connection-model.md).
- `mysql_thread_end()` is released on thread exit via a `thread_local` cleanup.

## Not done

Mass-login load test with bots is **pending**. Validated so far: build, boot (per-thread connection logs appear as threads reach the DB), and login/logout/relog.

📄 **Full rationale and trade-offs:** [docs/database-connection-model.md](https://github.com/opentibiabr/canary/blob/beats/db-per-thread-connections/docs/database-connection-model.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login reservation to prevent duplicate concurrent character logins
  * Asynchronous thread-pool player loading with dispatcher continuation
  * Option to defer world-data initialization during login

* **Improvements**
  * Player save split into two-phase build (dispatcher) and flush (worker) flow with per-player coordination
  * Per-thread database connections and query capture/replay for thread-safe saves
  * Per-player cached save flag to avoid extra lookups

* **Bug Fixes**
  * Bounded automatic transaction retry for deadlock/timeout recovery

* **Documentation**
  * Added detailed database connection, concurrency, and tuning guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->