### PR TITLE
fix(ci): serialize windows vcpkg cache writers

### DIFF
--- a/.github/workflows/reusable-build-windows.yml
+++ b/.github/workflows/reusable-build-windows.yml
@@ -31,6 +31,13 @@ jobs:
       fail-fast: false
       matrix:
         type: [CMake, Solution]
+    # Both matrix entries write overlapping host packages to the same NuGet
+    # feed on pushes to main. vcpkg treats a duplicate NuGet publish as an
+    # error, so serialize writers while keeping PR builds parallel.
+    concurrency:
+      group: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'vcpkg-windows-binary-cache-main' || format('vcpkg-windows-{0}-{1}', github.run_id, matrix.type) }}
+      cancel-in-progress: false
+      queue: max
     runs-on: windows-2025
     env:
       # Use GitHub Packages as a read-only vcpkg cache for PRs.


### PR DESCRIPTION
## Summary

- serialize Windows CI cache writers on direct pushes to `main`
- keep read-only pull request jobs parallel
- queue cache-writer jobs instead of cancelling pending jobs

## Root cause

The CMake and Solution matrix jobs wrote overlapping host vcpkg packages to the same GitHub Packages NuGet feed. A duplicate publish returns HTTP 409, which vcpkg reports as a failed binary-cache submission even though the build itself completed successfully.

## Impact

Only one Windows cache writer can publish at a time on `main`; the following job restores the published packages instead of racing to upload them.

## Validation

- `git diff --check`
- YAML parsed successfully with Ruby Psych and PyYAML

No local build was run because this change only modifies GitHub Actions scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Improved Windows build scheduling to serialize compatible package publishing jobs.
  * Prevented active builds from being canceled and limited queued builds to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->