### PR TITLE
fix: guard scheduled callbacks against stale spawn lifetime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@
 - Re-resolving an entity by ID is insufficient when that ID can be reused. Also validate the original object identity, generation, epoch, or session token before applying mutations.
 - Operations that remove, replace, reload, or reinterpret callback-owned state must cancel pending work or advance a generation token checked by every related callback.
 - Types that own scheduled callbacks must be non-movable unless moving explicitly cancels or rebinds every pending event, preserves event ownership, and has focused regression coverage.
-- Use signed or checked arithmetic for countdowns and retry intervals so subtraction cannot wrap into a large delay.
+- Use checked, saturating, or explicitly bounded arithmetic for countdowns and retry intervals so subtraction cannot wrap into a large delay. Match operand signedness deliberately; changing only the destination type does not prevent mixed signed/unsigned wrap.
 - A stale callback must become a no-op before performing gameplay mutations, Lua calls, combat, movement, persistence, or client output.
 - Where practical, cover destroyed owners, removed entries, reused IDs, generation mismatches, shutdown, and ownership transfer in focused tests.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,26 @@
 - Do not mix unrelated changes in the same commit unless the user explicitly asks for a single combined commit.
 - Before amending or rebasing commits that may already be pushed, check the remote state and prefer `--force-with-lease` when a rewrite is explicitly approved.
 
+## Recurring Defect Prevention
+
+- When a confirmed defect represents a reusable failure mode rather than an isolated mistake, inspect analogous code paths before closing the change. Search by behavior and ownership pattern, not only by the original symbol or file name.
+- After fixing such a defect, explicitly ask whether another contributor or generated change could recreate it elsewhere. If so, add or update a narrow prevention rule in the nearest applicable `AGENTS.md` before considering the task complete, unless code or tooling already makes that failure mode impossible.
+- Back the `AGENTS.md` rule with a helper API, type constraint, static check, architecture document, or focused test when practical. Prefer enforceable safeguards; use the instruction as the repository-wide review contract.
+- A reusable rule must describe the unsafe pattern, the required alternative, and the validation expected. Do not write rules that merely restate one incident, mention a specific pull request, or depend on undocumented context.
+- Keep the audit proportional to the failure mode. Fix confirmed sibling occurrences in atomic commits, but do not expand an incident into a speculative repository-wide refactor or add a permanent rule for a genuinely isolated mistake.
+- Treat review findings caused by common human or generated-code shortcuts as candidates for prevention, especially lifetime errors, unchecked arithmetic, stale identity, unsafe ownership transfer, missing bounds, and work that can escape its cancellation domain.
+
+## Deferred Callback Lifetime Safety
+
+- Treat every scheduled, deferred, asynchronous, timer, and worker-completion callback as potentially executing after its originating object or state has been destroyed, replaced, reloaded, disconnected, or moved.
+- Do not capture raw `this`, references, iterators, or pointers into mutable containers when the callback can outlive the current call. Prefer immutable value captures and `std::weak_ptr` ownership; lock at execution time and return safely if ownership expired.
+- Re-resolving an entity by ID is insufficient when that ID can be reused. Also validate the original object identity, generation, epoch, or session token before applying mutations.
+- Operations that remove, replace, reload, or reinterpret callback-owned state must cancel pending work or advance a generation token checked by every related callback.
+- Types that own scheduled callbacks must be non-movable unless moving explicitly cancels or rebinds every pending event, preserves event ownership, and has focused regression coverage.
+- Use signed or checked arithmetic for countdowns and retry intervals so subtraction cannot wrap into a large delay.
+- A stale callback must become a no-op before performing gameplay mutations, Lua calls, combat, movement, persistence, or client output.
+- Where practical, cover destroyed owners, removed entries, reused IDs, generation mismatches, shutdown, and ownership transfer in focused tests.
+
 ## Build Policy
 
 - Compile when the change is critical, complex, or likely to break compilation. For small documentation, script, or clearly non-build-affecting changes, avoid builds unless they add real validation value.

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -25,6 +25,7 @@
 #include "map/map.hpp"
 #include "map/spectators.hpp"
 #include "io/iobestiary.hpp"
+#include "utils/tools.hpp"
 
 int32_t Monster::despawnRange;
 int32_t Monster::despawnRadius;
