### PR TITLE
fix(audit): repair invalid item ranges and reduce storage false positives

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -44498,7 +44498,7 @@ Awarded by TibiaMisterios.com.br"/>
 	<item id="22327" article="a" name="stone spiked club">
 		<attribute key="primarytype" value="tools (objects)"/>
 	</item>
-	<item fromid="22328" toid="22323" article="a" name="large totem pole"/>
+	<item fromid="22328" toid="22333" article="a" name="large totem pole"/>
 	<item fromid="22334" toid="22335" article="a" name="clay hut">
 		<attribute key="primarytype" value="constructions"/>
 	</item>
@@ -48186,7 +48186,7 @@ hands of its owner. Granted by TibiaRoyal.com"/>
 		<attribute key="decayTo" value="0"/>
 	</item>
 	<item fromid="25135" toid="25138" name="unknown item"/>
-	<item fromid="25139" toid="25134" name="RESERVED SPRITE"/>
+	<item fromid="25139" toid="25140" name="RESERVED SPRITE"/>
 	<item id="25141" name="unknown item"/>
 	<item id="25142" name="dragon lair wall"/>
 	<item fromid="25143" toid="25145" name="RESERVED SPRITE"/>
@@ -62744,7 +62744,7 @@ hands of its owner. Granted by TibiaRoyal.com"/>
 	</item>
 	<item id="33211" article="a" name="cornerstone"/>
 	<item fromid="33212" toid="33226" article="a" name="wall"/>
-	<item fromid="33231" toid="33227" article="a" name="buttress"/>
+	<item fromid="33227" toid="33231" article="a" name="buttress"/>
 	<item id="33232" article="a" name="ramp"/>
 	<item id="33233" article="a" name="ramp">
 		<attribute key="floorchange" value="north"/>
@@ -81560,7 +81560,7 @@ Granted by TibiaGoals.com"/>
 	<item fromid="49297" toid="49301" article="a" name="dark wall">
 		<attribute key="primarytype" value="walls"/>
 	</item>
-	<item fromid="49318" toid="39321" article="a" name="dark wall">
+	<item fromid="49318" toid="49321" article="a" name="dark wall">
 		<attribute key="primarytype" value="walls"/>
 	</item>
 	<item fromid="49330" toid="49359" article="a" name="dark floor" />

--- a/docs/systems/content-reference-auditor.md
+++ b/docs/systems/content-reference-auditor.md
@@ -147,6 +147,12 @@ their runtime domain. The default configuration includes:
 For an XML storage, the effective value is `range.start + storage.key`. Invalid,
 overlapping, or out-of-range XML declarations produce error diagnostics.
 
+Only numeric literals, unambiguous numeric aliases, and symbols below a
+configured storage-table root become storage references. Other dotted Lua
+expressions and string keys remain unresolved: the auditor cannot prove that a
+local table field is an authoritative storage declaration, and string keys may
+address the process-local `Game` storage table without a numeric registry.
+
 Player and global storage values are separate domains because they use
 different runtime maps. A repeated numeric value across those domains is not by
 itself a collision. Dynamic receiver expressions and string-keyed in-memory

