### PR TITLE
fix: djinn NPCs should accept a normal greeting once the player is recognized

### DIFF
--- a/data-otservbr-global/npc/alesar.lua
+++ b/data-otservbr-global/npc/alesar.lua
@@ -99,7 +99,7 @@ local function greetCallback(npc, creature, message)
 
 	--Checks if the player has completed the quest
 	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Mission03) ~= 3 then
-		if not MsgContains(message, "djanni'hah") then
+		if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 			npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
 			endConversationWithDelay(npcHandler, npc, creature)
 			return false

--- a/data-otservbr-global/npc/baa_leal.lua
+++ b/data-otservbr-global/npc/baa_leal.lua
@@ -61,7 +61,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/bo_ques.lua
+++ b/data-otservbr-global/npc/bo_ques.lua
@@ -63,7 +63,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/fa_hradin.lua
+++ b/data-otservbr-global/npc/fa_hradin.lua
@@ -57,7 +57,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/gabel.lua
+++ b/data-otservbr-global/npc/gabel.lua
@@ -57,7 +57,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/haroun.lua
+++ b/data-otservbr-global/npc/haroun.lua
@@ -59,7 +59,7 @@ local function greetCallback(npc, creature, message)
 
 	--Checks if the player has completed the quest
 	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Mission03) ~= 3 then
-		if not MsgContains(message, "djanni'hah") then
+		if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 			npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 			endConversationWithDelay(npcHandler, npc, creature)
 			return false

--- a/data-otservbr-global/npc/malor.lua
+++ b/data-otservbr-global/npc/malor.lua
@@ -66,7 +66,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/nah_bob.lua
+++ b/data-otservbr-global/npc/nah_bob.lua
@@ -59,7 +59,7 @@ local function greetCallback(npc, creature, message)
 
 	--Checks if the player has completed the quest
 	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.MaridFaction.Mission03) ~= 3 then
-		if not MsgContains(message, "djanni'hah") then
+		if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 			npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 			endConversationWithDelay(npcHandler, npc, creature)
 			return false

--- a/data-otservbr-global/npc/ubaid.lua
+++ b/data-otservbr-global/npc/ubaid.lua
@@ -57,7 +57,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/umar.lua
+++ b/data-otservbr-global/npc/umar.lua
@@ -57,7 +57,7 @@ local function greetCallback(npc, creature, message)
 	local player = Player(creature)
 	local playerId = player:getId()
 
-	if not MsgContains(message, "djanni'hah") then
+	if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 		npcHandler:say("Whoa! A human! This is no place for you, |PLAYERNAME|. Go and play somewhere else.", npc, creature)
 		endConversationWithDelay(npcHandler, npc, creature)
 		return false

--- a/data-otservbr-global/npc/yaman.lua
+++ b/data-otservbr-global/npc/yaman.lua
@@ -59,7 +59,7 @@ local function greetCallback(npc, creature, message)
 
 	--Checks if the player has completed the quest
 	if player:getStorageValue(Storage.Quest.U7_4.DjinnWar.EfreetFaction.Mission03) ~= 3 then
-		if not MsgContains(message, "djanni'hah") then
+		if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
 			npcHandler:say("Shove off, little one! Humans are not welcome here, |PLAYERNAME|!", npc, creature)
 			endConversationWithDelay(npcHandler, npc, creature)
 			return false


### PR DESCRIPTION
## Description

In real Tibia, **DJANNI'HAH is only required while the djinn faction does not recognize the player** — after the recognition, a plain "hi" is enough (see the TibiaWiki NPC transcripts, e.g. Bo'Ques opens with `Player: hi` → `Bo'Ques: Hey! A human! What are you doing in my kitchen?`).

In the current datapack, the `greetCallback` of the 11 djinn NPCs (Umar, Bo'Ques, Fa'hradin, Gabel, Ubaid, Baa'leal, Malor, Nah'Bob, Haroun, Alesar, Yaman) rejects **any** greeting that does not contain `djanni'hah` before consulting `Storage.Quest.U7_4.DjinnWar.Faction.Greeting` — a storage the datapack already maintains (Melchior sets `1` when teaching the word; Umar/Ubaid set `0` on recognition) but that no script consulted to accept a greeting. The result: players must say DJANNI'HAH on **every** greeting, to **every** djinn, forever. Players following the wiki transcripts think the NPCs are broken and get stuck in The Djinn War quest — this is exactly how we found it.

The four traders (Nah'Bob, Haroun, Alesar, Yaman) already skip the check after completing their faction's Mission03, so for them the bug only shows during the quest; the other seven require the word unconditionally.

## Fix

One line per NPC (11 files, +11/−11): accept the normal greeting when `Faction.Greeting >= 0`.

```lua
if not MsgContains(message, "djanni'hah") and player:getStorageValue(Storage.Quest.U7_4.DjinnWar.Faction.Greeting) < 0 then
```

- The rejection is kept for players who were never recognized and don't say the word.
- The hostile-faction checks that follow are untouched (a player of the rival faction is still turned away).
- The traders keep their existing post-Mission03 bypass.

## Behaviour change

| Player state | Before | After |
|---|---|---|
| Never met Melchior (`Greeting == -1`), says "hi" | rejected | rejected (unchanged) |
| Knows the word / recognized (`Greeting >= 0`), says "hi" | rejected: *"Go and play somewhere else"* | greeted normally |
| Says "djanni'hah" | greeted | greeted (unchanged) |
| Rival faction member | mocked and dismissed | mocked and dismissed (unchanged) |

## Testing

Deployed on a live 15.11 server (Canary + OTBR datapack): a character with `Greeting = 0` / `MaridDoor = 1` in `player_storage` said "hi" to Bo'Ques and was greeted and focused (before the fix the same greeting was rejected and the conversation ended). Syntax of all 11 files validated with LuaJIT.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Live server, in-game verification with characters at different quest stages (see above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Djinn War NPC greeting interactions by considering quest progress when handling greeting messages.
  - Players with the appropriate quest state can now proceed through relevant NPC conversations without being incorrectly dismissed.
  - Updated greeting behavior across multiple Djinn War NPCs for more consistent quest interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->