### PR TITLE
fix(protocol): align 15.13 game event payload

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -1191,7 +1191,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count) {
 		if (skill == SKILL_LEVEL) {
 			sendTakeScreenshot(SCREENSHOT_TYPE_LEVELUP);
 		} else {
-			sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP);
+			sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(skill)), skills[skill].level);
 		}
 
 		g_creatureEvents().playerAdvance(static_self_cast<Player>(), skill, (skills[skill].level - 1), skills[skill].level);
@@ -3495,10 +3495,10 @@ void Player::addManaSpent(uint64_t amount) {
 		std::ostringstream ss;
 		ss << "You advanced to magic level " << magLevel << '.';
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, ss.str());
-		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP);
+		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(SKILL_MAGLEVEL)), magLevel);
 
 		g_creatureEvents().playerAdvance(static_self_cast<Player>(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
-		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP);
+		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(SKILL_MAGLEVEL)), magLevel);
 
 		sendUpdateStats = true;
 		currReqMana = nextReqMana;
@@ -7996,7 +7996,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries) {
 			std::ostringstream ss;
 			ss << "You advanced to magic level " << magLevel << '.';
 			sendTextMessage(MESSAGE_EVENT_ADVANCE, ss.str());
-			sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP);
+			sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(SKILL_MAGLEVEL)), magLevel);
 		}
 
 		uint8_t newPercent;
@@ -8056,7 +8056,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries) {
 			if (skill == SKILL_LEVEL) {
 				sendTakeScreenshot(SCREENSHOT_TYPE_LEVELUP);
 			} else {
-				sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP);
+				sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(skill)), skills[skill].level);
 			}
 		}
 
@@ -8368,9 +8368,9 @@ void Player::sendOpenStash(bool isNpc) const {
 	}
 }
 
