### PR TITLE
fix: NPCs sell spells under names that no spell registers

### DIFF
--- a/data-otservbr-global/npc/azalea.lua
+++ b/data-otservbr-global/npc/azalea.lua
@@ -167,7 +167,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -176,7 +176,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -200,7 +200,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })

--- a/data-otservbr-global/npc/barnabas_dee.lua
+++ b/data-otservbr-global/npc/barnabas_dee.lua
@@ -278,7 +278,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/charlotta.lua
+++ b/data-otservbr-global/npc/charlotta.lua
@@ -199,7 +199,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -208,7 +208,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -232,7 +232,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })

--- a/data-otservbr-global/npc/chatterbone.lua
+++ b/data-otservbr-global/npc/chatterbone.lua
@@ -143,7 +143,7 @@ local node30 = keywordHandler:addKeyword({ "ultimate healing" }, StdModule.say, 
 node30:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ultimate healing", vocation = { 1, 2, 5, 6 }, price = 1000, level = 30 })
 
 local node31 = keywordHandler:addKeyword({ "explosion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {explosion} magic spell for 1800 gold?" })
-node31:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "explosion", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
+node31:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Explosion Rune", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
 
 local node32 = keywordHandler:addKeyword({ "invisibility" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisibility} magic spell for 2000 gold?" })
 node32:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })

--- a/data-otservbr-global/npc/eroth.lua
+++ b/data-otservbr-global/npc/eroth.lua
@@ -92,7 +92,7 @@ local node2 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHan
 node2:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node3 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node3:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node3:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node4 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })

--- a/data-otservbr-global/npc/etzel.lua
+++ b/data-otservbr-global/npc/etzel.lua
@@ -77,7 +77,7 @@ local node8 = keywordHandler:addKeyword({ "energy beam" }, StdModule.say, { npcH
 node8:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "energy beam", vocation = { 1, 5 }, price = 1000, level = 23 })
 
 local node9 = keywordHandler:addKeyword({ "explosion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {explosion} magic spell for 1800 gold?" })
-node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "explosion", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
+node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Explosion Rune", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
 
 local node10 = keywordHandler:addKeyword({ "fire bomb" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Fire Bomb} Rune spell for 1500 gold?" })
 node10:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "fire bomb rune", vocation = { 1, 2, 5, 6 }, price = 1500, level = 27 })

