### PR TITLE
fix(ci): validate git refs in lua api check

### DIFF
--- a/tools/check_lua_api_binding_docs.py
+++ b/tools/check_lua_api_binding_docs.py
@@ -14,7 +14,7 @@ WEAK_PARAM_PATTERNS = (
     re.compile(r":\s*any\b"),
     re.compile(r"\barg\d+\b"),
 )
-GIT_REF_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{7,40}|[A-Za-z0-9][A-Za-z0-9._/-]*)$")
+GIT_REF_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{7,40}|[A-Za-z0-9][A-Za-z0-9._/\\-]*)$")
 
 @dataclass(frozen=True)
 class Binding:

--- a/tools/check_lua_api_binding_docs.py
+++ b/tools/check_lua_api_binding_docs.py
@@ -14,6 +14,7 @@ WEAK_PARAM_PATTERNS = (
     re.compile(r":\s*any\b"),
     re.compile(r"\barg\d+\b"),
 )
+GIT_REF_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{7,40}|[A-Za-z0-9][A-Za-z0-9._/-]*)$")
 
 @dataclass(frozen=True)
 class Binding:
@@ -29,13 +30,48 @@ def run_git(args):
     return completed.stdout
 
 
+def validate_git_ref(value):
+    if not isinstance(value, str):
+        raise ValueError(f"invalid git ref: {value!r}")
+
+    value = value.strip()
+    if not value or value.startswith("-"):
+        raise ValueError(f"invalid git ref: {value!r}")
+    if "\x00" in value or "\n" in value or "\r" in value:
+        raise ValueError(f"invalid git ref: {value!r}")
+    if ".." in value or value.endswith("/") or value.startswith("/") or "//" in value:
+        raise ValueError(f"invalid git ref: {value!r}")
+    if "@{" in value or " " in value:
+        raise ValueError(f"invalid git ref: {value!r}")
+    if any(ch in value for ch in " ~^:?*[]\\"):
+        raise ValueError(f"invalid git ref: {value!r}")
+    if not GIT_REF_PATTERN.fullmatch(value):
+        raise ValueError(f"invalid git ref: {value!r}")
+    for part in value.split("/"):
+        if part in {".", "..", ""}:
+            raise ValueError(f"invalid git ref: {value!r}")
+        if part.endswith(".") or part.startswith("."):
+            raise ValueError(f"invalid git ref: {value!r}")
+        if part.endswith(".lock"):
+            raise ValueError(f"invalid git ref: {value!r}")
+    return value
+
+
 def resolve_base_ref(explicit_base):
     candidates = []
     if explicit_base:
-        candidates.append(explicit_base)
+        try:
+            candidates.append(validate_git_ref(explicit_base))
+        except ValueError as error:
+            raise ValueError(f"invalid --base value: {error}") from None
+
     github_base_ref = os.environ.get("GITHUB_BASE_REF")
     if github_base_ref:
-        candidates.extend([f"origin/{github_base_ref}", github_base_ref])
+        try:
+            base_ref = validate_git_ref(github_base_ref)
+            candidates.extend([f"origin/{base_ref}", base_ref])
+        except ValueError:
+            pass
     candidates.extend(["origin/main", "main"])
 
     for candidate in candidates:
@@ -317,7 +353,7 @@ def main():
         base_ref = resolve_base_ref(args.base)
         bindings = parse_added_bindings(base_ref)
         docs = load_docs()
