### PR TITLE
fix: !autoloot all was unreachable — "all" commented out in validValues

### DIFF
--- a/data/scripts/talkactions/player/auto_loot.lua
+++ b/data/scripts/talkactions/player/auto_loot.lua
@@ -1,7 +1,7 @@
 local feature = TalkAction("!autoloot")
 
 local validValues = {
-	-- "all",
+	"all",
 	"on",
 	"off",
 }
@@ -16,7 +16,7 @@ function feature.onSay(player, words, param)
 	end
 	if not table.contains(validValues, param) then
 		local validValuesStr = table.concat(validValues, "/")
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !feature [" .. validValuesStr .. "]")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !autoloot [" .. validValuesStr .. "]")
 		return true
 	end
 


### PR DESCRIPTION
`!autoloot all` is validated against `validValues` before dispatch, but `"all"` was left commented out in the table:

```lua
local validValues = {
	-- "all",
	"on",
	"off",
}
```

The branch that implements it is still there and alive (`if param == "all" then player:setFeature(Features.AutoLoot, 2)`), so the feature exists and the only way in was closed — players typing `!autoloot all` got *"Invalid param specified"*.

This uncomments `"all"` and also fixes the usage hint, which printed `Usage: !feature [...]` — `feature` is the name of the local Lua variable holding the TalkAction, not a command that exists. It now prints `Usage: !autoloot [...]`.

Verified in-game on our production server (15.25): before the fix `!autoloot all` was rejected; after it, the mode is accepted and sticky.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `all` option to the `!autoloot` command.

* **Bug Fixes**
  * Corrected the usage message shown for invalid `!autoloot` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->