### PR TITLE
fix(build): preserve msvc ninja dependency tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,124 +1,42 @@
-## Git Safety
+# Canary-specific guidance
 
-- Before committing or pushing, always check `git status --short --branch` and `git branch -vv`.
-- Never push directly to `origin/main`, including from the local `main` branch. Changes targeting `main` must go through a pull request.
-- A working branch must not track `origin/main` unless the current branch is exactly `main`.
-- Create new working branches under the GitHub username prefix `dudantas/`, not `codex/`, unless the user explicitly asks for another name.
-- For feature/fix branches, the upstream must point to the same remote branch name, for example `dudantas/example -> origin/dudantas/example`.
-- If a branch is tracking the wrong upstream, stop and fix it before committing or pushing:
-  - `git branch --unset-upstream <branch>`
-  - then push explicitly with `git push -u origin <branch>` only when the branch should be published.
-- Prefer explicit push targets for safety: `git push origin HEAD:<branch>`.
-- Never push to `origin/main` from a feature/fix branch. The repository may allow bypassing main protections, so this check is mandatory.
-
-## Commit Policy
-
-- Use Conventional Commit style for commit titles: `<type>(optional-scope): <summary>`.
-- Prefer these commit types: `feat`, `fix`, `perf`, `refactor`, `test`, `docs`, `build`, `ci`, `chore`, and `revert`.
-- Keep commit titles concise, imperative, and lowercase after the type, for example `fix: prevent inbox overflow`.
-- Do not end commit titles with a period.
-- Use a scope when it adds useful context, for example `fix(container): avoid stale child updates`.
-- For release-only changes, use `chore: update release version to X.Y.Z`.
-- Do not mix unrelated changes in the same commit unless the user explicitly asks for a single combined commit.
-- Before amending or rebasing commits that may already be pushed, check the remote state and prefer `--force-with-lease` when a rewrite is explicitly approved.
+The global Git, commit, PR, C++ header, exception, and documentation policies apply. This file only records Canary-specific gates.
 
 ## Recurring Defect Prevention
 
-- When a confirmed defect represents a reusable failure mode rather than an isolated mistake, inspect analogous code paths before closing the change. Search by behavior and ownership pattern, not only by the original symbol or file name.
-- After fixing such a defect, explicitly ask whether another contributor or generated change could recreate it elsewhere. If so, add or update a narrow prevention rule in the nearest applicable `AGENTS.md` before considering the task complete, unless code or tooling already makes that failure mode impossible.
-- Back the `AGENTS.md` rule with a helper API, type constraint, static check, architecture document, or focused test when practical. Prefer enforceable safeguards; use the instruction as the repository-wide review contract.
-- A reusable rule must describe the unsafe pattern, the required alternative, and the validation expected. Do not write rules that merely restate one incident, mention a specific pull request, or depend on undocumented context.
-- Keep the audit proportional to the failure mode. Fix confirmed sibling occurrences in atomic commits, but do not expand an incident into a speculative repository-wide refactor or add a permanent rule for a genuinely isolated mistake.
-- Treat review findings caused by common human or generated-code shortcuts as candidates for prevention, especially lifetime errors, unchecked arithmetic, stale identity, unsafe ownership transfer, missing bounds, and work that can escape its cancellation domain.
+- For a reusable defect, inspect analogous paths by behavior and ownership, fix confirmed siblings atomically, and keep the audit proportional; do not turn a one-off into a speculative refactor.
+- Decide whether tooling makes recurrence impossible. If not, add a narrow rule to the nearest `AGENTS.md` that states the unsafe pattern, required alternative, and validation rather than incident history.
+- Prefer enforceable safeguards—types, helpers, static checks, architecture docs, or focused tests—especially for lifetime, arithmetic, identity, ownership, bounds, and cancellation escapes.
 
 ## Deferred Callback Lifetime Safety
 
