### PR TITLE
ci(release): link exact client release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,9 +202,205 @@ jobs:
       release_tag: ${{ needs.validate.outputs.tag }}
       checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
+  build-client-assets:
+    name: Build - Client Assets
+    needs: [prepare-tag, validate, checks, tests-lua]
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    outputs:
+      client_tag: ${{ steps.client.outputs.tag }}
+      client_commit_sha: ${{ steps.client.outputs.commit_sha }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
+      ASSETS_EDITOR_REPOSITORY: dudantas/Assets-Editor
+      # PR Arch-Mina/Assets-Editor#90 adds the export-legacy CLI required here.
+      ASSETS_EDITOR_REF: d8b1c0115574d8c6a9e7a296a0e281a9bc783584
+    steps:
+      - name: Resolve Tibia client tag
+        id: client
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $prefix = "${env:CLIENT_DISPLAY}."
+          $releases = gh api "repos/dudantas/tibia-client/releases?per_page=100" | ConvertFrom-Json
+          $release = $releases |
+            Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name.StartsWith($prefix) } |
+            Sort-Object { [DateTime]$_.published_at } -Descending |
+            Select-Object -First 1
+
+          if ($null -eq $release) {
+            throw "No published dudantas/tibia-client release tag was found for client ${env:CLIENT_DISPLAY}."
+          }
+
+          $ref = gh api "repos/dudantas/tibia-client/git/ref/tags/$($release.tag_name)" | ConvertFrom-Json
+          $commitSha = $ref.object.sha
+          if ($ref.object.type -eq "tag") {
+            $tagObject = gh api "repos/dudantas/tibia-client/git/tags/$commitSha" | ConvertFrom-Json
+            $commitSha = $tagObject.object.sha
+          }
+
+          "tag=$($release.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "commit_sha=$commitSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+          @(
+            "Resolved Tibia client release:"
+            ""
+            "- Tag: $($release.tag_name)"
+            "- Commit: $commitSha"
+            "- Published: $($release.published_at)"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+      - name: Checkout Tibia client
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          repository: dudantas/tibia-client
+          ref: ${{ steps.client.outputs.tag }}
+          path: tibia-client
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout Assets Editor CLI
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          repository: dudantas/Assets-Editor
+          ref: ${{ env.ASSETS_EDITOR_REF }}
+          path: assets-editor
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install .NET 10 SDK
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dotnetInstall = Join-Path $env:RUNNER_TEMP "dotnet-install.ps1"
+          Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $dotnetInstall
+          & $dotnetInstall -Channel 10.0 -Quality ga -InstallDir "$env:ProgramFiles\dotnet"
+          dotnet --list-sdks
+
+      - name: Build Assets Editor CLI
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          dotnet restore "assets-editor\Assets Editor\Assets Editor.sln"
+          dotnet publish "assets-editor\Assets Editor\AssetsEditor.csproj" `
+            --configuration Release `
+            --framework net10.0-windows7.0 `
+            --output "$env:RUNNER_TEMP\assets-editor"
+
+      - name: Package client and legacy assets
+        shell: pwsh
+        env:
+          CLIENT_RELEASE_TAG: ${{ steps.client.outputs.tag }}
+          CLIENT_COMMIT_SHA: ${{ steps.client.outputs.commit_sha }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $dist = Join-Path $PWD "client-dist"
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+
+          $clientRoot = (Resolve-Path "tibia-client").Path
+          $safeClientTag = $env:CLIENT_RELEASE_TAG -replace "[^A-Za-z0-9._-]", "-"
+
+          $mandatoryClientEntries = @(
+            "assets",
+            "assets.json",
+            "assets.json.sha256",
+            "bin",
+            "conf",
+            "package.json"
+          )
+          $optionalClientEntries = @(
+            "3rdpartylicences",
+            "docs",
+            "partial.package.json.version",
+            "sounds"
+          )
+
+          $clientPaths = @()
+          foreach ($entry in $mandatoryClientEntries) {
+            $path = Join-Path $clientRoot $entry
+            if (-not (Test-Path $path)) {
+              throw "Required Tibia client release entry is missing: $entry"
+            }
+            $clientPaths += $path
+          }
+          foreach ($entry in $optionalClientEntries) {
+            $path = Join-Path $clientRoot $entry
+            if (Test-Path $path) {
+              $clientPaths += $path
+            }
+          }
+
+          $clientManifest = @(
+            "client_repository=dudantas/tibia-client"
+            "client_tag=$env:CLIENT_RELEASE_TAG"
+            "client_commit_sha=$env:CLIENT_COMMIT_SHA"
+            "client_display=$env:CLIENT_DISPLAY"
+          )
+          $clientManifest | Set-Content -Path (Join-Path $clientRoot "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
+          $clientPaths += (Join-Path $clientRoot "CANARY_CLIENT_SOURCE.txt")
+
+          $clientZip = Join-Path $dist "tibia-client-$safeClientTag.zip"
+          Compress-Archive -Path $clientPaths -DestinationPath $clientZip -Force
+
+          $editorExe = (Resolve-Path "$env:RUNNER_TEMP\assets-editor\Assets Editor.exe").Path
+          $assetsInput = Join-Path $clientRoot "assets"
+          $profiles = @("cip860-extended", "client11-15x")
+          foreach ($profile in $profiles) {
+            $profileOutput = Join-Path $env:RUNNER_TEMP "legacy-assets\$profile"
+            New-Item -ItemType Directory -Force -Path $profileOutput | Out-Null
+
+            & $editorExe export-legacy `
+              --profile $profile `
+              --input $assetsInput `
+              --output $profileOutput `
+              --overwrite `
+              --no-backup
+            if ($LASTEXITCODE -ne 0) {
+              throw "Assets Editor export failed for profile $profile."
+            }
+
+            & $editorExe validate-legacy `
+              --profile $profile `
+              --dat (Join-Path $profileOutput "Tibia.dat") `
+              --spr (Join-Path $profileOutput "Tibia.spr")
+            if ($LASTEXITCODE -ne 0) {
+              throw "Assets Editor validation failed for profile $profile."
+            }
+
+            @(
+              "client_repository=dudantas/tibia-client"
+              "client_tag=$env:CLIENT_RELEASE_TAG"
+              "client_commit_sha=$env:CLIENT_COMMIT_SHA"
+              "client_display=$env:CLIENT_DISPLAY"
+              "assets_editor_repository=$env:ASSETS_EDITOR_REPOSITORY"
+              "assets_editor_ref=$env:ASSETS_EDITOR_REF"
+              "legacy_profile=$profile"
+            ) | Set-Content -Path (Join-Path $profileOutput "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
+
+            $legacyZip = Join-Path $dist "tibia-client-$safeClientTag-legacy-$profile.zip"
+            Compress-Archive -Path (Join-Path $profileOutput "*") -DestinationPath $legacyZip -Force
+          }
+
+          @(
+            "Prepared client release assets:"
+            ""
+            (Get-ChildItem -Path $dist -File | Sort-Object Name | ForEach-Object { "- $($_.Name)" })
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+      - name: Upload client assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: canary-client-assets
+          path: client-dist/*
+          if-no-files-found: error
+
   publish:
     name: Publish Release
-    needs: [prepare-tag, validate, build-linux, build-windows, build-macos, build-docker]
+    needs: [prepare-tag, validate, build-linux, build-windows, build-macos, build-docker, build-client-assets]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -214,6 +410,7 @@ jobs:
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
+      CLIENT_RELEASE_TAG: ${{ needs.build-client-assets.outputs.client_tag }}
       PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
       RELEASE_COMMIT_SHA: ${{ needs.prepare-tag.outputs.commit_sha }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
@@ -253,7 +450,7 @@ jobs:
           - #### For tutorials and additional resources, visit our [documentation](https://docs.opentibiabr.com/home/welcome).
 
           ------------------------------------
-          ### [Download Tibia Client ${CLIENT_DISPLAY}](https://github.com/dudantas/tibia-client/releases/latest)
+          ### [Download Tibia Client ${CLIENT_DISPLAY}](https://github.com/dudantas/tibia-client/releases/tag/${CLIENT_RELEASE_TAG})
           ### [Download OTClient Redemption](https://github.com/opentibiabr/otclient), thanks for @mehah
 
           ------------------------------------
@@ -269,9 +466,9 @@ jobs:
           set -euo pipefail
           mkdir -p dist
 
-          download_artifact_zip() {
+          download_artifact_archive() {
             local artifact_name="$1"
-            local asset_name="$2"
+            local output_path="$2"
             local url
             url="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
               --jq '.artifacts[] | "\(.name)\t\(.archive_download_url)"' \
@@ -285,7 +482,25 @@ jobs:
               --header "Authorization: Bearer ${GITHUB_TOKEN}" \
               --header "X-GitHub-Api-Version: 2022-11-28" \
               "${url}" \
-              --output "dist/${asset_name}"
+              --output "${output_path}"
+          }
+
+          download_artifact_zip() {
+            local artifact_name="$1"
+            local asset_name="$2"
+            download_artifact_archive "${artifact_name}" "dist/${asset_name}"
+          }
+
+          download_artifact_contents() {
+            local artifact_name="$1"
+            local archive_path
+            local extract_dir
+            archive_path="$(mktemp --suffix=.zip)"
+            extract_dir="$(mktemp -d)"
+
+            download_artifact_archive "${artifact_name}" "${archive_path}"
+            python3 -m zipfile -e "${archive_path}" "${extract_dir}"
+            find "${extract_dir}" -maxdepth 1 -type f -exec mv -f {} dist/ \;
           }
 
           download_artifact_zip "canary-linux-release" "canary-linux-release.zip"
@@ -294,6 +509,7 @@ jobs:
           download_artifact_zip "canary-windows-solution-debug" "canary-windows-solution-debug.zip"
           download_artifact_zip "canary-macos-release" "canary-macos-release.zip"
           download_artifact_zip "canary-docker" "canary-docker.zip"
+          download_artifact_contents "canary-client-assets"
 
       - name: Copy map from latest published release
         id: map

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
     outputs:
       client_tag: ${{ steps.client.outputs.tag }}
       client_commit_sha: ${{ steps.client.outputs.commit_sha }}
+      legacy_template_tag: ${{ steps.client.outputs.legacy_template_tag }}
     env:
       GH_TOKEN: ${{ github.token }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
@@ -230,9 +231,21 @@ jobs:
             Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name.StartsWith($prefix) } |
             Sort-Object { [DateTime]$_.published_at } -Descending |
             Select-Object -First 1
+          $legacyTemplateRelease = $releases |
+            Where-Object {
+              -not $_.draft -and
+              -not $_.prerelease -and
+              ($_.assets | Where-Object { $_.name -eq "client-11.zip" }) -and
+              ($_.assets | Where-Object { $_.name -eq "tibia-8.6-extended.zip" })
+            } |
+            Sort-Object { [DateTime]$_.published_at } -Descending |
+            Select-Object -First 1
 
           if ($null -eq $release) {
             throw "No published dudantas/tibia-client release tag was found for client ${env:CLIENT_DISPLAY}."
+          }
+          if ($null -eq $legacyTemplateRelease) {
+            throw "No published dudantas/tibia-client release was found with client-11.zip and tibia-8.6-extended.zip templates."
           }
 
           $ref = gh api "repos/dudantas/tibia-client/git/ref/tags/$($release.tag_name)" | ConvertFrom-Json
@@ -244,6 +257,7 @@ jobs:
 
           "tag=$($release.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "commit_sha=$commitSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "legacy_template_tag=$($legacyTemplateRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
           @(
             "Resolved Tibia client release:"
@@ -251,6 +265,7 @@ jobs:
             "- Tag: $($release.tag_name)"
             "- Commit: $commitSha"
             "- Published: $($release.published_at)"
+            "- Legacy template release: $($legacyTemplateRelease.tag_name)"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
 
       - name: Checkout Tibia client
@@ -295,6 +310,7 @@ jobs:
         env:
           CLIENT_RELEASE_TAG: ${{ steps.client.outputs.tag }}
           CLIENT_COMMIT_SHA: ${{ steps.client.outputs.commit_sha }}
+          LEGACY_TEMPLATE_TAG: ${{ steps.client.outputs.legacy_template_tag }}
         run: |
           $ErrorActionPreference = "Stop"
 
@@ -304,16 +320,16 @@ jobs:
           $clientRoot = (Resolve-Path "tibia-client").Path
           $safeClientTag = $env:CLIENT_RELEASE_TAG -replace "[^A-Za-z0-9._-]", "-"
 
+          $sevenZip = (Get-Command 7z -ErrorAction SilentlyContinue).Source
+          if (-not $sevenZip) {
+            $sevenZip = Join-Path $env:ProgramFiles "7-Zip\7z.exe"
+          }
+          if (-not (Test-Path $sevenZip)) {
+            throw "7-Zip was not found; cannot extract archived Tibia client runtime files."
+          }
+
           $archives = Get-ChildItem -Path $clientRoot -Recurse -File -Include "*.rar", "*.zip", "*.7z"
           if ($archives.Count -gt 0) {
-            $sevenZip = (Get-Command 7z -ErrorAction SilentlyContinue).Source
-            if (-not $sevenZip) {
-              $sevenZip = Join-Path $env:ProgramFiles "7-Zip\7z.exe"
-            }
-            if (-not (Test-Path $sevenZip)) {
-              throw "7-Zip was not found; cannot extract archived Tibia client runtime files."
-            }
-
             foreach ($archive in $archives) {
               & $sevenZip x $archive.FullName "-o$($archive.Directory.FullName)" -y
               if ($LASTEXITCODE -ne 0) {
@@ -365,10 +381,29 @@ jobs:
           $clientZip = Join-Path $dist "tibia-client-$safeClientTag.zip"
           Compress-Archive -Path $clientPaths -DestinationPath $clientZip -Force
 
+          $legacyTemplates = Join-Path $env:RUNNER_TEMP "legacy-client-templates"
+          New-Item -ItemType Directory -Force -Path $legacyTemplates | Out-Null
+          gh release download $env:LEGACY_TEMPLATE_TAG `
+            --repo dudantas/tibia-client `
+            --pattern "client-11.zip" `
+            --pattern "tibia-8.6-extended.zip" `
+            --dir $legacyTemplates
+
           $editorExe = (Resolve-Path "$env:RUNNER_TEMP\assets-editor\Assets Editor.exe").Path
           $assetsInput = Join-Path $clientRoot "assets"
-          $profiles = @("cip860-extended", "client11-15x")
-          foreach ($profile in $profiles) {
+          $legacyClients = @(
+            @{
+              Profile = "cip860-extended"
+              Template = "tibia-8.6-extended.zip"
+            },
+            @{
+              Profile = "client11-15x"
+              Template = "client-11.zip"
+            }
+          )
+          foreach ($legacyClient in $legacyClients) {
+            $profile = $legacyClient.Profile
+            $templateName = $legacyClient.Template
             $profileOutput = Join-Path $env:RUNNER_TEMP "legacy-assets\$profile"
             New-Item -ItemType Directory -Force -Path $profileOutput | Out-Null
 
@@ -390,18 +425,59 @@ jobs:
               throw "Assets Editor validation failed for profile $profile."
             }
 
+            $templateZip = Join-Path $legacyTemplates $templateName
+            if (-not (Test-Path $templateZip)) {
+              throw "Legacy client template was not downloaded: $templateName"
+            }
+
+            $legacyClientRoot = Join-Path $env:RUNNER_TEMP "legacy-client-packages\$profile"
+            New-Item -ItemType Directory -Force -Path $legacyClientRoot | Out-Null
+
+            & $sevenZip x $templateZip "-o$legacyClientRoot" -y
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to extract legacy client template: $templateZip"
+            }
+
+            $targetDat = Get-ChildItem -Path $legacyClientRoot -Recurse -File -Filter "Tibia.dat" | Select-Object -First 1
+            $targetSpr = Get-ChildItem -Path $legacyClientRoot -Recurse -File -Filter "Tibia.spr" | Select-Object -First 1
+            if ($null -eq $targetDat -or $null -eq $targetSpr) {
+              throw "Legacy client template $templateName does not contain Tibia.dat and Tibia.spr."
+            }
+
+            Copy-Item -LiteralPath (Join-Path $profileOutput "Tibia.dat") -Destination $targetDat.FullName -Force
+            Copy-Item -LiteralPath (Join-Path $profileOutput "Tibia.spr") -Destination $targetSpr.FullName -Force
+
+            $itemFlag = Join-Path $profileOutput "itemFlag.otml"
+            if (Test-Path $itemFlag) {
+              Copy-Item -LiteralPath $itemFlag -Destination (Join-Path $targetDat.Directory.FullName "itemFlag.otml") -Force
+            }
+
             @(
               "client_repository=dudantas/tibia-client"
               "client_tag=$env:CLIENT_RELEASE_TAG"
               "client_commit_sha=$env:CLIENT_COMMIT_SHA"
               "client_display=$env:CLIENT_DISPLAY"
+              "legacy_template_tag=$env:LEGACY_TEMPLATE_TAG"
+              "legacy_template_asset=$templateName"
               "assets_editor_repository=$env:ASSETS_EDITOR_REPOSITORY"
               "assets_editor_ref=$env:ASSETS_EDITOR_REF"
               "legacy_profile=$profile"
-            ) | Set-Content -Path (Join-Path $profileOutput "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
+            ) | Set-Content -Path (Join-Path $legacyClientRoot "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
 
-            $legacyZip = Join-Path $dist "tibia-client-$safeClientTag-legacy-$profile.zip"
-            Compress-Archive -Path (Join-Path $profileOutput "*") -DestinationPath $legacyZip -Force
+            $legacyZip = Join-Path $dist $templateName
+            if (Test-Path $legacyZip) {
+              Remove-Item -LiteralPath $legacyZip -Force
+            }
+            Push-Location $legacyClientRoot
+            try {
+              & $sevenZip a -tzip $legacyZip ".\*" -mx=9
+              if ($LASTEXITCODE -ne 0) {
+                throw "Failed to package updated legacy client: $templateName"
+              }
+            }
+            finally {
+              Pop-Location
+            }
           }
 
           @(
@@ -430,6 +506,7 @@ jobs:
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
       CLIENT_RELEASE_TAG: ${{ needs.build-client-assets.outputs.client_tag }}
+      CLIENT_RELEASE_TOKEN: ${{ secrets.TIBIA_CLIENT_RELEASE_TOKEN }}
       PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
       RELEASE_COMMIT_SHA: ${{ needs.prepare-tag.outputs.commit_sha }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
@@ -470,6 +547,7 @@ jobs:
 
           ------------------------------------
           ### [Download Tibia Client ${CLIENT_DISPLAY}](https://github.com/dudantas/tibia-client/releases/tag/${CLIENT_RELEASE_TAG})
+          ### Full client packages are attached to this release, including `client-11.zip` and `tibia-8.6-extended.zip` with updated assets.
           ### [Download OTClient Redemption](https://github.com/opentibiabr/otclient), thanks for @mehah
 
           ------------------------------------
@@ -589,6 +667,26 @@ jobs:
           gh release upload "${RELEASE_TAG}" dist/* \
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
+
+      - name: Mirror client assets to Tibia client release
+        if: env.DRY_RUN != 'true' && env.CLIENT_RELEASE_TOKEN != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TIBIA_CLIENT_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "${CLIENT_RELEASE_TAG}" \
+            dist/tibia-client-${CLIENT_RELEASE_TAG}.zip \
+            dist/client-11.zip \
+            dist/tibia-8.6-extended.zip \
+            --repo dudantas/tibia-client \
+            --clobber
+
+      - name: Warn when Tibia client release mirroring is disabled
+        if: env.DRY_RUN != 'true' && env.CLIENT_RELEASE_TOKEN == ''
+        shell: bash
+        run: |
+          echo "::warning::TIBIA_CLIENT_RELEASE_TOKEN is not configured; client assets were only uploaded to the Canary release."
 
       - name: Publish release
         if: env.DRY_RUN != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,300 +202,72 @@ jobs:
       release_tag: ${{ needs.validate.outputs.tag }}
       checkout_ref: ${{ needs.prepare-tag.outputs.commit_sha }}
 
-  build-client-assets:
-    name: Build - Client Assets
-    needs: [prepare-tag, validate, checks, tests-lua]
-    runs-on: windows-latest
+  validate-client-release:
+    name: Validate Client Release
+    needs: [prepare-tag, validate]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       client_tag: ${{ steps.client.outputs.tag }}
-      client_commit_sha: ${{ steps.client.outputs.commit_sha }}
-      legacy_template_tag: ${{ steps.client.outputs.legacy_template_tag }}
     env:
       GH_TOKEN: ${{ github.token }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
-      ASSETS_EDITOR_REPOSITORY: dudantas/Assets-Editor
-      # PR Arch-Mina/Assets-Editor#90 adds the export-legacy CLI required here.
-      ASSETS_EDITOR_REF: d8b1c0115574d8c6a9e7a296a0e281a9bc783584
     steps:
-      - name: Resolve Tibia client tag
+      - name: Resolve and validate Tibia client release
         id: client
-        shell: pwsh
+        shell: bash
         run: |
-          $ErrorActionPreference = "Stop"
+          set -euo pipefail
 
-          $prefix = "${env:CLIENT_DISPLAY}."
-          $releases = gh api "repos/dudantas/tibia-client/releases?per_page=100" | ConvertFrom-Json
-          $release = $releases |
-            Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name.StartsWith($prefix) } |
-            Sort-Object { [DateTime]$_.published_at } -Descending |
-            Select-Object -First 1
-          $legacyTemplateRelease = $releases |
-            Where-Object {
-              -not $_.draft -and
-              -not $_.prerelease -and
-              ($_.assets | Where-Object { $_.name -eq "client-11.zip" }) -and
-              ($_.assets | Where-Object { $_.name -eq "tibia-8.6-extended.zip" })
-            } |
-            Sort-Object { [DateTime]$_.published_at } -Descending |
-            Select-Object -First 1
+          prefix="${CLIENT_DISPLAY}."
+          releases="$(gh api "repos/dudantas/tibia-client/releases?per_page=100")"
+          client_tag="$(jq -r --arg prefix "${prefix}" '
+            [
+              .[]
+              | select(.draft | not)
+              | select(.prerelease | not)
+              | select(.tag_name | startswith($prefix))
+            ]
+            | sort_by(.published_at)
+            | last
+            | .tag_name // empty
+          ' <<<"${releases}")"
 
-          if ($null -eq $release) {
-            throw "No published dudantas/tibia-client release tag was found for client ${env:CLIENT_DISPLAY}."
-          }
-          if ($null -eq $legacyTemplateRelease) {
-            throw "No published dudantas/tibia-client release was found with client-11.zip and tibia-8.6-extended.zip templates."
-          }
+          if [[ -z "${client_tag}" ]]; then
+            echo "No published dudantas/tibia-client release was found for client ${CLIENT_DISPLAY}." >&2
+            exit 1
+          fi
 
-          $ref = gh api "repos/dudantas/tibia-client/git/ref/tags/$($release.tag_name)" | ConvertFrom-Json
-          $commitSha = $ref.object.sha
-          if ($ref.object.type -eq "tag") {
-            $tagObject = gh api "repos/dudantas/tibia-client/git/tags/$commitSha" | ConvertFrom-Json
-            $commitSha = $tagObject.object.sha
-          }
-
-          "tag=$($release.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "commit_sha=$commitSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "legacy_template_tag=$($legacyTemplateRelease.tag_name)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-          @(
-            "Resolved Tibia client release:"
-            ""
-            "- Tag: $($release.tag_name)"
-            "- Commit: $commitSha"
-            "- Published: $($release.published_at)"
-            "- Legacy template release: $($legacyTemplateRelease.tag_name)"
-          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-
-      - name: Checkout Tibia client
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          repository: dudantas/tibia-client
-          ref: ${{ steps.client.outputs.tag }}
-          path: tibia-client
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout Assets Editor CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
-        with:
-          repository: dudantas/Assets-Editor
-          ref: ${{ env.ASSETS_EDITOR_REF }}
-          path: assets-editor
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Install .NET 10 SDK
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $dotnetInstall = Join-Path $env:RUNNER_TEMP "dotnet-install.ps1"
-          Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $dotnetInstall
-          & $dotnetInstall -Channel 10.0 -Quality ga -InstallDir "$env:ProgramFiles\dotnet"
-          dotnet --list-sdks
-
-      - name: Build Assets Editor CLI
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          dotnet restore "assets-editor\Assets Editor\Assets Editor.sln"
-          dotnet publish "assets-editor\Assets Editor\AssetsEditor.csproj" `
-            --configuration Release `
-            --framework net10.0-windows7.0 `
-            --output "$env:RUNNER_TEMP\assets-editor"
-
-      - name: Package client and legacy assets
-        shell: pwsh
-        env:
-          CLIENT_RELEASE_TAG: ${{ steps.client.outputs.tag }}
-          CLIENT_COMMIT_SHA: ${{ steps.client.outputs.commit_sha }}
-          LEGACY_TEMPLATE_TAG: ${{ steps.client.outputs.legacy_template_tag }}
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          $dist = Join-Path $PWD "client-dist"
-          New-Item -ItemType Directory -Force -Path $dist | Out-Null
-
-          $clientRoot = (Resolve-Path "tibia-client").Path
-          $safeClientTag = $env:CLIENT_RELEASE_TAG -replace "[^A-Za-z0-9._-]", "-"
-
-          $sevenZip = (Get-Command 7z -ErrorAction SilentlyContinue).Source
-          if (-not $sevenZip) {
-            $sevenZip = Join-Path $env:ProgramFiles "7-Zip\7z.exe"
-          }
-          if (-not (Test-Path $sevenZip)) {
-            throw "7-Zip was not found; cannot extract archived Tibia client runtime files."
-          }
-
-          $archives = Get-ChildItem -Path $clientRoot -Recurse -File -Include "*.rar", "*.zip", "*.7z"
-          if ($archives.Count -gt 0) {
-            foreach ($archive in $archives) {
-              & $sevenZip x $archive.FullName "-o$($archive.Directory.FullName)" -y
-              if ($LASTEXITCODE -ne 0) {
-                throw "Failed to extract Tibia client archive: $($archive.FullName)"
-              }
-              Remove-Item -LiteralPath $archive.FullName -Force
-            }
-          }
-
-          $mandatoryClientEntries = @(
-            "assets",
-            "assets.json",
-            "assets.json.sha256",
-            "bin",
-            "conf",
-            "package.json"
+          required_assets=(
+            "tibia-client-${client_tag}.zip"
+            "client-11.zip"
+            "tibia-8.6-extended.zip"
           )
-          $optionalClientEntries = @(
-            "3rdpartylicences",
-            "docs",
-            "partial.package.json.version",
-            "sounds"
-          )
+          release_assets="$(gh release view "${client_tag}" \
+            --repo dudantas/tibia-client \
+            --json assets \
+            --jq '.assets[].name')"
 
-          $clientPaths = @()
-          foreach ($entry in $mandatoryClientEntries) {
-            $path = Join-Path $clientRoot $entry
-            if (-not (Test-Path $path)) {
-              throw "Required Tibia client release entry is missing: $entry"
-            }
-            $clientPaths += $path
-          }
-          foreach ($entry in $optionalClientEntries) {
-            $path = Join-Path $clientRoot $entry
-            if (Test-Path $path) {
-              $clientPaths += $path
-            }
-          }
+          for asset in "${required_assets[@]}"; do
+            if ! grep -Fxq "${asset}" <<<"${release_assets}"; then
+              echo "Client release ${client_tag} is missing required asset: ${asset}" >&2
+              exit 1
+            fi
+          done
 
-          $clientManifest = @(
-            "client_repository=dudantas/tibia-client"
-            "client_tag=$env:CLIENT_RELEASE_TAG"
-            "client_commit_sha=$env:CLIENT_COMMIT_SHA"
-            "client_display=$env:CLIENT_DISPLAY"
-          )
-          $clientManifest | Set-Content -Path (Join-Path $clientRoot "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
-          $clientPaths += (Join-Path $clientRoot "CANARY_CLIENT_SOURCE.txt")
+          echo "tag=${client_tag}" >> "$GITHUB_OUTPUT"
 
-          $clientZip = Join-Path $dist "tibia-client-$safeClientTag.zip"
-          Compress-Archive -Path $clientPaths -DestinationPath $clientZip -Force
-
-          $legacyTemplates = Join-Path $env:RUNNER_TEMP "legacy-client-templates"
-          New-Item -ItemType Directory -Force -Path $legacyTemplates | Out-Null
-          gh release download $env:LEGACY_TEMPLATE_TAG `
-            --repo dudantas/tibia-client `
-            --pattern "client-11.zip" `
-            --pattern "tibia-8.6-extended.zip" `
-            --dir $legacyTemplates
-
-          $editorExe = (Resolve-Path "$env:RUNNER_TEMP\assets-editor\Assets Editor.exe").Path
-          $assetsInput = Join-Path $clientRoot "assets"
-          $legacyClients = @(
-            @{
-              Profile = "cip860-extended"
-              Template = "tibia-8.6-extended.zip"
-            },
-            @{
-              Profile = "client11-15x"
-              Template = "client-11.zip"
-            }
-          )
-          foreach ($legacyClient in $legacyClients) {
-            $profile = $legacyClient.Profile
-            $templateName = $legacyClient.Template
-            $profileOutput = Join-Path $env:RUNNER_TEMP "legacy-assets\$profile"
-            New-Item -ItemType Directory -Force -Path $profileOutput | Out-Null
-
-            & $editorExe export-legacy `
-              --profile $profile `
-              --input $assetsInput `
-              --output $profileOutput `
-              --overwrite `
-              --no-backup
-            if ($LASTEXITCODE -ne 0) {
-              throw "Assets Editor export failed for profile $profile."
-            }
-
-            & $editorExe validate-legacy `
-              --profile $profile `
-              --dat (Join-Path $profileOutput "Tibia.dat") `
-              --spr (Join-Path $profileOutput "Tibia.spr")
-            if ($LASTEXITCODE -ne 0) {
-              throw "Assets Editor validation failed for profile $profile."
-            }
-
-            $templateZip = Join-Path $legacyTemplates $templateName
-            if (-not (Test-Path $templateZip)) {
-              throw "Legacy client template was not downloaded: $templateName"
-            }
-
-            $legacyClientRoot = Join-Path $env:RUNNER_TEMP "legacy-client-packages\$profile"
-            New-Item -ItemType Directory -Force -Path $legacyClientRoot | Out-Null
-
-            & $sevenZip x $templateZip "-o$legacyClientRoot" -y
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to extract legacy client template: $templateZip"
-            }
-
-            $targetDat = Get-ChildItem -Path $legacyClientRoot -Recurse -File -Filter "Tibia.dat" | Select-Object -First 1
-            $targetSpr = Get-ChildItem -Path $legacyClientRoot -Recurse -File -Filter "Tibia.spr" | Select-Object -First 1
-            if ($null -eq $targetDat -or $null -eq $targetSpr) {
-              throw "Legacy client template $templateName does not contain Tibia.dat and Tibia.spr."
-            }
-
-            Copy-Item -LiteralPath (Join-Path $profileOutput "Tibia.dat") -Destination $targetDat.FullName -Force
-            Copy-Item -LiteralPath (Join-Path $profileOutput "Tibia.spr") -Destination $targetSpr.FullName -Force
-
-            $itemFlag = Join-Path $profileOutput "itemFlag.otml"
-            if (Test-Path $itemFlag) {
-              Copy-Item -LiteralPath $itemFlag -Destination (Join-Path $targetDat.Directory.FullName "itemFlag.otml") -Force
-            }
-
-            @(
-              "client_repository=dudantas/tibia-client"
-              "client_tag=$env:CLIENT_RELEASE_TAG"
-              "client_commit_sha=$env:CLIENT_COMMIT_SHA"
-              "client_display=$env:CLIENT_DISPLAY"
-              "legacy_template_tag=$env:LEGACY_TEMPLATE_TAG"
-              "legacy_template_asset=$templateName"
-              "assets_editor_repository=$env:ASSETS_EDITOR_REPOSITORY"
-              "assets_editor_ref=$env:ASSETS_EDITOR_REF"
-              "legacy_profile=$profile"
-            ) | Set-Content -Path (Join-Path $legacyClientRoot "CANARY_CLIENT_SOURCE.txt") -Encoding UTF8
-
-            $legacyZip = Join-Path $dist $templateName
-            if (Test-Path $legacyZip) {
-              Remove-Item -LiteralPath $legacyZip -Force
-            }
-            Push-Location $legacyClientRoot
-            try {
-              & $sevenZip a -tzip $legacyZip ".\*" -mx=9
-              if ($LASTEXITCODE -ne 0) {
-                throw "Failed to package updated legacy client: $templateName"
-              }
-            }
-            finally {
-              Pop-Location
-            }
-          }
-
-          @(
-            "Prepared client release assets:"
-            ""
-            (Get-ChildItem -Path $dist -File | Sort-Object Name | ForEach-Object { "- $($_.Name)" })
-          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-
-      - name: Upload client assets
-        uses: actions/upload-artifact@v7
-        with:
-          name: canary-client-assets
-          path: client-dist/*
-          if-no-files-found: error
+          {
+            echo "Resolved Tibia client release ${client_tag} for client ${CLIENT_DISPLAY}."
+            echo ""
+            echo "Validated required assets:"
+            printf -- "- %s\n" "${required_assets[@]}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish Release
-    needs: [prepare-tag, validate, build-linux, build-windows, build-macos, build-docker, build-client-assets]
+    needs: [prepare-tag, validate, validate-client-release, build-linux, build-windows, build-macos, build-docker]
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -505,8 +277,7 @@ jobs:
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}
       CLIENT_DISPLAY: ${{ needs.validate.outputs.client_display }}
-      CLIENT_RELEASE_TAG: ${{ needs.build-client-assets.outputs.client_tag }}
-      CLIENT_RELEASE_TOKEN: ${{ secrets.TIBIA_CLIENT_RELEASE_TOKEN }}
+      CLIENT_RELEASE_TAG: ${{ needs.validate-client-release.outputs.client_tag }}
       PREVIOUS_TAG: ${{ needs.validate.outputs.previous_tag }}
       RELEASE_COMMIT_SHA: ${{ needs.prepare-tag.outputs.commit_sha }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
@@ -547,7 +318,7 @@ jobs:
 
           ------------------------------------
           ### [Download Tibia Client ${CLIENT_DISPLAY}](https://github.com/dudantas/tibia-client/releases/tag/${CLIENT_RELEASE_TAG})
-          ### Full client packages are attached to this release, including `client-11.zip` and `tibia-8.6-extended.zip` with updated assets.
+          ### Full client packages are published in the linked Tibia client release.
           ### [Download OTClient Redemption](https://github.com/opentibiabr/otclient), thanks for @mehah
 
           ------------------------------------
@@ -563,9 +334,9 @@ jobs:
           set -euo pipefail
           mkdir -p dist
 
-          download_artifact_archive() {
+          download_artifact_zip() {
             local artifact_name="$1"
-            local output_path="$2"
+            local asset_name="$2"
             local url
             url="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
               --jq '.artifacts[] | "\(.name)\t\(.archive_download_url)"' \
@@ -579,25 +350,7 @@ jobs:
               --header "Authorization: Bearer ${GITHUB_TOKEN}" \
               --header "X-GitHub-Api-Version: 2022-11-28" \
               "${url}" \
-              --output "${output_path}"
-          }
-
-          download_artifact_zip() {
-            local artifact_name="$1"
-            local asset_name="$2"
-            download_artifact_archive "${artifact_name}" "dist/${asset_name}"
-          }
-
-          download_artifact_contents() {
-            local artifact_name="$1"
-            local archive_path
-            local extract_dir
-            archive_path="$(mktemp --suffix=.zip)"
-            extract_dir="$(mktemp -d)"
-
-            download_artifact_archive "${artifact_name}" "${archive_path}"
-            python3 -m zipfile -e "${archive_path}" "${extract_dir}"
-            find "${extract_dir}" -maxdepth 1 -type f -exec mv -f {} dist/ \;
+              --output "dist/${asset_name}"
           }
 
           download_artifact_zip "canary-linux-release" "canary-linux-release.zip"
@@ -606,7 +359,6 @@ jobs:
           download_artifact_zip "canary-windows-solution-debug" "canary-windows-solution-debug.zip"
           download_artifact_zip "canary-macos-release" "canary-macos-release.zip"
           download_artifact_zip "canary-docker" "canary-docker.zip"
-          download_artifact_contents "canary-client-assets"
 
       - name: Copy map from latest published release
         id: map
@@ -667,26 +419,6 @@ jobs:
           gh release upload "${RELEASE_TAG}" dist/* \
             --repo "${GITHUB_REPOSITORY}" \
             --clobber
-
-      - name: Mirror client assets to Tibia client release
-        if: env.DRY_RUN != 'true' && env.CLIENT_RELEASE_TOKEN != ''
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.TIBIA_CLIENT_RELEASE_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh release upload "${CLIENT_RELEASE_TAG}" \
-            dist/tibia-client-${CLIENT_RELEASE_TAG}.zip \
-            dist/client-11.zip \
-            dist/tibia-8.6-extended.zip \
-            --repo dudantas/tibia-client \
-            --clobber
-
-      - name: Warn when Tibia client release mirroring is disabled
-        if: env.DRY_RUN != 'true' && env.CLIENT_RELEASE_TOKEN == ''
-        shell: bash
-        run: |
-          echo "::warning::TIBIA_CLIENT_RELEASE_TOKEN is not configured; client assets were only uploaded to the Canary release."
 
       - name: Publish release
         if: env.DRY_RUN != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,25 @@ jobs:
           $clientRoot = (Resolve-Path "tibia-client").Path
           $safeClientTag = $env:CLIENT_RELEASE_TAG -replace "[^A-Za-z0-9._-]", "-"
 
+          $archives = Get-ChildItem -Path $clientRoot -Recurse -File -Include "*.rar", "*.zip", "*.7z"
+          if ($archives.Count -gt 0) {
+            $sevenZip = (Get-Command 7z -ErrorAction SilentlyContinue).Source
+            if (-not $sevenZip) {
+              $sevenZip = Join-Path $env:ProgramFiles "7-Zip\7z.exe"
+            }
+            if (-not (Test-Path $sevenZip)) {
+              throw "7-Zip was not found; cannot extract archived Tibia client runtime files."
+            }
+
+            foreach ($archive in $archives) {
+              & $sevenZip x $archive.FullName "-o$($archive.Directory.FullName)" -y
+              if ($LASTEXITCODE -ne 0) {
+                throw "Failed to extract Tibia client archive: $($archive.FullName)"
+              }
+              Remove-Item -LiteralPath $archive.FullName -Force
+            }
+          }
+
           $mandatoryClientEntries = @(
             "assets",
             "assets.json",


### PR DESCRIPTION
## Summary

Updates the Canary release workflow to link to and validate the exact `dudantas/tibia-client` release that matches Canary `CLIENT_VERSION`.

- Resolves the matching client release from `CLIENT_VERSION` / `client_display`, for example `1513` -> `15.13.*`.
- Validates that the client release exists before publishing Canary.
- Requires the client release to include these assets:
  - `tibia-client-<client-tag>.zip`
  - `client-11.zip`
  - `tibia-8.6-extended.zip`
- Updates release notes to link to the exact client release tag instead of `latest`.
- Keeps client packaging and legacy `.dat/.spr` generation out of the Canary release workflow.

## Related client workflow

The client packaging/release automation now lives in dudantas/tibia-client#19.

That workflow is responsible for generating/updating the modern client zip and full 11/8.60 client zips with assets exported from the current client tag.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now link to the exact client release used for downloads, making it easier to find the correct package.
  * Added a clearer note pointing to where full client packages are published.

* **Bug Fixes**
  * Improved release validation to ensure download links only point to valid, published client releases.
  * Added checks to confirm required client package files are available before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `validate-client-release` job that resolves and validates the exact `dudantas/tibia-client` release matching `CLIENT_DISPLAY` before publishing Canary, and updates the release notes link from `/releases/latest` to the specific resolved tag.

- A new `validate-client-release` job queries the `dudantas/tibia-client` GitHub API, finds the most-recently-published non-draft, non-prerelease tag that starts with `CLIENT_DISPLAY.`, validates three required assets exist, and passes the resolved tag downstream.
- The `publish` job now depends on `validate-client-release` and substitutes `CLIENT_RELEASE_TAG` into the release notes link, replacing the previous hardcoded `/releases/latest` URL.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new validation job correctly gates publishing on a verified client release, with a minor gap in release pagination that is unlikely to matter until the tibia-client repo grows beyond 100 releases.

The core logic — resolving the matching client tag, validating required assets, and threading the resolved tag into release notes — is sound. The only practical weakness is that only the first 100 releases are fetched without pagination, meaning the workflow could silently fail to find a valid release once the tibia-client repo grows large enough. Today this repo almost certainly has far fewer than 100 releases, so the risk is low but real over time.

.github/workflows/release.yml — specifically the `gh api releases?per_page=100` call and the downstream jq expression, which together would need to be updated together if pagination is ever added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds validate-client-release job with correct jq filtering, asset validation, and output wiring; only fetches first 100 releases (no pagination) and the jq `last` on null produces a null result rather than the friendly error message. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push tag / workflow_dispatch] --> B[prepare-tag]
    B --> C[validate]
    C --> D[validate-client-release]
    C --> E[checks + tests-lua]
    E --> F[build-linux]
    E --> G[build-windows]
    E --> H[build-macos]
    E --> I[build-docker]
    D --> |client_tag output| J[publish]
    F --> J
    G --> J
    H --> J
    I --> J
    B --> J
    C --> J
    J --> K{DRY_RUN?}
    K -->|false| L[Create/update draft release]
    L --> M[Upload assets]
    M --> N[Publish release]
    K -->|true| O[Summarize dry run]
    N --> P[open-metadata-pr]

    D -->|gh api releases per_page=100| Q[(dudantas/tibia-client)]
    Q --> R{Match CLIENT_DISPLAY prefix?}
    R -->|yes| S[sort by published_at, take last]
    S --> T{Required assets present?}
    T -->|yes| U[Output client_tag]
    T -->|no| V[Exit 1]
    R -->|no| W[Exit 1]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[push tag / workflow_dispatch] --> B[prepare-tag]
    B --> C[validate]
    C --> D[validate-client-release]
    C --> E[checks + tests-lua]
    E --> F[build-linux]
    E --> G[build-windows]
    E --> H[build-macos]
    E --> I[build-docker]
    D --> |client_tag output| J[publish]
    F --> J
    G --> J
    H --> J
    I --> J
    B --> J
    C --> J
    J --> K{DRY_RUN?}
    K -->|false| L[Create/update draft release]
    L --> M[Upload assets]
    M --> N[Publish release]
    K -->|true| O[Summarize dry run]
    N --> P[open-metadata-pr]

    D -->|gh api releases per_page=100| Q[(dudantas/tibia-client)]
    Q --> R{Match CLIENT_DISPLAY prefix?}
    R -->|yes| S[sort by published_at, take last]
    S --> T{Required assets present?}
    T -->|yes| U[Output client_tag]
    T -->|no| V[Exit 1]
    R -->|no| W[Exit 1]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci(release): link exact client release"](https://github.com/opentibiabr/canary/commit/9b314821a0209588d03d3505031ba80e7bc7e7b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41501300)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->