### PR TITLE
fix: Henricus stays silent in four Inquisition states and misleads in two more

### DIFF
--- a/data-otservbr-global/npc/henricus.lua
+++ b/data-otservbr-global/npc/henricus.lua
@@ -113,6 +113,12 @@ local function creatureSayCallback(npc, creature, type, message)
 			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission02, 1) -- The Inquisition Questlog- "Mission 2: Eclipse"
 			player:addItem(133, 1)
 			npcHandler:setTopic(playerId, 0)
+		-- No topic here on purpose: mission 2 is completed by destroying the cauldron, not by
+		-- reporting. Topic 9 only checks for the grimoire, so it would let the player close the
+		-- mission without ever destroying the brew.
+		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 4 then
+			npcHandler:say("Your current mission is to destroy the witches' brew with the vial of holy water and to steal their grimoire.", npc, creature)
+			npcHandler:setTopic(playerId, 0)
 		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 5 then
 			npcHandler:say("Your current mission is to destroy this coven. Are you done with that mission?", npc, creature)
 			npcHandler:setTopic(playerId, 9)
@@ -152,13 +158,18 @@ local function creatureSayCallback(npc, creature, type, message)
 			if player:removeItem(6499, 20) then
 				npcHandler:say({
 					"You're indeed a dedicated protector of the true believers. Don't stop now. Kill as many of these creatures as you can. ...",
-					"I also have a reward for your great efforts. Talk to me about your {demon hunter outfit} anytime from now on. Afterwards, let's talk about the next mission that's awaiting you.",
+					"I also have a reward for your great efforts. Talk to me about your {outfit} anytime from now on. Afterwards, let's talk about the next mission that's awaiting you.",
 				}, npc, creature)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 16)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission05, 2) -- The Inquisition Questlog- "Mission 5: Essential Gathering"
 			else
 				npcHandler:say("You need 20 of them.", npc, creature)
 			end
+			npcHandler:setTopic(playerId, 0)
+		-- State 16 requires saying `outfit` to move on (16 -> 17), and this chain used to stay
+		-- silent about it. Repeats verbatim what the NPC says when entering the state.
+		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 16 then
+			npcHandler:say("Talk to me about your {outfit} anytime from now on. Afterwards, let's talk about the next mission that's awaiting you.", npc, creature)
 			npcHandler:setTopic(playerId, 0)
 		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 17 then
 			npcHandler:say({
@@ -168,6 +179,10 @@ local function creatureSayCallback(npc, creature, type, message)
 			}, npc, creature)
 			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 18)
 			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission06, 1) -- The Inquisition Questlog- "Mission 6: The Demon Ungreez"
+			npcHandler:setTopic(playerId, 0)
+		-- No topic: 18 -> 19 is triggered by killing Ungreez, not by reporting.
+		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 18 then
+			npcHandler:say("Your current mission is to take revenge and to kill the demon Ungreez. You'll find him in the depths of Edron.", npc, creature)
 			npcHandler:setTopic(playerId, 0)
 		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 19 then
 			npcHandler:say({
@@ -186,6 +201,11 @@ local function creatureSayCallback(npc, creature, type, message)
 		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 21 or player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 22 then
 			npcHandler:say("Your current mission is to destroy the shadow nexus in the Demon Forge. Are you done with that mission?", npc, creature)
 			npcHandler:setTopic(playerId, 6)
+		-- State 23 requires saying `outfit` to move on (23 -> 24, which also opens the reward
+		-- room door). Repeats verbatim what the NPC says when entering the state.
+		elseif player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 23 then
+			npcHandler:say("Don't forget to ask me about your {outfit} to receive the final addon as demon hunter.", npc, creature)
+			npcHandler:setTopic(playerId, 0)
 		end
 	elseif MsgContains(message, "yes") then
 		if npcHandler:getTopic(playerId) == 2 then
@@ -232,7 +252,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			if player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 22 then
 				npcHandler:say({
 					"Incredible! You're a true defender of faith! I grant you the title of a High Inquisitor for your noble deeds. From now on you can obtain the blessing of the inquisition which makes the pilgrimage of ashes obsolete ...",
-					"The blessing of the inquisition will bestow upon you all available blessings for the price of 110000 gold. Also, don't forget to ask me about your {outfit} to receive the final addon as demon hunter.",
+					"The blessing of the inquisition will bestow upon you all available blessings for a slightly higher price than if you'd buy them separately. Also, don't forget to ask me about your {outfit} to receive the final addon as demon hunter.",
 				}, npc, creature)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 23)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission07, 3) -- The Inquisition Questlog- "Mission 7: The Shadow Nexus"

--- a/data-otservbr-global/npc/henricus.lua
+++ b/data-otservbr-global/npc/henricus.lua
@@ -252,7 +252,7 @@ local function creatureSayCallback(npc, creature, type, message)
 			if player:getStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline) == 22 then
 				npcHandler:say({
 					"Incredible! You're a true defender of faith! I grant you the title of a High Inquisitor for your noble deeds. From now on you can obtain the blessing of the inquisition which makes the pilgrimage of ashes obsolete ...",
-					"The blessing of the inquisition will bestow upon you all available blessings for a slightly higher price than if you'd buy them separately. Also, don't forget to ask me about your {outfit} to receive the final addon as demon hunter.",
+					"The blessing of the inquisition will bestow upon you all available blessings for " .. totalBlessPrice .. " gold, which is slightly higher than if you'd buy them separately. Also, don't forget to ask me about your {outfit} to receive the final addon as demon hunter.",
 				}, npc, creature)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 23)
 				player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Mission07, 3) -- The Inquisition Questlog- "Mission 7: The Shadow Nexus"