-- Treat every scheduled, deferred, asynchronous, timer, and worker-completion callback as potentially executing after its originating object or state has been destroyed, replaced, reloaded, disconnected, or moved.
-- Do not capture raw `this`, references, iterators, or pointers into mutable containers when the callback can outlive the current call. Prefer immutable value captures and `std::weak_ptr` ownership; lock at execution time and return safely if ownership expired.
-- Re-resolving an entity by ID is insufficient when that ID can be reused. Also validate the original object identity, generation, epoch, or session token before applying mutations.
-- Operations that remove, replace, reload, or reinterpret callback-owned state must cancel pending work or advance a generation token checked by every related callback.
-- Types that own scheduled callbacks must be non-movable unless moving explicitly cancels or rebinds every pending event, preserves event ownership, and has focused regression coverage.
-- Use checked, saturating, or explicitly bounded arithmetic for countdowns and retry intervals so subtraction cannot wrap into a large delay. Match operand signedness deliberately; changing only the destination type does not prevent mixed signed/unsigned wrap.
-- A stale callback must become a no-op before performing gameplay mutations, Lua calls, combat, movement, persistence, or client output.
-- Where practical, cover destroyed owners, removed entries, reused IDs, generation mismatches, shutdown, and ownership transfer in focused tests.
+- Assume scheduled, deferred, timer, and worker callbacks can outlive their source object or state.
+- Never capture raw `this`, references, iterators, or mutable-container pointers across that boundary. Use immutable values plus `std::weak_ptr` or re-resolvable identity validated with the original identity, generation, epoch, or session token.
+- Removal, replacement, reload, or reinterpretation must cancel pending work or advance a checked generation. Callback-owning types are non-movable unless moving cancels or safely rebinds every event.
+- Use bounded arithmetic for intervals; stale work must become a no-op before gameplay, Lua, combat, movement, persistence, or client output. Cover destroyed/replaced owners, reused IDs, shutdown, and ownership transfer where practical.
 
-## Build Policy
+## Canary build discipline
 
-- Compile when the change is critical, complex, or likely to break compilation. For small documentation, script, or clearly non-build-affecting changes, avoid builds unless they add real validation value.
-- When compiling, prioritize the correct known workflow below instead of guessing commands or creating new build trees, to avoid wasting time on environment or cache mistakes.
-- When adding, removing, or renaming C++ source/header files, update every maintained build entry point in the same change. For Canary server code this usually means the relevant `CMakeLists.txt` file and the tracked Visual Studio project `vcproj/canary.vcxproj`; for tests, update the relevant test `CMakeLists.txt` as well. Missing `.cpp` entries in `vcproj/canary.vcxproj` commonly appear as unresolved external linker errors when building `vcproj/canary.sln`.
-- Before building on Windows, inspect the repository build entry points instead of guessing:
-  - Check `CMakePresets.json` and `CMakeLists.txt`.
-  - Check whether Visual Studio solutions exist, such as `vcproj/*.sln` or generated `build/**/*.sln`.
-  - Check whether a CMake cache already exists under `build/<preset>`.
-- Prefer the CMake preset workflow over Visual Studio solution builds unless the user explicitly asks for the solution path or the preset is unusable.
-- Prefer the release preset for normal local validation because it uses the intended cache and unity settings. The default Windows server build path is:
+- When a Canary build is authorized, inspect `CMakePresets.json`, `CMakeLists.txt`, any maintained solution, and the existing preset cache. Reuse the canonical preset/cache; do not create an ad-hoc tree or switch to a solution because configuration failed.
+- C++ source/header additions, removals, and renames must update every maintained entry: the relevant CMake list, server `vcproj/canary.vcxproj`, and test CMake list when applicable. Prefer `windows-release` for normal Windows CMake validation unless the task explicitly targets the solution.
+- Use the compatible Visual Studio developer or owning IDE environment and its Ninja. Recreate only a verified incompatible preset directory inside `build/`; never broad-clean caches.
 
-```bat
-cmake --preset windows-release
-cmake --build --preset windows-release --target canary
-```
+### MSVC Ninja dependency tracking
 
