### PR TITLE
ci(release): materialize tags before publishing

### DIFF
--- a/.github/scripts/release_metadata.py
+++ b/.github/scripts/release_metadata.py
@@ -159,9 +159,27 @@ def semver_tags_merged_into(tag: str) -> list[str]:
     return [line.strip() for line in output.splitlines() if line.strip()]
 
 
+def semver_tags() -> list[str]:
+    output = run_git(["tag", "--sort=-version:refname", "--list", "v[0-9]*.[0-9]*.[0-9]*"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def semver_tuple(tag: str) -> tuple[int, int, int]:
+    version = parse_tag(tag)
+    major, minor, patch = version.split(".")
+    return int(major), int(minor), int(patch)
+
+
 def previous_semver_tag(tag: str) -> str:
     for candidate in semver_tags_merged_into(tag):
         if candidate != tag and TAG_RE.match(candidate):
+            return candidate
+
+    current_version = semver_tuple(tag)
+    for candidate in semver_tags():
+        if candidate == tag or not TAG_RE.match(candidate):
+            continue
+        if semver_tuple(candidate) < current_version:
             return candidate
     return ""
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,90 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare-tag:
+    name: Prepare Release Tag
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+      commit_sha: ${{ steps.prepare.outputs.commit_sha }}
+      metadata_changed: ${{ steps.prepare.outputs.metadata_changed }}
+      tag_updated: ${{ steps.prepare.outputs.tag_updated }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      ALLOW_TAG_UPDATE: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Materialize release tag
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --force --tags origin
+          python3 .github/scripts/release_metadata.py materialize --tag "${RELEASE_TAG}"
+
+          tracked_paths=(
+            src/core.hpp
+            config.lua.dist
+            docker/data/start.sh
+            docker/.env.dist
+            docker/docker-compose.yml
+            docker/DOCKER.md
+            docker/quickstart/myaac/bootstrap.php
+          )
+
+          metadata_changed=false
+          tag_updated=false
+          if ! git diff --quiet -- "${tracked_paths[@]}"; then
+            metadata_changed=true
+
+            if [[ "${ALLOW_TAG_UPDATE}" == "true" ]]; then
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git config user.name "GitHub Actions"
+              git add "${tracked_paths[@]}"
+              git commit -m "chore: materialize release metadata for ${RELEASE_TAG}"
+              tag_object_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags" \
+                -f "tag=${RELEASE_TAG}" \
+                -f "message=${RELEASE_TAG}" \
+                -f "object=$(git rev-parse HEAD)" \
+                -f "type=commit" \
+                --jq .sha)"
+              gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
+                -f "sha=${tag_object_sha}" \
+                -F force=true >/dev/null
+              tag_updated=true
+            else
+              echo "::warning::Release metadata differs for ${RELEASE_TAG}, but dry_run=true prevents updating the tag."
+            fi
+          fi
+
+          commit_sha="$(git rev-parse HEAD)"
+          {
+            echo "tag=${RELEASE_TAG}"
+            echo "commit_sha=${commit_sha}"
+            echo "metadata_changed=${metadata_changed}"
+            echo "tag_updated=${tag_updated}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "Prepared ${RELEASE_TAG} at ${commit_sha}."
+            echo "Metadata changed: ${metadata_changed}"
+            echo "Tag updated: ${tag_updated}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   validate:
     name: Validate Release Metadata
+    needs: prepare-tag
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,38 +118,43 @@ jobs:
       previous_tag: ${{ steps.metadata.outputs.previous_tag }}
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
       - name: Validate release metadata
         id: metadata
         env:
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          RELEASE_TAG: ${{ needs.prepare-tag.outputs.tag }}
         run: |
+          git fetch --force --tags origin
           python3 .github/scripts/release_metadata.py materialize --tag "$RELEASE_TAG"
           python3 .github/scripts/release_metadata.py check --tag "$RELEASE_TAG" --strict
 
   checks:
     name: Fast Checks
-    needs: validate
+    needs: [prepare-tag, validate]
     permissions:
       contents: write
       checks: write
     uses: ./.github/workflows/reusable-checks.yml
+    with:
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
   tests-lua:
     name: Lua Tests
-    needs: validate
+    needs: [prepare-tag, validate]
     permissions:
       contents: read
     uses: ./.github/workflows/reusable-tests-lua.yml
+    with:
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
   build-linux:
     name: Build - Linux
-    needs: [validate, checks, tests-lua]
+    needs: [prepare-tag, validate, checks, tests-lua]
     permissions:
       contents: write
       packages: write
@@ -77,12 +164,13 @@ jobs:
       run_canary_smoke: true
       run_global_smoke: false
       release_tag: ${{ needs.validate.outputs.tag }}
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
     secrets:
       VCPKG_PACKAGES_TOKEN: ${{ secrets.VCPKG_PACKAGES_TOKEN }}
 
   build-windows:
     name: Build - Windows
-    needs: [validate, checks, tests-lua]
+    needs: [prepare-tag, validate, checks, tests-lua]
     permissions:
       contents: read
       packages: write
@@ -90,10 +178,11 @@ jobs:
     with:
       run_canary_smoke: true
       release_tag: ${{ needs.validate.outputs.tag }}
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
   build-macos:
     name: Build - macOS
-    needs: [validate, checks, tests-lua]
+    needs: [prepare-tag, validate, checks, tests-lua]
     permissions:
       contents: read
       packages: write
@@ -101,22 +190,24 @@ jobs:
     with:
       run_canary_smoke: true
       release_tag: ${{ needs.validate.outputs.tag }}
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
     secrets:
       VCPKG_PACKAGES_TOKEN: ${{ secrets.VCPKG_PACKAGES_TOKEN }}
 
   build-docker:
     name: Build - Docker
-    needs: [validate, checks, tests-lua]
+    needs: [prepare-tag, validate, checks, tests-lua]
     permissions:
       contents: read
       packages: write
     uses: ./.github/workflows/reusable-build-docker.yml
     with:
       release_tag: ${{ needs.validate.outputs.tag }}
+      checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
   publish:
     name: Publish Release
-    needs: [validate, build-linux, build-windows, build-macos, build-docker]
+    needs: [prepare-tag, validate, build-linux, build-windows, build-macos, build-docker]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -127,17 +218,20 @@ jobs:
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
       PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
+      RELEASE_COMMIT_SHA: ${{ needs.prepare-tag.outputs.commit_sha }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.validate.outputs.tag }}
+          ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
       - name: Materialize release metadata
-        run: python3 .github/scripts/release_metadata.py materialize --tag "${RELEASE_TAG}"
+        run: |
+          git fetch --force --tags origin
+          python3 .github/scripts/release_metadata.py materialize --tag "${RELEASE_TAG}"
 
       - name: Prepare release notes
         shell: bash
@@ -146,7 +240,7 @@ jobs:
 
           notes_args=(
             -f "tag_name=${RELEASE_TAG}"
-            -f "target_commitish=$(git rev-parse "${RELEASE_TAG}^{commit}")"
+            -f "target_commitish=${RELEASE_COMMIT_SHA}"
           )
           if [[ -n "${PREVIOUS_TAG}" ]]; then
             notes_args+=(-f "previous_tag_name=${PREVIOUS_TAG}")
@@ -297,8 +391,8 @@ jobs:
 
   open-metadata-pr:
     name: Open Release Metadata PR
-    needs: [validate, publish]
-    if: github.event_name != 'workflow_dispatch' || inputs.dry_run == false
+    needs: [prepare-tag, validate, publish]
+    if: (github.event_name != 'workflow_dispatch' || inputs.dry_run == false) && needs.prepare-tag.outputs.metadata_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -307,68 +401,56 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}
-      CLIENT_VERSION: ${{ needs.validate.outputs.client_version }}
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v6
+      - name: Checkout materialized release commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
-          ref: main
+          persist-credentials: false
+          ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
-      - name: Update tracked release metadata
-        id: metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python3 .github/scripts/release_metadata.py update \
-            --version "${RELEASE_VERSION}" \
-            --client-version "${CLIENT_VERSION}"
-
-          if git diff --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "Tracked release metadata already matches ${RELEASE_TAG}."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
-
-      - name: Commit metadata update
-        if: steps.metadata.outputs.has_changes == 'true'
+      - name: Push metadata branch
+        id: branch
         shell: bash
         run: |
           set -euo pipefail
 
           branch="release-${RELEASE_TAG}-metadata"
+          if [[ ! "${branch}" =~ ^release-v[0-9]+\.[0-9]+\.[0-9]+-metadata$ ]]; then
+            echo "::error::Release metadata branch does not match expected pattern: ${branch}"
+            exit 1
+          fi
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "GitHub Actions"
-          git switch -c "${branch}"
-          git add \
-            src/core.hpp \
-            config.lua.dist \
-            docker/data/start.sh \
-            docker/.env.dist \
-            docker/docker-compose.yml \
-            docker/DOCKER.md \
-            docker/quickstart/myaac/bootstrap.php
-          git commit -m "chore: update release metadata to ${RELEASE_VERSION}"
-          git push --force-with-lease origin "HEAD:${branch}"
+          branch_sha="$(git rev-parse HEAD)"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
+              -f "sha=${branch_sha}" \
+              -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/heads/${branch}" \
+              -f "sha=${branch_sha}" >/dev/null
+          fi
 
-          echo "branch=${branch}" >> "$GITHUB_ENV"
+          echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
       - name: Open or update pull request
-        if: steps.metadata.outputs.has_changes == 'true'
         shell: bash
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           set -euo pipefail
+          if [[ ! "${BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.[0-9]+-metadata$ ]]; then
+            echo "::error::Release metadata branch does not match expected pattern: ${BRANCH}"
+            exit 1
+          fi
 
           existing_pr="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
             --base main \
-            --head "${branch}" \
+            --head "${BRANCH}" \
             --state open \
             --json number \
             --jq '.[0].number // empty')"
@@ -379,7 +461,7 @@ jobs:
 
           Release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}
 
-          This keeps the default map URL, Docker quickstart defaults, MyAAC client version, and server release version aligned with the latest published release.
+          This PR is based on the same materialized commit used by the release tag. Merging it keeps the default map URL, Docker quickstart defaults, MyAAC client version, and server release version aligned with the latest published release.
           EOF_PR
           )"
 
@@ -393,7 +475,7 @@ jobs:
             pr_url="$(gh pr create \
               --repo "${GITHUB_REPOSITORY}" \
               --base main \
-              --head "${branch}" \
+              --head "${BRANCH}" \
               --title "${title}" \
               --body "${body}")"
           fi

--- a/.github/workflows/reusable-build-docker.yml
+++ b/.github/workflows/reusable-build-docker.yml
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -20,9 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Materialize release metadata
         if: inputs.release_tag != ''

--- a/.github/workflows/reusable-build-linux.yml
+++ b/.github/workflows/reusable-build-linux.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
     secrets:
       VCPKG_PACKAGES_TOKEN:
         required: false
@@ -58,7 +63,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Materialize release metadata
         if: inputs.release_tag != ''

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
     secrets:
       VCPKG_PACKAGES_TOKEN:
         required: false
@@ -30,7 +35,19 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;nugettimeout,600;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'readwrite' || 'read' }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Materialize release metadata
         if: inputs.release_tag != ''

