### PR TITLE
fix: Simon the Beggar's shovel has no price

### DIFF
--- a/data-otservbr-global/npc/simon_the_beggar.lua
+++ b/data-otservbr-global/npc/simon_the_beggar.lua
@@ -25,7 +25,7 @@ npcConfig.flags = {
 }
 npcConfig.speechBubble = SPEECHBUBBLE_BANKER
 npcConfig.shop = {
-	{ itemName = "shovel", clientId = 3457, count = 1 },
+	{ itemName = "shovel", clientId = 3457, buy = 50 },
 }
 
 -- On buy npc shop message


### PR DESCRIPTION
The shop table held a single entry with neither `buy` nor `sell`:

```lua
{ itemName = "shovel", clientId = 3457, count = 1 }
```

The shop itself is legitimate content, not leftover boilerplate: in Tibia, Simon sells a shovel for 50 gold — the [Shovel](https://tibia.fandom.com/wiki/Shovel) page lists **Simon the Beggar: 50** under *Buy From*, and [his transcript](https://tibia.fandom.com/wiki/Simon_the_Beggar/Transcripts) reads *\"Do you want to buy a shovel for 50 gold?\"*. It is how players dig their way back to the mainland from the Fibula shore where he stands.

This sets `buy = 50` (matching the entry format of the other shovel sellers, e.g. Timur and Al Dee) instead of removing the shop. He does not appear under *Sell To* for the item, so no `sell` price is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Simon the Beggar’s shovel shop so shovels can be purchased at the correct price.
  * Shovel buying, selling, and item-check interactions remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->