-- On Windows, prefer running the CMake commands from the Visual Studio Developer Command Prompt or Developer PowerShell. That environment is the expected reliable build environment because it already prepares the MSVC compiler, Windows SDK, CMake tools, Ninja, and the required environment variables.
-- If the shell is not already a Visual Studio developer environment, initialize it with `VsDevCmd.bat` before configuring or building. `cl.exe` and Ninja must be available in `PATH` before running CMake.
-- If Ninja is not in `PATH`, use the Ninja bundled with the Visual Studio CMake tools instead of changing generators or creating another build tree.
-- Treat these files/directories as signs of an active CMake/Ninja cache: `CMakeCache.txt`, `CMakeFiles/`, `build.ninja`, `.ninja_deps`, `.ninja_log`, `cmake_install.cmake`, `compile_commands.json`, `vcpkg-manifest-install.log`, and `VSInheritEnvironments.txt`.
-- If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
-- Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
-
-### MSVC Ninja Unity Dependency Tracking
-
-- On Windows, CMake writes Ninja's localized `msvc_deps_prefix` using the console output code page active during configuration. Ninja compares that prefix byte-for-byte with `cl.exe /showIncludes` output during the later build.
-- Do not configure a preset under one console code page and build it under another. That mismatch makes Ninja discard the include lines, leaves `.ninja_deps` with zero dependencies, and can make changed C++ or header files inside a generated unity source appear up to date.
-- When an IDE owns a preset directory, configure it from that IDE's build environment. Do not force a terminal code page onto its cache; if the environment is uncertain, compare the raw `msvc_deps_prefix` in `rules.ninja` with a raw `/showIncludes` sample first.
-- Treat this as an environment/cache mismatch, not as a source-code issue and not as a reason to clean the whole build tree. Re-run the same configure preset from the environment that will build it, then rebuild only the affected target or object files.
-- Before accepting `ninja: no work to do.` after a C++ or header edit, inspect `ninja -t deps <object>` and verify that the object records its included sources and headers. Keep MSVC compiler launchers disabled with Ninja unless they preserve raw `/showIncludes` output and this dependency check passes.
-- Never run two CMake/Ninja builds against the same preset directory concurrently. They can race while writing `.ninja_deps`; after a `premature end of file` or `stored deps info out of date` report, wait for every build to stop, run `ninja -t recompact`, and let one normal build re-establish only the stale dependency records.
+- Configure and build an existing preset under the same code page and environment. When uncertain, compare `rules.ninja`'s `msvc_deps_prefix` with raw `cl.exe /showIncludes`; compiler launchers stay disabled for MSVC Ninja builds.
+- Treat malformed or empty `.ninja_deps` as an environment/cache state: stop concurrent builds, reconfigure, force-rebuild the affected output, then inspect `ninja -t deps <object>`. `ninja -t recompact` only compacts existing records; it cannot recreate missing dependencies.
 
 ## Precompiled Header Policy
 
-- The project uses `src/pch.hpp` for common standard/library headers.
-- Do not add unguarded standard/library includes that are already provided by `src/pch.hpp`.
-- If a source or header needs a PCH-provided include for builds without precompiled headers, wrap it like:
-
-```cpp
-#ifndef USE_PRECOMPILED_HEADERS
-	#include <memory>
-#endif
-```
-
-- If a new broadly used standard/library header is required in PCH-enabled builds, add it to `src/pch.hpp` and keep local fallback includes guarded by `#ifndef USE_PRECOMPILED_HEADERS`.
+- `src/pch.hpp` owns broad shared standard includes; do not duplicate an unguarded PCH include.
+- Headers must declare their public dependencies. When a source needs a PCH-provided include without PCH, guard it with `#ifndef USE_PRECOMPILED_HEADERS`; add broad includes to the PCH with the same local fallback.
 
 ## Lua Shared Userdata Gate
 
-- Treat Lua bindings that store `std::shared_ptr<T>` in userdata as high-risk ownership code.
-- Before changing shared userdata bindings, read `docs/systems/lua-shared-userdata.md`.
-- New shared userdata types must define `LuaUserdataTraits<T>::name` and use `Lua::registerSharedClass<T>`, `Lua::pushSharedUserdata<T>`, or `Lua::pushBorrowedSharedUserdata<T>`.
-- Do not add new uses of `Lua::pushUserdata<T>(..., std::shared_ptr<T>)` followed by manual `Lua::setMetatable`.
-- Do not use `Lua::setWeakMetatable` for userdata that stores `std::shared_ptr<T>`; it removes `__gc` and can leak the stored C++ object.
-- Do not wrap borrowed objects as `std::shared_ptr<T>(&object)` without a no-op deleter. Prefer `Lua::pushBorrowedSharedUserdata<T>`.
-- When reviewing or validating Lua binding changes, run these checks from the repository root and investigate every match:
-
-```sh
-rg -n "pushUserdata<.*std::shared_ptr|setWeakMetatable|std::shared_ptr<[^>]+>\\(&" src/lua
-rg -n "registerSharedClass\\(L," src/lua
-```
+- Before changing `std::shared_ptr` Lua userdata, read `docs/systems/lua-shared-userdata.md` and use its typed trait, registration, and push helpers.
+- Never combine shared `pushUserdata` with a manual metatable, use a weak metatable for shared userdata, or wrap a borrowed object without a no-op deleter. Run the document's two `rg` checks and investigate every match.
 
 ## Docker Quickstart Policy
 
