### PR TITLE
fix: Barbarian Test Quest

### DIFF
--- a/data-otservbr-global/npc/sven.lua
+++ b/data-otservbr-global/npc/sven.lua
@@ -70,6 +70,10 @@ local function creatureSayCallback(npc, creature, type, message)
 	end
 
 	local questline = player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline)
+	local totalSips = player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips)
+	-- A honeycomb may only buy a new round when none is active: before the first
+	-- round (questline 1) or once the 20 sips of the current one are used up.
+	local canStartMeadRound = questline == 1 or (questline == 2 and totalSips >= 20)
 
 	if MsgContains(message, "barbarian") and questline < 1 then
 		npcHandler:say("A true barbarian is something special among our people. Everyone who wants to become a barbarian will have to pass the barbarian {test}.", npc, creature)
@@ -86,7 +90,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			"Are you willing to take the barbarian test?",
 		}, npc, creature)
 		npcHandler:setTopic(playerId, 2)
-	elseif MsgContains(message, "mead") and (questline == 1 or questline == 2) then
+	elseif MsgContains(message, "mead") and canStartMeadRound then
 		npcHandler:say("Do you have some honey with you?", npc, creature)
 		npcHandler:setTopic(playerId, 4)
 	elseif MsgContains(message, "mead") and questline == 3 then
@@ -152,7 +156,7 @@ local function creatureSayCallback(npc, creature, type, message)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 1) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
 			end
 		elseif npcHandler:getTopic(playerId) == 4 then
-			if player:removeItem(5902, 1) then
+			if canStartMeadRound and player:removeItem(5902, 1) then
 				npcHandler:say("Good, for this honeycomb I allow you 20 sips from the mead bucket over there. Talk to me again about barbarian mead if you have passed the test.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 2)

--- a/data-otservbr-global/npc/sven.lua
+++ b/data-otservbr-global/npc/sven.lua
@@ -69,19 +69,27 @@ local function creatureSayCallback(npc, creature, type, message)
 		return false
 	end
 
-	if MsgContains(message, "barbarian") and player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) < 1 then
+	local questline = player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline)
+
+	if MsgContains(message, "barbarian") and questline < 1 then
 		npcHandler:say("A true barbarian is something special among our people. Everyone who wants to become a barbarian will have to pass the barbarian {test}.", npc, creature)
 		npcHandler:setTopic(playerId, 1)
-	elseif MsgContains(message, "test") then
+	elseif (MsgContains(message, "test") or MsgContains(message, "mission") or MsgContains(message, "mammoth")) and questline >= 8 then
+		npcHandler:say("You have braved all three tests and are now an honorary barbarian.", npc, creature)
+		npcHandler:setTopic(playerId, 0)
+	elseif MsgContains(message, "join") then
+		npcHandler:say("You might become an honorary barbarian if you manage to pass the barbarian test.", npc, creature)
+		npcHandler:setTopic(playerId, 0)
+	elseif MsgContains(message, "test") and questline < 1 then
 		npcHandler:say({
 			"All of our juveniles have to take the barbarian test to become a true member of our community. Foreigners who manage to master the test are granted the title of an honorary barbarian and the respect of our people ...",
 			"Are you willing to take the barbarian test?",
 		}, npc, creature)
 		npcHandler:setTopic(playerId, 2)
-	elseif MsgContains(message, "mead") and player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 1 then
+	elseif MsgContains(message, "mead") and (questline == 1 or questline == 2) then
 		npcHandler:say("Do you have some honey with you?", npc, creature)
 		npcHandler:setTopic(playerId, 4)
