### PR TITLE
fix(network): retry rejected protocol cleanup

### DIFF
--- a/docs/systems/performance-lifetime/README.md
+++ b/docs/systems/performance-lifetime/README.md
@@ -169,6 +169,10 @@ Borrowed raw pointers must not cross these boundaries.
   documentation, and call sites make the borrowed lifetime obvious.
 - Do not introduce raw accessors that can be called from delayed or async code
   unless the accessor is only a local helper and all callers are audited.
+- Network-close cleanup that mutates protocol or player ownership must remain on
+  the dispatcher, must not expire, and must handle bounded-queue rejection
+  explicitly. Retain an owning handle until a dispatcher lane accepts the
+  cleanup instead of running it on an I/O thread or silently dropping it.
 
 ## Benchmark-only monster stress mode
 

--- a/docs/systems/performance-lifetime/README.md
+++ b/docs/systems/performance-lifetime/README.md
@@ -173,6 +173,8 @@ Borrowed raw pointers must not cross these boundaries.
   the dispatcher, must not expire, and must handle bounded-queue rejection
   explicitly. Retain an owning handle until a dispatcher lane accepts the
   cleanup instead of running it on an I/O thread or silently dropping it.
+  Terminal dispatcher shutdown ends I/O retries because the shutdown lifecycle
+  owns the remaining teardown.
 
 ## Benchmark-only monster stress mode
 

--- a/src/game/scheduling/dispatcher.hpp
+++ b/src/game/scheduling/dispatcher.hpp
@@ -179,6 +179,10 @@ public:
 		return dispacherContext;
 	}
 