### PR DESCRIPTION
# Description

Three fidelity issues in Henricus (**The Inquisition**), all in the same file. None of them touches
progression — they are all about what the player is told, and two of them leave the player stuck
guessing.

### 1. `mission` / `report` is silent in four states, and twice that is a dead end

The `elseif` chain covers states <1, 1, 2, 3, 5, 6, 7-10, 11, 12, 13, 14, 15, 17, 19, 20, 21 and 22
— but not **4, 16, 18 or 23** (24 and 25 are terminal). Two different consequences:

- In **4** (Eclipse in progress) and **18** (Ungreez in progress) the *"Are you done with that
  mission?"* the same NPC offers for 12/13 and 21/22 is simply missing — an internal inconsistency.
- In **16** and **23** it is worse: the flow **requires** saying `outfit` to move on (16 → 17 and
  23 → 24, the latter also opening the reward room door), and `mission` gives no hint of it.

**No dialogue was invented.** There is no transcript for what Henricus answers mid-mission in those
states, so each new branch reuses **what the NPC itself already says** when entering that state (16
and 23) or the description he just gave of that mission (4 and 18).

**None of the new branches sets a topic, on purpose.** All four states advance through a world
action (destroying the cauldron, killing Ungreez) or the `outfit` keyword — never through a "yes".
Giving them a topic would open progression skips: topic 9, for instance, only checks for the
grimoire, so in state 4 it would let the player close mission 2 **without ever destroying the
cauldron**.

### 2. The highlighted `{demon hunter outfit}` triggers the wrong keyword

The mission 5 message highlights `{demon hunter outfit}`, so that is what the player clicks. But
`demon` is registered in the keywordHandler as lore chat, and `NpcHandler:onSay` runs
`keywordHandler:processMessage` **before** `CALLBACK_MESSAGE_DEFAULT`, where the actual outfit
branch lives — it only falls through to the callback if the keywordHandler did not handle the
message. So clicking the highlighted phrase returns lore about demons and the quest does not move;
only plain `outfit` works.

Combined with the previous issue this is a genuine dead end: in state 16 `mission` stays silent
**and** the highlighted phrase misleads.

The fix is the phrase, not the keywordHandler: highlighting `{outfit}`, which is what the
walkthrough tells players to say.

### 3. The mission 7 report quotes a fixed price for a dynamic charge

The text says *"for the price of 110000 gold"*, but the real price comes from
`Blessings.getInquisitionPrice(player)` and depends on how many blessings the player is missing.
The original NPC gives no number at all: *"for a slightly higher price than if you'd buy them
separately"*. Cosmetic, but it misinforms about a six-figure charge. The charge itself is untouched.

## Behaviour

### **Actual**

- Ask Henricus for a `mission` while on questline state 4, 16, 18 or 23 → he says nothing at all.
- In state 16, click the highlighted `{demon hunter outfit}` → he replies with lore about demons and
  the quest stays where it was. Nothing tells the player that plain `outfit` is the way forward.
- Report mission 7 → he quotes 110000 gold regardless of what the blessing will actually cost.

### **Expected**

- `mission` answers in every non-terminal state, and points at the `outfit` keyword in the two
  states that require it.
- The highlighted phrase is the keyword that actually works.
- The mission 7 text does not quote a price the code does not charge.

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- **Offline scenario, 30 assertions.** The patched file passes **30/30**; the unpatched file scores
  **16/30 with 14 failures**, and those 14 are exactly the assertions describing the three issues.
  The 16 that pass on both sides are controls: the states that already answered (2, 5, 12, 21) still
  answer the same thing, and the terminal states (24, 25) stay silent — without them the scenario
  would only measure the new code and would not catch a regression.
- **Verified in-game on a live 15.25 server**, with three cases that back each other up:
  - From state 16, `mission` answers, and **following the hint it gives actually advances the
    quest**: questline 16 → 17 and Mission05 2 → 3 in the database, outfit granted. The effect is
    measured, not the message.
  - From the **same state**, saying the previously highlighted phrase (*"demon hunter outfit"*)
    returns demon lore and the questline **stays at 16**. This does not test the fix — it
    demonstrates the root cause, and it is what makes the pair comparable: same point in the quest,
    different text, different outcome.
  - Reporting mission 7 shows the transcript wording and no longer contains `110000`, with the
    mission properly reported (questline 22 → 23, Mission07 2 → 3).
- Running in production since 2026-08-13 with no reports.

**Test Configuration**:

  - Server Version: `main` (ec41dfc) — also running on a 15.25 fork
  - Client: 15.25
  - Operating System: Linux (Ubuntu 22.04) / AlmaLinux 9

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Henricus’s mission-status responses for several quest progression states.
  * Corrected outfit dialogue formatting for mission 5.
  * Updated the final blessing message to display the accurately calculated price instead of a fixed amount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->