### PR TITLE
fix: Augustin throws "message type invalid" on every sale

### DIFF
--- a/data-otservbr-global/npc/augustin.lua
+++ b/data-otservbr-global/npc/augustin.lua
@@ -178,7 +178,7 @@ npcType.onBuyItem = function(npc, player, itemId, subType, amount, ignore, inBac
 end
 -- On sell npc shop message
 npcType.onSellItem = function(npc, player, itemId, subtype, amount, ignore, name, totalCost)
-	player:sendTextMessage(MESSAGE_INFO_DESCR, string.format("Sold %ix %s for %i gold.", amount, name, totalCost))
+	player:sendTextMessage(MESSAGE_TRADE, string.format("Sold %ix %s for %i gold.", amount, name, totalCost))
 end
 -- On check npc shop message (look item)
 npcType.onCheckItem = function(npc, player, clientId, subType) end


### PR DESCRIPTION
### Bug

Selling anything to Augustin (Port Hope) pops up an error — *"message type invalid"* — instead of the *"Sold 1x … for … gold."* confirmation. The trade itself completes; only the confirmation text fails.

### Root cause

`npcType.onSellItem` sends the confirmation with `MESSAGE_INFO_DESCR`:

```lua
player:sendTextMessage(MESSAGE_INFO_DESCR, string.format("Sold %ix %s for %i gold.", ...))
```

That constant is not registered by the engine any more, so the global resolves to `nil`, the C++ side rejects the message type and reports it back as an error.

Augustin is the **only** NPC in the datapack still using it; every other trader uses `MESSAGE_TRADE`.

### Fix

Use `MESSAGE_TRADE`, aligning him with the rest of the traders.

### Testing

Deployed on a live 15.25 server (mounted copy of this file): the error popup is gone and the sale confirmation renders in the trade channel. In-game confirmation is queued on our side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Augustin’s sale confirmation message to display using the appropriate trade notification style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->