### PR TITLE
fix: Storkus outfit and dialogue (Inquisition mission 3 / Vampire Hunter)

### DIFF
--- a/data-otservbr-global/npc/storkus.lua
+++ b/data-otservbr-global/npc/storkus.lua
@@ -11,7 +11,7 @@ npcConfig.walkInterval = 2000
 npcConfig.walkRadius = 2
 
 npcConfig.outfit = {
-	lookType = 69,
+	lookType = 160,
 	lookHead = 57,
 	lookBody = 59,
 	lookLegs = 118,
@@ -65,9 +65,8 @@ local function creatureSayCallback(npc, creature, type, message)
 				npcHandler:say("So they've sent another one? I just hope ye' better than the last one. Are ye' ready for a mission?", npc, creature)
 				npcHandler:setTopic(playerId, 9)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust, 0)
-			end
-			if player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust) < 20 then
-				npcHandler:say("So far ye've brought me " .. player:getItemCount(5905) .. " of 20 {vampire dusts}. Do ye' have any more with ye'? ", npc, creature)
+			elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust) < 20 then
+				npcHandler:say("So far ye've brought me " .. math.max(player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust), 0) .. " of 20 {vampire dusts}. Do ye' have any more with ye'? ", npc, creature)
 				npcHandler:setTopic(playerId, 1)
 			elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust) == 20 then
 				npcHandler:say("Fine, you're done! Ye' should talk to me about your {mission} again now.", npc, creature)
@@ -131,7 +130,8 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust, player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust) + count)
 			player:removeItem(5905, count)
 
-			npcHandler:say("Ye've brought me " .. count .. " vampire dusts. " .. (20 - player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust)) == 0 and "Ask me for a {mission} to continue your quest." or ("Ye' need to bring " .. (20 - player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust)) .. " more."), npc, creature)
+			local remaining = 20 - player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust)
+			npcHandler:say("Ye've brought me " .. count .. " vampire dusts. " .. (remaining == 0 and "Ask me for a {mission} to continue your quest." or ("Ye' need to bring " .. remaining .. " more.")), npc, creature)
 			npcHandler:setTopic(playerId, 0)
 		elseif npcHandler:getTopic(playerId) == 3 then
 			if player:removeItem(8192, 1) then
@@ -191,12 +191,13 @@ local function creatureSayCallback(npc, creature, type, message)
 			npcHandler:setTopic(playerId, 0)
 		elseif npcHandler:getTopic(playerId) == 9 then
 			npcHandler:say("As they might have told ye', I'm a vampire hunter. If ye' want to be of any help, ye' can assist me with some of my tasks and bring me 20 ounces of vampire dust. This gives me some time to concentrate on a bigger project.", npc, creature)
-			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust, 1)
 			npcHandler:setTopic(playerId, 0)
 		end
 	end
 	return true
 end
+
+npcHandler:setMessage(MESSAGE_GREET, "Greetings, |PLAYERNAME|! Good you're showing up.")
 
 npcHandler:setCallback(CALLBACK_MESSAGE_DEFAULT, creatureSayCallback)
 npcHandler:addModule(FocusModule:new(), npcConfig.name, true, true, true)


### PR DESCRIPTION
Storkus (`data-otservbr-global/npc/storkus.lua`, The Inquisition Quest mission 3 / Vampire Hunter Quest) has five bugs compared to real Tibia. Play-tested and fixed on a production Canary 15.25 server; all five were confirmed present, byte-identical, in current `main`.

## 1. Wrong outfit (Dwarf monster look instead of the colorable NPC sprite)

**Symptom:** Storkus renders with the `Dwarf` monster appearance instead of his official human sprite, and the `lookHead`/`lookBody`/`lookLegs`/`lookFeet` color values already present in the script have no visible effect.

**Cause:** `lookType = 69` is the *monster* Dwarf outfit, which does not support the head/body/legs/feet color channels at all.

**Fix:** `lookType = 160`, the colorable NPC base that matches Storkus's official sprite. The existing color values (`57/59/118/114`) are kept as-is and now actually render.

## 2. No greeting

**Symptom:** Storkus never greets the player on approach.

**Cause:** `npcHandler:setMessage(MESSAGE_GREET, ...)` was never set.

**Fix:** added the real-Tibia greeting line: `"Greetings, |PLAYERNAME|! Good you're showing up."`

## 3. Dust progress line reports the wrong count

**Symptom:** "So far ye've brought me X of 20 vampire dusts" shows the number of dusts currently *carried* in the player's inventory rather than the number actually delivered/counted toward the mission.

**Cause:** the line used `player:getItemCount(5905)` (items in inventory) instead of the delivered-count storage `Storage.Quest.U8_2.TheInquisitionQuest.StorkusVampiredust` that the rest of the script uses to track progress.

**Fix:** report `math.max(player:getStorageValue(...StorkusVampiredust), 0)` instead, matching what is actually tracked/consumed by the quest logic.

## 4. Lua operator-precedence bug swallows the completion message

**Symptom:** After turning in the last dust, Storkus never says "Ask me for a {mission} to continue your quest." — the quest becomes silently stuck from the player's perspective.

**Cause:** `"a" .. "b" .. (n == 0) and A or B` binds `..` tighter than the surrounding ternary-style expression the way it was written, so the whole first `..` chain (a string) is what gets compared/branched on, not the intended `(n == 0)` condition alone — the greeting prefix is discarded and the wrong branch is effectively always taken.

**Fix:** introduced `local remaining = 20 - player:getStorageValue(...)` and parenthesized the ternary: `"Ye've brought me " .. count .. " vampire dusts. " .. (remaining == 0 and "..." or "...")`.

## 5. First-contact fall-through breaks the intro dialogue and plants a phantom dust

**Symptom:** The very first "mission" conversation (when `StorkusVampiredust < 0`, i.e. before the player has ever been assigned the task) shows the intro line and *immediately* also shows the dust-counter line in the same turn, and topic 9 (the follow-up "yes" branch that explains the mission) becomes unreachable because the topic gets overwritten right after being set. Additionally, answering "yes" to topic 9 planted a phantom 1 dust in the delivered-count storage.

**Cause:** the intro branch was `if StorkusVampiredust < 0 then ... end` followed by a separate `if StorkusVampiredust < 20 then ...`, so the second `if` always ran right after the first regardless of which topic had just been set.

**Fix:** changed to an `if / elseif` chain, and removed the incorrect `player:setStorageValue(...StorkusVampiredust, 1)` from the topic-9 "yes" branch (that branch only explains the mission; it should not touch the counter).

---

All five fixes were cross-checked against a real-Tibia NPC transcript for Storkus and verified in-game on our Canary 15.25 server (outfit renders correctly with colors, greeting shows, dust counter tracks delivered dusts, completion message appears at 20/20, and the intro dialogue is reachable and shows once without planting a phantom dust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Storkus’s appearance.
  * Improved quest dialogue to accurately reflect vampire dust progress and remaining requirements.
  * Added a refreshed greeting message.

* **Bug Fixes**
  * Corrected quest progression handling to prevent inaccurate progress updates and dialogue responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->