--- a/data-otservbr-global/npc/garamond.lua
+++ b/data-otservbr-global/npc/garamond.lua
@@ -60,7 +60,7 @@ local lightMagicMissileNode = keywordHandler:addKeyword({ "light magic missile" 
 lightMagicMissileNode:addChildKeyword({ "yes" }, StdModule.learnSpell, {
 	npcHandler = npcHandler,
 	premium = false,
-	spellName = "Light Magic Missile",
+	spellName = "Light Magic Missile Rune",
 	vocation = { 1, 2, 5, 6 },
 	price = 500,
 	level = 15,
@@ -172,7 +172,7 @@ local poisonFieldNode = keywordHandler:addKeyword({ "poison field" }, StdModule.
 poisonFieldNode:addChildKeyword({ "yes" }, StdModule.learnSpell, {
 	npcHandler = npcHandler,
 	premium = false,
-	spellName = "Poison Field",
+	spellName = "Poison Field Rune",
 	vocation = { 1, 2, 5, 6 },
 	price = 300,
 	level = 14,
@@ -186,7 +186,7 @@ local fireFieldNode = keywordHandler:addKeyword({ "fire field" }, StdModule.say,
 fireFieldNode:addChildKeyword({ "yes" }, StdModule.learnSpell, {
 	npcHandler = npcHandler,
 	premium = false,
-	spellName = "Fire Field",
+	spellName = "Fire Field Rune",
 	vocation = { 1, 2, 5, 6 },
 	price = 500,
 	level = 15,
@@ -200,7 +200,7 @@ local energyFieldNode = keywordHandler:addKeyword({ "energy field" }, StdModule.
 energyFieldNode:addChildKeyword({ "yes" }, StdModule.learnSpell, {
 	npcHandler = npcHandler,
 	premium = false,
-	spellName = "Energy Field",
+	spellName = "Energy Field Rune",
 	vocation = { 1, 2, 5, 6 },
 	price = 700,
 	level = 18,

--- a/data-otservbr-global/npc/gundralph.lua
+++ b/data-otservbr-global/npc/gundralph.lua
@@ -222,7 +222,7 @@ local node56 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node56:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node57 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node57:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node57:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node58 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node58:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -240,7 +240,7 @@ local node62 = keywordHandler:addKeyword({ "chill out" }, StdModule.say, { npcHa
 node62:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chill out", vocation = { 2, 6 }, price = 0, level = 1 })
 
 local node63 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node63:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node63:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node64 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node64:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })

--- a/data-otservbr-global/npc/kjesse.lua
+++ b/data-otservbr-global/npc/kjesse.lua
@@ -167,7 +167,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -176,7 +176,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -200,7 +200,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })

--- a/data-otservbr-global/npc/lea.lua
+++ b/data-otservbr-global/npc/lea.lua
@@ -77,7 +77,7 @@ local node8 = keywordHandler:addKeyword({ "energy beam" }, StdModule.say, { npcH
 node8:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "energy beam", vocation = { 1, 5 }, price = 1000, level = 23 })
 
 local node9 = keywordHandler:addKeyword({ "explosion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {explosion} magic spell for 1800 gold?" })
-node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "explosion", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
+node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Explosion Rune", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
 
 local node10 = keywordHandler:addKeyword({ "fire bomb" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Fire Bomb} Rune spell for 1500 gold?" })
 node10:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "fire bomb rune", vocation = { 1, 2, 5, 6 }, price = 1500, level = 27 })

--- a/data-otservbr-global/npc/malunga.lua
+++ b/data-otservbr-global/npc/malunga.lua
@@ -208,7 +208,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/marvik.lua
+++ b/data-otservbr-global/npc/marvik.lua
@@ -67,7 +67,7 @@ local node3 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHan
 node3:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node4 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node5 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node5:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })

--- a/data-otservbr-global/npc/muriel.lua
+++ b/data-otservbr-global/npc/muriel.lua
@@ -183,7 +183,7 @@ local node8 = keywordHandler:addKeyword({ "energy beam" }, StdModule.say, { npcH
 node8:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "energy beam", vocation = { 1, 5 }, price = 1000, level = 23 })
 
 local node9 = keywordHandler:addKeyword({ "explosion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {explosion} magic spell for 1800 gold?" })
-node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "explosion", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
+node9:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Explosion Rune", vocation = { 1, 2, 5, 6 }, price = 1800, level = 31 })
 
 local node10 = keywordHandler:addKeyword({ "fire bomb" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Fire Bomb} Rune spell for 1500 gold?" })
 node10:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "fire bomb rune", vocation = { 1, 2, 5, 6 }, price = 1500, level = 27 })

--- a/data-otservbr-global/npc/myra.lua
+++ b/data-otservbr-global/npc/myra.lua
@@ -469,7 +469,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/padreia.lua
+++ b/data-otservbr-global/npc/padreia.lua
@@ -136,7 +136,7 @@ local node3 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHan
 node3:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node4 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node5 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node5:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })

--- a/data-otservbr-global/npc/rahkem.lua
+++ b/data-otservbr-global/npc/rahkem.lua
@@ -290,7 +290,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -299,7 +299,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -323,7 +323,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })

--- a/data-otservbr-global/npc/romir.lua
+++ b/data-otservbr-global/npc/romir.lua
@@ -283,7 +283,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/shalmar.lua
+++ b/data-otservbr-global/npc/shalmar.lua
@@ -230,7 +230,7 @@ local node59 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node59:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 5, 6 }, price = 700, level = 17 })
 
 local node60 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node60:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node60:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node61 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node61:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -239,7 +239,7 @@ local node62 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node62:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node63 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node63:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node63:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node64 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node64:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -272,7 +272,7 @@ local node73 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node73:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node74 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node74:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node74:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node75 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node75:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/smiley.lua
+++ b/data-otservbr-global/npc/smiley.lua
@@ -62,7 +62,7 @@ local node3 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHan
 node3:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node4 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node5 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node5:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })

--- a/data-otservbr-global/npc/tamara.lua
+++ b/data-otservbr-global/npc/tamara.lua
@@ -167,7 +167,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -176,7 +176,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -200,7 +200,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })

--- a/data-otservbr-global/npc/tamoril.lua
+++ b/data-otservbr-global/npc/tamoril.lua
@@ -263,7 +263,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/tothdral.lua
+++ b/data-otservbr-global/npc/tothdral.lua
@@ -198,7 +198,7 @@ local node50 = keywordHandler:addKeyword({ "ignite" }, StdModule.say, { npcHandl
 node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "ignite", vocation = { 1, 5 }, price = 1500, level = 26 })
 
 local node51 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node52 = keywordHandler:addKeyword({ "lightning" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {lightning} magic spell for 5000 gold?" })
 node52:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "lightning", vocation = { 1, 5 }, price = 5000, level = 55 })