-    except (OSError, RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError) as error:
+    except (OSError, RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as error:
         print(f"::error::failed to run Lua API binding documentation check: {error}")
         return 1
 

--- a/tools/check_lua_api_binding_docs.py
+++ b/tools/check_lua_api_binding_docs.py
@@ -15,6 +15,14 @@ WEAK_PARAM_PATTERNS = (
     re.compile(r"\barg\d+\b"),
 )
 GIT_REF_PATTERN = re.compile(r"^(?:[0-9a-fA-F]{7,40}|[A-Za-z0-9][A-Za-z0-9._/\\-]*)$")
+INVALID_REF_CHARS = set(" ~^:?*[]\\\x00\n\r")
+
+
+def _has_invalid_ref_segment(value):
+    for part in value.split("/"):
+        if part in {".", "..", ""} or part.startswith(".") or part.endswith(".") or part.endswith(".lock"):
+            return True
+    return False
 
 @dataclass(frozen=True)
 class Binding:
@@ -35,25 +43,18 @@ def validate_git_ref(value):
         raise ValueError(f"invalid git ref: {value!r}")
 
     value = value.strip()
-    if not value or value.startswith("-"):
+    if (
+        not value
+        or value.startswith("-")
+        or value.startswith("/")
+        or value.endswith("/")
+        or ".." in value
+        or "//" in value
+        or any(ch in INVALID_REF_CHARS for ch in value)
+        or not GIT_REF_PATTERN.fullmatch(value)
+        or _has_invalid_ref_segment(value)
+    ):
         raise ValueError(f"invalid git ref: {value!r}")
-    if "\x00" in value or "\n" in value or "\r" in value:
-        raise ValueError(f"invalid git ref: {value!r}")
-    if ".." in value or value.endswith("/") or value.startswith("/") or "//" in value:
-        raise ValueError(f"invalid git ref: {value!r}")
-    if "@{" in value or " " in value:
-        raise ValueError(f"invalid git ref: {value!r}")
-    if any(ch in value for ch in " ~^:?*[]\\"):
-        raise ValueError(f"invalid git ref: {value!r}")
-    if not GIT_REF_PATTERN.fullmatch(value):
-        raise ValueError(f"invalid git ref: {value!r}")
-    for part in value.split("/"):
-        if part in {".", "..", ""}:
-            raise ValueError(f"invalid git ref: {value!r}")
-        if part.endswith(".") or part.startswith("."):
-            raise ValueError(f"invalid git ref: {value!r}")
-        if part.endswith(".lock"):
-            raise ValueError(f"invalid git ref: {value!r}")
     return value
 
 
@@ -353,7 +354,7 @@ def main():
         base_ref = resolve_base_ref(args.base)
         bindings = parse_added_bindings(base_ref)
         docs = load_docs()
-    except (OSError, RuntimeError, subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as error:
+    except (OSError, RuntimeError, subprocess.CalledProcessError, ValueError) as error:
         print(f"::error::failed to run Lua API binding documentation check: {error}")
         return 1
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of branch/ref inputs used during documentation checks, reducing failures from malformed or invalid values.
  * Added clearer CLI feedback when an invalid base reference is provided, and safely ignores invalid environment-provided values instead of failing.
  * Updated error handling to better surface input-related issues without treating unrelated parsing errors as expected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds git ref validation to the Lua API binding docs checker, preventing CI failures from malformed or adversarial `--base` arguments and `GITHUB_BASE_REF` environment values.

- `validate_git_ref` applies a layered guard (char-set reject, regex fullmatch, per-segment checks) before any validated ref is passed to `run_git`, eliminating the possibility of shell-unsafe strings reaching subprocess calls.
- Invalid `--base` arguments now raise a clear `ValueError` surfaced to the user, while a bad `GITHUB_BASE_REF` is silently skipped so the check can fall through to the `origin/main` / `main` defaults.
- The `main()` error handler was widened from `json.JSONDecodeError` to `ValueError`; since `json.JSONDecodeError` is a subclass of `ValueError`, the JSON decode path remains covered.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The validation logic is layered correctly, subprocess calls remain injection-free (list args, no shell=True), and the fallback behaviour is sensible.

The change is narrowly scoped to a single CI helper script. The new validation function is straightforward, the fallback chain in resolve_base_ref is correct, and widening the exception catch in main() to ValueError preserves coverage for json.JSONDecodeError via subclass. No functional regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/check_lua_api_binding_docs.py | Adds validate_git_ref() with layered guards (INVALID_REF_CHARS, GIT_REF_PATTERN regex, per-segment checks) and updates resolve_base_ref() to validate explicit and env-provided refs before use; error handling in main() broadened to ValueError. |

<sub>Reviews (2): Last reviewed commit: ["refactor(ci): simplify git ref validatio..."](https://github.com/opentibiabr/canary/commit/a9431e89ff1b367d75d93805d07d0ada67c5b6b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40918543)</sub>

<!-- /greptile_comment -->