### PR TITLE
docs(lua-api): sync screenshot signature

### DIFF
--- a/docs/lua-api/lua_api.d.lua
+++ b/docs/lua-api/lua_api.d.lua
@@ -4118,8 +4118,13 @@ function Player:setXpBoostTime(timeLeft) end
 function Player:showTextDialog(idOrNameOrUserdata, text, canWrite, length) end
 
 ---@param screenshotType any
+---@param skillId? number
+---@param skillLevel? number
+---@param achievementName? string
+---@param raceId? number
+---@param bestiaryStep? number
 ---@return boolean|nil
-function Player:takeScreenshot(screenshotType) end
+function Player:takeScreenshot(screenshotType, skillId, skillLevel, achievementName, raceId, bestiaryStep) end
 
 ---@param arg2? boolean
 ---@return boolean|nil

--- a/docs/lua-api/lua_api.json
+++ b/docs/lua-api/lua_api.json
@@ -7798,7 +7798,12 @@
       {
         "name": "takeScreenshot",
         "params": [
-          "screenshotType: any"
+          "screenshotType: any",
+          "skillId?: number",
+          "skillLevel?: number",
+          "achievementName?: string",
+          "raceId?: number",
+          "bestiaryStep?: number"
         ],
         "return": "boolean|nil",
         "source": "src/lua/functions/creatures/player/player_functions.cpp"

--- a/docs/lua-api/lua_api.md
+++ b/docs/lua-api/lua_api.md
@@ -5215,7 +5215,7 @@ C++ Lua binding handlers and registration lines can override inferred signatures
 - Returns: `boolean|nil`
 - Source: `src/lua/functions/creatures/player/player_functions.cpp`
 
-#### `Player:takeScreenshot(screenshotType: any)`
+#### `Player:takeScreenshot(screenshotType: any, skillId?: number, skillLevel?: number, achievementName?: string, raceId?: number, bestiaryStep?: number)`
 
 - Returns: `boolean|nil`
 - Source: `src/lua/functions/creatures/player/player_functions.cpp`


### PR DESCRIPTION
## Summary

- Regenerates the Lua API docs for `Player:takeScreenshot` after the optional screenshot context parameters added in #4022.
- Updates the LuaLS stub, Markdown reference, and JSON metadata so `main` no longer fails the generated docs check.

## Root cause

PR #4022 changed the inferred Lua binding signature but did not land the generated `docs/lua-api` artifacts. The PR workflow created a local docs commit in the runner, failed to push it back to the branch, and still reported success because the local runner tree was clean.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs/lua-api/lua_api.json','utf8')); console.log('json ok')"`
- `luac -p docs\\lua-api\\lua_api.d.lua`
- `rg -n "lua_api\\.lua|docs/lua_api|docs\\\\lua_api|enc_temp_folder|C:\\\\|D:\\\\|G:\\\\|/home/|/Users/|std::|shared_ptr|\\bvoid\\b|operator function" docs\\lua-api README.md config.lua.dist`

No compile/build was run; this PR only updates generated docs artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Lua API reference for screenshot capture to show additional optional inputs, including skill, achievement, race, and bestiary-related details.
  * Clarified the accepted parameters and return behavior so developers can better understand how to use the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->