--- a/data-otservbr-global/npc/ustan.lua
+++ b/data-otservbr-global/npc/ustan.lua
@@ -205,7 +205,7 @@ local node38 = keywordHandler:addKeyword({ "destroy field" }, StdModule.say, { n
 node38:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "destroy field rune", vocation = { 1, 2, 3, 5, 6, 7, 9, 10 }, price = 700, level = 17 })
 
 local node39 = keywordHandler:addKeyword({ "paralyse" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {Paralyse} Rune spell for 1900 gold?" })
-node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "paralyse rune", vocation = { 2, 6 }, price = 1900, level = 54 })
+node39:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Paralyze Rune", vocation = { 2, 6 }, price = 1900, level = 54 })
 
 local node40 = keywordHandler:addKeyword({ "animate dead" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {animate dead} magic spell for 1200 gold?" })
 node40:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "animate dead rune", vocation = { 1, 2, 5, 6 }, price = 1200, level = 27 })
@@ -214,7 +214,7 @@ local node41 = keywordHandler:addKeyword({ "chameleon" }, StdModule.say, { npcHa
 node41:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "chameleon rune", vocation = { 2, 6 }, price = 1300, level = 27 })
 
 local node42 = keywordHandler:addKeyword({ "convince creature" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {convince creature} magic spell for 800 gold?" })
-node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "convince creature", vocation = { 2, 6 }, price = 800, level = 16 })
+node42:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "Convince Creature Rune", vocation = { 2, 6 }, price = 800, level = 16 })
 
 local node43 = keywordHandler:addKeyword({ "creature illusion" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {creature illusion} magic spell for 1000 gold?" })
 node43:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "creature illusion", vocation = { 1, 2, 5, 6 }, price = 1000, level = 23 })
@@ -238,7 +238,7 @@ local node49 = keywordHandler:addKeyword({ "ice wave" }, StdModule.say, { npcHan
 node49:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = false, spellName = "ice wave", vocation = { 2, 6 }, price = 850, level = 18 })
 
 local node50 = keywordHandler:addKeyword({ "invisible" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {invisible} magic spell for 2000 gold?" })
-node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "invisible", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
+node50:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "Invisibility", vocation = { 1, 2, 5, 6 }, price = 2000, level = 35 })
 
 local node51 = keywordHandler:addKeyword({ "mass healing" }, StdModule.say, { npcHandler = npcHandler, onlyFocus = true, text = "Would you like to learn {mass healing} magic spell for 2200 gold?" })
 node51:addChildKeyword({ "yes" }, StdModule.learnSpell, { npcHandler = npcHandler, premium = true, spellName = "mass healing", vocation = { 2, 6 }, price = 2200, level = 36 })


### PR DESCRIPTION
`StdModule.learnSpell` hands its `spellName` straight to `canLearnSpell` / `getInstantSpellByName`, which look the spell up by name. Eight names offered by NPC nodes do not match any `spell:name()` in the datapack, so the node never grants the spell — and nothing is logged, so from the player's side the NPC just does nothing useful.

| `spellName` in the NPC node | Registered as | Sites |
|---|---|---|
| `invisible` | `Invisibility` | 13 |
| `convince creature` | `Convince Creature Rune` | 12 |
| `paralyse rune` | `Paralyze Rune` (s/z) | 8 |
| `explosion` | `Explosion Rune` | 4 |
| `Energy Field` | `Energy Field Rune` | 1 |
| `Fire Field` | `Fire Field Rune` | 1 |
| `Poison Field` | `Poison Field Rune` | 1 |
| `Light Magic Missile` | `Light Magic Missile Rune` | 1 |

Most of them are the rune spells missing their `Rune` suffix; `invisible`/`Invisibility` and `paralyse`/`Paralyze` are spelling drift.

### Scope

**Only the `spellName` field changed.** The keywords the player types (`addKeyword({ "convince creature" })`) and the player-facing text (`"Would you like to learn {convince creature} magic spell for 800 gold?"`) are left exactly as they are, so the dialogue reads the same and the same words still trigger it. Diff example:

```diff
-node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { ..., spellName = "convince creature", ... })
+node4:addChildKeyword({ "yes" }, StdModule.learnSpell, { ..., spellName = "Convince Creature Rune", ... })
```

### How they were found and checked

Every `spellName = "..."` in the datapack was diffed against the set of `spell:name("...")` actually registered; the 8 names above had no match. Each replacement target was confirmed to exist as a registered spell name before changing anything.

41 sites across 23 NPC files; all 23 parse with `luajit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected spell names shown and taught by NPCs across the game world.
  - Standardized rune names for Paralyze, Convince Creature, Explosion, Light Magic Missile, Poison Field, Fire Field, and Energy Field.
  - Corrected the Invisibility spell name and capitalization.
  - Existing prices, requirements, vocation restrictions, and dialogue remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->