-- The Docker quickstart is intended for non-expert users to run a local Canary stack with minimal setup.
-- Keep CI/build Docker, local development Docker, and user-facing quickstart Docker as separate responsibilities unless a change explicitly documents why they must overlap.
-- `docker/docker-compose.yml` must keep `login-server` as the default client login webservice.
-- Do not point clients to MyAAC `login.php`.
-- The MyAAC quickstart image must not include or expose `login.php`; MyAAC is used only as the website/admin AAC.
-- The default client login URL is `http://localhost:8088/login`.
-- The default web/admin URL is `http://localhost:8080`.
-- MyAAC must build from the `slawkens/myaac` `develop` branch unless a compatibility reason is documented.
-- Public Docker env vars for Canary should use the `CANARY_*` prefix. Avoid adding new public `MYSQL_*`, `OT_*`, or raw Lua config variable names.
-- The quickstart must not require compiling Canary locally; use the published Canary runtime image.
-
-## PR Communication Policy
-
-- Do not post any PR comments/reviews automatically.
-- Only post PR comments/reviews when the user explicitly asks.
-- All PR comments/reviews posted by me must be in English.
+- For quickstart changes, read `docs/docker/quickstart-for-beginners.md` and `docker/DOCKER.md`; keep CI/build, development, and user quickstart responsibilities separate.
+- The default client path is `login-server` at `http://localhost:8088/login`, never MyAAC `login.php`. MyAAC remains website/admin-only, uses `slawkens/myaac` `develop`, and keeps `http://localhost:8080`; public config stays `CANARY_*`, and the quickstart uses the published Canary runtime image.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ cmake --build --preset windows-release --target canary
 - If CMake reports changed compiler variables, missing `CMAKE_MAKE_PROGRAM`, or an incompatible cache, remove only the affected preset directory after verifying it is inside `build/`, then rerun the same preset. Do not create ad-hoc build directories for recovery.
 - Do not switch from CMake presets to a generated `.sln` just because configure failed. Fix the preset environment/cache first.
 
+### MSVC Ninja Unity Dependency Tracking
+
+- On Windows, CMake writes Ninja's localized `msvc_deps_prefix` using the console output code page active during configuration. Ninja compares that prefix byte-for-byte with `cl.exe /showIncludes` output during the later build.
+- Do not configure a preset under one console code page and build it under another. That mismatch makes Ninja discard the include lines, leaves `.ninja_deps` with zero dependencies, and can make changed C++ or header files inside a generated unity source appear up to date.
+- When an IDE owns a preset directory, configure it from that IDE's build environment. Do not force a terminal code page onto its cache; if the environment is uncertain, compare the raw `msvc_deps_prefix` in `rules.ninja` with a raw `/showIncludes` sample first.
+- Treat this as an environment/cache mismatch, not as a source-code issue and not as a reason to clean the whole build tree. Re-run the same configure preset from the environment that will build it, then rebuild only the affected target or object files.
+- Before accepting `ninja: no work to do.` after a C++ or header edit, inspect `ninja -t deps <object>` and verify that the object records its included sources and headers. Keep MSVC compiler launchers disabled with Ninja unless they preserve raw `/showIncludes` output and this dependency check passes.
+- Never run two CMake/Ninja builds against the same preset directory concurrently. They can race while writing `.ninja_deps`; after a `premature end of file` or `stored deps info out of date` report, wait for every build to stop, run `ninja -t recompact`, and let one normal build re-establish only the stale dependency records.
+
 ## Precompiled Header Policy
 
 - The project uses `src/pch.hpp` for common standard/library headers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,11 +193,13 @@ endif()
 # === SCCACHE ===
 if(OPTIONS_ENABLE_SCCACHE)
     if(MSVC
-       AND CMAKE_GENERATOR MATCHES "Ninja"
+       AND CMAKE_GENERATOR
+           MATCHES
+           "Ninja"
     )
