### PR TITLE
fix: increase the god maximum speed

### DIFF
--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -121,7 +121,7 @@ struct OpenContainer {
 using MuteCountMap = std::map<uint32_t, uint32_t>;
 
 static constexpr uint16_t PLAYER_MAX_SPEED = std::numeric_limits<uint16_t>::max();
-static constexpr uint16_t PLAYER_MAX_STAFF_SPEED = 1500;
+static constexpr uint16_t PLAYER_MAX_STAFF_SPEED = 65535;
 static constexpr uint16_t PLAYER_MIN_SPEED = 10;
 static constexpr uint8_t PLAYER_SOUND_HEALTH_CHANGE = 10;
 


### PR DESCRIPTION
# Description

Increase the team's maximum speed.

## Behaviour
### **Actual**

After the commit https://github.com/opentibiabr/canary/commit/e1229d543aa70db6e9f06a96034137eeee62247c, the staff (GOD, GM, CM) became very slow, with a maximum speed of 1500; this change reverts to the previous standard, with a maximum allowed speed of 65535.

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

**Test Configuration**:

  - Server Version: 3.6.1
  - Client: 15.25
  - Operating System: win/linux

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the maximum player staff movement speed limit, allowing higher speed settings when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->