-	elseif MsgContains(message, "barbarian mead") and player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 3 then
+	elseif MsgContains(message, "mead") and questline == 3 then
 		npcHandler:say({
 			"An impressive start. Here, take your own mead horn to fill it at the mead bucket as often as you like ...",
 			"But there is much left to be done. Your next test will be to hug a bear ...",
@@ -93,7 +101,7 @@ local function creatureSayCallback(npc, creature, type, message)
 		player:addItem(7140, 1)
 		npcHandler:setTopic(playerId, 0)
 	elseif MsgContains(message, "hug") then
-		if player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 5 then
+		if questline == 5 then
 			npcHandler:say({
 				"Amazing. That was as clever and brave as a barbarian is supposed to be. But a barbarian also has to be strong and fearless. To prove that you will have to knock over a mammoth ...",
 				"Did your face just turn into the color of fresh snow? However, you will find a lonely mammoth north west of the town in the wilderness. Knock it over to prove to be a true barbarian ...",
@@ -104,7 +112,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			npcHandler:setTopic(playerId, 0)
 		end
 	elseif MsgContains(message, "mammoth") then
-		if player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 7 then
+		if questline == 7 then
 			npcHandler:say({
 				"As you have passed all three tests, I welcome you in our town as an honorary barbarian. You can now become a citizen. Don't forget to talk to the people here. Some of them might need some help ...",
 				"We usually solve our problems on our own but some of the people might have a mission for you. Old Iskan, on the ice in the northern part of the town had some trouble with his dogs lately.",
@@ -114,7 +122,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			npcHandler:setTopic(playerId, 0)
 		end
 	elseif MsgContains(message, "yes") then
-		if player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.HuskyKillStatus) == 1 and player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 8 then
+		if player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.HuskyKillStatus) == 1 and questline == 8 then
 			if player:removeMoneyBank(player:getStorageValue(Storage.Quest.U8_0.TheIceIslands.HuskyKill) * 1500) then
 				npcHandler:say("Alright, we are even!", npc, creature)
 				player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.HuskyKillStatus, 0)
@@ -137,9 +145,12 @@ local function creatureSayCallback(npc, creature, type, message)
 				"Therefore, you have to get your own honey. You'll probably need more than one try so better get some extra honeycombs. Then talk to me again about barbarian {mead}.",
 			}, npc, creature)
 			npcHandler:setTopic(playerId, 0)
-			player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 1)
-			player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline, 1)
-			player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 1) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
+			-- Guard: the intro may only start the quest, never reset a player who already has progress.
+			if questline < 1 then
+				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 1)
+				player:setStorageValue(Storage.Quest.U8_0.TheIceIslands.Questline, 1)
+				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 1) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
+			end
 		elseif npcHandler:getTopic(playerId) == 4 then
 			if player:removeItem(5902, 1) then
 				npcHandler:say("Good, for this honeycomb I allow you 20 sips from the mead bucket over there. Talk to me again about barbarian mead if you have passed the test.", npc, creature)
@@ -147,6 +158,7 @@ local function creatureSayCallback(npc, creature, type, message)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 2)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 2) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips, 0)
+				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips, 0)
 			end
 		end
 	elseif MsgContains(message, "no") then

--- a/data-otservbr-global/scripts/quests/barbarian_test/action_mead.lua
+++ b/data-otservbr-global/scripts/quests/barbarian_test/action_mead.lua
@@ -3,11 +3,16 @@ condition:setOutfit({ lookTypeEx = 111 })
 condition:setTicks(1000)
 local barbarianMead = Action()
 function barbarianMead.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) == 2 and player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips) <= 20 then
+	local questline = player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline)
+	local totalSips = player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips)
+	if questline >= 3 then
+		player:say("You already passed the test, no need to torture yourself anymore.", TALKTYPE_MONSTER_SAY)
+	elseif questline == 2 and totalSips < 20 then
 		if math.random(5) > 1 then
 			player:say("The world seems to spin but you manage to stay on your feet.", TALKTYPE_MONSTER_SAY)
-			player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips, player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips) + 1)
-			if player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips) == 9 then -- 9 sips here cause local player at start
+			local successSips = math.max(player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips), 0) + 1
+			player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips, successSips)
+			if successSips >= 10 then
 				player:say("10 sips in a row. Yeah!", TALKTYPE_MONSTER_SAY)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 3)
 				player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 3) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
@@ -19,13 +24,11 @@ function barbarianMead.onUse(player, item, fromPosition, target, toPosition, isH
 			player:getPosition():sendMagicEffect(CONST_ME_HITBYPOISON)
 			player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadSuccessSips, 0)
 		end
-		player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips, player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips) + 1)
-	elseif player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips) > 20 then
+		player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.MeadTotalSips, totalSips + 1)
+	elseif (questline == 1 or questline == 2) and totalSips >= 20 then
 		player:say("Ask Sven for another round.", TALKTYPE_MONSTER_SAY)
 		player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline, 1)
 		player:setStorageValue(Storage.Quest.U8_0.BarbarianTest.Mission01, 1) -- Questlog Barbarian Test Quest Barbarian Test 1: Barbarian Booze
