### PR TITLE
fix: Brengus sells the tribal mask instead of buying it

### DIFF
--- a/data-otservbr-global/npc/brengus.lua
+++ b/data-otservbr-global/npc/brengus.lua
@@ -159,7 +159,7 @@ npcConfig.shop = {
 	{ itemName = "tarsal arrow", clientId = 14251, buy = 6 },
 	{ itemName = "throwing knife", clientId = 3298, buy = 25 },
 	{ itemName = "throwing star", clientId = 3287, buy = 42 },
-	{ itemName = "tribal mask", clientId = 3403, buy = 250 },
+	{ itemName = "tribal mask", clientId = 3403, sell = 100 },
 	{ itemName = "tusk shield", clientId = 3443, sell = 850 },
 	{ itemName = "two handed sword", clientId = 3265, buy = 950 },
 	{ itemName = "viking helmet", clientId = 3367, buy = 265 },


### PR DESCRIPTION
### Bug

Brengus (Kazordoon) offers the **tribal mask** for sale at 250 gp and does not buy it. In real Tibia it is the opposite: Brengus is one of the NPCs that **buys** tribal masks for 100 gp, and no NPC sells them — the mask is a drop players want to unload.

The consequence is not cosmetic: with no NPC buying it, there is no way to sell the item at all.

### Root cause

`buy`/`sell` in `npcConfig.shop` are written from the **player's** perspective, so

```lua
{ itemName = "tribal mask", clientId = 3403, buy = 250 },
```

means "the player buys it from Brengus for 250" — i.e. Brengus sells it.

### Fix

```lua
{ itemName = "tribal mask", clientId = 3403, sell = 100 },
```

Brengus now buys the mask for 100 gp and no longer offers it for sale, matching the real NPC.

### Testing

Deployed on a live 15.25 server (mounted copy of this file); the mask is gone from his sell list and appears as a buy offer at 100 gp. In-game confirmation of an actual sale is queued on our side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Brengus’s shop pricing for tribal masks.
  * Tribal masks are now sold to players for 100 gold instead of being bought for 250 gold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->