### PR TITLE
fix(recompile): back up the active runtime executable

### DIFF
--- a/recompile.sh
+++ b/recompile.sh
@@ -142,11 +142,156 @@ setup_canary() {
 	fi
 }
 
+cache_value() {
+	local variable_name=$1
+	local cache_file="build/${BUILD_TYPE}/CMakeCache.txt"
+
+	if [[ ! -f "$cache_file" ]]; then
+		return 1
+	fi
+
+	local cache_line
+	while IFS= read -r cache_line; do
+		if [[ $cache_line == "$variable_name":*=* || $cache_line == "$variable_name="* ]]; then
+			printf '%s\n' "${cache_line#*=}"
+			return 0
+		fi
+	done <"$cache_file"
+
+	return 1
+}
+
+cmake_arg_value() {
+	local variable_name=$1
+	local index=0
+	local found=0
+	local value=""
+
+	while ((index < ${#EXTRA_CMAKE_ARGS[@]})); do
+		local arg=${EXTRA_CMAKE_ARGS[$index]}
+
+		if [[ $arg == -D"$variable_name"=* || $arg == -D"$variable_name":*=* ]]; then
+			value=${arg#*=}
+			found=1
+		elif [[ $arg == "-D" ]]; then
+			((index += 1))
+			if ((index >= ${#EXTRA_CMAKE_ARGS[@]})); then
+				break
+			fi
+
+			arg=${EXTRA_CMAKE_ARGS[$index]}
+			if [[ $arg == "$variable_name"=* || $arg == "$variable_name":*=* ]]; then
+				value=${arg#*=}
+				found=1
+			fi
+		fi
+
+		((index += 1))
+	done
+
+	if [[ $found == 0 ]]; then
+		return 1
+	fi
+
+	printf '%s\n' "$value"
+}
+
+cmake_value() {
+	local variable_name=$1
+	local fallback=${2-}
+	local value
+
+	if value=$(cmake_arg_value "$variable_name"); then
+		printf '%s\n' "$value"
+	elif value=$(cache_value "$variable_name"); then
+		printf '%s\n' "$value"
+	elif [[ $# -ge 2 ]]; then
+		printf '%s\n' "$fallback"
+	else
+		return 1
+	fi
+}
+
+default_cmake_build_type() {
+	local preset_name=${BUILD_TYPE,,}
+
+	if [[ $preset_name == *debug* ]]; then
+		printf '%s\n' "Debug"
+	else
+		printf '%s\n' "RelWithDebInfo"
+	fi
+}
+
+cmake_enabled() {
+	local value=${1^^}
+	[[ $value == "1" || $value == "ON" || $value == "TRUE" || $value == "YES" ]]
+}
+
+executable_name() {
+	local build_type
+	build_type=$(cmake_value "CMAKE_BUILD_TYPE" "$(default_cmake_build_type)")
+
+	if [[ $build_type == "Debug" ]]; then
+		printf '%s\n' "canary-debug"
+	else
+		printf '%s\n' "canary"
+	fi
+}
+
+executable_suffix() {
+	local suffix
+	if suffix=$(cmake_value "CMAKE_EXECUTABLE_SUFFIX"); then
+		printf '%s\n' "$suffix"
+		return
+	fi
+
+	case "$(uname -s)" in
+		MINGW* | MSYS* | CYGWIN*)
+			printf '%s\n' ".exe"
+			;;
+		*)
+			printf '%s\n' ""
+			;;
+	esac
+}
+
+runtime_output_directory() {
+	local toggle_bin_folder
+	toggle_bin_folder=$(cmake_value "TOGGLE_BIN_FOLDER" "OFF")
+
+	if cmake_enabled "$toggle_bin_folder"; then
+		local cache_binary_dir
+		if cache_binary_dir=$(cache_value "CMAKE_CACHEFILE_DIR"); then
+			printf '%s\n' "${cache_binary_dir}/bin"
+		else
+			printf '%s\n' "build/${BUILD_TYPE}/bin"
+		fi
+	else
+		printf '%s\n' "."
+	fi
+}
+
+executable_path() {
+	local output_directory
+	output_directory=$(runtime_output_directory)
+
+	local executable_file
+	executable_file="$(executable_name)$(executable_suffix)"
+
+	if [[ $output_directory == "." ]]; then
+		printf '%s\n' "$executable_file"
+	else
+		printf '%s\n' "${output_directory}/${executable_file}"
+	fi
+}
+
 move_executable() {
-	local executable_name="canary"
-	if [[ -e "build/$executable_name" ]]; then
-		info "Saving previous build as ${executable_name}.old"
-		mv "build/$executable_name" "build/${executable_name}.old"
+	local current_executable
+	current_executable=$(executable_path)
+
+	if [[ -f "$current_executable" ]]; then
+		info "Saving previous build as ${current_executable}.old"
+		mv -f "$current_executable" "${current_executable}.old"
 	fi
 }
 

--- a/recompile.sh
+++ b/recompile.sh
@@ -12,6 +12,9 @@ BUILD_TYPE=${2:-"linux-release"}
 ARCHITECTURE=$(uname -m)
 EXTRA_CMAKE_ARGS=("${@:3}")
 IS_ARM64=0
+WORKTREE_ROOT=$PWD
+BACKED_UP_EXECUTABLE=""
+BACKED_UP_EXECUTABLE_OLD=""
 
 # ============================================================================
 # Logging helpers
@@ -142,6 +145,18 @@ setup_canary() {
 	fi
 }
 
+absolute_path() {
+	local path=$1
+	case "$path" in
+		/* | [A-Za-z]:/* | [A-Za-z]:\\*)
+			printf '%s\n' "$path"
+			;;
+		*)
+			printf '%s\n' "${WORKTREE_ROOT}/${path}"
+			;;
+	esac
+}
+
 cache_value() {
 	local variable_name=$1
 	local cache_file="build/${BUILD_TYPE}/CMakeCache.txt"
@@ -151,7 +166,8 @@ cache_value() {
 	fi
 
 	local cache_line
-	while IFS= read -r cache_line; do
+	while IFS= read -r cache_line || [[ -n "$cache_line" ]]; do
+		cache_line=${cache_line%$'\r'}
 		if [[ $cache_line == "$variable_name":*=* || $cache_line == "$variable_name="* ]]; then
 			printf '%s\n' "${cache_line#*=}"
 			return 0
@@ -168,7 +184,7 @@ cmake_arg_value() {
 	local value=""
 
 	while ((index < ${#EXTRA_CMAKE_ARGS[@]})); do
-		local arg=${EXTRA_CMAKE_ARGS[$index]}
+		local arg="${EXTRA_CMAKE_ARGS[$index]}"
 
 		if [[ $arg == -D"$variable_name"=* || $arg == -D"$variable_name":*=* ]]; then
 			value=${arg#*=}
@@ -179,7 +195,7 @@ cmake_arg_value() {
 				break
 			fi
 
-			arg=${EXTRA_CMAKE_ARGS[$index]}
+			arg="${EXTRA_CMAKE_ARGS[$index]}"
 			if [[ $arg == "$variable_name"=* || $arg == "$variable_name":*=* ]]; then
 				value=${arg#*=}
 				found=1
@@ -213,18 +229,25 @@ cmake_value() {
 }
 
 default_cmake_build_type() {
-	local preset_name=${BUILD_TYPE,,}
-
-	if [[ $preset_name == *debug* ]]; then
-		printf '%s\n' "Debug"
-	else
-		printf '%s\n' "RelWithDebInfo"
-	fi
+	case "$BUILD_TYPE" in
+		*[Dd][Ee][Bb][Uu][Gg]*)
+			printf '%s\n' "Debug"
+			;;
+		*)
+			printf '%s\n' "RelWithDebInfo"
+			;;
+	esac
 }
 
 cmake_enabled() {
-	local value=${1^^}
-	[[ $value == "1" || $value == "ON" || $value == "TRUE" || $value == "YES" ]]
+	case "${1-}" in
+		1 | [Oo][Nn] | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss])
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
 }
 
 executable_name() {
@@ -292,6 +315,40 @@ move_executable() {
 	if [[ -f "$current_executable" ]]; then
 		info "Saving previous build as ${current_executable}.old"
 		mv -f "$current_executable" "${current_executable}.old"
+		BACKED_UP_EXECUTABLE=$(absolute_path "$current_executable")
+		BACKED_UP_EXECUTABLE_OLD=$(absolute_path "${current_executable}.old")
+	fi
+}
+
+restore_executable_backup() {
+	if [[ -z $BACKED_UP_EXECUTABLE || -z $BACKED_UP_EXECUTABLE_OLD ]]; then
+		return 0
+	fi
+
+	if [[ ! -f $BACKED_UP_EXECUTABLE_OLD || -e $BACKED_UP_EXECUTABLE ]]; then
+		return 0
+	fi
+
+	info "Restoring previous build from ${BACKED_UP_EXECUTABLE_OLD}"
+	cp -p "$BACKED_UP_EXECUTABLE_OLD" "$BACKED_UP_EXECUTABLE"
+}
+
+fail_after_build_step() {
+	local message=$1
+	restore_executable_backup
+	error "$message"
+	exit 1
+}
+
+configure_or_restore() {
+	if ! configure_canary; then
+		fail_after_build_step "CMake configuration failed."
+	fi
+}
+
+compile_or_restore() {
+	if ! compile_canary; then
+		fail_after_build_step "Build failed."
 	fi
 }
 
@@ -349,8 +406,8 @@ main() {
 	move_executable
 	setup_canary
 
-	configure_canary || exit 1
-	compile_canary || exit 1
+	configure_or_restore
+	compile_or_restore
 }
 
 main


### PR DESCRIPTION
## Summary

- Resolve the executable name from the effective CMake build type, so Debug builds back up `canary-debug` while release-like builds back up `canary`.
- Resolve the executable directory from `TOGGLE_BIN_FOLDER`, supporting both the repository root output and `build/<preset>/bin` output.
- Read explicit `-D...` overrides first and fall back to the existing `CMakeCache.txt` when available, so reruns use the same output contract CMake configured.

## Context

This follows up on #3985. That PR correctly identified that the default `linux-release` flow writes the executable to the repository root, not `build/canary`, but hardcoding only `./canary` still misses Debug builds and `TOGGLE_BIN_FOLDER=ON` builds. This change makes the backup path match the active build mode instead of fixing only one output layout.

## Validation

- `bash -n recompile.sh`
- Exercised the path-resolution helpers without running `main`:
  - `linux-release` -> `canary`
  - `linux-debug` -> `canary-debug`
  - `linux-release -DTOGGLE_BIN_FOLDER=ON` -> `build/linux-release/bin/canary`
  - `linux-release -DTOGGLE_BIN_FOLDER=ON -DCMAKE_BUILD_TYPE=Debug` -> `build/linux-release/bin/canary-debug`
- `git diff --check`

No compile/build was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable handling during recompilation by dynamically locating the correct canary binary across different build types and platforms.
  * Added safer backup/restore behavior around configuration and compilation, so if a step fails after replacing the executable, the prior binary is restored automatically.
  * Replacements are now backed up using consistent, filesystem-accurate paths to reduce misdirected or broken updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `recompile.sh` so backup handling follows the active CMake output path. The main changes are:

- Resolve the executable name from the effective build type.
- Resolve the executable directory from `TOGGLE_BIN_FOLDER` and cache values.
- Restore the saved executable when configure or build fails.

<h3>Confidence Score: 4/5</h3>

This is close, but the restore path should be fixed before merging.

- Failed builds can still leave the runtime path without the last good executable.
- A failed-build artifact can block restore and later overwrite the saved backup.

recompile.sh

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| recompile.sh | Updates executable path resolution and restore-on-failure handling for the recompile flow. |

<sub>Reviews (2): Last reviewed commit: ["fix(recompile): harden executable backup..."](https://github.com/opentibiabr/canary/commit/d7ee2dab2728fc2083a77a1a236374c4d0b9ba93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42061813)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->