### PR TITLE
fix: Mortimer (Explorer Society) hands out the wrong pick and never advances the mission storages

### DIFF
--- a/data-otservbr-global/npc/mortimer.lua
+++ b/data-otservbr-global/npc/mortimer.lua
@@ -224,7 +224,7 @@ local function creatureSayCallback(npc, creature, type, message)
 		if player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt) == 17 and player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine) == 17 then
 			npcHandler:say("In this mission we require you to get us some plant samples from Tiquandan plants. Would you like to fulfil this mission?", npc, creature)
 			npcHandler:setTopic(playerId, 11)
-		elseif player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection) == 119 and player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine) == 19 then
+		elseif player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection) == 19 and player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine) == 19 then
 			npcHandler:say("Did you acquire the sample of the jungle bells plant we are looking for?", npc, creature)
 			npcHandler:setTopic(playerId, 12)
 		elseif player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection) == 20 and player:getStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine) == 20 then
@@ -359,31 +359,31 @@ local function creatureSayCallback(npc, creature, type, message)
 				npcHandler:setTopic(playerId, 0)
 			end
 		elseif npcHandler:getTopic(playerId) == 4 then
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 5)
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 5)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 6)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 6)
 			npcHandler:say({
 				"So listen please: Take this ice pick and use it on a block of ice in the caves beneath Folda. Get some ice and bring it here as fast as you can ...",
 				"Should the ice melt away, report on your ice delivery mission anyway. I will then tell you if the time is right to start another mission.",
 			}, npc, creature)
 			npcHandler:setTopic(playerId, 0)
-			player:addItem(3456, 1)
+			player:addItem(4872, 1)
 		elseif npcHandler:getTopic(playerId) == 5 then
 			if player:removeItem(4837, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 7)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 7)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 8)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 8)
 				npcHandler:say("Just in time. Sadly not much ice is left over but it will do. Thank you again.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end
 		elseif npcHandler:getTopic(playerId) == 6 then
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 5)
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 5)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheIceDelivery, 6)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 6)
 			npcHandler:say("*Sigh* I think the time is right to grant you another chance to get that ice. Hurry up this time.", npc, creature)
 			npcHandler:setTopic(playerId, 0)
 
 			-- BUTTERFLY HUNT
 		elseif npcHandler:getTopic(playerId) == 7 then
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 8)
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 8)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 9)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 9)
 			npcHandler:say({
 				"This preparation kit will allow you to collect a purple butterfly you have killed ...",
 				"Just use it on the fresh corpse of a purple butterfly, return the prepared butterfly to me and give me a report of your butterfly hunt.",
@@ -392,22 +392,22 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:addItem(4863, 1)
 		elseif npcHandler:getTopic(playerId) == 8 then
 			if player:removeItem(4864, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 10)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 10)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 11)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 11)
 				npcHandler:say("A little bit battered but it will do. Thank you! If you think you are ready, ask for another butterfly hunt.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end
 		elseif npcHandler:getTopic(playerId) == 9 then
 			if player:removeItem(4865, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 13)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 13)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 14)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 14)
 				npcHandler:say("A little bit battered but it will do. Thank you! If you think you are ready, ask for another butterfly hunt.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end
 		elseif npcHandler:getTopic(playerId) == 10 then
 			if player:removeItem(4866, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 16)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 16)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.TheButterflyHunt, 17)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 17)
 				npcHandler:say("That is an extraordinary species you have brought. Thank you! That was the last butterfly we needed.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end
@@ -415,22 +415,22 @@ local function creatureSayCallback(npc, creature, type, message)
 
 			-- PLANT COLLECTION
 		elseif npcHandler:getTopic(playerId) == 11 then
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 17)
-			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 17)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 18)
+			player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 18)
 			npcHandler:say("Fine! Here take this botanist's container. Use it on a jungle bells plant to collect a sample for us. Report about your plant collection when you have been successful.", npc, creature)
 			npcHandler:setTopic(playerId, 0)
 			player:addItem(4867, 1)
 		elseif npcHandler:getTopic(playerId) == 12 then
 			if player:removeItem(4868, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 19)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 19)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 20)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 20)
 				npcHandler:say("I see. It seems you've got some quite useful sample by sheer luck. Thank you! Just tell me when you are ready to continue with the plant collection.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end
 		elseif npcHandler:getTopic(playerId) == 13 then
 			if player:removeItem(4869, 1) then
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 22)
-				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 22)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.ThePlantCollection, 23)
+				player:setStorageValue(Storage.Quest.U7_6.ExplorerSociety.QuestLine, 23)
 				npcHandler:say("Ah, finally. I started to wonder what took you so long. But thank you! Another fine sample, indeed. Just tell me when you are ready to continue with the plant collection.", npc, creature)
 				npcHandler:setTopic(playerId, 0)
 			end


### PR DESCRIPTION
## Description

**Mortimer**, the Explorer Society base NPC in Northport (`data-otservbr-global/npc/mortimer.lua`), is a mistranscribed copy of his working twin **Angus** (Port Hope). Three families of bugs, all verified against Angus and on a live server:

### 1. Ice delivery — impossible to complete

- Accepting the mission (topic 4) hands out a **normal pick (3456)** instead of the **quest ice pick (4872)**, and sets `TheIceDelivery`/`QuestLine` to **5** instead of **6**. The ice block action (`actions_icicle.lua`, registered on item 4872) requires storage `== 6`, so the mission cannot advance at all.
- Since 5 is also the just-joined state, the mission can be re-asked forever (infinite free picks).
- Delivering the ice (topic 5) sets **7** instead of **8**, so the next rank never unlocks and Mortimer loops on "Did you get the ice?". The retry topic (6) has the same 5-for-6 error.

### 2. Butterfly hunt / plant collection — soft-lock on accept

The accept and delivery topics write the **same value the storage already has** instead of advancing it (`8→8` instead of `→9`, `10→10` instead of `→11`, `13→13`, `16→16`, `17→17`, `19→19`, `22→22`). The preparation kit action requires `TheButterflyHunt == 9`, so the mission soft-locks right after accepting it.

### 3. Typo in the jungle bells delivery condition

`ThePlantCollection == 119` — a typo for `19`; the second plant sample can never be reported.

## Fix

Port Angus's values into Mortimer's corresponding lines (22 lines, +22/−22), making the two bases functionally identical. Players affected by the old values are not stranded: the broken states (5/5, 8/8, …) are the same states the fixed NPC accepts the mission from, so they can simply re-ask for the mission.

## Testing

Deployed on a live 15.11 server (2026-07-06/07): ice delivery completed end to end via the fixed Mortimer (ice pick 4872 works on the Folda ice block, rank unlocks), and butterfly hunt + plant collection completed end to end (storages advance 9→17 and 18→26, rank 2 missions unlock afterwards).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Live server, quests completed end to end in-game

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quest progression for the Plant Collection, Butterfly Hunt, and Ice Delivery tasks.
  * Updated Ice Delivery completion to grant the correct reward item.
  * Adjusted follow-up quest stages to ensure subsequent objectives unlock properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->