### PR TITLE
ci(release): retag via git push in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,12 @@ jobs:
               git config user.name "GitHub Actions"
               git add "${tracked_paths[@]}"
               git commit -m "chore: materialize release metadata for ${RELEASE_TAG}"
+              current_tag_ref="$(git rev-parse "refs/tags/${RELEASE_TAG}")"
               # Publish the materialized commit and updated annotated tag together.
               git tag -fa "${RELEASE_TAG}" -m "${RELEASE_TAG}"
               git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
                 "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" \
-                --force
+                --force-with-lease="refs/tags/${RELEASE_TAG}:${current_tag_ref}"
               tag_updated=true
             else
               echo "::warning::Release metadata differs for ${RELEASE_TAG}, but dry_run=true prevents updating the tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,15 +74,11 @@ jobs:
               git config user.name "GitHub Actions"
               git add "${tracked_paths[@]}"
               git commit -m "chore: materialize release metadata for ${RELEASE_TAG}"
-              tag_object_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags" \
-                -f "tag=${RELEASE_TAG}" \
-                -f "message=${RELEASE_TAG}" \
-                -f "object=$(git rev-parse HEAD)" \
-                -f "type=commit" \
-                --jq .sha)"
-              gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
-                -f "sha=${tag_object_sha}" \
-                -F force=true >/dev/null
+              # Publish the materialized commit and updated annotated tag together.
+              git tag -fa "${RELEASE_TAG}" -m "${RELEASE_TAG}"
+              git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+                "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" \
+                --force
               tag_updated=true
             else
               echo "::warning::Release metadata differs for ${RELEASE_TAG}, but dry_run=true prevents updating the tag."


### PR DESCRIPTION
Simplify release tag updates by replacing the GitHub API tag-object/ref patch flow with native git commands. The workflow now force-updates the annotated tag locally and force-pushes it using GH_TOKEN, publishing the materialized release metadata commit and tag update in one step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release tagging process so updated annotated release tags are applied more consistently when tracked release metadata changes.  
  * Ensures the workflow reliably updates and publishes the correct tag reference during releases, reducing the chance of mismatched or stale tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the two-step GitHub API tag-creation flow (create tag object → patch ref) with native git commands to update the release tag after materializing metadata. The new approach captures the existing tag SHA before mutation, creates a new annotated tag locally, and force-pushes it using an explicit `--force-with-lease` reference.

- The old approach called `gh api repos/.../git/tags` then `gh api -X PATCH .../git/refs/tags/...` with `force=true`, offering no concurrency protection; the new approach captures `current_tag_ref` before overwriting and supplies it as the lease expectation, so a concurrent push will abort rather than silently overwrite.
- The materialized commit (created by `git commit` on detached HEAD) is transferred to the remote implicitly as part of the annotated tag push — git resolves and ships all objects reachable from pushed refs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the git-native tag update is functionally equivalent to the previous API approach and includes tighter concurrency protection via an explicit force-with-lease expectation.

The materialized commit is correctly transferred to the remote as part of the annotated tag push, the --force-with-lease with an explicit expected SHA is strictly safer than the old force=true API call, and the workflow re-trigger guard remains effective for git-push-initiated events. No correctness issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces GitHub API tag-object/ref flow with git tag -fa + git push --force-with-lease; logic is correct — commit is pushed implicitly via the tag, concurrency guard is tighter than before, and the re-trigger guard remains effective for the git-push path. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WF as Workflow Runner
    participant GIT as Local Git
    participant GH as GitHub Remote

    WF->>GH: git fetch --force --tags origin
    GH-->>WF: syncs refs/tags/RELEASE_TAG to current_tag_ref
    WF->>GIT: python3 release_metadata.py materialize
    WF->>GIT: "git add tracked_paths && git commit"
    Note over WF,GIT: new commit on detached HEAD
    WF->>GIT: "current_tag_ref = git rev-parse refs/tags/RELEASE_TAG"
    WF->>GIT: git tag -fa RELEASE_TAG -m RELEASE_TAG
    Note over WF,GIT: new annotated tag object points to new commit
    WF->>GH: git push refs/tags/RELEASE_TAG --force-with-lease
    alt remote tag unchanged since fetch
        GH-->>WF: push accepted
    else remote tag moved by concurrent run
        GH-->>WF: push rejected (lease mismatch)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WF as Workflow Runner
    participant GIT as Local Git
    participant GH as GitHub Remote

    WF->>GH: git fetch --force --tags origin
    GH-->>WF: syncs refs/tags/RELEASE_TAG to current_tag_ref
    WF->>GIT: python3 release_metadata.py materialize
    WF->>GIT: "git add tracked_paths && git commit"
    Note over WF,GIT: new commit on detached HEAD
    WF->>GIT: "current_tag_ref = git rev-parse refs/tags/RELEASE_TAG"
    WF->>GIT: git tag -fa RELEASE_TAG -m RELEASE_TAG
    Note over WF,GIT: new annotated tag object points to new commit
    WF->>GH: git push refs/tags/RELEASE_TAG --force-with-lease
    alt remote tag unchanged since fetch
        GH-->>WF: push accepted
    else remote tag moved by concurrent run
        GH-->>WF: push rejected (lease mismatch)
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["ci: guard release tag force update"](https://github.com/opentibiabr/canary/commit/b8b0816bff5cf0fc0226c0dbc4d6555fa8ec6b6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40973995)</sub>

<!-- /greptile_comment -->