### PR TITLE
fix: permanent The Inquisition questline rollback via holy water

### DIFF
--- a/data-otservbr-global/scripts/quests/others/actions_holy_water.lua
+++ b/data-otservbr-global/scripts/quests/others/actions_holy_water.lua
@@ -5,6 +5,16 @@ local effectPositions = {
 	Position(33116, 31702, 12),
 }
 
+-- The 2000 action id is a generic map-editor marker present on 147 tiles world wide
+-- (chests, barrels, drawers, coffins...). Only the 2x2 cauldron block on the witches'
+-- mountain uses these item ids together with that action id, so both must match.
+local eclipseCauldronItems = {
+	[2008] = true,
+	[2009] = true,
+	[2010] = true,
+	[2011] = true,
+}
+
 local function revertItem(position, itemId, transformId)
 	local item = Tile(position):getItemById(itemId)
 	if item then
@@ -56,6 +66,14 @@ function othersHolyWater.onUse(player, item, fromPosition, target, toPosition, i
 
 		-- Eclipse Quest
 	elseif target.actionid == 2000 then
+		if not eclipseCauldronItems[target.itemid] then
+			return true
+		end
+
+		if player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) ~= 4 then
+			return true
+		end
+
 		item:remove(1)
 		toPosition:sendMagicEffect(CONST_ME_FIREAREA)
 		player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission02, 2)
@@ -128,7 +146,6 @@ function othersHolyWater.onUse(player, item, fromPosition, target, toPosition, i
 			end
 			nexusMessage(player, player:getName() .. " destroyed the shadow nexus! In 10 seconds it will return to its original state.")
 			item:remove(1)
-			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 22)
 			toPosition:sendMagicEffect(CONST_ME_HOLYAREA)
 		else
 			target:transform(7925)


### PR DESCRIPTION
# Description

`actions_holy_water.lua` can permanently roll back **The Inquisition** questline, making the
**Blessing of the Inquisition** unobtainable for the rest of that character's life. Two independent
paths cause it, and a third change restores the intended scope of mission 2.

The damage is permanent because `Questline = 25` is written in exactly one place in the whole
datapack — `scripts/quests/the_inquisition_quest/actions_rewards.lua:17`, behind `if Reward < 1`,
i.e. **once per character**. On the second visit the reward chest answers *"The chest is empty"* and
never rewrites the 25. Since `npc/henricus.lua:75` requires `Questline == 25` to sell the blessing, a
character who already claimed the reward and then drops below 25 can climb back to 24 at most
(report → 23, `outfit` → 24) and is then stuck against an empty chest, forever.

### 1. The Eclipse branch (`actionid == 2000`) never validates progress

The branch writes `Questline = 5` and `Mission02 = 2` without reading where the player currently is.
Its two sibling branches in the very same file *do* validate: the `actionid == 2003` one bails out
with `if Questline ~= 12 then return true end`, and the graves one with `questline ~= 3`. So this is
an omission in one of three, not a convention of the file.

### 2. Action id 2000 is not exclusive to the cauldron

Scanning the `.otbm` for that action id returns **147 tiles**. Only 4 are the cauldron (the 2×2 block
of items 2008-2011 on the witches' mountain); the other **143 are chests, crates, barrels, drawers,
stone coffins, sarcophagi and corpses spread across the whole map**. Nothing else in the datapack
reads action id 2000 — it is an inert map-editor marker, and this action is the only thing reacting
to it.

That makes the bug trivial to hit by accident: the special flask (id 133) is cheap and common —
Henricus sells it ungated for 1000 gp (`npc/henricus.lua:389`) and hands it out in missions 2, 4 and
7 — so it is exactly the kind of item left forgotten in a backpack. Using it on any barrel in any
cave rewinds the questline. The only feedback is a fire effect, so the player has no way to connect
their rewound quest log to the flask.

For contrast: action id 2003, the branch that *does* have the guard, exists on exactly **one** tile
in the entire map.

### 3. The Shadow Nexus writes `Questline = 22` a second time, unguarded

In the destroyed-nexus branch, `Questline = 22` is written twice: once inside `if Questline < 22`
(correct) and once again unconditionally when the block closes. For a player below 22 the second
write is redundant; for anyone above it is a rollback. It looks like a merge artifact.

Realistic scenario: a veteran who already finished the quest (Questline 25) helps a friend destroy
the nexus, uses their own special flask on the destroyed nexus (item 7931) and drops to 22 — losing
the blessing permanently for the same reason as above.

## Behaviour

### **Actual**

- Use a special flask on any of the 143 unrelated objects carrying action id 2000 (a barrel, a
  chest, a coffin…) at any point of the questline → `Questline` is overwritten with 5.
- Use a special flask on the destroyed Shadow Nexus while above `Questline` 22 → `Questline` drops
  to 22.
- In both cases, a character who already claimed the reward room chest can never reach 25 again, so
  the Blessing of the Inquisition becomes unobtainable on that character.

### **Expected**

- The Eclipse branch only advances mission 2 for a player who is actually on it (`Questline == 4`),
  and only on the cauldron itself.
- Destroying the Shadow Nexus never moves a player's questline backwards.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- **Offline scenario, 26 assertions.** The patched file passes **26/26**; the unpatched file scores
  **15/26 with 11 failures**, and the failures land exactly on the assertions describing the two
  rollbacks and the cauldron scope. The other 15 (happy path of the cauldron, the 2003 branch, the
  antler talisman) pass in both, so the scenario measures the fix and not itself.
- **Verified in-game on a live 15.25 server** with a pair of mutually-validating cases, because the
  bug case asserts that *nothing* happens and a zero is indistinguishable from "the action never
  fired": the control case moves `Questline` 4 → 5 on the cauldron, and the bug case leaves a
  finished character's 25 untouched when the flask is used on an unrelated object carrying the same
  action id (same `clientId` 2010 in both).
- The three changes have been running in production since 2026-08-12 with no reports.

**Test Configuration**:

  - Server Version: `main` (ec41dfc) — also running on a 15.25 fork
  - Client: 15.25
  - Operating System: Linux (Ubuntu 22.04) / AlmaLinux 9

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Holy water in the Eclipse Quest now works only with the correct cauldron items and quest progression.
  * Prevented duplicate quest progress updates during the Shadow Nexus sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->