### PR TITLE
fix: allow spell casting while paralyzed

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -7457,10 +7457,6 @@ void Game::playerSay(uint32_t playerId, uint16_t channelId, SpeakClasses type, c
 }
 
 bool Game::playerSaySpell(const std::shared_ptr<Player> &player, SpeakClasses type, const std::string &text) {
-	if (player->walkExhausted()) {
-		return true;
-	}
-
 	std::string words = text;
 	TalkActionResult_t result = g_talkActions().checkPlayerCanSayTalkAction(player, type, words);
 	if (result == TALKACTION_BREAK) {


### PR DESCRIPTION
resolve problem in issue: #3986 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Spell and talkaction processing now continues while a player is walk-exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->