### PR TITLE
fix: Gerimor cult list (Cults of Tibia Quest)

### DIFF
--- a/data-otservbr-global/npc/gerimor.lua
+++ b/data-otservbr-global/npc/gerimor.lua
@@ -386,6 +386,9 @@ local function creatureSayCallback(npc, creature, type, message)
 				"You have undoubtedly bought your world some valuable time and weakened the enemy. Take my thanks in behalf of the world and keep up your heroic work. For your reward you must have two free slots. Are you ready to receive it?",
 			}, npc, creature)
 			npcHandler:setTopic(playerId, 4)
+		else
+			npcHandler:say("In which of the following topics are you interested in? Cult of {Life}, Cult of {Prosperity}, Cult of the {Minotaurs}, Cult of the {Barkless}, Cult of the {Misguided}, Cult of the {Orcs}, Cult of the {Humans}?", npc, creature)
+			npcHandler:setTopic(playerId, 2)
 		end
 	elseif npcHandler:getTopic(playerId) == 2 then
 		local missionsTable = config.missions[message:lower()]


### PR DESCRIPTION
### Bug

Gerimor greets with *"If you are interested in {missions} just ask."* and then **says nothing at all to `missions`**.

### Root cause

The `if MsgContains(message, "missions")` block has three branches (final boss already killed / all seven cults finished / `FinalBoss.Mission == 2`) and **no `else`**. For any other state he stays silent and the topic stays 0.

Both the cult menu **and the reward payout** live in `elseif npcHandler:getTopic(playerId) == 2`, so that whole branch is unreachable. The consequence is bigger than a missing line of dialogue: the 325k experience, the vocation crown, the Mystery Box, the *Corruption Contained* achievement and the **final boss** are all unobtainable — even though six of the seven cults can be played to completion without him.

### The fix

The missing line is restored from the otservbr-global script, using the wording from the TibiaWiki transcript (Cults of Tibia Quest/Spoiler):

> **Player:** missions
> **Gerimor:** In which of the following topics are you interested in? Cult of **Life**, Cult of **Prosperity**, Cult of the **Minotaurs**, Cult of the **Barkless**, Cult of the **Misguided**, Cult of the **Orcs**, Cult of the **Humans**?

(the older script had it as *"In wich"*; this uses the transcript spelling.)

### Ordering is unaffected

His start write is guarded by `< 1` and the boss deaths by `< value`, so talking to him before, after or never does not overwrite progress — which matches *"You can do all the cults access and bosses in any order"*. The numbers line up in any order too: each boss leaves the storage exactly at the value he expects to pay out (Barkless 6, Misguided 4, Orcs 2, Humans 2), or the intermediate NPC does (Jamesfrancis 5, Angelo 9).

### How it was tested

* Offline harness over the real script (LuaJIT): menu appears and lists the seven cults; accepting a cult sets its mission to 1; a mission already in progress is **not** overwritten ("You have not finished your work yet"); a finished cult pays the reward once and then answers "You already done this mission"; with all seven done, `missions` unlocks the final boss instead of showing the menu.
* In-game against a live 15.25 server: `hi → missions → barkless → yes` runs end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gerimor’s mission dialogue when completion or final-boss requirements have not yet been met.
  * Players can now view available cult-related topics and proceed to mission selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->