### PR TITLE
fix(network): avoid deprecated enum arithmetic

### DIFF
--- a/src/server/network/message/networkmessage.cpp
+++ b/src/server/network/message/networkmessage.cpp
@@ -276,7 +276,6 @@ const uint8_t* NetworkMessage::getBuffer() const {
 uint8_t* NetworkMessage::getBodyBuffer() {
 	info.position = 2;
 	// Return the pointer to the body of the buffer starting after the header
-	// Convert HEADER_LENGTH to uintptr_t to ensure safe pointer arithmetic with enum type
 	return buffer.data() + static_cast<std::uintptr_t>(HEADER_LENGTH);
 }
 

--- a/src/server/server_definitions.hpp
+++ b/src/server/server_definitions.hpp
@@ -14,8 +14,8 @@
 // Enums
 // Connection and networkmessage.
 enum { FORCE_CLOSE = true };
-enum { HEADER_LENGTH = 2 };
-enum { CHECKSUM_LENGTH = 4 };
+static constexpr int32_t HEADER_LENGTH = 2;
+static constexpr int32_t CHECKSUM_LENGTH = 4;
 enum { XTEA_MULTIPLE = 8 };
 enum { MAX_BODY_LENGTH = NETWORKMESSAGE_MAXSIZE - HEADER_LENGTH - CHECKSUM_LENGTH - XTEA_MULTIPLE };
 enum { MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10 };

--- a/src/server/server_definitions.hpp
+++ b/src/server/server_definitions.hpp
@@ -11,22 +11,21 @@
 
 #include "utils/const.hpp"
 
-// Enums
 // Connection and networkmessage.
-enum { FORCE_CLOSE = true };
+static constexpr bool FORCE_CLOSE = true;
 static constexpr int32_t HEADER_LENGTH = 2;
 static constexpr int32_t CHECKSUM_LENGTH = 4;
-enum { XTEA_MULTIPLE = 8 };
-enum { MAX_BODY_LENGTH = NETWORKMESSAGE_MAXSIZE - HEADER_LENGTH - CHECKSUM_LENGTH - XTEA_MULTIPLE };
-enum { MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10 };
+static constexpr int32_t XTEA_MULTIPLE = 8;
+static constexpr int32_t MAX_BODY_LENGTH = NETWORKMESSAGE_MAXSIZE - HEADER_LENGTH - CHECKSUM_LENGTH - XTEA_MULTIPLE;
+static constexpr int32_t MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10;
 
+// Enums
 enum ConnectionState_t : uint8_t {
 	CONNECTION_STATE_OPEN,
 	CONNECTION_STATE_IDENTIFYING,
 	CONNECTION_STATE_READINGS,
 	CONNECTION_STATE_CLOSED
 };
-// Connection and networkmessage.
 
 // Protocol.
 enum RequestedInfo_t : uint16_t {


### PR DESCRIPTION
## Summary

- replace the anonymous enum values used by connection and network-message constants with typed `constexpr` values
- eliminate deprecated cross-enum arithmetic in `TransportCodec` and the multiprotocol tests
- remove the stale comment that described `HEADER_LENGTH` as an enum

## Root cause

`HEADER_LENGTH` and `CHECKSUM_LENGTH` were declared in separate anonymous enums. Since C++20, arithmetic between different enum types is deprecated, so GCC 13/14 reports `-Wdeprecated-enum-enum-conversion` when the transport codec adds those values.

## Impact

All constant values remain unchanged. This is a compile-warning cleanup and consistency improvement with no protocol or runtime behavior change.

Closes #4037

## Validation

- `git diff --check`
- verified `clang-format` content after normalizing the repository's existing CRLF checkout line endings
- reviewed every affected constant usage

Build and test execution were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized protocol size-related constants with explicit 32-bit integer types for clearer, safer handling of message limits.
* **Bug Fixes**
  * Improved message body access by resetting the internal read/write cursor before returning the body buffer, enhancing consistency during protocol message parsing.
* **Tests**
  * No test-related changes included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->