### PR TITLE
fix: Barkless cult (Cults of Tibia Quest) 

### DIFF
--- a/data-otservbr-global/npc/tigo.lua
+++ b/data-otservbr-global/npc/tigo.lua
@@ -53,13 +53,12 @@ npcType.onCloseChannel = function(npc, creature)
 end
 
 local function greetCallback(npc, creature)
-	local playerId = creature:getId()
-
 	local player = Player(creature)
 
+	-- No setTopic here: NpcHandler:setInteraction() resets the topic to 0 right
+	-- after CALLBACK_GREET, so the chain has to be seeded from the "barkless" branch.
 	if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission) < 2 then
 		npcHandler:setMessage(MESSAGE_GREET, "There, there initiate. You will now become one of us, as so many before you. One of the {Barkless}. Walk with us and you will walk tall my friend.")
-		npcHandler:setTopic(playerId, 1)
 	end
 
 	return true
@@ -73,8 +72,17 @@ local function creatureSayCallback(npc, creature, type, message)
 		return false
 	end
 
-	if MsgContains(message, "barkless") and player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission) == 1 then
+	-- Tigo is the cult's entry point: he starts the mission and opens the trial
+	-- building himself. Guarded writes, so repeating the dialogue never rolls back.
+	if MsgContains(message, "barkless") and player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission) < 2 then
 		npcHandler:say({ "You are now one of us. Learn to endure this world's suffering in every facet and take delight in the soothing eternity that waits for the {purest} of us on the other side." }, npc, creature)
+		if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission) < 1 then
+			player:setStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission, 1)
+			player:setStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.TrialAccessDoor, 1)
+		end
+		if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Questline) < 1 then
+			player:setStorageValue(Storage.Quest.U11_40.CultsOfTibia.Questline, 1)
+		end
 		npcHandler:setTopic(playerId, 1)
 	elseif MsgContains(message, "purest") and npcHandler:getTopic(playerId) == 1 then
 		npcHandler:say({ "Purification is but one of the difficult steps on your way to the other side. The {trial} of tar, sulphur and ice." }, npc, creature)

--- a/data-otservbr-global/npc/tigo.lua
+++ b/data-otservbr-global/npc/tigo.lua
@@ -78,6 +78,8 @@ local function creatureSayCallback(npc, creature, type, message)
 		npcHandler:say({ "You are now one of us. Learn to endure this world's suffering in every facet and take delight in the soothing eternity that waits for the {purest} of us on the other side." }, npc, creature)
 		if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission) < 1 then
 			player:setStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.Mission, 1)
+		end
+		if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.TrialAccessDoor) < 1 then
 			player:setStorageValue(Storage.Quest.U11_40.CultsOfTibia.Barkless.TrialAccessDoor, 1)
 		end
 		if player:getStorageValue(Storage.Quest.U11_40.CultsOfTibia.Questline) < 1 then


### PR DESCRIPTION
### Bug

Tigo goes silent after his greeting and the trial building never opens, so the **whole Barkless cult of Cults of Tibia is unplayable**.

### Root cause

The `barkless` branch requires `Barkless.Mission == 1`, but **nothing in the datapack writes that value**. It used to be written right here: in the otservbr-global script this branch set `Barkless.Mission`, `Barkless.TrialAccessDoor` and `CultsOfTibia.Questline`. The port kept the branch and dropped the writes, so the NPC now *consumes* a storage he is supposed to *produce*.

Two knock-on effects:

* that branch is also the one seeding the topic, so `purest` and `trial` die with it;
* `TrialAccessDoor` — the storage the quest door in `data-otservbr-global/startup/tables/door_quest.lua` checks — is only set at the end of `trial`, i.e. never.

The only other writer of `Barkless.Mission` is Gerimor's mission menu, which is itself unreachable (see #4075).

### Why Tigo should start it himself

The other four cult entry NPCs already work this way and need nothing from Gerimor — Jamesfrancis (`yes` → `Minotaurs.Mission = 2`), Noozer (`pass` → `Misguided.Mission = 2`), Angelo (→ `Life.Mission = 2`) and Gareth (→ `MotA.Mission = 2`). Humans starts from a tile and Orcs from the boss kill. **Barkless was the only one left asking for permission instead of granting it.**

TibiaWiki (Cults of Tibia Quest/Spoiler) agrees: *"You can start most cult missions by going directly to the cult hideout"*, and for this one, *"you will meet the NPC Tigo. If you have not spoken to him before, you must ask for a mission before you can enter the building."*

### Notes on the diff

* The greet callback's `setTopic` is removed because it is **dead code**: `NpcHandler:setInteraction()` resets the topic to 0 right after `CALLBACK_GREET`. That is why the gate cannot be topic-based and has to key off the mission storage.
* Writes are guarded (`< 1`), so repeating the dialogue never revives or rolls back progress.
* The "initiate" window (`Mission < 2`) is the same one the greeting already uses.

### How it was tested

* Offline harness over the real script (LuaJIT): the full `hi → barkless → purest → trial` chain, plus re-entry cases (repeating the dialogue with the mission at 1 and at 4 does not move it).
* In-game against a live 15.25 server: the chain runs and the three storages land (`Mission = 1`, `TrialAccessDoor = 1`, `Questline = 1`), verified against the database after logout. The trial building opens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tigo’s Barkless mission dialogue for players with incomplete mission progress.
  * Ensured quest progression, trial-door access, and related mission states initialize correctly when beginning or resuming the interaction.
  * Reset dialogue topics appropriately to provide a consistent conversation flow.
  * Improved handling for players returning to the mission before completing its initial objectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->