### PR TITLE
ci(vcpkg): clean automatic baseline merge commits

### DIFF
--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -82,13 +82,17 @@ jobs:
 
           queue_auto_merge() {
             local pr_number="$1"
+            local merge_subject="chore(vcpkg): update baseline to ${RELEASE_TAG}"
+            local merge_body="vcpkg baseline: ${NEW_BASELINE}"
 
             if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
               echo "::error::Invalid baseline pull request number: ${pr_number}"
               return 1
             fi
 
-            if gh pr merge "${pr_number}" --auto --squash; then
+            if gh pr merge "${pr_number}" --auto --squash \
+              --subject "${merge_subject}" \
+              --body "${merge_body}"; then
               echo "Queued native GitHub auto-merge for PR #${pr_number}"
             else
               echo "::warning::Could not queue auto-merge for PR #${pr_number}. Repository auto-merge may be disabled or branch protection may require a review."


### PR DESCRIPTION
This keeps generated vcpkg baseline pull requests readable while ensuring the squash commit written to `main` uses a concise plain-text message.

## Fixes

- Pass an explicit `--subject` and plain-text `--body` to the baseline updater's `gh pr merge --auto --squash` call.
- Prevent Markdown release notes and PR formatting from being copied literally into the resulting squash commit.

## Improvements

- Preserve detailed Markdown release information on the pull request, where GitHub renders it correctly.
- Keep the resulting main-history commit traceable with the release tag and baseline SHA.

## Tests/Validation

- `git diff --check`
- `actionlint -shellcheck "" -pyflakes "" .github/workflows/update_vcpkg_baseline.yml`
- `bash -n` validation for the updater run block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency baseline updates by including the release tag and updated baseline details in squash-merge commit metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->