### PR TITLE
fix(monster): refresh renamed creatures

### DIFF
--- a/data/scripts/talkactions/god/manage_monster.lua
+++ b/data/scripts/talkactions/god/manage_monster.lua
@@ -107,21 +107,44 @@ function setMonsterName.onSay(player, words, param)
 	-- create log
 	logCommand(player, words, param)
 
-	if param == "" then
+	local splitParams = param:split(",")
+	local newMonsterName = splitParams[1]:trimSpace()
+	if newMonsterName == "" then
 		player:sendCancelMessage("Command param required.")
+		logger.warn("[setMonsterName.onSay] Player {} tried to rename monsters without providing a name", player:getName())
 		return true
 	end
 
-	local splitParams = param:split(",")
-	local newMonsterName = splitParams[1]
 	local spectators, spectator = Game.getSpectators(player:getPosition(), false, false, 4, 4, 4, 4)
+	local monsterCount = 0
+	local renamedCount = 0
 
 	for i = 1, #spectators do
 		spectator = spectators[i]
 		if spectator:isMonster() then
-			spectator:setName(newMonsterName)
+			monsterCount = monsterCount + 1
+			if spectator:getName() ~= newMonsterName then
+				spectator:setName(newMonsterName)
+				renamedCount = renamedCount + 1
+			end
 		end
 	end
+
+	if monsterCount == 0 then
+		player:sendCancelMessage("No monsters found within 4 tiles.")
+		logger.info("[setMonsterName.onSay] Player {} found no monsters within 4 tiles", player:getName())
+		return true
+	end
+
+	if renamedCount == 0 then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("All nearby monsters are already named '%s'.", newMonsterName))
+		logger.info("[setMonsterName.onSay] Player {} found {} nearby monster(s) already named '{}'", player:getName(), monsterCount, newMonsterName)
+		return true
+	end
+
+	local monsterNoun = renamedCount == 1 and "monster" or "monsters"
+	player:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("Renamed %d %s to '%s'.", renamedCount, monsterNoun, newMonsterName))
+	logger.info("[setMonsterName.onSay] Player {} renamed {} monster(s) to '{}'", player:getName(), renamedCount, newMonsterName)
 	return true
 end
 

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -154,7 +154,7 @@ void Monster::setName(const std::string &name) {
 	auto spectators = Spectators().find<Player>(position, true);
 	for (const auto &spectator : spectators) {
 		if (const auto &tmpPlayer = spectator->getPlayer()) {
-			tmpPlayer->sendUpdateTileCreature(static_self_cast<Monster>());
+			tmpPlayer->sendCreatureReload(static_self_cast<Monster>());
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Reload renamed monsters for current spectators so clients receive the complete creature description.
- Validate and trim the requested name before applying it.
- Report whether no monsters were found, all nearby monsters already had the requested name, or how many monsters were renamed.
- Log each outcome with the executing player, affected count, and requested name where applicable.
- Keep the generic known-creature handling in `sendUpdateTileCreature` unchanged.

## Root cause

`Monster::setName` updated the server-side name and then called `sendUpdateTileCreature`. Since the known-creature serialization fix, that path sends only the creature ID for creatures already cached by the client, so it cannot deliver the new name. The client therefore continued displaying the cached name even though the server state had changed.

The `/setmonstername` talkaction also returned silently after execution and did not distinguish between an empty area, an unchanged name, and a successful rename.

## Impact

Lua calls such as `monster:setName(...)` now refresh the displayed name immediately for nearby players. The `/setmonstername` talkaction provides clear in-game feedback, avoids redundant rename calls, and records the outcome in the server log. Other tile-creature updates retain their existing known-creature behavior.

## Validation

- `stylua --check data/scripts/talkactions/god/manage_monster.lua`
- `luac -p data/scripts/talkactions/god/manage_monster.lua`
- `git diff --check`
- Verified the branch contains one focused commit based directly on the current `origin/main`.
- Build not run for these focused call-site and Lua changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monster name change updates so clients reliably refresh the displayed monster for all visible spectators.
  * Improved `/setmonstername` behavior with stricter name parsing/validation, accurate counting of renamed monsters, and clearer player feedback (including cases where no monsters are found or all already match).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->