-	elseif player:getStorageValue(Storage.Quest.U8_0.BarbarianTest.Questline) >= 3 then
-		player:say("You already passed the test, no need to torture yourself anymore.", TALKTYPE_MONSTER_SAY)
 	end
 	return true
 end


### PR DESCRIPTION
## Description

Two bugs in the **Barbarian Test quest** (Svargrond, NPC Sven) that get players stuck or silently wipe their progress. Behaviour verified against the tibia.fandom.com transcripts ([Barbarian Test Quest/Spoiler](https://tibia.fandom.com/wiki/Barbarian_Test_Quest/Spoiler), [Sven/Transcripts](https://tibia.fandom.com/wiki/Sven/Transcripts)).

### Bug 1 — Sven ignores `mead` after the player passes the drinking test

With the mead test passed (`Questline == 3`), the only branch that hands out the mead horn required the literal phrase `barbarian mead`. But Sven tells the player *"talk to me again about barbarian {mead}"* — the highlighted keyword is **mead**, and saying it matched no branch: Sven stayed silent and the player was stuck with no way forward.

### Bug 2 — `test` resets quest progress from any state

The `{test}` intro branch had no state guard, so `test` → `yes` → `yes` re-ran `setStorageValue(Questline, 1)` from **any** quest state, silently wiping the progress of a player mid-quest (or after finishing). The intro now only runs with `Questline < 1`, and with the quest complete Sven answers with the honorary barbarian line, like on real Tibia.

### Faithfulness fixes in the same flow

- The sip streak now requires **exactly 10 sips in a row**: the counter started at `-1` and checked `== 9`, which meant 11 sips on the first round and 9 after passing out.
- **Exactly 20 sips per honeycomb** (was 21 because of `<= 20`), and the success streak resets when a new honeycomb round starts.
- *"You already passed the test"* is checked **first** at the mead bucket, so a player who already passed can never be pushed back into the honeycomb round.
- Added the `{join}` keyword from the transcripts.

## Behaviour

| Player says | Before | After |
|---|---|---|
| `mead` with test passed | *(silence — stuck)* | hands mead horn, starts bear hugging |
| `test` mid-quest → `yes`×2 | progress wiped to Questline 1 | intro only runs when quest not started |
| `test`/`mission` with quest complete | progress wiped | "You have braved all three tests..." |
| 10th consecutive sip | needed 11 (first round) / 9 (after KO) | passes exactly at 10 |

## Testing

Deployed on a live 15.11 server (mounted over the stock files) and completed the full quest in game: `mead` hands the horn after passing the test, `hug` and `mammoth` advance and finish the quest, `test` mid-quest no longer resets, storage progression tracked live in `player_storage` (keys 41174-41179).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Barbarian Test dialogue routing so responses and progression steps track the player’s current quest status more consistently.
  * Prevented quest progress from being reset when players revisit the honey/mead introduction.
  * Refined mead quest progression rules, including stricter checks for eligible quest stages and updated success/pass conditions to reduce unintended resets and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Sven's Barbarian Test quest flow. The main changes are:

- Adds quest-state guards around the `test` intro.
- Lets `mead` advance players after the drinking test.
- Resets mead sip streaks when a new honeycomb round starts.
- Adjusts the mead bucket to require 10 successful sips and 20 total attempts.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small dialog cleanup.

- The main quest progression fixes are consistent with the changed storage flow.
- One started-quest dialog path can now fall silent when players ask Sven about `test` again.

data-otservbr-global/npc/sven.lua

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| data-otservbr-global/npc/sven.lua | Updates Sven's quest-state dialog and progression guards; the started `test` keyword can now fall through without a response. |
| data-otservbr-global/scripts/quests/barbarian_test/action_mead.lua | Updates the mead bucket branch order and sip counters to match the intended drinking-test rules. |

<sub>Reviews (1): Last reviewed commit: ["fix: Barbarian Test quest — Sven ignores..."](https://github.com/opentibiabr/canary/commit/c924fdb05b0e8f6f7fccd248eceeb48ff27c7648) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42009562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->