-        # Ninja's MSVC dependency tracking relies on /showIncludes output.
-        # With sccache as a compiler launcher, Ninja may record empty deps,
-        # which breaks incremental builds for headers and CMake unity sources.
+        # Ninja's MSVC dependency tracking relies on /showIncludes output. With
+        # sccache as a compiler launcher, Ninja may record empty deps, which
+        # breaks incremental builds for headers and CMake unity sources.
         log_option_disabled("sccache for MSVC Ninja dependency tracking")
     else()
         find_program(SCCACHE_PATH sccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,40 @@ option(
 # Options Code
 # *****************************************************************************
 
+set(
+    CANARY_MSVC_NINJA
+    OFF
+)
+if(MSVC
+   AND CMAKE_GENERATOR
+       MATCHES
+       "Ninja"
+)
+    set(
+        CANARY_MSVC_NINJA
+        ON
+    )
+
+    # Native Ninja parses the raw localized /showIncludes output into
+    # .ninja_deps. A configured compiler launcher can hide or alter it.
+    foreach(
+        COMPILER_LAUNCHER
+        CMAKE_C_COMPILER_LAUNCHER
+        CMAKE_CXX_COMPILER_LAUNCHER
+    )
+        if(NOT
+           "${${COMPILER_LAUNCHER}}"
+           STREQUAL
+           ""
+        )
+            message(
+                FATAL_ERROR
+                    "MSVC Ninja builds require raw cl.exe /showIncludes output. Clear ${COMPILER_LAUNCHER} from the CMake cache or environment and reconfigure."
+            )
+        endif()
+    endforeach()
+endif()
+
 if(FEATURE_METRICS)
     log_option_enabled("metrics")
 else()
@@ -179,24 +213,24 @@ endif()
 
 # === CCACHE ===
 if(OPTIONS_ENABLE_CCACHE)
-    find_program(CCACHE ccache)
-    if(CCACHE)
-        log_option_enabled("ccache")
-        set(CMAKE_CXX_COMPILER_LAUNCHER
-            ${CCACHE}
-        )
+    if(CANARY_MSVC_NINJA)
+        log_option_disabled("ccache for MSVC Ninja dependency tracking")
     else()
-        log_option_disabled("ccache")
+        find_program(CCACHE ccache)
+        if(CCACHE)
+            log_option_enabled("ccache")
+            set(CMAKE_CXX_COMPILER_LAUNCHER
+                ${CCACHE}
+            )
+        else()
+            log_option_disabled("ccache")
+        endif()
     endif()
 endif()
 
 # === SCCACHE ===
 if(OPTIONS_ENABLE_SCCACHE)
-    if(MSVC
-       AND CMAKE_GENERATOR
-           MATCHES
-           "Ninja"
-    )
+    if(CANARY_MSVC_NINJA)
         # Ninja's MSVC dependency tracking relies on /showIncludes output. With
         # sccache as a compiler launcher, Ninja may record empty deps, which
         # breaks incremental builds for headers and CMake unity sources.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,7 @@ option(
 # Options Code
 # *****************************************************************************
 
-set(
-    CANARY_MSVC_NINJA
+set(CANARY_MSVC_NINJA
     OFF
 )
 if(MSVC
@@ -180,8 +179,7 @@ if(MSVC
        MATCHES
        "Ninja"
 )
-    set(
-        CANARY_MSVC_NINJA
+    set(CANARY_MSVC_NINJA
         ON
     )
 
@@ -189,8 +187,7 @@ if(MSVC
     # .ninja_deps. A configured compiler launcher can hide or alter it.
     foreach(
         COMPILER_LAUNCHER
-        CMAKE_C_COMPILER_LAUNCHER
-        CMAKE_CXX_COMPILER_LAUNCHER
+        CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER
     )
         if(NOT
            "${${COMPILER_LAUNCHER}}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,17 +192,26 @@ endif()
 
 # === SCCACHE ===
 if(OPTIONS_ENABLE_SCCACHE)
-    find_program(SCCACHE_PATH sccache)
-    if(SCCACHE_PATH)
-        log_option_enabled("sccache")
-        set(CMAKE_C_COMPILER_LAUNCHER
-            ${SCCACHE_PATH}
-        )
-        set(CMAKE_CXX_COMPILER_LAUNCHER
-            ${SCCACHE_PATH}
-        )
+    if(MSVC
+       AND CMAKE_GENERATOR MATCHES "Ninja"
+    )
+        # Ninja's MSVC dependency tracking relies on /showIncludes output.
+        # With sccache as a compiler launcher, Ninja may record empty deps,
+        # which breaks incremental builds for headers and CMake unity sources.
+        log_option_disabled("sccache for MSVC Ninja dependency tracking")
     else()
-        log_option_disabled("sccache")
+        find_program(SCCACHE_PATH sccache)
+        if(SCCACHE_PATH)
+            log_option_enabled("sccache")
+            set(CMAKE_C_COMPILER_LAUNCHER
+                ${SCCACHE_PATH}
+            )
+            set(CMAKE_CXX_COMPILER_LAUNCHER
+                ${SCCACHE_PATH}
+            )
+        else()
+            log_option_disabled("sccache")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability for MSVC projects using the Ninja generator by disabling incompatible compiler caching.
  * Preserved compiler caching for supported build configurations.

* **Documentation**
  * Added guidance for consistent build environments, dependency verification and recovery, cache management, callback safety, Lua resource ownership, Docker quickstart behavior, and coordinating CMake/Ninja builds.
  * Clarified build and pull request practices for Canary development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->