### PR TITLE
fix(protocol): align effect sources and virtue state

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -1036,7 +1036,7 @@ void Combat::sendCombatEffect(const std::shared_ptr<Creature> &caster, const Pos
 
 	// If not a Monk player, use the original effect
 	if (!casterPlayer || casterPlayer->getPlayerVocationEnum() != VOCATION_MONK_CIP) {
-		g_game().addMagicEffect(position, effect);
+		g_game().addMagicEffect(position, effect, caster);
 		return;
 	}
 
@@ -1046,7 +1046,7 @@ void Combat::sendCombatEffect(const std::shared_ptr<Creature> &caster, const Pos
 		effect = monkEffectByElementalBond(it.elementalBond, effect);
 	}
 
-	g_game().addMagicEffect(position, effect);
+	g_game().addMagicEffect(position, effect, caster);
 }
 
 void Combat::combatTileEffects(const CreatureVector &spectators, const std::shared_ptr<Creature> &caster, const std::shared_ptr<Tile> &tile, const CombatParams &params) {
@@ -1189,7 +1189,7 @@ void Combat::addDistanceEffect(const std::shared_ptr<Creature> &caster, const Po
 	}
 
 	if (effect != CONST_ANI_NONE) {
-		g_game().addDistanceEffect(fromPos, toPos, effect);
+		g_game().addDistanceEffect(fromPos, toPos, effect, caster);
 	}
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -2146,8 +2146,12 @@ void Player::sendPlayerVocation(const std::shared_ptr<Player> &player) const {
 }
 
 void Player::sendDistanceShoot(const Position &from, const Position &to, uint16_t type) const {
+	sendDistanceShoot(from, to, type, SourceEffect_t::OWN);
+}
+
+void Player::sendDistanceShoot(const Position &from, const Position &to, uint16_t type, SourceEffect_t source) const {
 	if (client) {
-		client->sendDistanceShoot(from, to, type);
+		client->sendDistanceShoot(from, to, type, source);
 	}
 }
 
@@ -2241,8 +2245,12 @@ void Player::sendGameNews() const {
 }
 
 void Player::sendMagicEffect(const Position &pos, uint16_t type) const {
+	sendMagicEffect(pos, type, SourceEffect_t::OWN);
+}
+
+void Player::sendMagicEffect(const Position &pos, uint16_t type, SourceEffect_t source) const {
 	if (client) {
-		client->sendMagicEffect(pos, type);
+		client->sendMagicEffect(pos, type, source);
 	}
 }
 

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -13031,15 +13031,17 @@ Virtue_t Player::getVirtue() const {
 	return virtue;
 }
 
-void Player::setVirtue(Virtue_t newVirtue) {
+void Player::setVirtue(Virtue_t newVirtue, bool notifyClient /* = true */) {
 	if (virtue == newVirtue) {
 		return;
 	}
 
 	virtue = newVirtue;
 
-	sendSkills();
-	sendMonkData(MonkData_t::Virtue, enumToValue(virtue));
+	if (notifyClient) {
+		sendSkills();
+		sendMonkData(MonkData_t::Virtue, enumToValue(virtue));
+	}
 }
 
 void Player::setSerene(bool b, int32_t ticks /* = -1 */) {

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -206,8 +206,9 @@ public:
 	/**
 	 * @brief Sets the player's virtue.
 	 * @param virtue The virtue to set.
+	 * @param notifyClient Whether to send the updated state to the client.
 	 */
-	void setVirtue(Virtue_t virtue);
+	void setVirtue(Virtue_t virtue, bool notifyClient = true);
 
 	/**
 	 * @brief Sets the player's serene state.

--- a/src/creatures/players/player.hpp
+++ b/src/creatures/players/player.hpp
@@ -1065,6 +1065,7 @@ public:
 	void sendPartyPlayerVocation(const std::shared_ptr<Player> &player) const;
 	void sendPlayerVocation(const std::shared_ptr<Player> &player) const;
 	void sendDistanceShoot(const Position &from, const Position &to, uint16_t type) const;
+	void sendDistanceShoot(const Position &from, const Position &to, uint16_t type, SourceEffect_t source) const;
 	void sendHouseWindow(const std::shared_ptr<House> &house, uint32_t listId) const;
 	void sendCreatePrivateChannel(uint16_t channelId, const std::string &channelName) const;
 	void sendClosePrivate(uint16_t channelId);
@@ -1075,6 +1076,7 @@ public:
 	void sendClientCheck() const;
 	void sendGameNews() const;
 	void sendMagicEffect(const Position &pos, uint16_t type) const;
+	void sendMagicEffect(const Position &pos, uint16_t type, SourceEffect_t source) const;
 	void removeMagicEffect(const Position &pos, uint16_t type) const;
 	void sendPing();
 	void sendPingBack() const;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -92,6 +92,20 @@ namespace {
 	MonsterPostThinkQueue backgroundMonsterPostThinkQueue;
 	std::array<std::atomic_uint64_t, 2> rejectedMonsterPostThinkTasks {};
 
+	SourceEffect_t classifyGraphicalEffectSource(const std::shared_ptr<Creature> &source, const std::shared_ptr<Creature> &spectator) {
+		using enum SourceEffect_t;
+		if (!source || source->getNpc()) {
+			return GLOBAL;
+		}
+		if (source == spectator) {
+			return OWN;
+		}
+		if (source->getPlayer()) {
+			return OTHERS;
+		}
+		return CREATURES;
+	}
+
 	MonsterPostThinkQueue &getMonsterPostThinkQueue(bool playerVisible) {
 		return playerVisible ? visibleMonsterPostThinkQueue : backgroundMonsterPostThinkQueue;
 	}
@@ -397,11 +411,11 @@ namespace InternalGame {
 
 	void sendBlockEffect(BlockType_t blockType, CombatType_t combatType, const Position &targetPos, const std::shared_ptr<Creature> &source) {
 		if (blockType == BLOCK_DEFENSE) {
-			g_game().addMagicEffect(targetPos, CONST_ME_POFF);
+			g_game().addMagicEffect(targetPos, CONST_ME_POFF, source);
 		} else if (blockType == BLOCK_ARMOR) {
-			g_game().addMagicEffect(targetPos, CONST_ME_BLOCKHIT);
+			g_game().addMagicEffect(targetPos, CONST_ME_BLOCKHIT, source);
 		} else if (blockType == BLOCK_DODGE) {
-			g_game().addMagicEffect(targetPos, CONST_ME_DODGE);
+			g_game().addMagicEffect(targetPos, CONST_ME_DODGE, source);
 		} else if (blockType == BLOCK_IMMUNITY) {
 			uint8_t hitEffect = 0;
 			switch (combatType) {
@@ -429,7 +443,7 @@ namespace InternalGame {
 					break;
 				}
 			}
-			g_game().addMagicEffect(targetPos, hitEffect);
+			g_game().addMagicEffect(targetPos, hitEffect, source);
 		}
 
 		if (blockType != BLOCK_NONE) {
@@ -8779,7 +8793,7 @@ void Game::sendDamageMessageAndEffects(
 	message.primary.value = damage.primary.value;
 	message.secondary.value = damage.secondary.value;
 
-	sendEffects(target, damage, targetPos, message, spectators);
+	sendEffects(attacker, target, damage, targetPos, message, spectators);
 
 	if (shouldSendMessage(message)) {
 		sendMessages(attacker, target, damage, targetPos, attackerPlayer, targetPlayer, message, spectators, realDamage);
@@ -8937,21 +8951,21 @@ void Game::buildMessageAsAttacker(
 }
 
 void Game::sendEffects(
-	const std::shared_ptr<Creature> &target, const CombatDamage &damage, const Position &targetPos, TextMessage &message,
-	const CreatureVector &spectators
+	const std::shared_ptr<Creature> &attacker, const std::shared_ptr<Creature> &target, const CombatDamage &damage,
+	const Position &targetPos, TextMessage &message, const CreatureVector &spectators
 ) {
 	uint16_t hitEffect;
 	if (message.primary.value) {
 		combatGetTypeInfo(damage.primary.type, target, message.primary.color, hitEffect);
 		if (hitEffect != CONST_ME_NONE) {
-			addMagicEffect(spectators, targetPos, hitEffect);
+			addMagicEffect(spectators, targetPos, hitEffect, attacker);
 		}
 	}
 
 	if (message.secondary.value) {
 		combatGetTypeInfo(damage.secondary.type, target, message.secondary.color, hitEffect);
 		if (hitEffect != CONST_ME_NONE) {
-			addMagicEffect(spectators, targetPos, hitEffect);
+			addMagicEffect(spectators, targetPos, hitEffect, attacker);
 		}
 	}
 }
@@ -9326,13 +9340,22 @@ void Game::addPlayerVocation(const std::shared_ptr<Player> &target) {
 
 void Game::addMagicEffect(const Position &pos, uint16_t effect) {
 	auto spectators = Spectators().find<Player>(pos, true);
-	addMagicEffect(spectators.data(), pos, effect);
+	addMagicEffect(spectators.data(), pos, effect, nullptr);
 }
 
 void Game::addMagicEffect(const CreatureVector &spectators, const Position &pos, uint16_t effect) {
+	addMagicEffect(spectators, pos, effect, nullptr);
+}
+
+void Game::addMagicEffect(const Position &pos, uint16_t effect, const std::shared_ptr<Creature> &source) {
+	auto spectators = Spectators().find<Player>(pos, true);
+	addMagicEffect(spectators.data(), pos, effect, source);
+}
+
+void Game::addMagicEffect(const CreatureVector &spectators, const Position &pos, uint16_t effect, const std::shared_ptr<Creature> &source) {
 	for (const auto &spectator : spectators) {
 		if (const auto &tmpPlayer = spectator->getPlayer()) {
-			tmpPlayer->sendMagicEffect(pos, effect);
+			tmpPlayer->sendMagicEffect(pos, effect, classifyGraphicalEffectSource(source, spectator));
 		}
 	}
 }
@@ -9352,13 +9375,24 @@ void Game::removeMagicEffect(const CreatureVector &spectators, const Position &p
 
 void Game::addDistanceEffect(const Position &fromPos, const Position &toPos, uint16_t effect) {
 	auto spectators = Spectators().find<Player>(fromPos).find<Player>(toPos);
-	addDistanceEffect(spectators.data(), fromPos, toPos, effect);
+	addDistanceEffect(spectators.data(), fromPos, toPos, effect, nullptr);
 }
 
 void Game::addDistanceEffect(const CreatureVector &spectators, const Position &fromPos, const Position &toPos, uint16_t effect) {
+	addDistanceEffect(spectators, fromPos, toPos, effect, nullptr);
+}
+
+void Game::addDistanceEffect(const Position &fromPos, const Position &toPos, uint16_t effect, const std::shared_ptr<Creature> &source) {
+	auto spectators = Spectators().find<Player>(fromPos).find<Player>(toPos);
+	addDistanceEffect(spectators.data(), fromPos, toPos, effect, source);
+}
+
+void Game::addDistanceEffect(
+	const CreatureVector &spectators, const Position &fromPos, const Position &toPos, uint16_t effect, const std::shared_ptr<Creature> &source
+) {
 	for (const auto &spectator : spectators) {
 		if (const auto &tmpPlayer = spectator->getPlayer()) {
-			tmpPlayer->sendDistanceShoot(fromPos, toPos, effect);
+			tmpPlayer->sendDistanceShoot(fromPos, toPos, effect, classifyGraphicalEffectSource(source, spectator));
 		}
 	}
 }

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -536,11 +536,17 @@ public:
 	void addPlayerMana(const std::shared_ptr<Player> &target);
 	void addPlayerVocation(const std::shared_ptr<Player> &target);
 	void addMagicEffect(const Position &pos, uint16_t effect);
+	void addMagicEffect(const Position &pos, uint16_t effect, const std::shared_ptr<Creature> &source);
 	static void addMagicEffect(const CreatureVector &spectators, const Position &pos, uint16_t effect);
+	static void addMagicEffect(const CreatureVector &spectators, const Position &pos, uint16_t effect, const std::shared_ptr<Creature> &source);
 	void removeMagicEffect(const Position &pos, uint16_t effect);
 	static void removeMagicEffect(const CreatureVector &spectators, const Position &pos, uint16_t effect);
 	void addDistanceEffect(const Position &fromPos, const Position &toPos, uint16_t effect);
+	void addDistanceEffect(const Position &fromPos, const Position &toPos, uint16_t effect, const std::shared_ptr<Creature> &source);
 	static void addDistanceEffect(const CreatureVector &spectators, const Position &fromPos, const Position &toPos, uint16_t effect);
+	static void addDistanceEffect(
+		const CreatureVector &spectators, const Position &fromPos, const Position &toPos, uint16_t effect, const std::shared_ptr<Creature> &source
+	);
 
 	int32_t getLightHour() const {
 		return lightHour;
@@ -950,7 +956,7 @@ private:
 	void updatePlayerPartyHuntAnalyzer(const CombatDamage &damage, const std::shared_ptr<Player> &player) const;
 
 	void sendEffects(
-		const std::shared_ptr<Creature> &target, const CombatDamage &damage, const Position &targetPos,
+		const std::shared_ptr<Creature> &attacker, const std::shared_ptr<Creature> &target, const CombatDamage &damage, const Position &targetPos,
 		TextMessage &message, const CreatureVector &spectators
 	);
 

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -1019,7 +1019,7 @@ void IOLoginDataLoad::loadPlayerInitializeSystem(const std::shared_ptr<Player> &
 	// Load and apply the player's Virtue from the saved spell data, if available
 	auto kv = player->kv()->scoped("spells");
 	if (auto kvOpt = kv->get("virtue")) {
-		player->setVirtue(static_cast<Virtue_t>(kvOpt->getNumber()));
+		player->setVirtue(static_cast<Virtue_t>(kvOpt->getNumber()), false);
 	}
 
 	if (auto kvOpt = kv->get("harmony")) {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -8095,7 +8095,7 @@ void ProtocolGame::sendPingBack() {
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendDistanceShoot(const Position &from, const Position &to, uint16_t type) {
+void ProtocolGame::sendDistanceShoot(const Position &from, const Position &to, uint16_t type, SourceEffect_t source) {
 	const bool useLegacyU16Effect = oldProtocol && hasProtocolFeature(protocolProfile, ProtocolFeature::MagicEffectU16);
 	if (oldProtocol && !useLegacyU16Effect && type > 0xFF) {
 		return;
@@ -8118,11 +8118,15 @@ void ProtocolGame::sendDistanceShoot(const Position &from, const Position &to, u
 		msg.addByte(static_cast<uint8_t>(static_cast<int8_t>(static_cast<int32_t>(to.x) - static_cast<int32_t>(from.x))));
 		msg.addByte(static_cast<uint8_t>(static_cast<int8_t>(static_cast<int32_t>(to.y) - static_cast<int32_t>(from.y))));
 		if (hasProtocolFeature(protocolProfile, ProtocolFeature::GraphicalEffectSourceByte)) {
-			msg.addByte(magic_enum::enum_integer(SourceEffect_t::OWN));
+			msg.addByte(magic_enum::enum_integer(source));
 		}
 		msg.addByte(MAGIC_EFFECTS_END_LOOP);
 	}
 	writeToOutputBuffer(msg);
+}
+
+void ProtocolGame::sendDistanceShoot(const Position &from, const Position &to, uint16_t type) {
+	sendDistanceShoot(from, to, type, SourceEffect_t::OWN);
 }
 
 void ProtocolGame::sendRestingStatus(uint8_t protection) {
@@ -8170,7 +8174,7 @@ void ProtocolGame::sendRestingStatus(uint8_t protection) {
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendMagicEffect(const Position &pos, uint16_t type) {
+void ProtocolGame::sendMagicEffect(const Position &pos, uint16_t type, SourceEffect_t source) {
 	const bool useLegacyU16Effect = oldProtocol && hasProtocolFeature(protocolProfile, ProtocolFeature::MagicEffectU16);
 	if (!canSee(pos) || (oldProtocol && !useLegacyU16Effect && type > 0xFF)) {
 		return;
@@ -8191,11 +8195,15 @@ void ProtocolGame::sendMagicEffect(const Position &pos, uint16_t type) {
 		msg.addByte(MAGIC_EFFECTS_CREATE_EFFECT);
 		msg.add<uint16_t>(type);
 		if (hasProtocolFeature(protocolProfile, ProtocolFeature::GraphicalEffectSourceByte)) {
-			msg.addByte(magic_enum::enum_integer(SourceEffect_t::OWN));
+			msg.addByte(magic_enum::enum_integer(source));
 		}
 		msg.addByte(MAGIC_EFFECTS_END_LOOP);
 	}
 	writeToOutputBuffer(msg);
+}
+
+void ProtocolGame::sendMagicEffect(const Position &pos, uint16_t type) {
+	sendMagicEffect(pos, type, SourceEffect_t::OWN);
 }
 
 void ProtocolGame::removeMagicEffect(const Position &pos, uint16_t type) {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -8647,10 +8647,12 @@ void ProtocolGame::sendAddCreature(const std::shared_ptr<Creature> &creature, co
 
 	if (player->getPlayerVocationEnum() == Vocation_t::VOCATION_MONK_CIP) {
 		sendMonkData(MonkData_t::Harmony, player->getHarmony());
-		auto virtue = player->getVirtue();
-		virtue = virtue != Virtue_t::None ? virtue : Virtue_t::Harmony;
-		sendMonkData(MonkData_t::Virtue, enumToValue(virtue));
-		sendMonkData(MonkData_t::Serenity, 1);
+		const bool officialVocationData = hasProtocolFeature(protocolProfile, ProtocolFeature::OfficialVocationSpecificPlayerData);
+		const auto virtue = player->getVirtue();
+		if (virtue != Virtue_t::None || !officialVocationData) {
+			sendMonkData(MonkData_t::Virtue, enumToValue(virtue != Virtue_t::None ? virtue : Virtue_t::Harmony));
+		}
+		sendMonkData(MonkData_t::Serenity, officialVocationData ? player->hasCondition(CONDITION_SERENE) : true);
 	}
 
 	if (version >= 1100) {
@@ -12071,10 +12073,25 @@ void ProtocolGame::sendMonkData(MonkData_t type, uint8_t value) {
 				msg.addByte(value != 0 ? 0x01 : 0x00);
 				break;
 			case MonkData_t::Virtue: {
-				const uint8_t virtueCount = value != 0 ? 1 : 0;
+				uint16_t spellId = 0;
+				switch (static_cast<Virtue_t>(value)) {
+					case Virtue_t::Harmony:
+						spellId = 274;
+						break;
+					case Virtue_t::Justice:
+						spellId = 275;
+						break;
+					case Virtue_t::Sustain:
+						spellId = 276;
+						break;
+					case Virtue_t::None:
+						break;
+				}
+
+				const uint8_t virtueCount = spellId != 0 ? 1 : 0;
 				msg.addByte(virtueCount);
 				if (virtueCount != 0) {
-					msg.add<uint16_t>(value);
+					msg.add<uint16_t>(spellId);
 				}
 				break;
 			}

--- a/src/server/network/protocol/protocolgame.hpp
+++ b/src/server/network/protocol/protocolgame.hpp
@@ -351,7 +351,9 @@ private:
 	void sendBosstiaryEntryChanged(uint32_t bossid);
 
 	void sendAllowBugReport();
+	void sendDistanceShoot(const Position &from, const Position &to, uint16_t type, SourceEffect_t source);
 	void sendDistanceShoot(const Position &from, const Position &to, uint16_t type);
+	void sendMagicEffect(const Position &pos, uint16_t type, SourceEffect_t source);
 	void sendMagicEffect(const Position &pos, uint16_t type);
 	void removeMagicEffect(const Position &pos, uint16_t type);
 	void sendRestingStatus(uint8_t protection);


### PR DESCRIPTION
## Summary

- propagate the originating creature through combat magic and distance effects
- classify effects as global, own, another player, or another creature for each spectator
- stop fabricating a default virtue during official-client login
- serialize active virtues with their official spell IDs and restore the actual serenity state
- restore persisted virtues without emitting packets before the login bootstrap

## Why

Graphical effect packets always attributed effects to the observing player. The login bootstrap also synthesized a Harmony virtue and an active serenity state when neither was present. Together, these behaviors could make client-side filters and packet consumers interpret combat and vocation state incorrectly.

For the official vocation-specific payload, a virtue is an active-spell collection encoded as a `u8` count followed by `u16` spell IDs. Harmony, Justice, and Sustain use spell IDs 274, 275, and 276.

## Compatibility

- the graphical source byte remains gated by `ProtocolFeature::GraphicalEffectSourceByte`
- the login and spell-ID behavior is gated by `ProtocolFeature::OfficialVocationSpecificPlayerData`
- legacy custom Monk payloads retain their previous behavior
- clearing an active virtue during gameplay still sends an empty collection so the client removes it

## Validation

- `git diff --check origin/main...HEAD`
- verified the branch is exactly two commits ahead of the current `origin/main`
- reviewed the affected combat, player persistence, login bootstrap, and protocol serialization paths statically

Build not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combat visual effects now identify their source, improving clarity between self, player, creature, and global effects.
  * Graphical effect source information is supported for compatible client profiles while preserving legacy behavior.
  * Virtue and serenity data are now displayed conditionally based on vocation support.
* **Bug Fixes**
  * Corrected virtue restoration and mapping when loading saved player data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->