-void Player::sendTakeScreenshot(Screenshot_t screenshotType) const {
+void Player::sendTakeScreenshot(Screenshot_t screenshotType, uint8_t skillId, uint16_t skillLevel, const std::string &achievementName, uint16_t raceId, uint8_t bestiaryStep) const {
 	if (client) {
-		client->sendTakeScreenshot(screenshotType);
+		client->sendTakeScreenshot(screenshotType, skillId, skillLevel, achievementName, raceId, bestiaryStep);
 	}
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -3498,7 +3498,6 @@ void Player::addManaSpent(uint64_t amount) {
 		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(SKILL_MAGLEVEL)), magLevel);
 
 		g_creatureEvents().playerAdvance(static_self_cast<Player>(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
-		sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP, static_cast<uint8_t>(getCipbiaSkill(SKILL_MAGLEVEL)), magLevel);
 
 		sendUpdateStats = true;
 		currReqMana = nextReqMana;

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1149,7 +1149,7 @@ public:
 
 	void sendOpenStash(bool isNpc = false) const;
 
-	void sendTakeScreenshot(Screenshot_t screenshotType) const;
+	void sendTakeScreenshot(Screenshot_t screenshotType, uint8_t skillId = 0, uint16_t skillLevel = 0, const std::string &achievementName = "", uint16_t raceId = 0, uint8_t bestiaryStep = 0) const;
 
 	void onThink(uint32_t interval) override;
 

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -5019,7 +5019,7 @@ int PlayerFunctions::luaPlayerAddAchievement(lua_State* L) {
 
 	const bool success = player->achiev().add(achievementId, Lua::getBoolean(L, 3, true));
 	if (success) {
-		player->sendTakeScreenshot(SCREENSHOT_TYPE_ACHIEVEMENT);
+		player->sendTakeScreenshot(SCREENSHOT_TYPE_ACHIEVEMENT, 0, 0, g_game().getAchievementById(achievementId).name);
 	}
 
 	Lua::pushBoolean(L, success);
@@ -5179,7 +5179,7 @@ int PlayerFunctions::luaPlayerCreateTransactionSummary(lua_State* L) {
 }
 
 int PlayerFunctions::luaPlayerTakeScreenshot(lua_State* L) {
-	// player:takeScreenshot(screenshotType)
+	// player:takeScreenshot(screenshotType[, skillId = 0[, skillLevel = 0[, achievementName = ""[, raceId = 0[, bestiaryStep = 0]]]]])
 	const auto &player = Lua::getUserdataShared<Player>(L, 1, "Player");
 	if (!player) {
 		lua_pushnil(L);
@@ -5187,7 +5187,12 @@ int PlayerFunctions::luaPlayerTakeScreenshot(lua_State* L) {
 	}
 
 	const auto screenshotType = Lua::getNumber<Screenshot_t>(L, 2);
-	player->sendTakeScreenshot(screenshotType);
+	const auto skillId = Lua::getNumber<uint8_t>(L, 3, 0);
+	const auto skillLevel = Lua::getNumber<uint16_t>(L, 4, 0);
+	const auto achievementName = Lua::getString(L, 5, "");
+	const auto raceId = Lua::getNumber<uint16_t>(L, 6, 0);
+	const auto bestiaryStep = Lua::getNumber<uint8_t>(L, 7, 0);
+	player->sendTakeScreenshot(screenshotType, skillId, skillLevel, achievementName, raceId, bestiaryStep);
 	Lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/server/network/protocol/protocol_profile.cpp
+++ b/src/server/network/protocol/protocol_profile.cpp
@@ -199,7 +199,7 @@ namespace {
 		.supportState = ProtocolSupportState::Enabled,
 		.itemMapperPolicy = ItemMapperPolicy::NotRequired,
 		.initialBehavior = currentInitialBehavior,
-		.features = protocolFeatureMask(ProtocolFeature::CurrentPayload | ProtocolFeature::LoginSpeedFormula | ProtocolFeature::ModernLoginSideSystems | ProtocolFeature::ResourceBalancePackets | ProtocolFeature::CustomMonkPackets | ProtocolFeature::MarketPackets | ProtocolFeature::ImbuementWindow | ProtocolFeature::MemorialPackets),
+		.features = protocolFeatureMask(ProtocolFeature::CurrentPayload | ProtocolFeature::LoginSpeedFormula | ProtocolFeature::ModernLoginSideSystems | ProtocolFeature::ResourceBalancePackets | ProtocolFeature::CustomMonkPackets | ProtocolFeature::MarketPackets | ProtocolFeature::ImbuementWindow | ProtocolFeature::MemorialPackets | ProtocolFeature::PlayerDataLevelPercentU16 | ProtocolFeature::GameEventPayload),
 		.name = "current",
 		.supportLabel = "",
 	};

--- a/src/server/network/protocol/protocol_profile.hpp
+++ b/src/server/network/protocol/protocol_profile.hpp
@@ -66,6 +66,10 @@ enum class ProtocolFeature : uint64_t {
 	MarketPackets = 1ULL << 11,
 	ImbuementWindow = 1ULL << 12,
 	MemorialPackets = 1ULL << 13,
+	// Modern 0xA0 player data sends level percent as centesimal u16 instead of u8.
+	PlayerDataLevelPercentU16 = 1ULL << 14,
+	// 0x75 uses a client event selector before event-specific fields.
+	GameEventPayload = 1ULL << 15,
 };
 
 [[nodiscard]] constexpr ProtocolFeature operator|(ProtocolFeature left, ProtocolFeature right) {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -11139,7 +11139,7 @@ void ProtocolGame::sendDisableLoginMusic() {
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType) {
+void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType, uint8_t skillId, uint16_t skillLevel, const std::string &achievementName, uint16_t raceId, uint8_t bestiaryStep) {
 	if (screenshotType == SCREENSHOT_TYPE_NONE || oldProtocol) {
 		return;
 	}
@@ -11149,14 +11149,33 @@ void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType) {
 
 	if (hasProtocolFeature(protocolProfile, ProtocolFeature::GameEventPayload)) {
 		switch (screenshotType) {
+			case SCREENSHOT_TYPE_ACHIEVEMENT:
+				if (achievementName.empty()) {
+					return;
+				}
+				msg.addByte(0x02);
+				msg.addString(achievementName);
+				break;
+			case SCREENSHOT_TYPE_BESTIARYENTRYCOMPLETED:
+			case SCREENSHOT_TYPE_BESTIARYENTRYUNLOCKED:
+				if (raceId == 0) {
+					return;
+				}
+				msg.addByte(0x06);
+				msg.add<uint16_t>(raceId);
+				msg.addByte(bestiaryStep);
+				break;
 			case SCREENSHOT_TYPE_LEVELUP:
 				msg.addByte(0x04);
 				msg.add<uint16_t>(std::min<uint32_t>(player ? player->getLevel() : 0, 0xFFFF));
 				break;
 			case SCREENSHOT_TYPE_SKILLUP:
+				if (skillId == 0 || skillLevel == 0) {
+					return;
+				}
 				msg.addByte(0x05);
-				msg.addByte(0x00);
-				msg.add<uint16_t>(0x00);
+				msg.addByte(skillId);
+				msg.add<uint16_t>(skillLevel);
 				break;
 			case SCREENSHOT_TYPE_BOSSDEFEATED:
 				msg.addByte(0x01);
@@ -11193,12 +11212,9 @@ void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType) {
 			default:
 				return;
 		}
-
-		writeToOutputBuffer(msg);
-		return;
+	} else {
+		msg.addByte(screenshotType);
 	}
-
-	msg.addByte(screenshotType);
 
 	writeToOutputBuffer(msg);
 }

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -9285,7 +9285,7 @@ void ProtocolGame::AddPlayerStats(NetworkMessage &msg) {
 
 	msg.add<uint16_t>(player->getLevel());
 	if (!oldProtocol) {
-		if (clientVersion >= 1513) {
+		if (hasProtocolFeature(protocolProfile, ProtocolFeature::PlayerDataLevelPercentU16)) {
 			const auto levelPercent = std::min<uint16_t>(static_cast<uint16_t>(player->getLevelPercent()) * 100, 10000);
 			msg.add<uint16_t>(levelPercent);
 		} else {
@@ -11146,7 +11146,60 @@ void ProtocolGame::sendTakeScreenshot(Screenshot_t screenshotType) {
 
 	NetworkMessage msg;
 	msg.addByte(0x75);
+
+	if (hasProtocolFeature(protocolProfile, ProtocolFeature::GameEventPayload)) {
+		switch (screenshotType) {
+			case SCREENSHOT_TYPE_LEVELUP:
+				msg.addByte(0x04);
+				msg.add<uint16_t>(std::min<uint32_t>(player ? player->getLevel() : 0, 0xFFFF));
+				break;
+			case SCREENSHOT_TYPE_SKILLUP:
+				msg.addByte(0x05);
+				msg.addByte(0x00);
+				msg.add<uint16_t>(0x00);
+				break;
+			case SCREENSHOT_TYPE_BOSSDEFEATED:
+				msg.addByte(0x01);
+				msg.addByte(0x01);
+				break;
+			case SCREENSHOT_TYPE_DEATHPVE:
+				msg.addByte(0x01);
+				msg.addByte(0x02);
+				break;
+			case SCREENSHOT_TYPE_DEATHPVP:
+				msg.addByte(0x01);
+				msg.addByte(0x03);
+				break;
+			case SCREENSHOT_TYPE_PLAYERKILLASSIST:
+				msg.addByte(0x01);
+				msg.addByte(0x04);
+				break;
+			case SCREENSHOT_TYPE_PLAYERKILL:
+				msg.addByte(0x01);
+				msg.addByte(0x05);
+				break;
+			case SCREENSHOT_TYPE_PLAYERATTACKING:
+				msg.addByte(0x01);
+				msg.addByte(0x06);
+				break;
+			case SCREENSHOT_TYPE_TREASUREFOUND:
+				msg.addByte(0x01);
+				msg.addByte(0x07);
+				break;
+			case SCREENSHOT_TYPE_GIFTOFLIFE:
+				msg.addByte(0x01);
+				msg.addByte(0x08);
+				break;
+			default:
+				return;
+		}
+
+		writeToOutputBuffer(msg);
+		return;
+	}
+
 	msg.addByte(screenshotType);
+
 	writeToOutputBuffer(msg);
 }
 

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -636,7 +636,7 @@ private:
 	void sendAmbientSoundEffect(const SoundAmbientEffect_t id);
 	void sendMusicSoundEffect(const SoundMusicEffect_t id);
 
-	void sendTakeScreenshot(Screenshot_t screenshotType);
+	void sendTakeScreenshot(Screenshot_t screenshotType, uint8_t skillId = 0, uint16_t skillLevel = 0, const std::string &achievementName = "", uint16_t raceId = 0, uint8_t bestiaryStep = 0);
 	void sendDisableLoginMusic();
 
 	uint8_t m_playerDeathTime = 0;


### PR DESCRIPTION
## Summary

Fixes the current profile `0x75` game event payload used by screenshot-triggered events such as player death.

The current profile should send a client event selector before event-specific fields. Death events now use the simple client event contract:

- PvE death: `0x75 0x01 0x02`
- PvP death: `0x75 0x01 0x03`

This avoids sending the old screenshot enum value directly, which can make the client interpret the payload as a different event body and desynchronize the packet stream.

## Root Cause

The death flow was sending the wrong shape for `0x75`: the byte after the opcode was interpreted as an event/body selector by the client, not as the old local screenshot enum. For death, that caused the client to parse the following byte as part of an unrelated event payload and lose packet alignment.

## Validation

- Decoded the failing client log payload with LogReader.
- Confirmed the bad stream parsed `0x75 0x08 0x03` as an incorrect event body and consumed bytes from following packets.
- Simulated the corrected `0x75 0x01 0x03` payload and confirmed LogReader advanced to the next packet boundary correctly.
- No server build was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer screenshot/game-event payload support, including optional skill id/level, achievement name, race id, and bestiary step.
  * Extended protocol feature flags to enable higher-precision player level percentage transmission when supported by the connection.
* **Bug Fixes**
  * Preserved legacy message formats for older clients and non-applicable screenshot types to avoid protocol mismatches.
  * Updated Lua achievement and screenshot calls to forward the new optional context fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `0x75` game event packet for protocol profile 15.13 by introducing a `GameEventPayload` feature flag and routing each `Screenshot_t` value to the correct client event selector byte, preventing packet stream desynchronisation on death and other events. It also adds a `PlayerDataLevelPercentU16` flag to send level percent as a centesimal `uint16_t` on the current profile, and threads per-event context (skill id/level, achievement name, race id, bestiary step) through the entire call chain.

- `sendTakeScreenshot` now builds the correct two-byte `0x01 0xNN` selector for simple events (death, boss, kill, etc.) and properly structured payloads for achievement (`0x02 + name`), level-up (`0x04 + level`), skill-up (`0x05 + skillId + level`), and bestiary (`0x06 + raceId + step`), falling back to the legacy single-byte format for older clients.
- A duplicate `sendTakeScreenshot(SCREENSHOT_TYPE_SKILLUP)` call that fired immediately after `g_creatureEvents().playerAdvance` in `addManaSpent` is removed; all call sites now supply real skill id and level values instead of the former hardcoded zeros.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the protocol fix is well-scoped and the legacy fallback path is preserved for older clients.

The two most impactful issues from the previous review round are both addressed by this PR. The remaining observations are implicit narrowing of uint32_t magLevel to uint16_t and integer-promotion in the centesimal level-percent computation — neither causes incorrect runtime behaviour at realistic values. Feature-flag gating keeps old-protocol clients unaffected.

src/server/network/protocol/protocolgame.cpp — the new sendTakeScreenshot switch and the levelPercent computation are worth a second pair of eyes for the integer-promotion style issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/server/network/protocol/protocolgame.cpp | Core fix: sendTakeScreenshot now branches on GameEventPayload feature flag and emits correct 0x75 client event selector format; also fixes duplicate SKILLUP send; removes direct clientVersion version check in AddPlayerStats in favour of feature flag. |
| src/server/network/protocol/protocol_profile.cpp | Adds PlayerDataLevelPercentU16 and GameEventPayload feature flags to the current profile; straightforward change aligned with the two new enum values. |
| src/server/network/protocol/protocol_profile.hpp | Defines two new ProtocolFeature flags (PlayerDataLevelPercentU16 at bit 14 and GameEventPayload at bit 15); no conflicts with existing bits. |
| src/creatures/players/player.cpp | Threads skillId/skillLevel/achievementName/raceId/bestiaryStep through sendTakeScreenshot; fixes duplicate SKILLUP call in addManaSpent; passes uint32_t magLevel where uint16_t is expected (implicit narrowing). |
| src/creatures/players/player.hpp | Declaration updated with new optional parameters; all new params have sensible defaults. |
| src/lua/functions/creatures/player/player_functions.cpp | Lua binding for player:takeScreenshot extended with optional args; luaPlayerAddAchievement now passes achievement name for correct GameEventPayload format. |
| src/server/network/protocol/protocolgame.hpp | Header declaration updated to match the new sendTakeScreenshot signature; no issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Player event (death, level, skill, achievement, bestiary)"] --> B["Player::sendTakeScreenshot"]
    B --> C["ProtocolGame::sendTakeScreenshot"]
    C --> D{oldProtocol?}
    D -- yes --> E["drop"]
    D -- no --> F{GameEventPayload feature?}
    F -- no --> G["0x75 + screenshotType byte (legacy)"]
    F -- yes --> H{screenshotType}
    H -- LEVELUP --> I["0x75 0x04 + level u16"]
    H -- SKILLUP --> J{skillId==0 or skillLevel==0?}
    J -- yes --> K["drop"]
    J -- no --> L["0x75 0x05 + skillId + level u16"]
    H -- ACHIEVEMENT --> M{achievementName empty?}
    M -- yes --> N["drop"]
    M -- no --> O["0x75 0x02 + name string"]
    H -- BESTIARY --> P{raceId==0?}
    P -- yes --> Q["drop"]
    P -- no --> R["0x75 0x06 + raceId u16 + step"]
    H -- "DEATH/BOSS/KILL/etc." --> S["0x75 0x01 + sub-selector"]
    G --> T[writeToOutputBuffer]
    I --> T
    L --> T
    O --> T
    R --> T
    S --> T
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Player event (death, level, skill, achievement, bestiary)"] --> B["Player::sendTakeScreenshot"]
    B --> C["ProtocolGame::sendTakeScreenshot"]
    C --> D{oldProtocol?}
    D -- yes --> E["drop"]
    D -- no --> F{GameEventPayload feature?}
    F -- no --> G["0x75 + screenshotType byte (legacy)"]
    F -- yes --> H{screenshotType}
    H -- LEVELUP --> I["0x75 0x04 + level u16"]
    H -- SKILLUP --> J{skillId==0 or skillLevel==0?}
    J -- yes --> K["drop"]
    J -- no --> L["0x75 0x05 + skillId + level u16"]
    H -- ACHIEVEMENT --> M{achievementName empty?}
    M -- yes --> N["drop"]
    M -- no --> O["0x75 0x02 + name string"]
    H -- BESTIARY --> P{raceId==0?}
    P -- yes --> Q["drop"]
    P -- no --> R["0x75 0x06 + raceId u16 + step"]
    H -- "DEATH/BOSS/KILL/etc." --> S["0x75 0x01 + sub-selector"]
    G --> T[writeToOutputBuffer]
    I --> T
    L --> T
    O --> T
    R --> T
    S --> T
```

</a>

<sub>Reviews (3): Last reviewed commit: ["fix(player): avoid duplicate skill scree..."](https://github.com/opentibiabr/canary/commit/90d7b7809e38b3e0553420e2f339445da8157aad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41678187)</sub>

<!-- /greptile_comment -->