### PR TITLE
refactor(conditions): add typed damage condition factory

### DIFF
--- a/src/creatures/combat/condition.cpp
+++ b/src/creatures/combat/condition.cpp
@@ -323,7 +323,7 @@ bool Condition::executeCondition(const std::shared_ptr<Creature> &creature, int3
 	return true;
 }
 
-std::shared_ptr<Condition> Condition::createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param /* = 0*/, bool buff /* = false*/, uint32_t subId /* = 0*/, bool isPersistent /* = false*/) {
+std::shared_ptr<ConditionDamage> Condition::createDamageCondition(ConditionId_t id, ConditionType_t type, bool buff /* = false*/, uint32_t subId /* = 0*/) {
 	switch (type) {
 		case CONDITION_POISON:
 		case CONDITION_FIRE:
@@ -335,6 +335,17 @@ std::shared_ptr<Condition> Condition::createCondition(ConditionId_t id, Conditio
 		case CONDITION_BLEEDING:
 			return ObjectPool<ConditionDamage, 1024>::allocateShared(id, type, buff, subId);
 
+		default:
+			return nullptr;
+	}
+}
+
+std::shared_ptr<Condition> Condition::createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param /* = 0*/, bool buff /* = false*/, uint32_t subId /* = 0*/, bool isPersistent /* = false*/) {
+	if (const auto damageCondition = createDamageCondition(id, type, buff, subId)) {
+		return damageCondition;
+	}
+
+	switch (type) {
 		case CONDITION_HASTE:
 		case CONDITION_PARALYZE:
 			return ObjectPool<ConditionSpeed, 1024>::allocateShared(id, type, ticks, buff, subId, param);

--- a/src/creatures/combat/condition.hpp
+++ b/src/creatures/combat/condition.hpp
@@ -15,6 +15,7 @@
 enum class PlayerIcon : uint8_t;
 
 class Creature;
+class ConditionDamage;
 struct MapCacheFloorCursor;
 class Player;
 class PropStream;
@@ -41,6 +42,7 @@ public:
 	int32_t getTicks() const;
 	void setTicks(int32_t newTicks);
 
+	static std::shared_ptr<ConditionDamage> createDamageCondition(ConditionId_t id, ConditionType_t type, bool buff = false, uint32_t subId = 0);
 	static std::shared_ptr<Condition> createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param = 0, bool buff = false, uint32_t subId = 0, bool isPersistent = false);
 	static std::shared_ptr<Condition> createCondition(PropStream &propStream);
 

--- a/src/creatures/monsters/monsters.cpp
+++ b/src/creatures/monsters/monsters.cpp
@@ -45,8 +45,7 @@ bool MonsterType::canSpawn(const Position &pos) const {
 }
 
 std::shared_ptr<ConditionDamage> Monsters::getDamageCondition(ConditionType_t conditionType, int32_t maxDamage, int32_t minDamage, int32_t startDamage, uint32_t tickInterval) const {
-	const auto baseCondition = Condition::createCondition(CONDITIONID_COMBAT, conditionType, 0, 0);
-	const auto condition = std::dynamic_pointer_cast<ConditionDamage>(baseCondition);
+	const auto condition = Condition::createDamageCondition(CONDITIONID_COMBAT, conditionType);
 	if (!condition) {
 		return nullptr;
 	}

--- a/tests/unit/game/CMakeLists.txt
+++ b/tests/unit/game/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
     canary_ut
-    PRIVATE dispatcher_budget_test.cpp
+    PRIVATE condition_factory_test.cpp
+            dispatcher_budget_test.cpp
             dispatcher_policy_test.cpp
             dispatcher_wdrr_test.cpp
             events_scheduler_test.cpp

--- a/tests/unit/game/condition_factory_test.cpp
+++ b/tests/unit/game/condition_factory_test.cpp
@@ -1,0 +1,49 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019–present OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "creatures/combat/condition.hpp"
+
+TEST(ConditionFactoryTest, CreatesSupportedDamageConditions) {
+	constexpr uint32_t testSubId = 42;
+	constexpr std::array damageConditionTypes {
+		CONDITION_POISON,
+		CONDITION_FIRE,
+		CONDITION_ENERGY,
+		CONDITION_DROWN,
+		CONDITION_FREEZING,
+		CONDITION_DAZZLED,
+		CONDITION_CURSED,
+		CONDITION_BLEEDING,
+	};
+
+	for (const auto conditionType : damageConditionTypes) {
+		const auto condition = Condition::createDamageCondition(CONDITIONID_COMBAT, conditionType, false, testSubId);
+
+		ASSERT_TRUE(condition);
+		EXPECT_EQ(conditionType, condition->getType());
+		EXPECT_EQ(CONDITIONID_COMBAT, condition->getId());
+		EXPECT_EQ(testSubId, condition->getSubId());
+	}
+}
+
+TEST(ConditionFactoryTest, RejectsNonDamageCondition) {
+	EXPECT_FALSE(Condition::createDamageCondition(CONDITIONID_COMBAT, CONDITION_HASTE));
+}
+
+TEST(ConditionFactoryTest, RejectsUnsupportedCondition) {
+	EXPECT_FALSE(Condition::createDamageCondition(CONDITIONID_COMBAT, CONDITION_AGONY));
+}
+
+TEST(ConditionFactoryTest, PreservesGenericDamageConditionCreation) {
+	const auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_FIRE, 0);
+
+	ASSERT_TRUE(condition);
+	EXPECT_EQ(CONDITION_FIRE, condition->getType());
+	EXPECT_EQ(CONDITIONID_COMBAT, condition->getId());
+}


### PR DESCRIPTION
## Summary

Add a typed factory for damage conditions and use it when loading monster spells.

## Motivation

`Condition::createCondition` returns `std::shared_ptr<Condition>` even when the requested type creates a `ConditionDamage`. Monster spell loading therefore had to recover the concrete type with `std::dynamic_pointer_cast`.

The condition factory already owns the mapping between `ConditionType_t` values and concrete condition implementations. Exposing that knowledge through a typed factory keeps the mapping centralized and avoids RTTI, duplicated condition-type checks, and unsafe static casts in callers.

## Changes

- Add `Condition::createDamageCondition`, returning `std::shared_ptr<ConditionDamage>`.
- Keep the supported damage-condition mapping in that typed factory.
- Make the generic `Condition::createCondition` delegate damage-condition creation to it.
- Update monster spell loading to consume the typed result directly.
- Add unit coverage for:
  - every supported damage condition type;
  - non-damage and unsupported condition types;
  - `ConditionId` and sub-ID propagation;
  - compatibility with the generic condition factory.

## Behavior

Supported damage conditions keep their existing behavior and object-pool allocation. Non-damage or unsupported types return `nullptr`, preserving the validation introduced in #4072.

## Validation

- `clang-format --dry-run --Werror`
- `git diff --check`
- Static verification that monster spell loading no longer uses `dynamic_pointer_cast<ConditionDamage>`

A local build was not run; the added unit tests are registered in the existing CMake test target and will run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creation of damage-based combat conditions.
  * Unsupported or non-damage condition types are now rejected consistently.
  * Monster damage effects are created more reliably with the correct condition details.

* **Tests**
  * Added coverage for supported damage conditions, identifiers, sub-identifiers, and invalid condition types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->