@@ -1607,7 +1608,7 @@ void Monster::onThink(uint32_t interval) {
 	}
 
 	if (challengeMeleeDuration != 0) {
-		challengeMeleeDuration -= interval;
+		challengeMeleeDuration = subtractElapsedTime(challengeMeleeDuration, interval);
 		if (challengeMeleeDuration <= 0) {
 			challengeMeleeDuration = 0;
 			targetDistance = m_monsterType->info.targetDistance;
@@ -2143,7 +2144,7 @@ void Monster::onThinkTarget(uint32_t interval) {
 			bool canChangeTarget = true;
 
 			if (challengeFocusDuration > 0) {
-				challengeFocusDuration -= interval;
+				challengeFocusDuration = subtractElapsedTime(challengeFocusDuration, interval);
 				canChangeTarget = false;
 
 				if (challengeFocusDuration <= 0) {
@@ -2152,7 +2153,7 @@ void Monster::onThinkTarget(uint32_t interval) {
 			}
 
 			if (fatalHoldDuration > 0 && runAwayHealth > 0) {
-				fatalHoldDuration -= interval;
+				fatalHoldDuration = subtractElapsedTime(fatalHoldDuration, interval);
 
 				if (fatalHoldDuration <= 0) {
 					fatalHoldDuration = 0;
@@ -2160,7 +2161,7 @@ void Monster::onThinkTarget(uint32_t interval) {
 			}
 
 			if (m_targetChangeCooldown > 0) {
-				m_targetChangeCooldown -= interval;
+				m_targetChangeCooldown = subtractElapsedTime(m_targetChangeCooldown, interval);
 
 				if (m_targetChangeCooldown <= 0) {
 					m_targetChangeCooldown = 0;

--- a/src/creatures/monsters/spawns/spawn_monster.cpp
+++ b/src/creatures/monsters/spawns/spawn_monster.cpp
@@ -470,6 +470,7 @@ void SpawnMonster::removeMonsters() {
 }
 
 void SpawnMonster::setMonsterVariant(const std::string &variant) {
+	++spawnGeneration;
 	for (auto &[monsterId, monsterInfo] : spawnMonsterMap) {
 		if (monsterId == 0) {
 			continue;

--- a/src/creatures/monsters/spawns/spawn_monster.cpp
+++ b/src/creatures/monsters/spawns/spawn_monster.cpp
@@ -339,7 +339,7 @@ void SpawnMonster::checkSpawnMonster() {
 	}
 }
 
-void SpawnMonster::scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &mType, uint16_t interval, bool startup, uint64_t generation) {
+void SpawnMonster::scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &mType, int32_t interval, bool startup, uint64_t generation) {
 	if (generation != spawnGeneration) {
 		return;
 	}

--- a/src/creatures/monsters/spawns/spawn_monster.cpp
+++ b/src/creatures/monsters/spawns/spawn_monster.cpp
@@ -181,31 +181,6 @@ SpawnMonster::~SpawnMonster() {
 	stopEvent();
 }
 
-// moveable
-
-SpawnMonster::SpawnMonster(SpawnMonster &&rhs) noexcept :
-	spawnedMonsterMap(std::move(rhs.spawnedMonsterMap)),
-	spawnMonsterMap(std::move(rhs.spawnMonsterMap)),
-	centerPos(rhs.centerPos),
-	radius(rhs.radius),
-	interval(rhs.interval),
-	checkSpawnMonsterEvent(rhs.checkSpawnMonsterEvent),
-	spawnGeneration(rhs.spawnGeneration) { }
-
-SpawnMonster &SpawnMonster::operator=(SpawnMonster &&rhs) noexcept {
-	if (this != &rhs) {
-		spawnMonsterMap = std::move(rhs.spawnMonsterMap);
-		spawnedMonsterMap = std::move(rhs.spawnedMonsterMap);
-
-		checkSpawnMonsterEvent = rhs.checkSpawnMonsterEvent;
-		centerPos = rhs.centerPos;
-		radius = rhs.radius;
-		interval = rhs.interval;
-		spawnGeneration = rhs.spawnGeneration;
-	}
-	return *this;
-}
-
 bool SpawnMonster::findPlayer(const Position &pos) {
 	auto spectators = Spectators().find<Player>(pos);
 	return std::ranges::any_of(spectators, [](const auto &spectator) {

--- a/src/creatures/monsters/spawns/spawn_monster.cpp
+++ b/src/creatures/monsters/spawns/spawn_monster.cpp
@@ -164,8 +164,15 @@ bool SpawnsMonster::isInZone(const Position &centerPos, int32_t radius, const Po
 
 void SpawnMonster::startSpawnMonsterCheck() {
 	if (checkSpawnMonsterEvent == 0) {
+		const std::weak_ptr<SpawnMonster> weakSelf = static_self_cast<SpawnMonster>();
 		checkSpawnMonsterEvent = g_dispatcher().scheduleEvent(
-			getInterval(), [this] { checkSpawnMonster(); }, "SpawnMonster::checkSpawnMonster", DispatcherLane::Maintenance
+			getInterval(),
+			[weakSelf] {
+				if (const auto self = weakSelf.lock()) {
+					self->checkSpawnMonster();
+				}
+			},
+			"SpawnMonster::checkSpawnMonster", DispatcherLane::Maintenance
 		);
 	}
 }
@@ -182,7 +189,8 @@ SpawnMonster::SpawnMonster(SpawnMonster &&rhs) noexcept :
 	centerPos(rhs.centerPos),
 	radius(rhs.radius),
 	interval(rhs.interval),
-	checkSpawnMonsterEvent(rhs.checkSpawnMonsterEvent) { }
+	checkSpawnMonsterEvent(rhs.checkSpawnMonsterEvent),
+	spawnGeneration(rhs.spawnGeneration) { }
 
 SpawnMonster &SpawnMonster::operator=(SpawnMonster &&rhs) noexcept {
 	if (this != &rhs) {
@@ -193,6 +201,7 @@ SpawnMonster &SpawnMonster::operator=(SpawnMonster &&rhs) noexcept {
 		centerPos = rhs.centerPos;
 		radius = rhs.radius;
 		interval = rhs.interval;
+		spawnGeneration = rhs.spawnGeneration;
 	}
 	return *this;
 }
@@ -262,15 +271,24 @@ void SpawnMonster::startup(bool delayed) {
 			}
 		}
 	}
+	const std::weak_ptr<SpawnMonster> weakSelf = static_self_cast<SpawnMonster>();
+	const auto generation = spawnGeneration;
 	for (auto &[spawnMonsterId, sb] : spawnMonsterMap) {
 		const auto &mType = sb.getMonsterType();
 		if (!mType) {
 			continue;
 		}
 		if (delayed) {
-			g_dispatcher().addEvent([this, spawnMonsterId, &sb, mType] { scheduleSpawn(spawnMonsterId, sb, mType, 0, true); }, __FUNCTION__);
+			g_dispatcher().addEvent(
+				[weakSelf, spawnMonsterId, mType, generation] {
+					if (const auto self = weakSelf.lock()) {
+						self->scheduleSpawn(spawnMonsterId, mType, 0, true, generation);
+					}
+				},
+				__FUNCTION__
+			);
 		} else {
-			scheduleSpawn(spawnMonsterId, sb, mType, 0, true);
+			scheduleSpawn(spawnMonsterId, mType, 0, true, generation);
 		}
 	}
 }
@@ -303,24 +321,48 @@ void SpawnMonster::checkSpawnMonster() {
 		if (mType->info.isBlockable) {
 			spawnMonster(spawnMonsterId, sb, mType);
 		} else {
-			scheduleSpawn(spawnMonsterId, sb, mType, 3 * NONBLOCKABLE_SPAWN_MONSTER_INTERVAL);
+			scheduleSpawn(spawnMonsterId, mType, 3 * NONBLOCKABLE_SPAWN_MONSTER_INTERVAL, false, spawnGeneration);
 		}
 	}
 
 	if (spawnedMonsterMap.size() < spawnMonsterMap.size()) {
+		const std::weak_ptr<SpawnMonster> weakSelf = static_self_cast<SpawnMonster>();
 		checkSpawnMonsterEvent = g_dispatcher().scheduleEvent(
-			getInterval(), [this] { checkSpawnMonster(); }, "SpawnMonster::checkSpawnMonster", DispatcherLane::Maintenance
+			getInterval(),
+			[weakSelf] {
+				if (const auto self = weakSelf.lock()) {
+					self->checkSpawnMonster();
+				}
+			},
+			"SpawnMonster::checkSpawnMonster", DispatcherLane::Maintenance
 		);
 	}
 }
 
-void SpawnMonster::scheduleSpawn(uint32_t spawnMonsterId, spawnBlock_t &sb, const std::shared_ptr<MonsterType> &mType, uint16_t interval, bool startup /*= false*/) {
+void SpawnMonster::scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &mType, uint16_t interval, bool startup, uint64_t generation) {
+	if (generation != spawnGeneration) {
+		return;
+	}
+
+	const auto spawnIt = spawnMonsterMap.find(spawnMonsterId);
+	if (spawnIt == spawnMonsterMap.end()) {
+		return;
+	}
+	spawnBlock_t &sb = spawnIt->second;
+
 	if (interval <= 0) {
 		spawnMonster(spawnMonsterId, sb, mType, startup);
 	} else {
 		g_game().addMagicEffect(sb.pos, CONST_ME_TELEPORT);
+		const std::weak_ptr<SpawnMonster> weakSelf = static_self_cast<SpawnMonster>();
 		g_dispatcher().scheduleEvent(
-			NONBLOCKABLE_SPAWN_MONSTER_INTERVAL, [=, this, &sb] { scheduleSpawn(spawnMonsterId, sb, mType, interval - NONBLOCKABLE_SPAWN_MONSTER_INTERVAL, startup); }, "SpawnMonster::scheduleSpawn", DispatcherLane::Maintenance
+			NONBLOCKABLE_SPAWN_MONSTER_INTERVAL,
+			[weakSelf, spawnMonsterId, mType, interval, startup, generation] {
+				if (const auto self = weakSelf.lock()) {
+					self->scheduleSpawn(spawnMonsterId, mType, interval - NONBLOCKABLE_SPAWN_MONSTER_INTERVAL, startup, generation);
+				}
+			},
+			"SpawnMonster::scheduleSpawn", DispatcherLane::Maintenance
 		);
 	}
 }
@@ -422,6 +464,7 @@ void SpawnMonster::removeMonster(const std::shared_ptr<Monster> &monster) {
 }
 
 void SpawnMonster::removeMonsters() {
+	++spawnGeneration;
 	spawnMonsterMap.clear();
 	spawnedMonsterMap.clear();
 }
@@ -448,6 +491,7 @@ void SpawnMonster::setMonsterVariant(const std::string &variant) {
 }
 
 void SpawnMonster::stopEvent() {
+	++spawnGeneration;
 	if (checkSpawnMonsterEvent != 0) {
 		g_dispatcher().stopEvent(checkSpawnMonsterEvent);
 		checkSpawnMonsterEvent = 0;

--- a/src/creatures/monsters/spawns/spawn_monster.hpp
+++ b/src/creatures/monsters/spawns/spawn_monster.hpp
@@ -75,7 +75,7 @@ private:
 	static bool findPlayer(const Position &pos);
 	bool spawnMonster(uint32_t spawnMonsterId, spawnBlock_t &sb, const std::shared_ptr<MonsterType> &monsterType, bool startup = false);
 	void checkSpawnMonster();
-	void scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &monsterType, uint16_t interval, bool startup, uint64_t generation);
+	void scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &monsterType, int32_t interval, bool startup, uint64_t generation);
 };
 
 class SpawnsMonster {

--- a/src/creatures/monsters/spawns/spawn_monster.hpp
+++ b/src/creatures/monsters/spawns/spawn_monster.hpp
@@ -33,14 +33,11 @@ public:
 		centerPos(initPos), radius(initRadius) { }
 	~SpawnMonster();
 
-	// non-copyable
+	// non-copyable and non-moveable
 	SpawnMonster(const SpawnMonster &) = delete;
 	SpawnMonster &operator=(const SpawnMonster &) = delete;
-
-	// moveable
-	SpawnMonster(SpawnMonster &&rhs) noexcept;
-
-	SpawnMonster &operator=(SpawnMonster &&rhs) noexcept;
+	SpawnMonster(SpawnMonster &&) = delete;
+	SpawnMonster &operator=(SpawnMonster &&) = delete;
 
 	bool addMonster(const std::string &name, const Position &pos, Direction dir, uint32_t interval, uint32_t weight = 1);
 	void removeMonster(const std::shared_ptr<Monster> &monster);

--- a/src/creatures/monsters/spawns/spawn_monster.hpp
+++ b/src/creatures/monsters/spawns/spawn_monster.hpp
@@ -70,11 +70,12 @@ private:
 	int32_t radius;
 	uint32_t interval = 30000;
 	uint32_t checkSpawnMonsterEvent = 0;
+	uint64_t spawnGeneration = 0;
 
 	static bool findPlayer(const Position &pos);
 	bool spawnMonster(uint32_t spawnMonsterId, spawnBlock_t &sb, const std::shared_ptr<MonsterType> &monsterType, bool startup = false);
 	void checkSpawnMonster();
-	void scheduleSpawn(uint32_t spawnMonsterId, spawnBlock_t &sb, const std::shared_ptr<MonsterType> &monsterType, uint16_t interval, bool startup = false);
+	void scheduleSpawn(uint32_t spawnMonsterId, const std::shared_ptr<MonsterType> &monsterType, uint16_t interval, bool startup, uint64_t generation);
 };
 
 class SpawnsMonster {

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -914,11 +914,17 @@ void Npc::onPlayerSellItem(const std::shared_ptr<Player> &player, uint16_t itemI
 
 	if (itemId == ITEM_GOLD_POUCH && context.lootPouch == nullptr) {
 		const auto npcId = getID();
+		const std::weak_ptr<Player> weakPlayer = player;
 		g_dispatcher().scheduleEvent(
 			SCHEDULER_MINTICKS,
-			[npcId, playerId = player->getID(), ignore] {
+			[npcId, playerId = player->getID(), weakPlayer, ignore] {
+				const auto originalPlayer = weakPlayer.lock();
+				if (!originalPlayer) {
+					return;
+				}
+
 				const auto &scheduledPlayer = g_game().getPlayerByID(playerId);
-				if (!scheduledPlayer) {
+				if (!scheduledPlayer || scheduledPlayer != originalPlayer || scheduledPlayer->isRemoved()) {
 					return;
 				}
 

--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -913,16 +913,22 @@ void Npc::onPlayerSellItem(const std::shared_ptr<Player> &player, uint16_t itemI
 	}
 
 	if (itemId == ITEM_GOLD_POUCH && context.lootPouch == nullptr) {
+		const auto npcId = getID();
 		g_dispatcher().scheduleEvent(
 			SCHEDULER_MINTICKS,
-			[this, playerId = player->getID(), ignore] {
+			[npcId, playerId = player->getID(), ignore] {
 				const auto &scheduledPlayer = g_game().getPlayerByID(playerId);
 				if (!scheduledPlayer) {
 					return;
 				}
 
+				const auto &scheduledNpc = g_game().getNpcByID(npcId);
+				if (!scheduledNpc) {
+					return;
+				}
+
 				uint64_t totalPrice = 0;
-				onPlayerSellAllLoot(scheduledPlayer, ignore, totalPrice);
+				scheduledNpc->onPlayerSellAllLoot(scheduledPlayer, ignore, totalPrice);
 			},
 			__FUNCTION__,
 			DispatcherLane::PlayerAction,

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -155,13 +155,21 @@ bool SpawnsNpc::isInZone(const Position &centerPos, int32_t radius, const Positi
 
 void SpawnNpc::startSpawnNpcCheck() {
 	if (checkSpawnNpcEvent == 0) {
+		const std::weak_ptr<SpawnNpc> weakSelf = static_self_cast<SpawnNpc>();
 		checkSpawnNpcEvent = g_dispatcher().scheduleEvent(
-			getInterval(), [this] { checkSpawnNpc(); }, "SpawnNpc::checkSpawnNpc", DispatcherLane::Maintenance
+			getInterval(),
+			[weakSelf] {
+				if (const auto self = weakSelf.lock()) {
+					self->checkSpawnNpc();
+				}
+			},
+			"SpawnNpc::checkSpawnNpc", DispatcherLane::Maintenance
 		);
 	}
 }
 
 SpawnNpc::~SpawnNpc() {
+	stopEvent();
 	for (const auto &[spawnId, npc] : spawnedNpcMap) {
 		if (spawnId == 0) {
 			continue;
@@ -241,24 +249,48 @@ void SpawnNpc::checkSpawnNpc() {
 				continue;
 			}
 
-			scheduleSpawnNpc(spawnId, npcInfo, 3 * NONBLOCKABLE_SPAWN_NPC_INTERVAL);
+			scheduleSpawnNpc(spawnId, 3 * NONBLOCKABLE_SPAWN_NPC_INTERVAL, spawnGeneration);
 		}
 	}
 
 	if (spawnedNpcMap.size() < spawnNpcMap.size()) {
+		const std::weak_ptr<SpawnNpc> weakSelf = static_self_cast<SpawnNpc>();
 		checkSpawnNpcEvent = g_dispatcher().scheduleEvent(
-			getInterval(), [this] { checkSpawnNpc(); }, __FUNCTION__, DispatcherLane::Maintenance
+			getInterval(),
+			[weakSelf] {
+				if (const auto self = weakSelf.lock()) {
+					self->checkSpawnNpc();
+				}
+			},
+			__FUNCTION__, DispatcherLane::Maintenance
 		);
 	}
 }
 
-void SpawnNpc::scheduleSpawnNpc(uint32_t spawnId, spawnBlockNpc_t &sb, uint16_t interval) {
+void SpawnNpc::scheduleSpawnNpc(uint32_t spawnId, uint16_t interval, uint64_t generation) {
+	if (generation != spawnGeneration) {
+		return;
+	}
+
+	const auto spawnIt = spawnNpcMap.find(spawnId);
+	if (spawnIt == spawnNpcMap.end()) {
+		return;
+	}
+	spawnBlockNpc_t &sb = spawnIt->second;
+
 	if (interval <= 0) {
 		spawnNpc(spawnId, sb.npcType, sb.pos, sb.direction);
 	} else {
 		g_game().addMagicEffect(sb.pos, CONST_ME_TELEPORT);
+		const std::weak_ptr<SpawnNpc> weakSelf = static_self_cast<SpawnNpc>();
 		g_dispatcher().scheduleEvent(
-			1400, [=, this, &sb] { scheduleSpawnNpc(spawnId, sb, interval - NONBLOCKABLE_SPAWN_NPC_INTERVAL); }, __FUNCTION__, DispatcherLane::Maintenance
+			NONBLOCKABLE_SPAWN_NPC_INTERVAL,
+			[weakSelf, spawnId, interval, generation] {
+				if (const auto self = weakSelf.lock()) {
+					self->scheduleSpawnNpc(spawnId, interval - NONBLOCKABLE_SPAWN_NPC_INTERVAL, generation);
+				}
+			},
+			__FUNCTION__, DispatcherLane::Maintenance
 		);
 	}
 }
@@ -308,6 +340,7 @@ void SpawnNpc::removeNpc(const std::shared_ptr<Npc> &npc) {
 }
 
 void SpawnNpc::stopEvent() {
+	++spawnGeneration;
 	if (checkSpawnNpcEvent != 0) {
 		g_dispatcher().stopEvent(checkSpawnNpcEvent);
 		checkSpawnNpcEvent = 0;

--- a/src/creatures/npcs/spawns/spawn_npc.cpp
+++ b/src/creatures/npcs/spawns/spawn_npc.cpp
@@ -267,7 +267,7 @@ void SpawnNpc::checkSpawnNpc() {
 	}
 }
 
-void SpawnNpc::scheduleSpawnNpc(uint32_t spawnId, uint16_t interval, uint64_t generation) {
+void SpawnNpc::scheduleSpawnNpc(uint32_t spawnId, int32_t interval, uint64_t generation) {
 	if (generation != spawnGeneration) {
 		return;
 	}

--- a/src/creatures/npcs/spawns/spawn_npc.hpp
+++ b/src/creatures/npcs/spawns/spawn_npc.hpp
@@ -63,7 +63,7 @@ private:
 	static bool findPlayer(const Position &pos);
 	bool spawnNpc(uint32_t spawnId, const std::shared_ptr<NpcType> &npcType, const Position &pos, Direction dir, bool startup = false);
 	void checkSpawnNpc();
-	void scheduleSpawnNpc(uint32_t spawnId, uint16_t interval, uint64_t generation);
+	void scheduleSpawnNpc(uint32_t spawnId, int32_t interval, uint64_t generation);
 };
 
 class SpawnsNpc {

--- a/src/creatures/npcs/spawns/spawn_npc.hpp
+++ b/src/creatures/npcs/spawns/spawn_npc.hpp
@@ -58,11 +58,12 @@ private:
 
 	uint32_t interval = 60000;
 	uint32_t checkSpawnNpcEvent = 0;
+	uint64_t spawnGeneration = 0;
 
 	static bool findPlayer(const Position &pos);
 	bool spawnNpc(uint32_t spawnId, const std::shared_ptr<NpcType> &npcType, const Position &pos, Direction dir, bool startup = false);
 	void checkSpawnNpc();
-	void scheduleSpawnNpc(uint32_t spawnId, spawnBlockNpc_t &sb, uint16_t interval);
+	void scheduleSpawnNpc(uint32_t spawnId, uint16_t interval, uint64_t generation);
 };
 
 class SpawnsNpc {

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -79,6 +79,13 @@ IntegerVector vectorAtoi(const StringVector &stringVector);
 	return (flags & flag) != 0;
 }
 
+[[nodiscard]] constexpr int32_t subtractElapsedTime(int32_t remaining, uint32_t elapsed) noexcept {
+	if (remaining <= 0 || elapsed >= static_cast<uint32_t>(remaining)) {
+		return 0;
+	}
+	return remaining - static_cast<int32_t>(elapsed);
+}
+
 std::mt19937 &getRandomGenerator();
 int32_t uniform_random(int32_t minNumber, int32_t maxNumber);
 int32_t normal_random(int32_t minNumber, int32_t maxNumber);

--- a/tests/unit/game/spawn_monster_test.cpp
+++ b/tests/unit/game/spawn_monster_test.cpp
@@ -15,6 +15,13 @@
 #include <random>
 #include <vector>
 
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <type_traits>
+#endif
+
+static_assert(!std::is_move_constructible_v<SpawnMonster>);
+static_assert(!std::is_move_assignable_v<SpawnMonster>);
+
 namespace {
 	std::shared_ptr<MonsterType> makeMonsterType(const std::string &name, bool isBoss = false) {
 		auto monsterType = std::make_shared<MonsterType>(name);

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
     canary_ut
-    PRIVATE position_functions_test.cpp
+    PRIVATE numeric_functions_test.cpp
+            position_functions_test.cpp
             string_functions_test.cpp
             map_download_test.cpp
             test_batch_update.cpp

--- a/tests/unit/utils/numeric_functions_test.cpp
+++ b/tests/unit/utils/numeric_functions_test.cpp
@@ -1,0 +1,24 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (c) 2019-present OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "utils/tools.hpp"
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <limits>
+#endif
+
+TEST(NumericFunctionsTest, SubtractsElapsedTimeWithoutCrossingZero) {
+	EXPECT_EQ(750, subtractElapsedTime(1000, 250));
+	EXPECT_EQ(1000, subtractElapsedTime(1000, 0));
+	EXPECT_EQ(0, subtractElapsedTime(1000, 1000));
+	EXPECT_EQ(0, subtractElapsedTime(1000, 1001));
+	EXPECT_EQ(0, subtractElapsedTime(1, std::numeric_limits<uint32_t>::max()));
+	EXPECT_EQ(0, subtractElapsedTime(0, 1));
+	EXPECT_EQ(0, subtractElapsedTime(-1, 1));
+}


### PR DESCRIPTION
## Summary

- make delayed monster and NPC spawn callbacks hold weak owners instead of raw `this` pointers
- re-resolve spawn blocks by ID when each delayed step executes
- invalidate pending spawn chains by generation when spawn events are stopped or removed
- re-resolve the NPC and player before executing delayed gold-pouch sales

## Root cause

Non-blockable spawn countdowns captured both a raw spawn owner and a reference to an element inside the spawn map. `SpawnsMonster::clear()` and `SpawnsNpc::clear()` only canceled the recurring check event, so already scheduled countdown callbacks could execute after the container or its owner was no longer valid. This allowed a stale callback to enter `SpawnMonster::spawnMonster()` and access a destroyed `spawnedMonsterMap`.

Weak ownership prevents callbacks from dereferencing destroyed spawn objects. Stable IDs and generations additionally prevent callbacks from operating on removed or logically replaced spawn definitions when another object still keeps the spawn owner alive.

The delayed NPC loot-sale path had the same lifetime shape: it captured a raw NPC pointer without a cancelable event handle. It now resolves both entities by ID at execution time.

## Validation

- `git diff --check origin/main...HEAD`
- `clang-format --dry-run --Werror` on all changed files
- static audit of direct and indirect dispatcher callbacks for borrowed references and raw destructible owners
- no local build was run, following the repository build policy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of scheduled monster and NPC spawning when events are stopped, removed, or restarted.
  * Prevented outdated delayed actions from affecting current game state or accessing unavailable characters.
  * Improved delayed gold-pouch sales by verifying involved characters remain valid.
  * Prevented cooldown timers from underflowing when elapsed time exceeds the remaining duration.

* **Tests**
  * Added coverage for spawn lifecycle safety and timer calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes crash: 
[crash.txt](https://github.com/user-attachments/files/31066538/crash.txt)
