### PR TITLE
fix(build): preserve msvc ninja dependency tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ cmake --build --preset windows-release --target canary
 - If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
 - Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
 
+### MSVC Ninja Unity Dependency Tracking
+
+- On Windows, CMake writes Ninja's localized `msvc_deps_prefix` using the console output code page active during configuration. Ninja compares that prefix byte-for-byte with `cl.exe /showIncludes` output during the later build.
+- Do not configure a preset under one console code page and build it under another. That mismatch makes Ninja discard the include lines, leaves `.ninja_deps` with zero dependencies, and can make changed C++ or header files inside a generated unity source appear up to date.
+- When an IDE owns a preset directory, configure it from that IDE's build environment. Do not force a terminal code page onto its cache; if the environment is uncertain, compare the raw `msvc_deps_prefix` in `rules.ninja` with a raw `/showIncludes` sample first.
+- Treat this as an environment/cache mismatch, not as a source-code issue and not as a reason to clean the whole build tree. Re-run the same configure preset from the environment that will build it, then rebuild only the affected target or object files.
+- Before accepting `ninja: no work to do.` after a C++ or header edit, inspect `ninja -t deps <object>` and verify that the object records its included sources and headers. Keep MSVC compiler launchers disabled with Ninja unless they preserve raw `/showIncludes` output and this dependency check passes.
+- Never run two CMake/Ninja builds against the same preset directory concurrently. They can race while writing `.ninja_deps`; after a `premature end of file` or `stored deps info out of date` report, wait for every build to stop, run `ninja -t recompact`, and let one normal build re-establish only the stale dependency records.
+
 ## Precompiled Header Policy
 
 - The project uses `src/pch.hpp` for common standard/library headers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,11 +193,13 @@ endif()
 # === SCCACHE ===
 if(OPTIONS_ENABLE_SCCACHE)
     if(MSVC
-       AND CMAKE_GENERATOR MATCHES "Ninja"
+       AND CMAKE_GENERATOR
+           MATCHES
+           "Ninja"
     )
-        # Ninja's MSVC dependency tracking relies on /showIncludes output.
-        # With sccache as a compiler launcher, Ninja may record empty deps,
-        # which breaks incremental builds for headers and CMake unity sources.
+        # Ninja's MSVC dependency tracking relies on /showIncludes output. With
+        # sccache as a compiler launcher, Ninja may record empty deps, which
+        # breaks incremental builds for headers and CMake unity sources.
         log_option_disabled("sccache for MSVC Ninja dependency tracking")
     else()
         find_program(SCCACHE_PATH sccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,17 +192,26 @@ endif()
 
 # === SCCACHE ===
 if(OPTIONS_ENABLE_SCCACHE)
-    find_program(SCCACHE_PATH sccache)
-    if(SCCACHE_PATH)
-        log_option_enabled("sccache")
-        set(CMAKE_C_COMPILER_LAUNCHER
-            ${SCCACHE_PATH}
-        )
-        set(CMAKE_CXX_COMPILER_LAUNCHER
-            ${SCCACHE_PATH}
-        )
+    if(MSVC
+       AND CMAKE_GENERATOR MATCHES "Ninja"
+    )
+        # Ninja's MSVC dependency tracking relies on /showIncludes output.
+        # With sccache as a compiler launcher, Ninja may record empty deps,
+        # which breaks incremental builds for headers and CMake unity sources.
+        log_option_disabled("sccache for MSVC Ninja dependency tracking")
     else()
-        log_option_disabled("sccache")
+        find_program(SCCACHE_PATH sccache)
+        if(SCCACHE_PATH)
+            log_option_enabled("sccache")
+            set(CMAKE_C_COMPILER_LAUNCHER
+                ${SCCACHE_PATH}
+            )
+            set(CMAKE_CXX_COMPILER_LAUNCHER
+                ${SCCACHE_PATH}
+            )
+        else()
+            log_option_disabled("sccache")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

- prevent sccache from hiding MSVC/Ninja dependencies
- document the code-page contract and safe dependency recovery path

## Validation

- documentation and CMake review only; no build run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency tracking for builds using the MSVC Ninja configuration.
  - Preserved consistent compiler behavior and targeted recovery during build operations.
  - Prevented conflicting concurrent CMake and Ninja builds.

- **Chores**
  - Updated build configuration so compiler caching remains available where compatible, while avoiding configurations that could interfere with dependency tracking.
  - Documented build environment and preset requirements for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->