--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ""
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -48,7 +53,19 @@ jobs:
           vs-version: "latest"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Materialize release metadata
         if: inputs.release_tag != ''

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -3,23 +3,39 @@ name: Reusable Fast Checks
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   run-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (PR head branch for same-repo PRs)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == '' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.head_ref }}
 
       - name: Checkout repository (default ref)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Git
         run: |

--- a/.github/workflows/reusable-tests-lua.yml
+++ b/.github/workflows/reusable-tests-lua.yml
@@ -1,7 +1,14 @@
+---
 name: Reusable Lua Tests
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Optional ref or SHA to check out.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   job:
@@ -11,7 +18,18 @@ jobs:
       - name: Setup Lua
         run: sudo apt-get update && sudo apt-get install -y luajit
       - name: Check out code
-        uses: actions/checkout@v6
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check out requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
       - name: Run Tests
         run: |
           failed=0

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -1,0 +1,84 @@
+---
+name: Sync Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync merged release tag
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'release-v') && endsWith(github.event.pull_request.head.ref, '-metadata')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: main
+
+      - name: Move release tag to merged main commit
+        shell: bash
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          tag="${PR_HEAD_REF#release-}"
+          tag="${tag%-metadata}"
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping unexpected release metadata branch ${PR_HEAD_REF}."
+            exit 0
+          fi
+
+          git fetch --force --tags origin main
+
+          merge_sha="${MERGE_COMMIT_SHA}"
+          if [[ -z "${merge_sha}" || "${merge_sha}" == "null" ]]; then
+            merge_sha="$(git rev-parse origin/main)"
+          fi
+
+          current_sha="$(git rev-parse "${tag}^{commit}" 2>/dev/null || true)"
+          if [[ "${current_sha}" == "${merge_sha}" ]]; then
+            echo "${tag} already points to ${merge_sha}."
+            exit 0
+          fi
+          if [[ -z "${current_sha}" ]]; then
+            echo "::warning::${tag} does not exist; leaving tags unchanged."
+            exit 0
+          fi
+
+          current_tree="$(git rev-parse "${current_sha}^{tree}")"
+          merge_tree="$(git rev-parse "${merge_sha}^{tree}")"
+          if [[ "${current_tree}" != "${merge_tree}" ]]; then
+            echo "::warning::Merged commit ${merge_sha} contains changes outside ${tag}; leaving ${tag} at ${current_sha}."
+            {
+              echo "Kept ${tag} at ${current_sha} because ${merge_sha} has a different tree."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          tag_object_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f "tag=${tag}" \
+            -f "message=${tag}" \
+            -f "object=${merge_sha}" \
+            -f "type=commit" \
+            --jq .sha)"
+          gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
+            -f "sha=${tag_object_sha}" \
+            -F force=true >/dev/null
+
+          {
+            echo "Moved ${tag} from ${current_sha:-missing} to ${merge_sha}."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,27 +2,205 @@
 
 Canary releases are published from stable SemVer tags such as `v3.6.0`. Pushing
 a release tag starts `.github/workflows/release.yml`, materializes release
-metadata from the tag inside the GitHub Actions checkout, builds the release
-artifacts, copies `otservbr.otbm` from the latest published release, publishes
-the GitHub release after all assets are uploaded, and opens a pull request that
-syncs tracked release metadata back to `main`.
+metadata from the tag, moves the tag to that materialized commit when needed,
+builds the release artifacts, copies `otservbr.otbm` from the latest published
+release, publishes the GitHub release after all assets are uploaded, and opens a
+pull request that syncs tracked release metadata back to `main`.
 
 ## Publish
 
-Create and push the tag from the commit you want to release:
+Create and push the tag from the `main` commit you want to release. For a
+normal release, update your local `main` first:
 
 ```bash
+git switch main
+git pull --ff-only origin main
+git fetch --force --tags origin
 git tag -a v3.6.0 -m v3.6.0
 git push origin v3.6.0
 ```
 
 The tag is the source of truth for the release version. The workflow rewrites
-release-only metadata in its own checkout before building, so a release does not
-need a separate pull request just to change `3.5.0` to `3.6.0`.
+release-only metadata before building and force-updates the release tag to that
+materialized commit when the tracked files were stale. This keeps GitHub's
+automatic `Source code (zip)` and `Source code (tar.gz)` archives aligned with
+the published release.
 
 After publishing, the workflow opens or updates a branch named like
-`release-v3.6.0-metadata` with the permanent metadata changes. Review
-and merge that pull request to keep `main` aligned with the latest release.
+`release-v3.6.0-metadata` from the same materialized commit used by the release
+tag. Review and merge that pull request to keep `main` aligned with the latest
+release. After the pull request is merged, `.github/workflows/sync-release-tag.yml`
+moves the release tag to the merged `main` commit when that commit has the same
+tree as the materialized release commit. If `main` advanced with other changes
+before the metadata pull request was merged, the workflow leaves the tag on the
+release commit so the source archive does not accidentally include post-release
+changes.
+
+## Choosing The Next Version
+
+Use the smallest SemVer bump that accurately describes the user, operator, and
+developer impact since the previous release.
+
+- Patch, for example `v3.6.0` to `v3.6.1`: bug fixes, crash fixes,
+  non-breaking CI/build/release fixes, documentation updates, world-data fixes,
+  or small compatibility corrections that do not add a new public feature and do
+  not require operators to change configs, schemas, clients, or deployment
+  steps.
+- Minor, for example `v3.6.0` to `v3.7.0`: new backwards-compatible gameplay
+  features, new systems, new optional config, new supported protocol/client
+  functionality, compatible database migrations, new Docker/operator
+  convenience, or meaningful content additions.
+- Major, for example `v3.6.0` to `v4.0.0`: breaking config or deployment
+  changes, required manual operator migration, incompatible database/storage
+  changes, removed Lua/C++ APIs, removed supported behavior, protocol changes
+  that make existing clients or integrations incompatible, or any change where a
+  server owner should expect a migration project instead of a routine update.
+
+When a release contains both fixes and features, choose the highest required
+bump. When unsure between patch and minor, prefer minor if users or operators
+will notice new behavior. When unsure between minor and major, choose major only
+when an existing supported setup can break without a deliberate migration.
+
+## Tagging Tutorial
+
+This is the normal maintainer flow for publishing a new release:
+
+1. Inspect the changes since the latest stable release tag.
+2. Choose the next SemVer tag.
+3. Push the new annotated tag to GitHub.
+4. Wait for the `Release` workflow to finish.
+5. Check that the GitHub release has the expected assets.
+6. Merge the generated `release-vX.Y.Z-metadata` pull request.
+
+The release itself does not wait for the metadata pull request. The workflow
+uses the materialized release commit to publish the release and to keep GitHub's
+automatic source archives correct. The metadata pull request only keeps `main`
+aligned after the release is already published.
+
+First inspect the range since the latest stable release tag.
+
+On Bash:
+
+```bash
+git fetch origin main --tags
+previous_tag="$(git tag --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' | head -n 1)"
+git log --oneline --decorate --first-parent "${previous_tag}..origin/main"
+git diff --name-only "${previous_tag}..origin/main"
+```
+
+On PowerShell:
+
+```powershell
+git fetch origin main --tags
+$previousTag = git tag --sort=-version:refname --list "v[0-9]*.[0-9]*.[0-9]*" | Select-Object -First 1
+git log --oneline --decorate --first-parent "$previousTag..origin/main"
+git diff --name-only "$previousTag..origin/main"
+```
+
+Then choose the next version:
+
+- Patch: increment only the third number, for example `v3.6.0` to `v3.6.1`.
+- Minor: increment the second number and reset patch to zero, for example
+  `v3.6.0` to `v3.7.0`.
+- Major: increment the first number and reset minor and patch to zero, for
+  example `v3.6.0` to `v4.0.0`.
+
+After choosing the version, create and push an annotated tag. Replace `v3.7.0`
+with the version selected for the release.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch --force --tags origin
+git tag -a v3.7.0 -m v3.7.0
+git push origin v3.7.0
+```
+
+PowerShell uses the same Git commands:
+
+```powershell
+git switch main
+git pull --ff-only origin main
+git fetch --force --tags origin
+git tag -a v3.7.0 -m v3.7.0
+git push origin v3.7.0
+```
+
+Pushing the tag is the only action that starts the release. The workflow then:
+
+- materializes `SERVER_RELEASE_VERSION` from the tag;
+- updates release map URLs to the new tag;
+- updates Docker and MyAAC defaults from the current `CLIENT_VERSION` in
+  `src/core.hpp`;
+- creates a materialized release commit and moves the tag to it when tracked
+  metadata was stale;
+- runs checks and release builds;
+- downloads the GitHub Actions artifact zips and uploads them as release assets;
+- copies `otservbr.otbm` from the latest published release;
+- publishes the GitHub release;
+- opens `release-vX.Y.Z-metadata` so the same metadata can be merged into
+  `main`.
+
+After the workflow finishes, check the release page and confirm that these
+assets exist:
+
+- `canary-linux-release.zip`
+- `canary-linux-debug.zip`
+- `canary-windows-cmake-release.zip`
+- `canary-windows-solution-debug.zip`
+- `canary-macos-release.zip`
+- `canary-docker.zip`
+- `otservbr.otbm`
+
+Then merge the generated metadata pull request. That merge is required to keep
+`main` current, but it is not required for the already published release assets
+or GitHub source archives to be correct.
+
+If the supported Tibia protocol changed, update `CLIENT_VERSION` in
+`src/core.hpp` on a normal pull request before tagging. The release automation
+uses that value to update Docker and MyAAC defaults.
+
+Do not reuse an already published tag for a different release unless correcting
+a release automation incident. For routine releases, create the next SemVer tag.
+
+## AI Version Prompt
+
+Use this prompt when a maintainer wants help choosing the next tag. Paste the
+command output from the tagging tutorial into the placeholders.
+
+```markdown
+You are helping choose the next Canary release version.
+
+Previous release tag: <previous tag>
+Candidate release target: origin/main
+Commit range: <previous tag>..origin/main
+
+Use this SemVer policy:
+- PATCH for bug fixes, crash fixes, non-breaking CI/build/release fixes,
+  documentation updates, world-data fixes, or compatibility corrections that do
+  not require config, schema, client, deployment, or operator changes.
+- MINOR for backwards-compatible gameplay features, new systems, optional
+  config, new supported protocol/client functionality, compatible migrations,
+  Docker/operator convenience, or meaningful content additions.
+- MAJOR for breaking config/deployment changes, required manual migrations,
+  incompatible database/storage changes, removed APIs, removed supported
+  behavior, or protocol/client incompatibility.
+
+Analyze these inputs:
+
+Commit log:
+<paste git log --oneline --decorate --first-parent output>
+
+Changed files:
+<paste git diff --name-only output>
+
+Return:
+1. Recommended next tag.
+2. Whether the bump is patch, minor, or major.
+3. The concrete commits or file areas that justify the bump.
+4. Any release risks or manual notes maintainers should check.
+5. The exact tag commands to run.
+```
 
 ## Optional Metadata Update
 
@@ -71,8 +249,9 @@ workflow manually with:
 - `dry_run`: `true`
 
 Dry runs validate metadata, build artifacts, download the Action artifact zips,
-copy the map from the latest release, and prepare release notes. They skip
-release creation, asset upload, publishing, and the metadata pull request.
+copy the map from the latest release, and prepare release notes. They skip tag
+updates, release creation, asset upload, publishing, and the metadata pull
+request.
 
 ## Assets
 


### PR DESCRIPTION
## Summary
- materialize release metadata before build/publish and force-update the release tag when tracked metadata is stale
- pass the prepared release commit to reusable checks/builds so jobs do not checkout the original stale tag SHA
- open the metadata PR from the same materialized commit used by the release tag
- add a post-merge sync workflow that only retargets the release tag to `main` when the merged tree still matches the release tree
- document the new tag-driven release flow, including how to choose patch/minor/major tags and an AI prompt for deciding the next version

## Validation
- `python -m py_compile .github/scripts/release_metadata.py`
- `python .github/scripts/release_metadata.py check --tag v3.6.0 --strict`
- workflow YAML parsed with PyYAML
- `git diff --check`

`actionlint` is not installed in the local environment, so expression-level GitHub Actions linting was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release pipeline now materializes release metadata, pins a specific commit for builds/publish, and exposes tag/commit/metadata-change outputs via a prepare-tag job; downstream jobs run from that materialized commit.
  * Reusable workflows accept an optional checkout_ref to allow checking out a specific ref/SHA.
  * Added automated release-tag sync workflow for merged metadata branches.

* **Documentation**
  * Release docs rewritten to describe the tag-driven publish flow, metadata materialization, tag-sync behavior, and updated post-tag checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->