### PR TITLE
fix(forge): prevent same-item double-removal in fuse/transfer flows

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -5879,9 +5879,9 @@ void Player::getAllItemTypeCountAndSubtype(std::map<uint32_t, uint32_t> &countMa
 	}
 }
 
-std::shared_ptr<Item> Player::getForgeItemFromId(uint16_t itemId, uint8_t tier) const {
+std::shared_ptr<Item> Player::getForgeItemFromId(uint16_t itemId, uint8_t tier, const std::shared_ptr<Item> &exclude /*= nullptr*/) const {
 	for (const auto &item : getAllInventoryItems(true)) {
-		if (!item) {
+		if (!item || item == exclude) {
 			continue;
 		}
 		if (item->hasImbuements()) {
@@ -10994,7 +10994,7 @@ void Player::forgeFuseItems(ForgeAction_t actionType, uint16_t firstItemId, uint
 		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
 		return;
 	}
-	const auto &secondForgingItem = getForgeItemFromId(secondItemId, tier);
+	const auto &secondForgingItem = getForgeItemFromId(secondItemId, tier, firstForgingItem);
 	if (!secondForgingItem) {
 		g_logger().error("[Log 2] Player with name {} failed to fuse item with id {}", getName(), secondItemId);
 		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
@@ -11290,7 +11290,7 @@ void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemI
 		return;
 	}
 
-	const auto &receiveItem = getForgeItemFromId(receiveItemId, 0);
+	const auto &receiveItem = getForgeItemFromId(receiveItemId, 0, donorItem);
 	if (!receiveItem) {
 		g_logger().error("[Log 2] Player with name {} failed to transfer item with id {}", getName(), receiveItemId);
 		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1619,7 +1619,7 @@ private:
 	// Function from player class with correct type sizes (uint16_t)
 	std::map<uint16_t, uint16_t> &getAllSaleItemIdAndCount(std::map<uint16_t, uint16_t> &countMap) const;
 	void getAllItemTypeCountAndSubtype(std::map<uint32_t, uint32_t> &countMap) const;
-	std::shared_ptr<Item> getForgeItemFromId(uint16_t itemId, uint8_t tier) const;
+	std::shared_ptr<Item> getForgeItemFromId(uint16_t itemId, uint8_t tier, const std::shared_ptr<Item> &exclude = nullptr) const;
 	std::shared_ptr<Thing> getThing(size_t index) const override;
 
 	void internalAddThing(const std::shared_ptr<Thing> &thing) override;

--- a/tests/integration/game/forge_it.cpp
+++ b/tests/integration/game/forge_it.cpp
@@ -351,3 +351,131 @@ TEST_F(ForgeIntegrationTest, ForgeFuseItemsFromGameFlowFailsWhenBackpackIsFull) 
 	EXPECT_TRUE(hasItem(*player, fixture.firstForgeItemId, 1));
 	EXPECT_TRUE(hasItem(*player, fixture.secondForgeItemId, 1));
 }
+
+// Regression (forge fusion same-item double-removal):
+// Real fusion combines two copies of the SAME item id + tier. getForgeItemFromId
+// returns the first inventory match, so resolving BOTH forging items before removing
+// either must still yield two DISTINCT instances. Otherwise the second internalRemoveItem
+// operates on the already-removed instance and fails with
+// "[Log 2] Failed to remove forge item ... from player". The pre-existing success test
+// uses two DIFFERENT ids, so it never exercised this path.
+TEST_F(ForgeIntegrationTest, ForgeFuseItemsWithIdenticalItemIdConsumesTwoDistinctCopies) {
+	ensureBackpack();
+	const auto &fixture = testState();
+
+	seedGameRng(1337);
+	const uint64_t dustCost = g_configManager().getNumber(FORGE_FUSION_DUST_COST);
+	const uint64_t goldCost = fixture.fusionCostForTier(2);
+	setPlayerResources(dustCost + 5, goldCost + 7);
+
+	// Two copies of the SAME item id at the same tier - the real fusion scenario.
+	addPlayerItemBackpack(fixture.firstForgeItemId, 1, 2);
+
+	const auto startDust = player->getForgeDusts();
+	const auto startBalance = player->getBankBalance();
+	const auto startChest = countItem(*player, ITEM_EXALTATION_CHEST, 0);
+	ASSERT_EQ(2u, countItem(*player, fixture.firstForgeItemId, 1));
+
+	player->forgeFuseItems(ForgeAction_t::FUSION, fixture.firstForgeItemId, 1, fixture.firstForgeItemId, true, false, false, 0, 0);
+
+	// Both inputs consumed (the bug removed only the first copy then aborted).
+	EXPECT_EQ(0u, countItem(*player, fixture.firstForgeItemId, 1));
+	EXPECT_GT(countItem(*player, ITEM_EXALTATION_CHEST, 0), startChest);
+	EXPECT_EQ(player->getForgeDusts(), startDust - dustCost);
+	EXPECT_EQ(player->getBankBalance(), startBalance - goldCost);
+}
+
+// Regression guard: with only ONE matching item, fusion must abort BEFORE mutating
+// anything. The buggy ordering returned the same (non-null) instance twice, so it
+// added the exaltation chest and removed the single copy before failing on the second
+// removal, leaving partial state. The fix makes the second lookup return nullptr, so
+// the null-check aborts before any inventory/resource mutation.
+TEST_F(ForgeIntegrationTest, ForgeFuseItemsWithSingleCopyAbortsBeforeMutating) {
+	ensureBackpack();
+	const auto &fixture = testState();
+
+	const uint64_t dustCost = g_configManager().getNumber(FORGE_FUSION_DUST_COST);
+	const uint64_t goldCost = fixture.fusionCostForTier(2);
+	setPlayerResources(dustCost + 5, goldCost + 7);
+
+	addPlayerItemBackpack(fixture.firstForgeItemId, 1, 1); // only one copy
+
+	const auto startDust = player->getForgeDusts();
+	const auto startBalance = player->getBankBalance();
+
+	player->forgeFuseItems(ForgeAction_t::FUSION, fixture.firstForgeItemId, 1, fixture.firstForgeItemId, true, false, false, 0, 0);
+
+	EXPECT_FALSE(hasItem(*player, ITEM_EXALTATION_CHEST));
+	EXPECT_TRUE(hasItem(*player, fixture.firstForgeItemId, 1));
+	EXPECT_EQ(player->getForgeDusts(), startDust);
+	EXPECT_EQ(player->getBankBalance(), startBalance);
+}
+
+// Regression guard for forgeTransferItemTier (same reordering as 519ab0c):
+// donor and receive are resolved before either is removed. When the donor and receive
+// share the SAME item id (donor at a higher tier, receive at tier 0), the receive lookup
+// must resolve to the DISTINCT tier-0 instance and not alias the donor. The transfer must
+// succeed, consuming the donor (tier 2) and the receive (tier 0) and producing a tier-1
+// copy of the receive id inside the exaltation chest.
+TEST_F(ForgeIntegrationTest, ForgeTransferItemTierWithIdenticalItemIdUsesDistinctCopies) {
+	ensureBackpack();
+	const auto &fixture = testState();
+
+	const uint8_t transferToTier = 1;
+	const uint8_t transferFromTier = 2;
+	const auto* classification = fixture.getClassification();
+	ASSERT_NE(nullptr, classification);
+	const auto transferCoreCost = classification->tiers.contains(transferToTier) ? classification->tiers.at(transferToTier).corePrice : 0;
+	const auto transferGoldCost = fixture.fusionCostForTier(transferToTier);
+	const uint64_t dustCost = g_configManager().getNumber(FORGE_TRANSFER_DUST_COST);
+
+	setPlayerResources(dustCost, transferGoldCost + 7);
+	const auto startDust = player->getForgeDusts();
+	const auto startBalance = player->getBankBalance();
+	const auto startChest = countItem(*player, ITEM_EXALTATION_CHEST, 0);
+
+	// Donor (tier 2) and receive (tier 0) share the same item id.
+	addPlayerItemBackpack(fixture.donorItemId, transferFromTier);
+	addPlayerItemBackpack(fixture.donorItemId, 0);
+
+	const auto &forgeCore = Item::CreateItem(ITEM_FORGE_CORE, transferCoreCost);
+	ASSERT_NE(nullptr, forgeCore);
+	ASSERT_EQ(RETURNVALUE_NOERROR, g_game().internalPlayerAddItem(player, forgeCore, false, CONST_SLOT_BACKPACK));
+
+	player->forgeTransferItemTier(ForgeAction_t::TRANSFER, fixture.donorItemId, transferFromTier, fixture.donorItemId, false);
+
+	EXPECT_EQ(player->getForgeDusts(), startDust - dustCost);
+	EXPECT_EQ(player->getBankBalance(), startBalance - transferGoldCost);
+	EXPECT_FALSE(hasItem(*player, fixture.donorItemId, transferFromTier));
+	EXPECT_FALSE(hasItem(*player, fixture.donorItemId, 0));
+	EXPECT_TRUE(hasItem(*player, fixture.donorItemId, transferToTier));
+	EXPECT_GT(countItem(*player, ITEM_EXALTATION_CHEST, 0), startChest);
+}
+
+// Regression guard: with only ONE matching item, a transfer that reuses that id for both
+// donor and receive must abort without mutating inventory or resources. Without the
+// exclude guard the receive lookup could alias the single donor instance and lead to a
+// double removal. The fix makes the receive lookup return nullptr, aborting cleanly.
+TEST_F(ForgeIntegrationTest, ForgeTransferItemTierWithSingleCopyAbortsBeforeMutating) {
+	ensureBackpack();
+	const auto &fixture = testState();
+
+	const uint8_t transferFromTier = 2;
+	const auto* classification = fixture.getClassification();
+	ASSERT_NE(nullptr, classification);
+	const uint64_t dustCost = g_configManager().getNumber(FORGE_TRANSFER_DUST_COST);
+
+	setPlayerResources(dustCost + 5, 1000);
+	const auto startDust = player->getForgeDusts();
+	const auto startBalance = player->getBankBalance();
+
+	// Only a single tier-2 copy exists; no tier-0 receive candidate.
+	addPlayerItemBackpack(fixture.donorItemId, transferFromTier, 1);
+
+	player->forgeTransferItemTier(ForgeAction_t::TRANSFER, fixture.donorItemId, transferFromTier, fixture.donorItemId, false);
+
+	EXPECT_FALSE(hasItem(*player, ITEM_EXALTATION_CHEST));
+	EXPECT_TRUE(hasItem(*player, fixture.donorItemId, transferFromTier));
+	EXPECT_EQ(player->getForgeDusts(), startDust);
+	EXPECT_EQ(player->getBankBalance(), startBalance);
+}


### PR DESCRIPTION
# Description

Forge **fusion** combines two copies of the *same* item id + tier. After #3928 (commit `519ab0c`, which fixed #3737), fusing two identical items consumes one item and fails to deliver the result, leaving the player without the consumed item and without a usable result.

**Root cause.** #3928 reordered `Player::forgeFuseItems` to reserve the exaltation chest before consuming resources — a correct goal — but as a side effect it now resolves **both** forging items via `getForgeItemFromId` *before* either is removed from the inventory.

Before #3928 the first item was removed *before* the second lookup, which implicitly guaranteed two distinct instances:

```cpp
g_game().internalRemoveItem(firstForgingItem, 1);          // remove first FIRST
const auto &secondForgingItem = getForgeItemFromId(...);   // then look up second
g_game().internalRemoveItem(secondForgingItem, 1);
```

After #3928 both lookups run against the intact inventory:

```cpp
const auto &firstForgingItem  = getForgeItemFromId(firstItemId, tier);
const auto &secondForgingItem = getForgeItemFromId(secondItemId, tier);  // intact inventory
...
internalAddItem(exaltationChest);
internalRemoveItem(firstForgingItem, 1);
internalRemoveItem(secondForgingItem, 1);   // aliases the first when id+tier match
```

`getForgeItemFromId` returns the first inventory match for `id + tier`. With both items resolved against the intact inventory, fusing two items with the **same id + tier** makes `secondForgingItem` the **same `shared_ptr`** as `firstForgingItem`.

**Fix.** Add an optional `exclude` parameter to `getForgeItemFromId` so a second lookup skips the already-selected instance:

- `forgeFuseItems`: resolve `secondForgingItem` excluding `firstForgingItem`.
- `forgeTransferItemTier`: resolve `receiveItem` excluding `donorItem` (defensive — donor/receive are filtered by different tiers, so a real collision would require `tier == 0`, which already aborts in pre-validation before any mutation; the guard keeps the invariant explicit and consistent with the fuse path).

> The pre-existing success test fused two **different** item ids, so it never exercised this path.

## Behaviour
### **Actual**

Fusing two items with the same id + tier adds the exaltation chest and removes the first item, then fails on the second removal (`"[Log 2] Failed to remove forge item ... from player"`), leaving the player without the consumed item and without a usable result.

### **Expected**

Fusing two items with the same id + tier consumes both copies and delivers the exaltation chest with the forged result, as with two different item ids.

### Fixes (regression from #3928, originally #3737)

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

Added integration tests in `tests/integration/game/forge_it.cpp`:

  - [x] Fuse with identical item id consumes **two distinct copies** (fails without the fix)
  - [x] Fuse with a single copy **aborts before mutating** inventory/resources
  - [x] Transfer with identical item id uses distinct copies
  - [x] Transfer with a single copy aborts before mutating

Built `linux-release-enabled-tests` and ran the suite — all 7 `ForgeIntegrationTest` cases pass:

```
[==========] Running 7 tests from 1 test suite.
[  PASSED  ] 7 tests.
```

**Test Configuration**:

  - Server Version: main branch
  - Client: 15.11 - OTClient
  - Operating System: Linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forging mechanics to prevent reusing the same item instance when selecting multiple items for fusion operations
  * Corrected forge transfer functionality to ensure donor and receive slots cannot reference the same item instance

* **Tests**
  * Added integration tests validating fusion behavior with identical item specifications
  * Added integration tests for transfer operations with matching item properties across tiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->