### PR TITLE
fix: Zoltan Myra addon reward for male summoners

### DIFF
--- a/data-otservbr-global/npc/zoltan.lua
+++ b/data-otservbr-global/npc/zoltan.lua
@@ -91,7 +91,8 @@ local function creatureSayCallback(npc, creature, type, message)
 			end
 		end
 	elseif MsgContains(message, "myra") then
-		if player:getSex() == PLAYERSEX_FEMALE and player:getStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.AddonHatCloak) == 10 and not player:hasOutfit(138, 2) then
+		local addonHatCloak = player:getStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.AddonHatCloak)
+		if player:getSex() == PLAYERSEX_FEMALE and addonHatCloak == 10 and not player:hasOutfit(138, 2) then
 			npcHandler:say({
 				"Bah, I know. I received some sort of 'nomination' from our outpost in Port Hope. ...",
 				"Usually it takes a little more than that for an award though. However, I honour Myra's word. ...",
@@ -102,7 +103,18 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
 			player:setStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.AddonHatCloak, 11)
 			player:setStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.MissionHatCloak, 0)
-		elseif player:getStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.AddonHatCloak) == 11 then
+		elseif player:getSex() == PLAYERSEX_MALE and addonHatCloak == 10 and not player:hasOutfit(133, 2) then
+			npcHandler:say({
+				"Bah, I know. I received some sort of 'nomination' from our outpost in Port Hope. ...",
+				"Usually it takes a little more than that for an award though. However, I honour Myra's word. ...",
+				"I hereby grant you the right to wear a special sign of honour, acknowledged by the academy of Edron. There you go.",
+			}, npc, creature, 100)
+			player:addOutfitAddon(133, 2) -- male summoner addon
+			player:addOutfitAddon(130, 2) -- male mage addon
+			player:getPosition():sendMagicEffect(CONST_ME_MAGIC_BLUE)
+			player:setStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.AddonHatCloak, 11)
+			player:setStorageValue(Storage.Quest.U7_8.MageAndSummonerOutfits.MissionHatCloak, 0)
+		elseif addonHatCloak == 11 then
 			npcHandler:say("Stop bothering me. I am a far too busy man to be constantly giving out awards.", npc, creature)
 		else
 			npcHandler:say("What the hell are you talking about?", npc, creature)


### PR DESCRIPTION
### Bug

A **male** character who finishes the Mage and Summoner outfit questline never receives addon `133,2` (male summoner, second addon). Nobody in the datapack grants it — not Zoltan, not an item, not a script — so the addon is unobtainable for male players.

### Root cause

In `data-otservbr-global/npc/zoltan.lua`, the `myra` keyword only has a `PLAYERSEX_FEMALE` branch:

```lua
if player:getSex() == PLAYERSEX_FEMALE and ... AddonHatCloak == 10 and not player:hasOutfit(138, 2) then
    ...
    player:addOutfitAddon(138, 2)
    player:addOutfitAddon(141, 2)
```

Male characters fall straight through to the `AddonHatCloak == 11` branch ("Stop bothering me…") or to the default reply, so the male counterpart of that grant never happens.

The female summoner addon (`138,2`) is in fact granted **twice** — by this keyword and by Ferumbras' hat/proof branch — while the male one (`133,2`) is granted by neither.

### Fix

Add the mirrored `PLAYERSEX_MALE` branch: with `AddonHatCloak == 10` it grants `133,2` and `130,2` (male summoner and mage), sends the same magic effect and leaves both storages exactly as the female branch does.

The storage read is hoisted into a local so the two sex branches and the `== 11` check share it, instead of reading it three times.

The **female branch is untouched**, so no existing behaviour changes for female characters.

### Testing

Deployed on a live 15.25 server (as a mounted copy of this file): boot with no Lua errors, and the male branch is reachable through `myra` with `AddonHatCloak == 10`. In-game confirmation with a male character is queued on our side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Myra addon quest flow for male characters.
  * Male characters can now correctly receive the Mage and Summoner addons.
  * Updated addon progress tracking and completion feedback to ensure the rewards are granted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->