--- a/tools/canary_audit/baseline.json
+++ b/tools/canary_audit/baseline.json
@@ -1,37 +1,4 @@
 {
   "schemaVersion": 1,
-  "waivers": [
-    {
-      "fingerprint": "a2d89429072e2baf6b707dfb04f072e80ae4fa0964c269bcf70af002e4024f57",
-      "reason": "Existing reversed items.xml range 22328-22323 in the Canary profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "252795deab5ed28d8b56c0b73c5d1f286659a0ed78f885cea5e494e2cc1ce3c7",
-      "reason": "Existing reversed items.xml range 22328-22323 in the global profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "2ff14bfd5d93b9db67cf3b36e678ad67977545aa554f3745ab535313499705a8",
-      "reason": "Existing reversed items.xml range 25139-25134 in the Canary profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "2e9ff76b39f1b0d5b54d8ee7e0d598774dcba10d4a6f8c5c33f36cf49d40fd14",
-      "reason": "Existing reversed items.xml range 25139-25134 in the global profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "7a7191014b45313b60e27558028f7acd80089abf9ef679adec742f384ed4079a",
-      "reason": "Existing reversed items.xml range 33231-33227 in the Canary profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "f31419c2a4cadea91e4f5143faeb971cb95accb6d0830a0b3291aa3e80395aef",
-      "reason": "Existing reversed items.xml range 33231-33227 in the global profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "f92dd971c8b7ed4c464cc3b1276081c23d0dd22d26ab46ee1e0b658671588cbe",
-      "reason": "Existing reversed items.xml range 49318-39321 in the Canary profile; repair separately from introducing the auditor."
-    },
-    {
-      "fingerprint": "6e28fa0f2005c0d92a609d9cab852844e0e622e7c6817ecdf22bf606822e1398",
-      "reason": "Existing reversed items.xml range 49318-39321 in the global profile; repair separately from introducing the auditor."
-    }
-  ]
+  "waivers": []
 }

--- a/tools/canary_audit/extractors.py
+++ b/tools/canary_audit/extractors.py
@@ -226,7 +226,8 @@ def _static_or_unresolved_fact(
 	token: Token,
 	extractor: str,
 	owner: str,
-	allow_symbol: bool = False,
+	allowed_symbol_roots: frozenset[str] = frozenset(),
+	allow_string_literal: bool = True,
 ) -> Fact:
 	value = resolve_scalar(argument, constants)
 	symbol = dotted_identifier(argument)
@@ -237,7 +238,18 @@ def _static_or_unresolved_fact(
 		and argument[0].kind == "identifier"
 		and str(argument[0].value) in constants
 	)
-	if value is not None and (allow_symbol or symbol is None or is_constant_alias):
+	is_allowed_symbol = symbol is not None and any(
+		symbol == root or symbol.startswith(f"{root}.")
+		for root in allowed_symbol_roots
+	)
+	is_allowed_string = (
+		allow_string_literal
+		or not isinstance(value, str)
+		or is_allowed_symbol
+	)
+	if value is not None and is_allowed_string and (
+		symbol is None or is_constant_alias or is_allowed_symbol
+	):
 		return Fact(
 			domain=domain,
 			role=role,  # type: ignore[arg-type]
@@ -247,7 +259,7 @@ def _static_or_unresolved_fact(
 			location=_location(path, argument[0] if argument else token),
 			extractor=extractor,
 			confidence="derived" if len(argument) == 1 and argument[0].kind == "identifier" else "exact",
-			symbol=symbol if allow_symbol else None,
+			symbol=symbol if is_allowed_symbol else None,
 			owner=owner,
 		)
 	return Fact(
@@ -303,6 +315,7 @@ def extract_lua(path: DiscoveredFile, config: AuditConfig) -> ExtractionResult:
 		return result
 
 	constants = collect_static_bindings(tokens)
+	storage_symbol_roots = frozenset(table.root for table in config.storage_tables)
 	delimiter_pairs = matching_delimiters(tokens)
 	assignments = _assignment_calls(
 		tokens,
@@ -476,7 +489,8 @@ def extract_lua(path: DiscoveredFile, config: AuditConfig) -> ExtractionResult:
 					token=token,
 					extractor="lua.storage-call",
 					owner=f"{receiver}.{method}",
-					allow_symbol=True,
+					allowed_symbol_roots=storage_symbol_roots,
+					allow_string_literal=False,
 				)
 			)
 		elif receiver == "Game" and method in {"createMonster", "createNpc", "createItem"}:

--- a/tools/canary_audit/tests/test_extractors.py
+++ b/tools/canary_audit/tests/test_extractors.py
@@ -148,6 +148,44 @@ event:register()
 			[("item.name", "reference", "gold coin")],
 		)
 
