### PR TITLE
fix(npc): Cipfried and Dallheim don't cure burning

### DIFF
--- a/data-otservbr-global/npc/cipfried.lua
+++ b/data-otservbr-global/npc/cipfried.lua
@@ -133,6 +133,16 @@ keywordHandler:addAliasKeyword({ "wolves" })
 keywordHandler:addKeyword({ "adventure" }, StdModule.say, { npcHandler = npcHandler, text = "I can see a bright future for you... you will soon embark on a very big adventure and explore the world of {Tibia} - maybe even influence history!" })
 keywordHandler:addAliasKeyword({ "explore" })
 
+keywordHandler:addKeyword({ "heal" }, StdModule.say, { npcHandler = npcHandler, text = "You are burning. Let me quench those flames." }, function(player)
+	return player:getCondition(CONDITION_FIRE)
+end, function(player)
+	local health = player:getHealth()
+	if health < 65 then
+		player:addHealth(65 - health)
+	end
+	player:removeCondition(CONDITION_FIRE)
+	player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
+end)
 keywordHandler:addKeyword({ "heal" }, StdModule.say, { npcHandler = npcHandler, text = "You are poisoned. I will help you." }, function(player)
 	return player:getCondition(CONDITION_POISON)
 end, function(player)

--- a/data-otservbr-global/npc/dallheim.lua
+++ b/data-otservbr-global/npc/dallheim.lua
@@ -194,6 +194,16 @@ keywordHandler:addKeyword({ "billy" }, StdModule.say, { npcHandler = npcHandler,
 keywordHandler:addAliasKeyword({ "willie" })
 
 -- Healing
+keywordHandler:addKeyword({ "heal" }, StdModule.say, { npcHandler = npcHandler, text = "You are burning. Let me quench those flames." }, function(player)
+	return player:getCondition(CONDITION_FIRE) ~= nil
+end, function(player)
+	local health = player:getHealth()
+	if health < 65 then
+		player:addHealth(65 - health)
+	end
+	player:removeCondition(CONDITION_FIRE)
+	player:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
+end)
 keywordHandler:addKeyword({ "heal" }, StdModule.say, { npcHandler = npcHandler, text = "You are poisoned. I will help you." }, function(player)
 	return player:getCondition(CONDITION_POISON) ~= nil
 end, function(player)


### PR DESCRIPTION
Both offer free healing and both handle `CONDITION_POISON` only, so a player who says `hi` / `heal` while on fire is told they look fine and keeps burning. They are the two free healers newcomers reach first (Rookgaard and the starter towns), so it is the most noticeable case.

Other healer NPCs already handle this: Quentin, Alia, Amanda, Azalea and Cedrik all cure `CONDITION_FIRE` alongside poison. This just brings these two in line with them, adding the fire branch before the poison one so the more specific condition is matched first, following the same pattern Quentin uses.

Counted across `data-otservbr-global/npc`: 35 NPCs expose a `heal` keyword, 37 handle poison, and noticeably fewer handle fire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a healing response for burning players when requesting help from Cipfried or Dallheim.
  * The healing restores up to 65 health, removes the burning effect, and displays a green magic effect.
* **Bug Fixes**
  * Players affected by fire can now receive appropriate treatment from these NPCs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->