### PR TITLE
fix: `!autoloot all` was unreachable — "all" left commented out in validValues

### DIFF
--- a/data/scripts/talkactions/player/auto_loot.lua
+++ b/data/scripts/talkactions/player/auto_loot.lua
@@ -1,7 +1,7 @@
 local feature = TalkAction("!autoloot")
 
 local validValues = {
-	-- "all",
+	"all",
 	"on",
 	"off",
 }
@@ -16,7 +16,7 @@ function feature.onSay(player, words, param)
 	end
 	if not table.contains(validValues, param) then
 		local validValuesStr = table.concat(validValues, "/")
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !feature [" .. validValuesStr .. "]")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !autoloot [" .. validValuesStr .. "]")
 		return true
 	end
 


### PR DESCRIPTION
### Problem

`!autoloot all` replies **"Invalid param specified"**. The parameter is checked against `validValues` before dispatch, and `"all"` is commented out there — while the branch that implements it is still present and working a few lines below:

```lua
if param == "all" then
    player:setFeature(Features.AutoLoot, 2)
    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "AutoLoot is now enabled for all kills (including bosses).")
```

So the feature exists and the only door into it is closed. There is currently no way for a player to include bosses in autoloot.

### Also fixed

The usage hint printed `Usage: !feature [on/off]`. `!feature` is the name of the local Lua variable holding the TalkAction, not a command that exists — it should name the command the player just typed.

### How it was found

Our login message tells new players `Say !autoloot all to include bosses`, and an automated in-game QA scenario caught the server rejecting our own advice. Verified on a live 15.25 server before and after: before, `Invalid param specified. Usage: !feature [on/off]`; after, `AutoLoot is now enabled for all kills (including bosses).`

### Test

- `!autoloot all` -> enabled for all kills (including bosses)
- `!autoloot on` / `!autoloot off` -> unchanged
- `!autoloot xyz` -> `Invalid param specified. Usage: !autoloot [all/on/off]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for using `all` with the `!autoloot` command.
  * Corrected the usage message shown for invalid `!autoloot` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->