### PR TITLE
perf(database): reduce query construction allocations

### DIFF
--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -453,7 +453,7 @@ bool DBInsert::execute() {
 	if (!upsertColumns.empty()) {
 		size_t estimatedSize = 32;
 		for (const auto &column : upsertColumns) {
-			estimatedSize += (column.size() * 2) + 6;
+			estimatedSize += (column.size() * 2) + 16;
 		}
 
 		upsertQuery.reserve(estimatedSize);
@@ -467,8 +467,15 @@ bool DBInsert::execute() {
 	}
 
 	std::string currentBatch = values;
+	const bool baseHasSpace = !baseQuery.empty() && baseQuery.back() == ' ';
+	const size_t separatorSize = baseHasSpace ? 0U : 1U;
+	const size_t queryPrefixSize = baseQuery.size() + separatorSize + upsertQuery.size();
+	if (queryPrefixSize >= Database::MAX_QUERY_SIZE) {
+		return false;
+	}
+
 	while (!currentBatch.empty()) {
-		size_t cutPos = Database::MAX_QUERY_SIZE - baseQuery.size() - upsertQuery.size();
+		size_t cutPos = Database::MAX_QUERY_SIZE - queryPrefixSize;
 		if (cutPos < currentBatch.size()) {
 			cutPos = currentBatch.rfind("),(", cutPos);
 			if (cutPos == std::string::npos) {
@@ -486,8 +493,7 @@ bool DBInsert::execute() {
 		currentBatch = currentBatch.substr(cutPos);
 
 		std::string query;
-		const bool baseHasSpace = !baseQuery.empty() && baseQuery.back() == ' ';
-		query.reserve(baseQuery.size() + (baseHasSpace ? 0U : 1U) + batchValues.size() + upsertQuery.size());
+		query.reserve(queryPrefixSize + batchValues.size());
 		query.append(baseQuery);
 		if (!baseHasSpace) {
 			query.push_back(' ');

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -20,6 +20,17 @@
 	#include <fmt/format.h>
 #endif
 
+namespace {
+
+void appendInsertBaseQuery(std::string &sql, const std::string &baseQuery, bool baseHasSpace) {
+	sql += baseQuery;
+	if (!baseHasSpace) {
+		sql.push_back(' ');
+	}
+}
+
+}
+
 Database::~Database() {
 	if (handle != nullptr) {
 		mysql_close(handle);
@@ -447,11 +458,7 @@ bool DBInsert::execute() {
 		return true;
 	}
 
-	std::string baseQuery = this->query;
-	if (baseQuery.empty() || baseQuery.back() != ' ') {
-		baseQuery.push_back(' ');
-	}
-
+	const std::string &baseQuery = this->query;
 	std::string upsertQuery;
 
 	if (!upsertColumns.empty()) {
@@ -473,7 +480,9 @@ bool DBInsert::execute() {
 	}
 
 	std::string currentBatch = values;
-	const size_t queryPrefixSize = baseQuery.size() + upsertQuery.size();
+	const bool baseHasSpace = !baseQuery.empty() && baseQuery.back() == ' ';
+	const size_t separatorSize = baseHasSpace ? 0U : 1U;
+	const size_t queryPrefixSize = baseQuery.size() + separatorSize + upsertQuery.size();
 	if (queryPrefixSize >= Database::MAX_QUERY_SIZE) {
 		return false;
 	}
@@ -498,7 +507,7 @@ bool DBInsert::execute() {
 
 		std::string sql;
 		sql.reserve(queryPrefixSize + batchValues.size());
-		sql += baseQuery;
+		appendInsertBaseQuery(sql, baseQuery, baseHasSpace);
 		sql += batchValues;
 		sql += upsertQuery;
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -14,6 +14,8 @@
 #include "lib/metrics/metrics.hpp"
 #include "utils/tools.hpp"
 
+#include <iterator>
+
 Database::~Database() {
 	if (handle != nullptr) {
 		mysql_close(handle);
@@ -441,19 +443,23 @@ bool DBInsert::execute() {
 		return true;
 	}
 
-	std::string baseQuery = this->query;
+	const std::string &baseQuery = this->query;
 	std::string upsertQuery;
 
 	if (!upsertColumns.empty()) {
-		std::ostringstream upsertStream;
-		upsertStream << " ON DUPLICATE KEY UPDATE ";
+		size_t estimatedSize = 32;
+		for (const auto &column : upsertColumns) {
+			estimatedSize += (column.size() * 2) + 6;
+		}
+
+		upsertQuery.reserve(estimatedSize);
+		upsertQuery.append(" ON DUPLICATE KEY UPDATE ");
 		for (size_t i = 0; i < upsertColumns.size(); ++i) {
-			upsertStream << "`" << upsertColumns[i] << "` = VALUES(`" << upsertColumns[i] << "`)";
-			if (i < upsertColumns.size() - 1) {
-				upsertStream << ", ";
+			fmt::format_to(std::back_inserter(upsertQuery), "`{0}` = VALUES(`{0}`)", upsertColumns[i]);
+			if (i + 1 < upsertColumns.size()) {
+				upsertQuery.append(", ");
 			}
 		}
-		upsertQuery = upsertStream.str();
 	}
 
 	std::string currentBatch = values;
@@ -470,19 +476,27 @@ bool DBInsert::execute() {
 		}
 
 		std::string batchValues = currentBatch.substr(0, cutPos);
-		if (batchValues.back() == ',') {
+		if (!batchValues.empty() && batchValues.back() == ',') {
 			batchValues.pop_back();
 		}
 		currentBatch = currentBatch.substr(cutPos);
 
-		std::ostringstream query;
-		query << baseQuery << " " << batchValues << upsertQuery;
-		if (!Database::getInstance().executeQuery(query.str())) {
+		std::string query;
+		const bool baseHasSpace = !baseQuery.empty() && baseQuery.back() == ' ';
+		query.reserve(baseQuery.size() + (baseHasSpace ? 0U : 1U) + batchValues.size() + upsertQuery.size());
+		query.append(baseQuery);
+		if (!baseHasSpace) {
+			query.push_back(' ');
+		}
+		query.append(batchValues);
+		query.append(upsertQuery);
+
+		if (!g_database().executeQuery(query)) {
 			return false;
 		}
 	}
 
 	values.clear();
-	length = query.length();
+	length = this->query.length();
 	return true;
 }

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -18,11 +18,12 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <fmt/format.h>
+	#include <string_view>
 #endif
 
 namespace {
 
-	void appendInsertBaseQuery(std::string &sql, const std::string &baseQuery, bool baseHasSpace) {
+	void appendInsertBaseQuery(std::string &sql, std::string_view baseQuery, bool baseHasSpace) {
 		sql += baseQuery;
 		if (!baseHasSpace) {
 			sql.push_back(' ');

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -16,6 +16,10 @@
 
 #include <iterator>
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <fmt/format.h>
+#endif
+
 Database::~Database() {
 	if (handle != nullptr) {
 		mysql_close(handle);

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -22,12 +22,12 @@
 
 namespace {
 
-void appendInsertBaseQuery(std::string &sql, const std::string &baseQuery, bool baseHasSpace) {
-	sql += baseQuery;
-	if (!baseHasSpace) {
-		sql.push_back(' ');
+	void appendInsertBaseQuery(std::string &sql, const std::string &baseQuery, bool baseHasSpace) {
+		sql += baseQuery;
+		if (!baseHasSpace) {
+			sql.push_back(' ');
+		}
 	}
-}
 
 }
 

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -447,7 +447,11 @@ bool DBInsert::execute() {
 		return true;
 	}
 
-	const std::string &baseQuery = this->query;
+	std::string baseQuery = this->query;
+	if (baseQuery.empty() || baseQuery.back() != ' ') {
+		baseQuery.push_back(' ');
+	}
+
 	std::string upsertQuery;
 
 	if (!upsertColumns.empty()) {
@@ -457,19 +461,19 @@ bool DBInsert::execute() {
 		}
 
 		upsertQuery.reserve(estimatedSize);
-		upsertQuery.append(" ON DUPLICATE KEY UPDATE ");
+		upsertQuery += " ON DUPLICATE KEY UPDATE ";
+		auto upsertOutput = std::back_inserter(upsertQuery);
 		for (size_t i = 0; i < upsertColumns.size(); ++i) {
-			fmt::format_to(std::back_inserter(upsertQuery), "`{0}` = VALUES(`{0}`)", upsertColumns[i]);
+			upsertOutput = fmt::format_to(upsertOutput, "`{0}` = VALUES(`{0}`)", upsertColumns[i]);
 			if (i + 1 < upsertColumns.size()) {
-				upsertQuery.append(", ");
+				upsertQuery.push_back(',');
+				upsertQuery.push_back(' ');
 			}
 		}
 	}
 
 	std::string currentBatch = values;
-	const bool baseHasSpace = !baseQuery.empty() && baseQuery.back() == ' ';
-	const size_t separatorSize = baseHasSpace ? 0U : 1U;
-	const size_t queryPrefixSize = baseQuery.size() + separatorSize + upsertQuery.size();
+	const size_t queryPrefixSize = baseQuery.size() + upsertQuery.size();
 	if (queryPrefixSize >= Database::MAX_QUERY_SIZE) {
 		return false;
 	}
@@ -492,16 +496,13 @@ bool DBInsert::execute() {
 		}
 		currentBatch = currentBatch.substr(cutPos);
 
-		std::string query;
-		query.reserve(queryPrefixSize + batchValues.size());
-		query.append(baseQuery);
-		if (!baseHasSpace) {
-			query.push_back(' ');
-		}
-		query.append(batchValues);
-		query.append(upsertQuery);
+		std::string sql;
+		sql.reserve(queryPrefixSize + batchValues.size());
+		sql += baseQuery;
+		sql += batchValues;
+		sql += upsertQuery;
 
-		if (!g_database().executeQuery(query)) {
+		if (!g_database().executeQuery(sql)) {
 			return false;
 		}
 	}

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -28,6 +28,7 @@
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <fmt/format.h>
 	#include <string_view>
+	#include <utility>
 #endif
 
 bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
@@ -40,6 +41,7 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 	const uint32_t playerGuid = player->getGUID();
 	fmt::memory_buffer rowBuffer;
 	rowBuffer.reserve(256);
+	auto rowOutput = std::back_inserter(rowBuffer);
 
 	// Initialize variables
 	using ContainerBlock = std::pair<std::shared_ptr<Container>, int32_t>;
@@ -93,8 +95,8 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 
 		// Build query string and add row
 		rowBuffer.clear();
-		fmt::format_to(
-			std::back_inserter(rowBuffer),
+		rowOutput = fmt::format_to(
+			rowOutput,
 			"{},{},{},{},{},{}",
 			playerGuid,
 			pid,
@@ -158,8 +160,8 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 
 			// Build query string and add row
 			rowBuffer.clear();
-			fmt::format_to(
-				std::back_inserter(rowBuffer),
+			rowOutput = fmt::format_to(
+				rowOutput,
 				"{},{},{},{},{},{}",
 				playerGuid,
 				parentId,
@@ -215,12 +217,13 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 
 	std::string setClause;
 	setClause.reserve(4096);
+	auto setClauseOutput = std::back_inserter(setClause);
 
-	auto appendColumn = [&setClause]<typename... Args>(std::string_view format, Args &&... args) {
+	auto appendColumn = [&setClause, &setClauseOutput]<typename... Args>(std::string_view format, Args &&... args) {
 		if (!setClause.empty()) {
-			setClause.append(", ");
+			setClause += ", ";
 		}
-		fmt::format_to(std::back_inserter(setClause), fmt::runtime(format), args...);
+		setClauseOutput = fmt::format_to(setClauseOutput, fmt::runtime(format), std::forward<Args>(args)...);
 	};
 
 	appendColumn("`name` = {}", db.escapeString(player->name));
@@ -383,6 +386,7 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 	DBInsert stashQuery("INSERT INTO `player_stash` (`player_id`,`item_id`,`item_count`) VALUES ");
 	fmt::memory_buffer rowBuffer;
 	rowBuffer.reserve(48);
+	auto rowOutput = std::back_inserter(rowBuffer);
 	for (const auto &[itemId, itemCount] : player->getStashItems()) {
 		const ItemType &itemType = Item::items[itemId];
 		if (itemType.decayTo >= 0 && itemType.decayTime > 0) {
@@ -396,7 +400,7 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 		}
 
 		rowBuffer.clear();
-		fmt::format_to(std::back_inserter(rowBuffer), "{},{},{}", playerGuid, itemId, itemCount);
+		rowOutput = fmt::format_to(rowOutput, "{},{},{}", playerGuid, itemId, itemCount);
 		if (!stashQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
@@ -424,9 +428,10 @@ bool IOLoginDataSave::savePlayerSpells(const std::shared_ptr<Player> &player) {
 	DBInsert spellsQuery("INSERT INTO `player_spells` (`player_id`, `name` ) VALUES ");
 	fmt::memory_buffer rowBuffer;
 	rowBuffer.reserve(64);
+	auto rowOutput = std::back_inserter(rowBuffer);
 	for (const std::string &spellName : player->learnedInstantSpellList) {
 		rowBuffer.clear();
-		fmt::format_to(std::back_inserter(rowBuffer), "{},{}", playerGuid, db.escapeString(spellName));
+		rowOutput = fmt::format_to(rowOutput, "{},{}", playerGuid, db.escapeString(spellName));
 		if (!spellsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
@@ -454,9 +459,10 @@ bool IOLoginDataSave::savePlayerKills(const std::shared_ptr<Player> &player) {
 	DBInsert killsQuery("INSERT INTO `player_kills` (`player_id`, `target`, `time`, `unavenged`) VALUES");
 	fmt::memory_buffer rowBuffer;
 	rowBuffer.reserve(80);
+	auto rowOutput = std::back_inserter(rowBuffer);
 	for (const auto &kill : player->unjustifiedKills) {
 		rowBuffer.clear();
-		fmt::format_to(std::back_inserter(rowBuffer), "{},{},{},{}", playerGuid, kill.target, kill.time, kill.unavenged);
+		rowOutput = fmt::format_to(rowOutput, "{},{},{},{}", playerGuid, kill.target, kill.time, kill.unavenged);
 		if (!killsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
@@ -659,47 +665,52 @@ bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player)
 
 	Database &db = Database::getInstance();
 	const uint32_t playerGuid = player->getGUID();
-	if (g_configManager().getBoolean(PREY_ENABLED)) {
-		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
-			if (const auto &slot = player->getPreySlotById(static_cast<PreySlot_t>(slotId))) {
-				PropWriteStream propPreyStream;
-				[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propPreyStream](uint16_t raceId) {
-					propPreyStream.write<uint16_t>(raceId);
-				});
+	if (!g_configManager().getBoolean(PREY_ENABLED)) {
+		return true;
+	}
 
-				size_t preySize;
-				const char* preyList = propPreyStream.getStream(preySize);
-				const std::string query = fmt::format(
-					"INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
-					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
-					"ON DUPLICATE KEY UPDATE "
-					"`state` = VALUES(`state`), "
-					"`raceid` = VALUES(`raceid`), "
-					"`option` = VALUES(`option`), "
-					"`bonus_type` = VALUES(`bonus_type`), "
-					"`bonus_rarity` = VALUES(`bonus_rarity`), "
-					"`bonus_percentage` = VALUES(`bonus_percentage`), "
-					"`bonus_time` = VALUES(`bonus_time`), "
-					"`free_reroll` = VALUES(`free_reroll`), "
-					"`monster_list` = VALUES(`monster_list`)",
-					playerGuid,
-					static_cast<uint16_t>(slot->id),
-					static_cast<uint16_t>(slot->state),
-					slot->selectedRaceId,
-					static_cast<uint16_t>(slot->option),
-					static_cast<uint16_t>(slot->bonus),
-					static_cast<uint16_t>(slot->bonusRarity),
-					slot->bonusPercentage,
-					slot->bonusTimeLeft,
-					slot->freeRerollTimeStamp,
-					db.escapeBlob(preyList, static_cast<uint32_t>(preySize))
-				);
+	for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
+		const auto &slot = player->getPreySlotById(static_cast<PreySlot_t>(slotId));
+		if (!slot) {
+			continue;
+		}
 
-				if (!db.executeQuery(query)) {
-					g_logger().warn("[IOLoginData::savePlayer] - Error saving prey slot data from player: {}", player->getName());
-					return false;
-				}
-			}
+		PropWriteStream propPreyStream;
+		[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propPreyStream](uint16_t raceId) {
+			propPreyStream.write<uint16_t>(raceId);
+		});
+
+		size_t preySize;
+		const char* preyList = propPreyStream.getStream(preySize);
+		const std::string query = fmt::format(
+			"INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
+			"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+			"ON DUPLICATE KEY UPDATE "
+			"`state` = VALUES(`state`), "
+			"`raceid` = VALUES(`raceid`), "
+			"`option` = VALUES(`option`), "
+			"`bonus_type` = VALUES(`bonus_type`), "
+			"`bonus_rarity` = VALUES(`bonus_rarity`), "
+			"`bonus_percentage` = VALUES(`bonus_percentage`), "
+			"`bonus_time` = VALUES(`bonus_time`), "
+			"`free_reroll` = VALUES(`free_reroll`), "
+			"`monster_list` = VALUES(`monster_list`)",
+			playerGuid,
+			static_cast<uint16_t>(slot->id),
+			static_cast<uint16_t>(slot->state),
+			slot->selectedRaceId,
+			static_cast<uint16_t>(slot->option),
+			static_cast<uint16_t>(slot->bonus),
+			static_cast<uint16_t>(slot->bonusRarity),
+			slot->bonusPercentage,
+			slot->bonusTimeLeft,
+			slot->freeRerollTimeStamp,
+			db.escapeBlob(preyList, static_cast<uint32_t>(preySize))
+		);
+
+		if (!db.executeQuery(query)) {
+			g_logger().warn("[IOLoginData::savePlayer] - Error saving prey slot data from player: {}", player->getName());
+			return false;
 		}
 	}
 	return true;
@@ -713,45 +724,50 @@ bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &
 
 	Database &db = Database::getInstance();
 	const uint32_t playerGuid = player->getGUID();
-	if (g_configManager().getBoolean(TASK_HUNTING_ENABLED)) {
-		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
-			if (const auto &slot = player->getTaskHuntingSlotById(static_cast<PreySlot_t>(slotId))) {
-				PropWriteStream propTaskHuntingStream;
-				[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propTaskHuntingStream](uint16_t raceId) {
-					propTaskHuntingStream.write<uint16_t>(raceId);
-				});
+	if (!g_configManager().getBoolean(TASK_HUNTING_ENABLED)) {
+		return true;
+	}
 
-				size_t taskHuntingSize;
-				const char* taskHuntingList = propTaskHuntingStream.getStream(taskHuntingSize);
-				const std::string query = fmt::format(
-					"INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) "
-					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
-					"ON DUPLICATE KEY UPDATE "
-					"`state` = VALUES(`state`), "
-					"`raceid` = VALUES(`raceid`), "
-					"`upgrade` = VALUES(`upgrade`), "
-					"`rarity` = VALUES(`rarity`), "
-					"`kills` = VALUES(`kills`), "
-					"`disabled_time` = VALUES(`disabled_time`), "
-					"`free_reroll` = VALUES(`free_reroll`), "
-					"`monster_list` = VALUES(`monster_list`)",
-					playerGuid,
-					static_cast<uint16_t>(slot->id),
-					static_cast<uint16_t>(slot->state),
-					slot->selectedRaceId,
-					slot->upgrade ? 1 : 0,
-					static_cast<uint16_t>(slot->rarity),
-					slot->currentKills,
-					slot->disabledUntilTimeStamp,
-					slot->freeRerollTimeStamp,
-					db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize))
-				);
+	for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
+		const auto &slot = player->getTaskHuntingSlotById(static_cast<PreySlot_t>(slotId));
+		if (!slot) {
+			continue;
+		}
 
-				if (!db.executeQuery(query)) {
-					g_logger().warn("[IOLoginData::savePlayer] - Error saving task hunting slot data from player: {}", player->getName());
-					return false;
-				}
-			}
+		PropWriteStream propTaskHuntingStream;
+		[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propTaskHuntingStream](uint16_t raceId) {
+			propTaskHuntingStream.write<uint16_t>(raceId);
+		});
+
+		size_t taskHuntingSize;
+		const char* taskHuntingList = propTaskHuntingStream.getStream(taskHuntingSize);
+		const std::string query = fmt::format(
+			"INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) "
+			"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+			"ON DUPLICATE KEY UPDATE "
+			"`state` = VALUES(`state`), "
+			"`raceid` = VALUES(`raceid`), "
+			"`upgrade` = VALUES(`upgrade`), "
+			"`rarity` = VALUES(`rarity`), "
+			"`kills` = VALUES(`kills`), "
+			"`disabled_time` = VALUES(`disabled_time`), "
+			"`free_reroll` = VALUES(`free_reroll`), "
+			"`monster_list` = VALUES(`monster_list`)",
+			playerGuid,
+			static_cast<uint16_t>(slot->id),
+			static_cast<uint16_t>(slot->state),
+			slot->selectedRaceId,
+			slot->upgrade ? 1 : 0,
+			static_cast<uint16_t>(slot->rarity),
+			slot->currentKills,
+			slot->disabledUntilTimeStamp,
+			slot->freeRerollTimeStamp,
+			db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize))
+		);
+
+		if (!db.executeQuery(query)) {
+			g_logger().warn("[IOLoginData::savePlayer] - Error saving task hunting slot data from player: {}", player->getName());
+			return false;
 		}
 	}
 	return true;
@@ -794,8 +810,9 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 	const char* chars = stream.getStream(size);
 	fmt::memory_buffer rowBuffer;
 	rowBuffer.reserve(96);
-	fmt::format_to(
-		std::back_inserter(rowBuffer),
+	auto rowOutput = std::back_inserter(rowBuffer);
+	rowOutput = fmt::format_to(
+		rowOutput,
 		"{},{},{},{},{}",
 		playerGuid,
 		player->getSlotBossId(1),
@@ -803,6 +820,7 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 		player->getRemoveTimes(),
 		db.escapeBlob(chars, static_cast<uint32_t>(size))
 	);
+	static_cast<void>(rowOutput);
 
 	if (!insertQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 		return false;

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -211,57 +211,64 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 		return db.executeQuery(fmt::format("UPDATE `players` SET `lastlogin` = {}, `lastip` = {} WHERE `id` = {}", player->lastLoginSaved, player->lastIP, playerGuid));
 	}
 
-	std::vector<std::string> columns;
-	columns.reserve(96);
+	std::string setClause;
+	setClause.reserve(4096);
 
-	columns.emplace_back(fmt::format("`name` = {}", db.escapeString(player->name)));
-	columns.emplace_back(fmt::format("`level` = {}", player->level));
-	columns.emplace_back(fmt::format("`group_id` = {}", player->group->id));
-	columns.emplace_back(fmt::format("`vocation` = {}", player->getVocationId()));
-	columns.emplace_back(fmt::format("`health` = {}", player->health));
-	columns.emplace_back(fmt::format("`healthmax` = {}", player->healthMax));
-	columns.emplace_back(fmt::format("`experience` = {}", player->experience));
-	columns.emplace_back(fmt::format("`lookbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookBody)));
-	columns.emplace_back(fmt::format("`lookfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookFeet)));
-	columns.emplace_back(fmt::format("`lookhead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookHead)));
-	columns.emplace_back(fmt::format("`looklegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookLegs)));
-	columns.emplace_back(fmt::format("`looktype` = {}", player->defaultOutfit.lookType));
-	columns.emplace_back(fmt::format("`lookaddons` = {}", static_cast<uint32_t>(player->defaultOutfit.lookAddons)));
-	columns.emplace_back(fmt::format("`lookmountbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountBody)));
-	columns.emplace_back(fmt::format("`lookmountfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountFeet)));
-	columns.emplace_back(fmt::format("`lookmounthead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountHead)));
-	columns.emplace_back(fmt::format("`lookmountlegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountLegs)));
-	columns.emplace_back(fmt::format("`lookfamiliarstype` = {}", player->defaultOutfit.lookFamiliarsType));
-	columns.emplace_back(fmt::format("`isreward` = {}", static_cast<uint16_t>(player->isDailyReward)));
-	columns.emplace_back(fmt::format("`maglevel` = {}", player->magLevel));
-	columns.emplace_back(fmt::format("`mana` = {}", player->mana));
-	columns.emplace_back(fmt::format("`manamax` = {}", player->manaMax));
-	columns.emplace_back(fmt::format("`manaspent` = {}", player->manaSpent));
-	columns.emplace_back(fmt::format("`soul` = {}", static_cast<uint16_t>(player->soul)));
+	auto appendColumn = [&setClause]<typename... Args>(fmt::format_string<Args...> format, Args &&... args) {
+		if (!setClause.empty()) {
+			setClause.append(", ");
+		}
+		fmt::format_to(std::back_inserter(setClause), format, args...);
+	};
+
+	appendColumn("`name` = {}", db.escapeString(player->name));
+	appendColumn("`level` = {}", player->level);
+	appendColumn("`group_id` = {}", player->group->id);
+	appendColumn("`vocation` = {}", player->getVocationId());
+	appendColumn("`health` = {}", player->health);
+	appendColumn("`healthmax` = {}", player->healthMax);
+	appendColumn("`experience` = {}", player->experience);
+	appendColumn("`lookbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookBody));
+	appendColumn("`lookfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookFeet));
+	appendColumn("`lookhead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookHead));
+	appendColumn("`looklegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookLegs));
+	appendColumn("`looktype` = {}", player->defaultOutfit.lookType);
+	appendColumn("`lookaddons` = {}", static_cast<uint32_t>(player->defaultOutfit.lookAddons));
+	appendColumn("`lookmountbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountBody));
+	appendColumn("`lookmountfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountFeet));
+	appendColumn("`lookmounthead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountHead));
+	appendColumn("`lookmountlegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountLegs));
+	appendColumn("`lookfamiliarstype` = {}", player->defaultOutfit.lookFamiliarsType);
+	appendColumn("`isreward` = {}", static_cast<uint16_t>(player->isDailyReward));
+	appendColumn("`maglevel` = {}", player->magLevel);
+	appendColumn("`mana` = {}", player->mana);
+	appendColumn("`manamax` = {}", player->manaMax);
+	appendColumn("`manaspent` = {}", player->manaSpent);
+	appendColumn("`soul` = {}", static_cast<uint16_t>(player->soul));
 	if (player->town) {
-		columns.emplace_back(fmt::format("`town_id` = {}", player->town->getID()));
+		appendColumn("`town_id` = {}", player->town->getID());
 	}
 
 	const Position &loginPosition = player->getLoginPosition();
-	columns.emplace_back(fmt::format("`posx` = {}", loginPosition.getX()));
-	columns.emplace_back(fmt::format("`posy` = {}", loginPosition.getY()));
-	columns.emplace_back(fmt::format("`posz` = {}", loginPosition.getZ()));
+	appendColumn("`posx` = {}", loginPosition.getX());
+	appendColumn("`posy` = {}", loginPosition.getY());
+	appendColumn("`posz` = {}", loginPosition.getZ());
 
-	columns.emplace_back(fmt::format("`prey_wildcard` = {}", player->getPreyCards()));
-	columns.emplace_back(fmt::format("`task_points` = {}", player->getTaskHuntingPoints()));
-	columns.emplace_back(fmt::format("`boss_points` = {}", player->getBossPoints()));
-	columns.emplace_back(fmt::format("`forge_dusts` = {}", player->getForgeDusts()));
-	columns.emplace_back(fmt::format("`forge_dust_level` = {}", player->getForgeDustLevel()));
-	columns.emplace_back(fmt::format("`randomize_mount` = {}", static_cast<uint16_t>(player->isRandomMounted())));
-	columns.emplace_back(fmt::format("`cap` = {}", (player->capacity / 100)));
-	columns.emplace_back(fmt::format("`sex` = {}", static_cast<uint16_t>(player->sex)));
+	appendColumn("`prey_wildcard` = {}", player->getPreyCards());
+	appendColumn("`task_points` = {}", player->getTaskHuntingPoints());
+	appendColumn("`boss_points` = {}", player->getBossPoints());
+	appendColumn("`forge_dusts` = {}", player->getForgeDusts());
+	appendColumn("`forge_dust_level` = {}", player->getForgeDustLevel());
+	appendColumn("`randomize_mount` = {}", static_cast<uint16_t>(player->isRandomMounted()));
+	appendColumn("`cap` = {}", (player->capacity / 100));
+	appendColumn("`sex` = {}", static_cast<uint16_t>(player->sex));
 
 	if (player->lastLoginSaved != 0) {
-		columns.emplace_back(fmt::format("`lastlogin` = {}", player->lastLoginSaved));
+		appendColumn("`lastlogin` = {}", player->lastLoginSaved);
 	}
 
 	if (player->lastIP != 0) {
-		columns.emplace_back(fmt::format("`lastip` = {}", player->lastIP));
+		appendColumn("`lastip` = {}", player->lastIP);
 	}
 
 	// serialize conditions
@@ -276,7 +283,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	size_t attributesSize;
 	const char* attributes = propWriteStream.getStream(attributesSize);
 
-	columns.emplace_back(fmt::format("`conditions` = {}", db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))));
+	appendColumn("`conditions` = {}", db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize)));
 
 	// serialize animus mastery
 	PropWriteStream propAnimusMasteryStream;
@@ -284,7 +291,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	size_t animusMasterySize;
 	const char* animusMastery = propAnimusMasteryStream.getStream(animusMasterySize);
 
-	columns.emplace_back(fmt::format("`animus_mastery` = {}", db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize))));
+	appendColumn("`animus_mastery` = {}", db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize)));
 
 	if (g_game().getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
 		int64_t skullTime = 0;
@@ -294,7 +301,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 			skullTime = now + player->skullTicks;
 		}
 
-		columns.emplace_back(fmt::format("`skulltime` = {}", skullTime));
+		appendColumn("`skulltime` = {}", skullTime);
 
 		Skulls_t skull = SKULL_NONE;
 		if (player->skull == SKULL_RED) {
@@ -302,68 +309,54 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 		} else if (player->skull == SKULL_BLACK) {
 			skull = SKULL_BLACK;
 		}
-		columns.emplace_back(fmt::format("`skull` = {}", static_cast<int64_t>(skull)));
+		appendColumn("`skull` = {}", static_cast<int64_t>(skull));
 	}
 
-	columns.emplace_back(fmt::format("`lastlogout` = {}", player->getLastLogout()));
-	columns.emplace_back(fmt::format("`balance` = {}", player->bankBalance));
-	columns.emplace_back(fmt::format("`offlinetraining_time` = {}", player->getOfflineTrainingTime() / 1000));
-	columns.emplace_back(fmt::format("`offlinetraining_skill` = {}", std::to_string(player->getOfflineTrainingSkill())));
-	columns.emplace_back(fmt::format("`stamina` = {}", player->getStaminaMinutes()));
-	columns.emplace_back(fmt::format("`skill_fist` = {}", player->skills[SKILL_FIST].level));
-	columns.emplace_back(fmt::format("`skill_fist_tries` = {}", player->skills[SKILL_FIST].tries));
-	columns.emplace_back(fmt::format("`skill_club` = {}", player->skills[SKILL_CLUB].level));
-	columns.emplace_back(fmt::format("`skill_club_tries` = {}", player->skills[SKILL_CLUB].tries));
-	columns.emplace_back(fmt::format("`skill_sword` = {}", player->skills[SKILL_SWORD].level));
-	columns.emplace_back(fmt::format("`skill_sword_tries` = {}", player->skills[SKILL_SWORD].tries));
-	columns.emplace_back(fmt::format("`skill_axe` = {}", player->skills[SKILL_AXE].level));
-	columns.emplace_back(fmt::format("`skill_axe_tries` = {}", player->skills[SKILL_AXE].tries));
-	columns.emplace_back(fmt::format("`skill_dist` = {}", player->skills[SKILL_DISTANCE].level));
-	columns.emplace_back(fmt::format("`skill_dist_tries` = {}", player->skills[SKILL_DISTANCE].tries));
-	columns.emplace_back(fmt::format("`skill_shielding` = {}", player->skills[SKILL_SHIELD].level));
-	columns.emplace_back(fmt::format("`skill_shielding_tries` = {}", player->skills[SKILL_SHIELD].tries));
-	columns.emplace_back(fmt::format("`skill_fishing` = {}", player->skills[SKILL_FISHING].level));
-	columns.emplace_back(fmt::format("`skill_fishing_tries` = {}", player->skills[SKILL_FISHING].tries));
-	columns.emplace_back(fmt::format("`skill_critical_hit_chance` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].level));
-	columns.emplace_back(fmt::format("`skill_critical_hit_chance_tries` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].tries));
-	columns.emplace_back(fmt::format("`skill_critical_hit_damage` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].level));
-	columns.emplace_back(fmt::format("`skill_critical_hit_damage_tries` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries));
-	columns.emplace_back(fmt::format("`skill_life_leech_chance` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].level));
-	columns.emplace_back(fmt::format("`skill_life_leech_chance_tries` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].tries));
-	columns.emplace_back(fmt::format("`skill_life_leech_amount` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].level));
-	columns.emplace_back(fmt::format("`skill_life_leech_amount_tries` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].tries));
-	columns.emplace_back(fmt::format("`skill_mana_leech_chance` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].level));
-	columns.emplace_back(fmt::format("`skill_mana_leech_chance_tries` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].tries));
-	columns.emplace_back(fmt::format("`skill_mana_leech_amount` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].level));
-	columns.emplace_back(fmt::format("`skill_mana_leech_amount_tries` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].tries));
-	columns.emplace_back(fmt::format("`manashield` = {}", player->getManaShield()));
-	columns.emplace_back(fmt::format("`max_manashield` = {}", player->getMaxManaShield()));
-	columns.emplace_back(fmt::format("`xpboost_value` = {}", player->getXpBoostPercent()));
-	columns.emplace_back(fmt::format("`xpboost_stamina` = {}", player->getXpBoostTime()));
-	columns.emplace_back(fmt::format("`quickloot_fallback` = {}", player->quickLootFallbackToMainContainer ? 1 : 0));
+	appendColumn("`lastlogout` = {}", player->getLastLogout());
+	appendColumn("`balance` = {}", player->bankBalance);
+	appendColumn("`offlinetraining_time` = {}", player->getOfflineTrainingTime() / 1000);
+	appendColumn("`offlinetraining_skill` = {}", player->getOfflineTrainingSkill());
+	appendColumn("`stamina` = {}", player->getStaminaMinutes());
+	appendColumn("`skill_fist` = {}", player->skills[SKILL_FIST].level);
+	appendColumn("`skill_fist_tries` = {}", player->skills[SKILL_FIST].tries);
+	appendColumn("`skill_club` = {}", player->skills[SKILL_CLUB].level);
+	appendColumn("`skill_club_tries` = {}", player->skills[SKILL_CLUB].tries);
+	appendColumn("`skill_sword` = {}", player->skills[SKILL_SWORD].level);
+	appendColumn("`skill_sword_tries` = {}", player->skills[SKILL_SWORD].tries);
+	appendColumn("`skill_axe` = {}", player->skills[SKILL_AXE].level);
+	appendColumn("`skill_axe_tries` = {}", player->skills[SKILL_AXE].tries);
+	appendColumn("`skill_dist` = {}", player->skills[SKILL_DISTANCE].level);
+	appendColumn("`skill_dist_tries` = {}", player->skills[SKILL_DISTANCE].tries);
+	appendColumn("`skill_shielding` = {}", player->skills[SKILL_SHIELD].level);
+	appendColumn("`skill_shielding_tries` = {}", player->skills[SKILL_SHIELD].tries);
+	appendColumn("`skill_fishing` = {}", player->skills[SKILL_FISHING].level);
+	appendColumn("`skill_fishing_tries` = {}", player->skills[SKILL_FISHING].tries);
+	appendColumn("`skill_critical_hit_chance` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].level);
+	appendColumn("`skill_critical_hit_chance_tries` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].tries);
+	appendColumn("`skill_critical_hit_damage` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].level);
+	appendColumn("`skill_critical_hit_damage_tries` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries);
+	appendColumn("`skill_life_leech_chance` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].level);
+	appendColumn("`skill_life_leech_chance_tries` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].tries);
+	appendColumn("`skill_life_leech_amount` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].level);
+	appendColumn("`skill_life_leech_amount_tries` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].tries);
+	appendColumn("`skill_mana_leech_chance` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].level);
+	appendColumn("`skill_mana_leech_chance_tries` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].tries);
+	appendColumn("`skill_mana_leech_amount` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].level);
+	appendColumn("`skill_mana_leech_amount_tries` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].tries);
+	appendColumn("`manashield` = {}", player->getManaShield());
+	appendColumn("`max_manashield` = {}", player->getMaxManaShield());
+	appendColumn("`xpboost_value` = {}", player->getXpBoostPercent());
+	appendColumn("`xpboost_stamina` = {}", player->getXpBoostTime());
+	appendColumn("`quickloot_fallback` = {}", player->quickLootFallbackToMainContainer ? 1 : 0);
 
 	if (!player->isOffline()) {
 		auto now = std::chrono::system_clock::now();
 		auto lastLoginSaved = std::chrono::system_clock::from_time_t(player->lastLoginSaved);
-		columns.emplace_back(fmt::format("`onlinetime` = `onlinetime` + {}", std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count()));
+		appendColumn("`onlinetime` = `onlinetime` + {}", std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count());
 	}
 
 	for (int i = 1; i <= 8; i++) {
-		columns.emplace_back(fmt::format("`blessings{}` = {}", i, static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i)))));
-	}
-
-	size_t estimatedSize = 0;
-	for (const auto &column : columns) {
-		estimatedSize += column.size() + 2;
-	}
-
-	std::string setClause;
-	setClause.reserve(estimatedSize);
-	for (size_t i = 0; i < columns.size(); ++i) {
-		setClause.append(columns[i]);
-		if (i + 1 < columns.size()) {
-			setClause.append(", ");
-		}
+		appendColumn("`blessings{}` = {}", i, static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i))));
 	}
 
 	if (!db.executeQuery(fmt::format("UPDATE `players` SET {} WHERE `id` = {}", setClause, playerGuid))) {

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -25,6 +25,10 @@
 
 #include <iterator>
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <fmt/format.h>
+#endif
+
 bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
@@ -195,73 +199,69 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	savePlayerExivaRestrictions(player);
 
 	Database &db = Database::getInstance();
+	const uint32_t playerGuid = player->getGUID();
 
-	std::ostringstream query;
-	query << "SELECT `save` FROM `players` WHERE `id` = " << player->getGUID();
-	DBResult_ptr result = db.storeQuery(query.str());
+	DBResult_ptr result = db.storeQuery(fmt::format("SELECT `save` FROM `players` WHERE `id` = {}", playerGuid));
 	if (!result) {
 		g_logger().warn("[IOLoginData::savePlayer] - Error for select result query from player: {}", player->getName());
 		return false;
 	}
 
 	if (result->getNumber<uint16_t>("save") == 0) {
-		query.str("");
-		query << "UPDATE `players` SET `lastlogin` = " << player->lastLoginSaved << ", `lastip` = " << player->lastIP << " WHERE `id` = " << player->getGUID();
-		return db.executeQuery(query.str());
+		return db.executeQuery(fmt::format("UPDATE `players` SET `lastlogin` = {}, `lastip` = {} WHERE `id` = {}", player->lastLoginSaved, player->lastIP, playerGuid));
 	}
 
-	// First, an UPDATE query to write the player itself
-	query.str("");
-	query << "UPDATE `players` SET ";
-	query << "`name` = " << db.escapeString(player->name) << ",";
-	query << "`level` = " << player->level << ",";
-	query << "`group_id` = " << player->group->id << ",";
-	query << "`vocation` = " << player->getVocationId() << ",";
-	query << "`health` = " << player->health << ",";
-	query << "`healthmax` = " << player->healthMax << ",";
-	query << "`experience` = " << player->experience << ",";
-	query << "`lookbody` = " << static_cast<uint32_t>(player->defaultOutfit.lookBody) << ",";
-	query << "`lookfeet` = " << static_cast<uint32_t>(player->defaultOutfit.lookFeet) << ",";
-	query << "`lookhead` = " << static_cast<uint32_t>(player->defaultOutfit.lookHead) << ",";
-	query << "`looklegs` = " << static_cast<uint32_t>(player->defaultOutfit.lookLegs) << ",";
-	query << "`looktype` = " << player->defaultOutfit.lookType << ",";
-	query << "`lookaddons` = " << static_cast<uint32_t>(player->defaultOutfit.lookAddons) << ",";
-	query << "`lookmountbody` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountBody) << ",";
-	query << "`lookmountfeet` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountFeet) << ",";
-	query << "`lookmounthead` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountHead) << ",";
-	query << "`lookmountlegs` = " << static_cast<uint32_t>(player->defaultOutfit.lookMountLegs) << ",";
-	query << "`lookfamiliarstype` = " << player->defaultOutfit.lookFamiliarsType << ",";
-	query << "`isreward` = " << static_cast<uint16_t>(player->isDailyReward) << ",";
-	query << "`maglevel` = " << player->magLevel << ",";
-	query << "`mana` = " << player->mana << ",";
-	query << "`manamax` = " << player->manaMax << ",";
-	query << "`manaspent` = " << player->manaSpent << ",";
-	query << "`soul` = " << static_cast<uint16_t>(player->soul) << ",";
+	std::vector<std::string> columns;
+	columns.reserve(96);
+
+	columns.emplace_back(fmt::format("`name` = {}", db.escapeString(player->name)));
+	columns.emplace_back(fmt::format("`level` = {}", player->level));
+	columns.emplace_back(fmt::format("`group_id` = {}", player->group->id));
+	columns.emplace_back(fmt::format("`vocation` = {}", player->getVocationId()));
+	columns.emplace_back(fmt::format("`health` = {}", player->health));
+	columns.emplace_back(fmt::format("`healthmax` = {}", player->healthMax));
+	columns.emplace_back(fmt::format("`experience` = {}", player->experience));
+	columns.emplace_back(fmt::format("`lookbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookBody)));
+	columns.emplace_back(fmt::format("`lookfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookFeet)));
+	columns.emplace_back(fmt::format("`lookhead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookHead)));
+	columns.emplace_back(fmt::format("`looklegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookLegs)));
+	columns.emplace_back(fmt::format("`looktype` = {}", player->defaultOutfit.lookType));
+	columns.emplace_back(fmt::format("`lookaddons` = {}", static_cast<uint32_t>(player->defaultOutfit.lookAddons)));
+	columns.emplace_back(fmt::format("`lookmountbody` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountBody)));
+	columns.emplace_back(fmt::format("`lookmountfeet` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountFeet)));
+	columns.emplace_back(fmt::format("`lookmounthead` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountHead)));
+	columns.emplace_back(fmt::format("`lookmountlegs` = {}", static_cast<uint32_t>(player->defaultOutfit.lookMountLegs)));
+	columns.emplace_back(fmt::format("`lookfamiliarstype` = {}", player->defaultOutfit.lookFamiliarsType));
+	columns.emplace_back(fmt::format("`isreward` = {}", static_cast<uint16_t>(player->isDailyReward)));
+	columns.emplace_back(fmt::format("`maglevel` = {}", player->magLevel));
+	columns.emplace_back(fmt::format("`mana` = {}", player->mana));
+	columns.emplace_back(fmt::format("`manamax` = {}", player->manaMax));
+	columns.emplace_back(fmt::format("`manaspent` = {}", player->manaSpent));
+	columns.emplace_back(fmt::format("`soul` = {}", static_cast<uint16_t>(player->soul)));
 	if (player->town) {
-		query << "`town_id` = " << player->town->getID() << ",";
+		columns.emplace_back(fmt::format("`town_id` = {}", player->town->getID()));
 	}
 
 	const Position &loginPosition = player->getLoginPosition();
-	query << "`posx` = " << loginPosition.getX() << ",";
-	query << "`posy` = " << loginPosition.getY() << ",";
-	query << "`posz` = " << loginPosition.getZ() << ",";
+	columns.emplace_back(fmt::format("`posx` = {}", loginPosition.getX()));
+	columns.emplace_back(fmt::format("`posy` = {}", loginPosition.getY()));
+	columns.emplace_back(fmt::format("`posz` = {}", loginPosition.getZ()));
 
-	query << "`prey_wildcard` = " << player->getPreyCards() << ",";
-	query << "`task_points` = " << player->getTaskHuntingPoints() << ",";
-	query << "`boss_points` = " << player->getBossPoints() << ",";
-	query << "`forge_dusts` = " << player->getForgeDusts() << ",";
-	query << "`forge_dust_level` = " << player->getForgeDustLevel() << ",";
-	query << "`randomize_mount` = " << static_cast<uint16_t>(player->isRandomMounted()) << ",";
-
-	query << "`cap` = " << (player->capacity / 100) << ",";
-	query << "`sex` = " << static_cast<uint16_t>(player->sex) << ",";
+	columns.emplace_back(fmt::format("`prey_wildcard` = {}", player->getPreyCards()));
+	columns.emplace_back(fmt::format("`task_points` = {}", player->getTaskHuntingPoints()));
+	columns.emplace_back(fmt::format("`boss_points` = {}", player->getBossPoints()));
+	columns.emplace_back(fmt::format("`forge_dusts` = {}", player->getForgeDusts()));
+	columns.emplace_back(fmt::format("`forge_dust_level` = {}", player->getForgeDustLevel()));
+	columns.emplace_back(fmt::format("`randomize_mount` = {}", static_cast<uint16_t>(player->isRandomMounted())));
+	columns.emplace_back(fmt::format("`cap` = {}", (player->capacity / 100)));
+	columns.emplace_back(fmt::format("`sex` = {}", static_cast<uint16_t>(player->sex)));
 
 	if (player->lastLoginSaved != 0) {
-		query << "`lastlogin` = " << player->lastLoginSaved << ",";
+		columns.emplace_back(fmt::format("`lastlogin` = {}", player->lastLoginSaved));
 	}
 
 	if (player->lastIP != 0) {
-		query << "`lastip` = " << player->lastIP << ",";
+		columns.emplace_back(fmt::format("`lastip` = {}", player->lastIP));
 	}
 
 	// serialize conditions
@@ -276,7 +276,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	size_t attributesSize;
 	const char* attributes = propWriteStream.getStream(attributesSize);
 
-	query << "`conditions` = " << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize)) << ",";
+	columns.emplace_back(fmt::format("`conditions` = {}", db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))));
 
 	// serialize animus mastery
 	PropWriteStream propAnimusMasteryStream;
@@ -284,7 +284,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	size_t animusMasterySize;
 	const char* animusMastery = propAnimusMasteryStream.getStream(animusMasterySize);
 
-	query << "`animus_mastery` = " << db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize)) << ",";
+	columns.emplace_back(fmt::format("`animus_mastery` = {}", db.escapeBlob(animusMastery, static_cast<uint32_t>(animusMasterySize))));
 
 	if (g_game().getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
 		int64_t skullTime = 0;
@@ -294,7 +294,7 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 			skullTime = now + player->skullTicks;
 		}
 
-		query << "`skulltime` = " << skullTime << ",";
+		columns.emplace_back(fmt::format("`skulltime` = {}", skullTime));
 
 		Skulls_t skull = SKULL_NONE;
 		if (player->skull == SKULL_RED) {
@@ -302,59 +302,71 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 		} else if (player->skull == SKULL_BLACK) {
 			skull = SKULL_BLACK;
 		}
-		query << "`skull` = " << static_cast<int64_t>(skull) << ",";
+		columns.emplace_back(fmt::format("`skull` = {}", static_cast<int64_t>(skull)));
 	}
 
-	query << "`lastlogout` = " << player->getLastLogout() << ",";
-	query << "`balance` = " << player->bankBalance << ",";
-	query << "`offlinetraining_time` = " << player->getOfflineTrainingTime() / 1000 << ",";
-	query << "`offlinetraining_skill` = " << std::to_string(player->getOfflineTrainingSkill()) << ",";
-	query << "`stamina` = " << player->getStaminaMinutes() << ",";
-	query << "`skill_fist` = " << player->skills[SKILL_FIST].level << ",";
-	query << "`skill_fist_tries` = " << player->skills[SKILL_FIST].tries << ",";
-	query << "`skill_club` = " << player->skills[SKILL_CLUB].level << ",";
-	query << "`skill_club_tries` = " << player->skills[SKILL_CLUB].tries << ",";
-	query << "`skill_sword` = " << player->skills[SKILL_SWORD].level << ",";
-	query << "`skill_sword_tries` = " << player->skills[SKILL_SWORD].tries << ",";
-	query << "`skill_axe` = " << player->skills[SKILL_AXE].level << ",";
-	query << "`skill_axe_tries` = " << player->skills[SKILL_AXE].tries << ",";
-	query << "`skill_dist` = " << player->skills[SKILL_DISTANCE].level << ",";
-	query << "`skill_dist_tries` = " << player->skills[SKILL_DISTANCE].tries << ",";
-	query << "`skill_shielding` = " << player->skills[SKILL_SHIELD].level << ",";
-	query << "`skill_shielding_tries` = " << player->skills[SKILL_SHIELD].tries << ",";
-	query << "`skill_fishing` = " << player->skills[SKILL_FISHING].level << ",";
-	query << "`skill_fishing_tries` = " << player->skills[SKILL_FISHING].tries << ",";
-	query << "`skill_critical_hit_chance` = " << player->skills[SKILL_CRITICAL_HIT_CHANCE].level << ",";
-	query << "`skill_critical_hit_chance_tries` = " << player->skills[SKILL_CRITICAL_HIT_CHANCE].tries << ",";
-	query << "`skill_critical_hit_damage` = " << player->skills[SKILL_CRITICAL_HIT_DAMAGE].level << ",";
-	query << "`skill_critical_hit_damage_tries` = " << player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries << ",";
-	query << "`skill_life_leech_chance` = " << player->skills[SKILL_LIFE_LEECH_CHANCE].level << ",";
-	query << "`skill_life_leech_chance_tries` = " << player->skills[SKILL_LIFE_LEECH_CHANCE].tries << ",";
-	query << "`skill_life_leech_amount` = " << player->skills[SKILL_LIFE_LEECH_AMOUNT].level << ",";
-	query << "`skill_life_leech_amount_tries` = " << player->skills[SKILL_LIFE_LEECH_AMOUNT].tries << ",";
-	query << "`skill_mana_leech_chance` = " << player->skills[SKILL_MANA_LEECH_CHANCE].level << ",";
-	query << "`skill_mana_leech_chance_tries` = " << player->skills[SKILL_MANA_LEECH_CHANCE].tries << ",";
-	query << "`skill_mana_leech_amount` = " << player->skills[SKILL_MANA_LEECH_AMOUNT].level << ",";
-	query << "`skill_mana_leech_amount_tries` = " << player->skills[SKILL_MANA_LEECH_AMOUNT].tries << ",";
-	query << "`manashield` = " << player->getManaShield() << ",";
-	query << "`max_manashield` = " << player->getMaxManaShield() << ",";
-	query << "`xpboost_value` = " << player->getXpBoostPercent() << ",";
-	query << "`xpboost_stamina` = " << player->getXpBoostTime() << ",";
-	query << "`quickloot_fallback` = " << (player->quickLootFallbackToMainContainer ? 1 : 0) << ",";
+	columns.emplace_back(fmt::format("`lastlogout` = {}", player->getLastLogout()));
+	columns.emplace_back(fmt::format("`balance` = {}", player->bankBalance));
+	columns.emplace_back(fmt::format("`offlinetraining_time` = {}", player->getOfflineTrainingTime() / 1000));
+	columns.emplace_back(fmt::format("`offlinetraining_skill` = {}", std::to_string(player->getOfflineTrainingSkill())));
+	columns.emplace_back(fmt::format("`stamina` = {}", player->getStaminaMinutes()));
+	columns.emplace_back(fmt::format("`skill_fist` = {}", player->skills[SKILL_FIST].level));
+	columns.emplace_back(fmt::format("`skill_fist_tries` = {}", player->skills[SKILL_FIST].tries));
+	columns.emplace_back(fmt::format("`skill_club` = {}", player->skills[SKILL_CLUB].level));
+	columns.emplace_back(fmt::format("`skill_club_tries` = {}", player->skills[SKILL_CLUB].tries));
+	columns.emplace_back(fmt::format("`skill_sword` = {}", player->skills[SKILL_SWORD].level));
+	columns.emplace_back(fmt::format("`skill_sword_tries` = {}", player->skills[SKILL_SWORD].tries));
+	columns.emplace_back(fmt::format("`skill_axe` = {}", player->skills[SKILL_AXE].level));
+	columns.emplace_back(fmt::format("`skill_axe_tries` = {}", player->skills[SKILL_AXE].tries));
+	columns.emplace_back(fmt::format("`skill_dist` = {}", player->skills[SKILL_DISTANCE].level));
+	columns.emplace_back(fmt::format("`skill_dist_tries` = {}", player->skills[SKILL_DISTANCE].tries));
+	columns.emplace_back(fmt::format("`skill_shielding` = {}", player->skills[SKILL_SHIELD].level));
+	columns.emplace_back(fmt::format("`skill_shielding_tries` = {}", player->skills[SKILL_SHIELD].tries));
+	columns.emplace_back(fmt::format("`skill_fishing` = {}", player->skills[SKILL_FISHING].level));
+	columns.emplace_back(fmt::format("`skill_fishing_tries` = {}", player->skills[SKILL_FISHING].tries));
+	columns.emplace_back(fmt::format("`skill_critical_hit_chance` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_critical_hit_chance_tries` = {}", player->skills[SKILL_CRITICAL_HIT_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_critical_hit_damage` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].level));
+	columns.emplace_back(fmt::format("`skill_critical_hit_damage_tries` = {}", player->skills[SKILL_CRITICAL_HIT_DAMAGE].tries));
+	columns.emplace_back(fmt::format("`skill_life_leech_chance` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_life_leech_chance_tries` = {}", player->skills[SKILL_LIFE_LEECH_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_life_leech_amount` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].level));
+	columns.emplace_back(fmt::format("`skill_life_leech_amount_tries` = {}", player->skills[SKILL_LIFE_LEECH_AMOUNT].tries));
+	columns.emplace_back(fmt::format("`skill_mana_leech_chance` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].level));
+	columns.emplace_back(fmt::format("`skill_mana_leech_chance_tries` = {}", player->skills[SKILL_MANA_LEECH_CHANCE].tries));
+	columns.emplace_back(fmt::format("`skill_mana_leech_amount` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].level));
+	columns.emplace_back(fmt::format("`skill_mana_leech_amount_tries` = {}", player->skills[SKILL_MANA_LEECH_AMOUNT].tries));
+	columns.emplace_back(fmt::format("`manashield` = {}", player->getManaShield()));
+	columns.emplace_back(fmt::format("`max_manashield` = {}", player->getMaxManaShield()));
+	columns.emplace_back(fmt::format("`xpboost_value` = {}", player->getXpBoostPercent()));
+	columns.emplace_back(fmt::format("`xpboost_stamina` = {}", player->getXpBoostTime()));
+	columns.emplace_back(fmt::format("`quickloot_fallback` = {}", player->quickLootFallbackToMainContainer ? 1 : 0));
 
 	if (!player->isOffline()) {
 		auto now = std::chrono::system_clock::now();
 		auto lastLoginSaved = std::chrono::system_clock::from_time_t(player->lastLoginSaved);
-		query << "`onlinetime` = `onlinetime` + " << std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count() << ",";
+		columns.emplace_back(fmt::format("`onlinetime` = `onlinetime` + {}", std::chrono::duration_cast<std::chrono::seconds>(now - lastLoginSaved).count()));
 	}
 
 	for (int i = 1; i <= 8; i++) {
-		query << "`blessings" << i << "`"
-			  << " = " << static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i))) << ((i == 8) ? " " : ",");
+		columns.emplace_back(fmt::format("`blessings{}` = {}", i, static_cast<uint32_t>(player->getBlessingCount(static_cast<uint8_t>(i)))));
 	}
-	query << " WHERE `id` = " << player->getGUID();
 
-	if (!db.executeQuery(query.str())) {
+	size_t estimatedSize = 0;
+	for (const auto &column : columns) {
+		estimatedSize += column.size() + 2;
+	}
+
+	std::string setClause;
+	setClause.reserve(estimatedSize);
+	for (size_t i = 0; i < columns.size(); ++i) {
+		setClause.append(columns[i]);
+		if (i + 1 < columns.size()) {
+			setClause.append(", ");
+		}
+	}
+
+	if (!db.executeQuery(fmt::format("UPDATE `players` SET {} WHERE `id` = {}", setClause, playerGuid))) {
 		return false;
 	}
 	return true;

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -23,6 +23,8 @@
 #include "io/player_storage_repository.hpp"
 #include "kv/kv.hpp"
 
+#include <iterator>
+
 bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
 	if (!player) {
 		g_logger().warn("[IOLoginData::savePlayer] - Player nullptr: {}", __FUNCTION__);
@@ -30,7 +32,9 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 	}
 
 	const Database &db = Database::getInstance();
-	std::ostringstream ss;
+	const uint32_t playerGuid = player->getGUID();
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(256);
 
 	// Initialize variables
 	using ContainerBlock = std::pair<std::shared_ptr<Container>, int32_t>;
@@ -83,8 +87,18 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 		const char* attributes = propWriteStream.getStream(attributesSize);
 
 		// Build query string and add row
-		ss << player->getGUID() << ',' << pid << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize));
-		if (!query_insert.addRow(ss)) {
+		rowBuffer.clear();
+		fmt::format_to(
+			std::back_inserter(rowBuffer),
+			"{},{},{},{},{},{}",
+			playerGuid,
+			pid,
+			runningId,
+			item->getID(),
+			item->getSubType(),
+			db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))
+		);
+		if (!query_insert.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			g_logger().error("Error adding row to query.");
 			return false;
 		}
@@ -137,8 +151,18 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 			const char* attributes = propWriteStream.getStream(attributesSize);
 
 			// Build query string and add row
-			ss << player->getGUID() << ',' << parentId << ',' << runningId << ',' << item->getID() << ',' << item->getSubType() << ',' << db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize));
-			if (!query_insert.addRow(ss)) {
+			rowBuffer.clear();
+			fmt::format_to(
+				std::back_inserter(rowBuffer),
+				"{},{},{},{},{},{}",
+				playerGuid,
+				parentId,
+				runningId,
+				item->getID(),
+				item->getSubType(),
+				db.escapeBlob(attributes, static_cast<uint32_t>(attributesSize))
+			);
+			if (!query_insert.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 				g_logger().error("Error adding row to query for container item.");
 				return false;
 			}

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -27,6 +27,7 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <fmt/format.h>
+	#include <string_view>
 #endif
 
 bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const ItemBlockList &itemList, DBInsert &query_insert, PropWriteStream &propWriteStream) {
@@ -214,11 +215,11 @@ bool IOLoginDataSave::savePlayerFirst(const std::shared_ptr<Player> &player) {
 	std::string setClause;
 	setClause.reserve(4096);
 
-	auto appendColumn = [&setClause]<typename... Args>(fmt::format_string<Args...> format, Args &&... args) {
+	auto appendColumn = [&setClause]<typename... Args>(std::string_view format, Args &&... args) {
 		if (!setClause.empty()) {
 			setClause.append(", ");
 		}
-		fmt::format_to(std::back_inserter(setClause), format, args...);
+		fmt::format_to(std::back_inserter(setClause), fmt::runtime(format), args...);
 	};
 
 	appendColumn("`name` = {}", db.escapeString(player->name));

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -114,6 +114,7 @@ bool IOLoginDataSave::saveItems(const std::shared_ptr<Player> &player, const Ite
 		const ContainerBlock &cb = queue.front();
 		const std::shared_ptr<Container> &container = cb.first;
 		if (!container) {
+			queue.pop_front();
 			continue;
 		}
 

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -379,15 +379,15 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 	}
 
 	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_stash` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_stash` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert stashQuery("INSERT INTO `player_stash` (`player_id`,`item_id`,`item_count`) VALUES ");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(48);
 	for (const auto &[itemId, itemCount] : player->getStashItems()) {
 		const ItemType &itemType = Item::items[itemId];
 		if (itemType.decayTo >= 0 && itemType.decayTime > 0) {
@@ -400,8 +400,9 @@ bool IOLoginDataSave::savePlayerStash(const std::shared_ptr<Player> &player) {
 			continue;
 		}
 
-		query << player->getGUID() << ',' << itemId << ',' << itemCount;
-		if (!stashQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(std::back_inserter(rowBuffer), "{},{},{}", playerGuid, itemId, itemCount);
+		if (!stashQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -419,18 +420,19 @@ bool IOLoginDataSave::savePlayerSpells(const std::shared_ptr<Player> &player) {
 	}
 
 	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_spells` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_spells` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert spellsQuery("INSERT INTO `player_spells` (`player_id`, `name` ) VALUES ");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(64);
 	for (const std::string &spellName : player->learnedInstantSpellList) {
-		query << player->getGUID() << ',' << db.escapeString(spellName);
-		if (!spellsQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(std::back_inserter(rowBuffer), "{},{}", playerGuid, db.escapeString(spellName));
+		if (!spellsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -448,18 +450,19 @@ bool IOLoginDataSave::savePlayerKills(const std::shared_ptr<Player> &player) {
 	}
 
 	Database &db = Database::getInstance();
-	std::ostringstream query;
-	query << "DELETE FROM `player_kills` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_kills` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
-
 	DBInsert killsQuery("INSERT INTO `player_kills` (`player_id`, `target`, `time`, `unavenged`) VALUES");
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(80);
 	for (const auto &kill : player->unjustifiedKills) {
-		query << player->getGUID() << ',' << kill.target << ',' << kill.time << ',' << kill.unavenged;
-		if (!killsQuery.addRow(query)) {
+		rowBuffer.clear();
+		fmt::format_to(std::back_inserter(rowBuffer), "{},{},{},{}", playerGuid, kill.target, kill.time, kill.unavenged);
+		if (!killsQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 			return false;
 		}
 	}
@@ -477,16 +480,7 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 
 	Database &db = Database::getInstance();
-
-	std::ostringstream query;
-	query << "UPDATE `player_charms` SET ";
-	query << "`charm_points` = " << player->charmPoints << ",";
-	query << "`minor_charm_echoes` = " << player->minorCharmEchoes << ",";
-	query << "`max_charm_points` = " << player->maxCharmPoints << ",";
-	query << "`max_minor_charm_echoes` = " << player->maxMinorCharmEchoes << ",";
-	query << "`charm_expansion` = " << (player->charmExpansion ? 1 : 0) << ",";
-	query << "`UsedRunesBit` = " << player->UsedRunesBit << ",";
-	query << "`UnlockedRunesBit` = " << player->UnlockedRunesBit << ",";
+	const uint32_t playerGuid = player->getGUID();
 
 	PropWriteStream charmsStream;
 	for (uint8_t id = magic_enum::enum_value<charmRune_t>(1); id <= magic_enum::enum_count<charmRune_t>(); id++) {
@@ -497,7 +491,6 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 	size_t size;
 	const char* charmsList = charmsStream.getStream(size);
-	query << " `charms` = " << db.escapeBlob(charmsList, static_cast<uint32_t>(size)) << ",";
 
 	PropWriteStream propBestiaryStream;
 	for (const auto &trackedType : player->getCyclopediaMonsterTrackerSet(false)) {
@@ -505,10 +498,31 @@ bool IOLoginDataSave::savePlayerBestiarySystem(const std::shared_ptr<Player> &pl
 	}
 	size_t trackerSize;
 	const char* trackerList = propBestiaryStream.getStream(trackerSize);
-	query << " `tracker list` = " << db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize));
-	query << " WHERE `player_id` = " << player->getGUID();
+	const std::string query = fmt::format(
+		"UPDATE `player_charms` SET "
+		"`charm_points` = {}, "
+		"`minor_charm_echoes` = {}, "
+		"`max_charm_points` = {}, "
+		"`max_minor_charm_echoes` = {}, "
+		"`charm_expansion` = {}, "
+		"`UsedRunesBit` = {}, "
+		"`UnlockedRunesBit` = {}, "
+		"`charms` = {}, "
+		"`tracker list` = {} "
+		"WHERE `player_id` = {}",
+		player->charmPoints,
+		player->minorCharmEchoes,
+		player->maxCharmPoints,
+		player->maxMinorCharmEchoes,
+		player->charmExpansion ? 1 : 0,
+		player->UsedRunesBit,
+		player->UnlockedRunesBit,
+		db.escapeBlob(charmsList, static_cast<uint32_t>(size)),
+		db.escapeBlob(trackerList, static_cast<uint32_t>(trackerSize)),
+		playerGuid
+	);
 
-	if (!db.executeQuery(query.str())) {
+	if (!db.executeQuery(query)) {
 		g_logger().warn("[IOLoginData::savePlayer] - Error saving bestiary data from player: {}", player->getName());
 		return false;
 	}
@@ -523,9 +537,9 @@ bool IOLoginDataSave::savePlayerItem(const std::shared_ptr<Player> &player) {
 
 	Database &db = Database::getInstance();
 	PropWriteStream propWriteStream;
-	std::ostringstream query;
-	query << "DELETE FROM `player_items` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_items` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		g_logger().warn("[IOLoginData::savePlayer] - Error delete query 'player_items' from player: {}", player->getName());
 		return false;
 	}
@@ -556,15 +570,13 @@ bool IOLoginDataSave::savePlayerDepotItems(const std::shared_ptr<Player> &player
 	Database &db = Database::getInstance();
 	PropWriteStream propWriteStream;
 	ItemDepotList depotList;
+	const uint32_t playerGuid = player->getGUID();
 	if (player->lastDepotId != -1) {
-		std::ostringstream query;
-		query << "DELETE FROM `player_depotitems` WHERE `player_id` = " << player->getGUID();
+		const std::string deleteQuery = fmt::format("DELETE FROM `player_depotitems` WHERE `player_id` = {}", playerGuid);
 
-		if (!db.executeQuery(query.str())) {
+		if (!db.executeQuery(deleteQuery)) {
 			return false;
 		}
-
-		query.str("");
 
 		DBInsert depotQuery("INSERT INTO `player_depotitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 
@@ -588,10 +600,11 @@ bool IOLoginDataSave::saveRewardItems(const std::shared_ptr<Player> &player) {
 		return false;
 	}
 
-	std::ostringstream query;
-	query << "DELETE FROM `player_rewards` WHERE `player_id` = " << player->getGUID();
+	Database &db = Database::getInstance();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_rewards` WHERE `player_id` = {}", playerGuid);
 
-	if (!Database::getInstance().executeQuery(query.str())) {
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
@@ -625,13 +638,12 @@ bool IOLoginDataSave::savePlayerInbox(const std::shared_ptr<Player> &player) {
 	Database &db = Database::getInstance();
 	PropWriteStream propWriteStream;
 	ItemInboxList inboxList;
-	std::ostringstream query;
-	query << "DELETE FROM `player_inboxitems` WHERE `player_id` = " << player->getGUID();
-	if (!db.executeQuery(query.str())) {
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_inboxitems` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
 	DBInsert inboxQuery("INSERT INTO `player_inboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 
 	for (const auto &item : player->getInbox()->getItemList()) {
@@ -651,23 +663,10 @@ bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player)
 	}
 
 	Database &db = Database::getInstance();
+	const uint32_t playerGuid = player->getGUID();
 	if (g_configManager().getBoolean(PREY_ENABLED)) {
-		std::ostringstream query;
 		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
 			if (const auto &slot = player->getPreySlotById(static_cast<PreySlot_t>(slotId))) {
-				query.str(std::string());
-				query << "INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
-					  << "VALUES (" << player->getGUID() << ", "
-					  << static_cast<uint16_t>(slot->id) << ", "
-					  << static_cast<uint16_t>(slot->state) << ", "
-					  << slot->selectedRaceId << ", "
-					  << static_cast<uint16_t>(slot->option) << ", "
-					  << static_cast<uint16_t>(slot->bonus) << ", "
-					  << static_cast<uint16_t>(slot->bonusRarity) << ", "
-					  << slot->bonusPercentage << ", "
-					  << slot->bonusTimeLeft << ", "
-					  << slot->freeRerollTimeStamp << ", ";
-
 				PropWriteStream propPreyStream;
 				[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propPreyStream](uint16_t raceId) {
 					propPreyStream.write<uint16_t>(raceId);
@@ -675,20 +674,33 @@ bool IOLoginDataSave::savePlayerPreyClass(const std::shared_ptr<Player> &player)
 
 				size_t preySize;
 				const char* preyList = propPreyStream.getStream(preySize);
-				query << db.escapeBlob(preyList, static_cast<uint32_t>(preySize)) << ")";
+				const std::string query = fmt::format(
+					"INSERT INTO player_prey (`player_id`, `slot`, `state`, `raceid`, `option`, `bonus_type`, `bonus_rarity`, `bonus_percentage`, `bonus_time`, `free_reroll`, `monster_list`) "
+					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+					"ON DUPLICATE KEY UPDATE "
+					"`state` = VALUES(`state`), "
+					"`raceid` = VALUES(`raceid`), "
+					"`option` = VALUES(`option`), "
+					"`bonus_type` = VALUES(`bonus_type`), "
+					"`bonus_rarity` = VALUES(`bonus_rarity`), "
+					"`bonus_percentage` = VALUES(`bonus_percentage`), "
+					"`bonus_time` = VALUES(`bonus_time`), "
+					"`free_reroll` = VALUES(`free_reroll`), "
+					"`monster_list` = VALUES(`monster_list`)",
+					playerGuid,
+					static_cast<uint16_t>(slot->id),
+					static_cast<uint16_t>(slot->state),
+					slot->selectedRaceId,
+					static_cast<uint16_t>(slot->option),
+					static_cast<uint16_t>(slot->bonus),
+					static_cast<uint16_t>(slot->bonusRarity),
+					slot->bonusPercentage,
+					slot->bonusTimeLeft,
+					slot->freeRerollTimeStamp,
+					db.escapeBlob(preyList, static_cast<uint32_t>(preySize))
+				);
 
-				query << " ON DUPLICATE KEY UPDATE "
-					  << "`state` = VALUES(`state`), "
-					  << "`raceid` = VALUES(`raceid`), "
-					  << "`option` = VALUES(`option`), "
-					  << "`bonus_type` = VALUES(`bonus_type`), "
-					  << "`bonus_rarity` = VALUES(`bonus_rarity`), "
-					  << "`bonus_percentage` = VALUES(`bonus_percentage`), "
-					  << "`bonus_time` = VALUES(`bonus_time`), "
-					  << "`free_reroll` = VALUES(`free_reroll`), "
-					  << "`monster_list` = VALUES(`monster_list`)";
-
-				if (!db.executeQuery(query.str())) {
+				if (!db.executeQuery(query)) {
 					g_logger().warn("[IOLoginData::savePlayer] - Error saving prey slot data from player: {}", player->getName());
 					return false;
 				}
@@ -705,22 +717,10 @@ bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &
 	}
 
 	Database &db = Database::getInstance();
+	const uint32_t playerGuid = player->getGUID();
 	if (g_configManager().getBoolean(TASK_HUNTING_ENABLED)) {
-		std::ostringstream query;
 		for (uint8_t slotId = PreySlot_First; slotId <= PreySlot_Last; slotId++) {
 			if (const auto &slot = player->getTaskHuntingSlotById(static_cast<PreySlot_t>(slotId))) {
-				query.str("");
-				query << "INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) VALUES (";
-				query << player->getGUID() << ", ";
-				query << static_cast<uint16_t>(slot->id) << ", ";
-				query << static_cast<uint16_t>(slot->state) << ", ";
-				query << slot->selectedRaceId << ", ";
-				query << (slot->upgrade ? 1 : 0) << ", ";
-				query << static_cast<uint16_t>(slot->rarity) << ", ";
-				query << slot->currentKills << ", ";
-				query << slot->disabledUntilTimeStamp << ", ";
-				query << slot->freeRerollTimeStamp << ", ";
-
 				PropWriteStream propTaskHuntingStream;
 				[[maybe_unused]] auto lambda = std::ranges::for_each(slot->raceIdList, [&propTaskHuntingStream](uint16_t raceId) {
 					propTaskHuntingStream.write<uint16_t>(raceId);
@@ -728,19 +728,31 @@ bool IOLoginDataSave::savePlayerTaskHuntingClass(const std::shared_ptr<Player> &
 
 				size_t taskHuntingSize;
 				const char* taskHuntingList = propTaskHuntingStream.getStream(taskHuntingSize);
-				query << db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize)) << ")";
+				const std::string query = fmt::format(
+					"INSERT INTO `player_taskhunt` (`player_id`, `slot`, `state`, `raceid`, `upgrade`, `rarity`, `kills`, `disabled_time`, `free_reroll`, `monster_list`) "
+					"VALUES ({}, {}, {}, {}, {}, {}, {}, {}, {}, {}) "
+					"ON DUPLICATE KEY UPDATE "
+					"`state` = VALUES(`state`), "
+					"`raceid` = VALUES(`raceid`), "
+					"`upgrade` = VALUES(`upgrade`), "
+					"`rarity` = VALUES(`rarity`), "
+					"`kills` = VALUES(`kills`), "
+					"`disabled_time` = VALUES(`disabled_time`), "
+					"`free_reroll` = VALUES(`free_reroll`), "
+					"`monster_list` = VALUES(`monster_list`)",
+					playerGuid,
+					static_cast<uint16_t>(slot->id),
+					static_cast<uint16_t>(slot->state),
+					slot->selectedRaceId,
+					slot->upgrade ? 1 : 0,
+					static_cast<uint16_t>(slot->rarity),
+					slot->currentKills,
+					slot->disabledUntilTimeStamp,
+					slot->freeRerollTimeStamp,
+					db.escapeBlob(taskHuntingList, static_cast<uint32_t>(taskHuntingSize))
+				);
 
-				query << " ON DUPLICATE KEY UPDATE "
-					  << "`state` = VALUES(`state`), "
-					  << "`raceid` = VALUES(`raceid`), "
-					  << "`upgrade` = VALUES(`upgrade`), "
-					  << "`rarity` = VALUES(`rarity`), "
-					  << "`kills` = VALUES(`kills`), "
-					  << "`disabled_time` = VALUES(`disabled_time`), "
-					  << "`free_reroll` = VALUES(`free_reroll`), "
-					  << "`monster_list` = VALUES(`monster_list`)";
-
-				if (!db.executeQuery(query.str())) {
+				if (!db.executeQuery(query)) {
 					g_logger().warn("[IOLoginData::savePlayer] - Error saving task hunting slot data from player: {}", player->getName());
 					return false;
 				}
@@ -765,13 +777,13 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 		return false;
 	}
 
-	std::ostringstream query;
-	query << "DELETE FROM `player_bosstiary` WHERE `player_id` = " << player->getGUID();
-	if (!Database::getInstance().executeQuery(query.str())) {
+	Database &db = Database::getInstance();
+	const uint32_t playerGuid = player->getGUID();
+	const std::string deleteQuery = fmt::format("DELETE FROM `player_bosstiary` WHERE `player_id` = {}", playerGuid);
+	if (!db.executeQuery(deleteQuery)) {
 		return false;
 	}
 
-	query.str("");
 	DBInsert insertQuery("INSERT INTO `player_bosstiary` (`player_id`, `bossIdSlotOne`, `bossIdSlotTwo`, `removeTimes`, `tracker`) VALUES");
 
 	// Bosstiary tracker
@@ -785,14 +797,19 @@ bool IOLoginDataSave::savePlayerBosstiary(const std::shared_ptr<Player> &player)
 	}
 	size_t size;
 	const char* chars = stream.getStream(size);
-	// Append query informations
-	query << player->getGUID() << ','
-		  << player->getSlotBossId(1) << ','
-		  << player->getSlotBossId(2) << ','
-		  << std::to_string(player->getRemoveTimes()) << ','
-		  << Database::getInstance().escapeBlob(chars, static_cast<uint32_t>(size));
+	fmt::memory_buffer rowBuffer;
+	rowBuffer.reserve(96);
+	fmt::format_to(
+		std::back_inserter(rowBuffer),
+		"{},{},{},{},{}",
+		playerGuid,
+		player->getSlotBossId(1),
+		player->getSlotBossId(2),
+		player->getRemoveTimes(),
+		db.escapeBlob(chars, static_cast<uint32_t>(size))
+	);
 
-	if (!insertQuery.addRow(query)) {
+	if (!insertQuery.addRow(std::string_view(rowBuffer.data(), rowBuffer.size()))) {
 		return false;
 	}
 

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -361,7 +361,11 @@ void IOLoginData::increaseBankBalance(uint32_t guid, uint64_t bankBalance) {
 }
 
 std::vector<VIPEntry> IOLoginData::getVIPEntries(uint32_t accountId) {
-	std::string query = fmt::format("SELECT `player_id`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `name`, `description`, `icon`, `notify` FROM `account_viplist` WHERE `account_id` = {}", accountId);
+	const std::string query = fmt::format(
+		"SELECT `player_id`, (SELECT `name` FROM `players` WHERE `id` = `player_id`) AS `name`, `description`, `icon`, `notify` "
+		"FROM `account_viplist` WHERE `account_id` = {}",
+		accountId
+	);
 	std::vector<VIPEntry> entries;
 
 	if (const auto &result = Database::getInstance().storeQuery(query)) {
@@ -381,26 +385,47 @@ std::vector<VIPEntry> IOLoginData::getVIPEntries(uint32_t accountId) {
 }
 
 void IOLoginData::addVIPEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) {
-	std::string query = fmt::format("INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES ({}, {}, {}, {}, {})", accountId, guid, g_database().escapeString(description), icon, notify);
+	const std::string query = fmt::format(
+		"INSERT INTO `account_viplist` (`account_id`, `player_id`, `description`, `icon`, `notify`) VALUES ({}, {}, {}, {}, {})",
+		accountId,
+		guid,
+		g_database().escapeString(description),
+		icon,
+		notify
+	);
 	if (!g_database().executeQuery(query)) {
 		g_logger().error("Failed to add VIP entry for account {}. QUERY: {}", accountId, query.c_str());
 	}
 }
 
 void IOLoginData::editVIPEntry(uint32_t accountId, uint32_t guid, const std::string &description, uint32_t icon, bool notify) {
-	std::string query = fmt::format("UPDATE `account_viplist` SET `description` = {}, `icon` = {}, `notify` = {} WHERE `account_id` = {} AND `player_id` = {}", g_database().escapeString(description), icon, notify, accountId, guid);
+	const std::string query = fmt::format(
+		"UPDATE `account_viplist` SET `description` = {}, `icon` = {}, `notify` = {} WHERE `account_id` = {} AND `player_id` = {}",
+		g_database().escapeString(description),
+		icon,
+		notify,
+		accountId,
+		guid
+	);
 	if (!g_database().executeQuery(query)) {
 		g_logger().error("Failed to edit VIP entry for account {}. QUERY: {}", accountId, query.c_str());
 	}
 }
 
 void IOLoginData::removeVIPEntry(uint32_t accountId, uint32_t guid) {
-	std::string query = fmt::format("DELETE FROM `account_viplist` WHERE `account_id` = {} AND `player_id` = {}", accountId, guid);
+	const std::string query = fmt::format(
+		"DELETE FROM `account_viplist` WHERE `account_id` = {} AND `player_id` = {}",
+		accountId,
+		guid
+	);
 	g_database().executeQuery(query);
 }
 
 std::vector<VIPGroupEntry> IOLoginData::getVIPGroupEntries(uint32_t accountId, uint32_t guid) {
-	std::string query = fmt::format("SELECT `id`, `name`, `customizable` FROM `account_vipgroups` WHERE `account_id` = {}", accountId);
+	const std::string query = fmt::format(
+		"SELECT `id`, `name`, `customizable` FROM `account_vipgroups` WHERE `account_id` = {}",
+		accountId
+	);
 
 	std::vector<VIPGroupEntry> entries;
 
@@ -411,7 +436,7 @@ std::vector<VIPGroupEntry> IOLoginData::getVIPGroupEntries(uint32_t accountId, u
 			entries.emplace_back(
 				result->getNumber<uint8_t>("id"),
 				result->getString("name"),
-				result->getNumber<uint8_t>("customizable") == 0 ? false : true
+				result->getNumber<uint8_t>("customizable") != 0
 			);
 		} while (result->next());
 	}
@@ -419,32 +444,57 @@ std::vector<VIPGroupEntry> IOLoginData::getVIPGroupEntries(uint32_t accountId, u
 }
 
 void IOLoginData::addVIPGroupEntry(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) {
-	std::string query = fmt::format("INSERT INTO `account_vipgroups` (`id`, `account_id`, `name`, `customizable`) VALUES ({}, {}, {}, {})", groupId, accountId, g_database().escapeString(groupName), customizable);
+	const std::string query = fmt::format(
+		"INSERT INTO `account_vipgroups` (`id`, `account_id`, `name`, `customizable`) VALUES ({}, {}, {}, {})",
+		groupId,
+		accountId,
+		g_database().escapeString(groupName),
+		customizable
+	);
 	if (!g_database().executeQuery(query)) {
 		g_logger().error("Failed to add VIP Group entry for account {} and group {}. QUERY: {}", accountId, groupId, query.c_str());
 	}
 }
 
 void IOLoginData::editVIPGroupEntry(uint8_t groupId, uint32_t accountId, const std::string &groupName, bool customizable) {
-	std::string query = fmt::format("UPDATE `account_vipgroups` SET `name` = {}, `customizable` = {} WHERE `id` = {} AND `account_id` = {}", g_database().escapeString(groupName), customizable, groupId, accountId);
+	const std::string query = fmt::format(
+		"UPDATE `account_vipgroups` SET `name` = {}, `customizable` = {} WHERE `id` = {} AND `account_id` = {}",
+		g_database().escapeString(groupName),
+		customizable,
+		groupId,
+		accountId
+	);
 	if (!g_database().executeQuery(query)) {
 		g_logger().error("Failed to update VIP Group entry for account {} and group {}. QUERY: {}", accountId, groupId, query.c_str());
 	}
 }
 
 void IOLoginData::removeVIPGroupEntry(uint8_t groupId, uint32_t accountId) {
-	std::string query = fmt::format("DELETE FROM `account_vipgroups` WHERE `id` = {} AND `account_id` = {}", groupId, accountId);
+	const std::string query = fmt::format(
+		"DELETE FROM `account_vipgroups` WHERE `id` = {} AND `account_id` = {}",
+		groupId,
+		accountId
+	);
 	g_database().executeQuery(query);
 }
 
 void IOLoginData::addGuidVIPGroupEntry(uint8_t groupId, uint32_t accountId, uint32_t guid) {
-	std::string query = fmt::format("INSERT INTO `account_vipgrouplist` (`account_id`, `player_id`, `vipgroup_id`) VALUES ({}, {}, {})", accountId, guid, groupId);
+	const std::string query = fmt::format(
+		"INSERT INTO `account_vipgrouplist` (`account_id`, `player_id`, `vipgroup_id`) VALUES ({}, {}, {})",
+		accountId,
+		guid,
+		groupId
+	);
 	if (!g_database().executeQuery(query)) {
 		g_logger().error("Failed to add guid VIP Group entry for account {}, player {} and group {}. QUERY: {}", accountId, guid, groupId, query.c_str());
 	}
 }
 
 void IOLoginData::removeGuidVIPGroupEntry(uint32_t accountId, uint32_t guid) {
-	std::string query = fmt::format("DELETE FROM `account_vipgrouplist` WHERE `account_id` = {} AND `player_id` = {}", accountId, guid);
+	const std::string query = fmt::format(
+		"DELETE FROM `account_vipgrouplist` WHERE `account_id` = {} AND `player_id` = {}",
+		accountId,
+		guid
+	);
 	g_database().executeQuery(query);
 }


### PR DESCRIPTION
## Summary

This PR keeps the useful, low-risk parts of #3720 and narrows the scope to query construction improvements.

- Reduces allocation and stream overhead in `DBInsert::execute()` by reserving string capacity, formatting upsert clauses with `fmt`, and safely handling empty batch values.
- Reuses formatting buffers while saving player rows and rewrites several player save queries with clearer `fmt`-based construction.
- Cleans up VIP query formatting and simplifies the `customizable` boolean conversion without changing the data access flow.

## Notes

The broader repository/test abstraction and async save scheduling from #3720 were intentionally left out. Player saves remain in the existing synchronous transaction flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized bulk insert/update assembly and batching for player persistence, improving performance and reducing memory overhead when saving inventories, containers, spells, bestiary, rewards, depots and related data.
  * Reworked player save paths to use efficient, reusable buffers and streamlined query/payload construction for more reliable bulk operations.
  * Reformatted VIP-related query generation for consistency and readability while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->