+	def test_storage_calls_only_promote_authoritative_static_keys(self) -> None:
+		source = '''local STATIC_KEY = 400
+player:getStorageValue(Storage.Quest.Known)
+player:setStorageValue(config.storage, 1)
+player:getStorageValue(STATIC_KEY)
+Game.getStorageValue("ephemeral-key")
+Game.setStorageValue(GlobalStorage.Event.Active, 1)
+'''
+		with tempfile.TemporaryDirectory() as temporary:
+			path = discovered_file(Path(temporary), "data/scripts/storage.lua", source)
+			result = extract_lua(path, self.config)
+
+		references = {
+			(fact.domain, fact.value, fact.symbol)
+			for fact in result.facts
+			if fact.role == "reference"
+		}
+		self.assertEqual(
+			references,
+			{
+				("storage.player", "Storage.Quest.Known", "Storage.Quest.Known"),
+				("storage.player", 400, None),
+				("storage.global", "GlobalStorage.Event.Active", "GlobalStorage.Event.Active"),
+			},
+		)
+		unresolved = {
+			(fact.domain, fact.value)
+			for fact in result.facts
+			if fact.role == "unresolved"
+		}
+		self.assertEqual(
+			unresolved,
+			{
+				("storage.player", "config.storage"),
+				("storage.global", "'ephemeral-key'"),
+			},
+		)
+
 
 class XmlAndProtobufExtractorTests(unittest.TestCase):
 	def setUp(self) -> None:


### PR DESCRIPTION
## Summary

- repair four invalid `items.xml` ranges so their metadata is applied at runtime;
- remove the eight profile-specific baseline waivers that are no longer needed;
- restrict storage-reference promotion to numeric keys, unambiguous numeric aliases, and configured storage-table namespaces;
- keep local table fields, dynamic expressions, and string-backed in-memory storage keys visible as unresolved coverage instead of reporting false missing definitions;
- add regression coverage and document the refined storage-audit contract.

## Root cause

The four item ranges had reversed or mistyped endpoints. `Items::loadFromXml` iterates ranges only while `id <= toId`, so those entries were silently skipped and their XML metadata was never applied.

The storage extractor also treated every dotted Lua identifier and string key as an authoritative static reference. Expressions such as `config.storage`, local table fields, and process-local string keys therefore produced misleading missing-definition findings even though the auditor could not prove their authoritative source.

## Changes

The corrected item ranges are:

- `22328-22323` -> `22328-22333`
- `25139-25134` -> `25139-25140`
- `33231-33227` -> `33227-33231`
- `49318-39321` -> `49318-49321`

The storage extractor remains conservative: configured symbols such as `Storage.*`, `GlobalStorage.*`, and `Global.Storage.*` are still checked, while unconfigured/dynamic expressions remain present in the generated index with the `unresolved` role.

## Impact

The full two-profile scan now reports:

- 0 errors, down from 8;
- 405 storage information findings, down from 1,225;
- 1,366 total findings, down from 2,194;
- 0 operational diagnostics and 0 new blocking findings.

The remaining warnings are intentionally preserved because they represent actual legacy content issues rather than extractor false positives.

## Validation

```sh
python -m unittest discover -s tools/canary_audit/tests -t . -p "test_*.py" -v
python -m tools.canary_audit validate-schemas
python -m tools.canary_audit scan --profile all --output-dir artifacts/canary-audit
python -m tools.canary_audit validate --input-dir artifacts/canary-audit
git diff --check
```

- 72 tests passed.
- All bundled schemas passed validation.
- The full scan completed for both profiles with 0 errors and 0 diagnostics.
- All generated audit artifacts passed schema validation.

No C++ build was run because this change is limited to content XML and Python audit tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected item ID ranges for several game objects, including large totem poles, buttresses, dark walls, and reserved sprites.
  * Improved content auditing so only authoritative static storage references are recognized; dynamic and ambiguous keys remain unresolved.

* **Documentation**
  * Clarified which storage references the content auditor can identify.

* **Tests**
  * Added coverage for static, dynamic, and string-based storage key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->