### PR TITLE
fix: familiar spells unlearnable — NPCs sell a spell name that does not exist

### DIFF
--- a/data/scripts/spells/familiar/druid_familiar.lua
+++ b/data/scripts/spells/familiar/druid_familiar.lua
@@ -7,7 +7,7 @@ end
 
 spell:group("support")
 spell:id(spellId)
-spell:name("Druid familiar")
+spell:name("Summon Druid Familiar")
 spell:words("utevo gran res dru")
 spell:castSound(SOUND_EFFECT_TYPE_SPELL_SUMMON_DRUID_FAMILIAR)
 spell:level(200)

--- a/data/scripts/spells/familiar/knight_familiar.lua
+++ b/data/scripts/spells/familiar/knight_familiar.lua
@@ -7,7 +7,7 @@ end
 
 spell:group("support")
 spell:id(spellId)
-spell:name("Knight familiar")
+spell:name("Summon Knight Familiar")
 spell:words("utevo gran res eq")
 spell:castSound(SOUND_EFFECT_TYPE_SPELL_SUMMON_KNIGHT_FAMILIAR)
 spell:level(200)

--- a/data/scripts/spells/familiar/paladin_familiar.lua
+++ b/data/scripts/spells/familiar/paladin_familiar.lua
@@ -7,7 +7,7 @@ end
 
 spell:group("support")
 spell:id(spellId)
-spell:name("Paladin familiar")
+spell:name("Summon Paladin Familiar")
 spell:words("utevo gran res sac")
 spell:castSound(SOUND_EFFECT_TYPE_SPELL_SUMMON_PALADIN_FAMILIAR)
 spell:level(200)

--- a/data/scripts/spells/familiar/sorcerer_familiar.lua
+++ b/data/scripts/spells/familiar/sorcerer_familiar.lua
@@ -7,7 +7,7 @@ end
 
 spell:group("support")
 spell:id(spellId)
-spell:name("Sorcerer familiar")
+spell:name("Summon Sorcerer Familiar")
 spell:words("utevo gran res ven")
 spell:castSound(SOUND_EFFECT_TYPE_SPELL_SUMMON_SORCERER_FAMILIAR)
 spell:level(200)


### PR DESCRIPTION
## Description

All 32 familiar buy nodes in the OTBR datapack (8 NPCs × 4 classic vocations — e.g. `azalea.lua`, `charlotta.lua`, …) teach `spellName = "summon knight familiar"` (and the druid/sorcerer/paladin equivalents), but the spells themselves are registered as `"Knight familiar"`, `"Druid familiar"`, etc. (`data/scripts/spells/familiar/*.lua`).

`canLearnSpell` → `getInstantSpellByName` does an **exact match**, so every purchase attempt fails with *"You cannot learn this spell."* With `toggleLearnSpells = true`, the four classic-vocation familiars are **unobtainable** — on our live server there were 0 rows for these spells in `player_spells` until the fix. The monk familiar already follows the new naming convention and works.

## Fix

Rename the four spells to the official Tibia names — which is exactly what the NPCs already ask for:

- `Knight familiar` → `Summon Knight Familiar`
- `Druid familiar` → `Summon Druid Familiar`
- `Sorcerer familiar` → `Summon Sorcerer Familiar`
- `Paladin familiar` → `Summon Paladin Familiar`

Safe rename: the familiar summon system resolves by spell id + monster name, not by this string, and the NPC keyword nodes match case-insensitively against the learned spell name.

Side note from the same audit: 8 other legacy NPC buy nodes reference spells that no longer exist (old rune names) — no gameplay impact, left untouched.

## Testing

Deployed on a live 15.11 server with `toggleLearnSpells = true`: after the rename, buying the spell from the NPC succeeds and the familiar can be summoned. (Players who had failed attempts should not need anything — there was nothing stored.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Live server, in-game purchase and summon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated familiar spell names to clearly use the “Summon [Class] Familiar” format for druid, knight, paladin, and sorcerer spells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->