+	[[nodiscard]] bool isShuttingDown() const noexcept {
+		return shuttingDown.load(std::memory_order_acquire);
+	}
+
 private:
 	thread_local static DispatcherContext dispacherContext;
 	struct LaneExecutionResult {

--- a/src/game/scheduling/dispatcher_policy.hpp
+++ b/src/game/scheduling/dispatcher_policy.hpp
@@ -31,6 +31,12 @@ struct DispatcherQueueSnapshot {
 	std::string_view oldestContext;
 };
 
+enum class DispatcherAdmissionResult : uint8_t {
+	Accepted,
+	Saturated,
+	ShuttingDown,
+};
+
 class DispatcherAdmissionCounter final {
 public:
 	[[nodiscard]] bool tryReserve(size_t capacity) {
@@ -180,6 +186,13 @@ public:
 			return eventId;
 		}
 		return std::invoke(scheduler, fallbackLane);
+	}
+
+	[[nodiscard]] static DispatcherAdmissionResult classifyAdmission(bool accepted, bool shuttingDown) {
+		if (accepted) {
+			return DispatcherAdmissionResult::Accepted;
+		}
+		return shuttingDown ? DispatcherAdmissionResult::ShuttingDown : DispatcherAdmissionResult::Saturated;
 	}
 
 	[[nodiscard]] static int64_t timestamp(TimePoint timePoint) {

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -116,7 +116,8 @@ void Connection::dispatchProtocolRelease() {
 		DispatcherLane::ProtocolInput,
 		DispatcherLane::WorldCommit
 	);
-	if (accepted) {
+	const auto admissionResult = DispatcherPolicy::classifyAdmission(accepted, g_dispatcher().isShuttingDown());
+	if (admissionResult != DispatcherAdmissionResult::Saturated) {
 		protocolReleaseRetryAttempts = 0;
 		return;
 	}

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -20,6 +20,24 @@
 #include "server/server.hpp"
 #include "utils/tools.hpp"
 
+namespace {
+	constexpr auto PROTOCOL_RELEASE_RETRY_DELAY = std::chrono::milliseconds(50);
+	constexpr auto PROTOCOL_RELEASE_WARNING_INTERVAL = std::chrono::seconds(5);
+
+	bool shouldLogProtocolReleaseRetry() {
+		static std::mutex warningLock;
+		static auto nextWarningAt = std::chrono::steady_clock::time_point {};
+
+		std::scoped_lock lock(warningLock);
+		const auto now = std::chrono::steady_clock::now();
+		if (now < nextWarningAt) {
+			return false;
+		}
+		nextWarningAt = now + PROTOCOL_RELEASE_WARNING_INTERVAL;
+		return true;
+	}
+}
+
 ConnectionManager &ConnectionManager::getInstance() {
 	return inject<ConnectionManager>();
 }
@@ -55,6 +73,7 @@ void ConnectionManager::closeAll() {
 Connection::Connection(asio::io_service &initIoService, ConstServicePort_ptr initservicePort) :
 	readTimer(initIoService),
 	writeTimer(initIoService),
+	protocolReleaseRetryTimer(initIoService),
 	service_port(std::move(initservicePort)),
 	transportCodec(&TransportCodecs::rawClientFirst()),
 	socket(initIoService), m_msg() {
@@ -72,12 +91,50 @@ void Connection::close(bool force) {
 	connectionState = CONNECTION_STATE_CLOSED;
 
 	if (protocol) {
-		g_dispatcher().addEvent([protocol = protocol] { protocol->release(); }, __FUNCTION__, std::chrono::milliseconds(CONNECTION_WRITE_TIMEOUT * 1000).count());
+		dispatchProtocolRelease();
 	}
 
 	if (messageQueue.empty() || force) {
 		closeSocket();
 	}
+}
+
+void Connection::dispatchProtocolRelease() {
+	std::scoped_lock lock(connectionLock);
+	if (!protocol) {
+		return;
+	}
+
+	std::function<void()> releaseTask = [protocolToRelease = protocol] {
+		protocolToRelease->release();
+	};
+	const auto producerToken = reinterpret_cast<uintptr_t>(protocol.get());
+	const bool accepted = DispatcherPolicy::scheduleWithFallbackLane(
+		[&releaseTask, producerToken](DispatcherLane lane) {
+			return g_dispatcher().addEvent(std::move(releaseTask), "Connection::dispatchProtocolRelease", 0, lane, producerToken);
+		},
+		DispatcherLane::ProtocolInput,
+		DispatcherLane::WorldCommit
+	);
+	if (accepted) {
+		protocolReleaseRetryAttempts = 0;
+		return;
+	}
+
+	++protocolReleaseRetryAttempts;
+	if (shouldLogProtocolReleaseRetry()) {
+		g_logger().warn(
+			"[Connection::dispatchProtocolRelease] Dispatcher saturated; retrying protocol cleanup (attempt {}).",
+			protocolReleaseRetryAttempts
+		);
+	}
+
+	protocolReleaseRetryTimer.expires_from_now(PROTOCOL_RELEASE_RETRY_DELAY);
+	protocolReleaseRetryTimer.async_wait([self = shared_from_this()](const std::error_code &error) {
+		if (error != asio::error::operation_aborted) {
+			self->dispatchProtocolRelease();
+		}
+	});
 }
 
 void Connection::closeSocket() {

--- a/src/server/network/connection/connection.hpp
+++ b/src/server/network/connection/connection.hpp
@@ -98,6 +98,7 @@ private:
 
 	static void handleTimeout(ConnectionWeak_ptr connectionWeak, const std::error_code &error);
 
+	void dispatchProtocolRelease();
 	void closeSocket();
 	void internalWorker();
 	void internalSend(const OutputMessage_ptr &outputMessage);
@@ -108,6 +109,7 @@ private:
 
 	asio::high_resolution_timer readTimer;
 	asio::high_resolution_timer writeTimer;
+	asio::high_resolution_timer protocolReleaseRetryTimer;
 
 	std::recursive_mutex connectionLock;
 
@@ -127,6 +129,7 @@ private:
 	uint32_t ip = 1;
 
 	std::underlying_type_t<ConnectionState_t> connectionState = CONNECTION_STATE_OPEN;
+	uint64_t protocolReleaseRetryAttempts = 0;
 	bool receivedFirst = false;
 
 	friend class ServicePort;

--- a/tests/unit/game/dispatcher_policy_test.cpp
+++ b/tests/unit/game/dispatcher_policy_test.cpp
@@ -218,7 +218,7 @@ TEST(DispatcherPolicyTest, ReturnsAcceptedBooleanFromFallbackLane) {
 	std::vector<DispatcherLane> attempts;
 	const bool accepted = DispatcherPolicy::scheduleWithFallbackLane(
 		[&attempts](DispatcherLane lane) {
-			attempts.emplace_back(lane);
+			attempts.push_back(lane);
 			return lane == DispatcherLane::WorldCommit;
 		},
 		DispatcherLane::ProtocolInput,
@@ -227,6 +227,12 @@ TEST(DispatcherPolicyTest, ReturnsAcceptedBooleanFromFallbackLane) {
 
 	EXPECT_TRUE(accepted);
 	EXPECT_EQ(attempts, (std::vector { DispatcherLane::ProtocolInput, DispatcherLane::WorldCommit }));
+}
+
+TEST(DispatcherPolicyTest, StopsRetryAfterPermanentShutdownRejection) {
+	EXPECT_EQ(DispatcherPolicy::classifyAdmission(true, true), DispatcherAdmissionResult::Accepted);
+	EXPECT_EQ(DispatcherPolicy::classifyAdmission(false, false), DispatcherAdmissionResult::Saturated);
+	EXPECT_EQ(DispatcherPolicy::classifyAdmission(false, true), DispatcherAdmissionResult::ShuttingDown);
 }
 
 TEST(DispatcherPolicyTest, RequeuesAnUnprocessedSliceWithoutChangingFifoOrder) {

--- a/tests/unit/game/dispatcher_policy_test.cpp
+++ b/tests/unit/game/dispatcher_policy_test.cpp
@@ -214,6 +214,21 @@ TEST(DispatcherPolicyTest, RetriesRejectedScheduleOnceOnFallbackLane) {
 	EXPECT_EQ(attempts, (std::vector { DispatcherLane::Maintenance, DispatcherLane::WorldCommit }));
 }
 
+TEST(DispatcherPolicyTest, ReturnsAcceptedBooleanFromFallbackLane) {
+	std::vector<DispatcherLane> attempts;
+	const bool accepted = DispatcherPolicy::scheduleWithFallbackLane(
+		[&attempts](DispatcherLane lane) {
+			attempts.emplace_back(lane);
+			return lane == DispatcherLane::WorldCommit;
+		},
+		DispatcherLane::ProtocolInput,
+		DispatcherLane::WorldCommit
+	);
+
+	EXPECT_TRUE(accepted);
+	EXPECT_EQ(attempts, (std::vector { DispatcherLane::ProtocolInput, DispatcherLane::WorldCommit }));
+}
+
 TEST(DispatcherPolicyTest, RequeuesAnUnprocessedSliceWithoutChangingFifoOrder) {
 	std::deque<int> queue { 4, 5 };
 	std::vector<int> slice { 1, 2, 3 };


### PR DESCRIPTION
# Description

Dispatcher immediate queues now use bounded admission. `Connection::close()` still ignored the boolean returned by `Dispatcher::addEvent()` and submitted `Protocol::release()` with a 30-second expiration.

Under sustained dispatcher backlog, protocol cleanup could therefore be rejected at admission or expire before execution. In that case, `ProtocolGame` could remain attached to its player longer than intended, leaving the regular ping-timeout path to perform the eventual cleanup and making the delay appear inside `Game::checkCreatures` telemetry.

This PR makes protocol cleanup reliable while preserving dispatcher ownership:

- removes the expiration from `Protocol::release()` dispatch;
- tries `ProtocolInput` first and `WorldCommit` as a bounded fallback;
- retains the connection and retries after 50 ms when both lanes reject admission;
- keeps at most one retry timer per closing connection;
- treats dispatcher shutdown as terminal and does not rearm the I/O retry;
- rate-limits the saturation warning globally to once every five seconds;
- keeps all protocol/player ownership mutation on the dispatcher thread.

The normal disconnected-player reconnect window and the existing 60-second forced logout behavior are unchanged.

## Behaviour

### **Actual**

A full dispatcher lane could reject or later expire the protocol-release callback. The rejection was ignored, so cleanup had no guaranteed continuation path.

### **Expected**

A closing connection retains ownership until a non-expiring protocol-release callback is accepted by a dispatcher lane. Saturation is reported without flooding the logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested

- [x] Added unit coverage for boolean fallback-lane admission and terminal shutdown classification.
- [x] Ran `git diff --check`.
- [x] Verified the changed C++ ranges against the repository `clang-format` configuration.
- [ ] Local build and executable unit tests were not run; GitHub Actions provides the executable validation for this PR.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the performance/lifetime documentation.
- [x] I have added focused unit coverage for the fallback policy used by the fix.
- [ ] All PR checks have completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup reliability when dispatcher lanes are busy.
  * Added automatic retries for protocol cleanup, with fallback processing paths and rate-limited warnings.
  * Prevented cleanup tasks from being silently dropped or executed on I/O threads.
  * Ensured cleanup stops retrying when the dispatcher is shutting down.

* **Tests**
  * Added coverage verifying dispatcher fallback scheduling and acceptance reporting.

* **Documentation**
  * Documented requirements for reliable network-close cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
