### PR TITLE
fix(docker): use MyAAC 2.x and enable FreeType support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,4 @@ The global Git, commit, PR, C++ header, exception, and documentation policies ap
 ## Docker Quickstart Policy
 
 - For quickstart changes, read `docs/docker/quickstart-for-beginners.md` and `docker/DOCKER.md`; keep CI/build, development, and user quickstart responsibilities separate.
-- The default client path is `login-server` at `http://localhost:8088/login`, never MyAAC `login.php`. MyAAC remains website/admin-only, uses `slawkens/myaac` `develop`, and keeps `http://localhost:8080`; public config stays `CANARY_*`, and the quickstart uses the published Canary runtime image.
+- The default client path is `login-server` at `http://localhost:8088/login`, never MyAAC `login.php`. MyAAC remains website/admin-only, uses `slawkens/myaac` `2.x`, and keeps `http://localhost:8080`; public config stays `CANARY_*`, and the quickstart uses the published Canary runtime image.

--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -30,10 +30,10 @@ CANARY_TEST_ACCOUNTS=true
 CANARY_DATA_PACK=data-otservbr-global
 CANARY_MAP_URL=https://github.com/opentibiabr/canary/releases/download/v3.6.1/otservbr.otbm
 
-# MyAAC site. The Dockerfile builds from the MyAAC develop branch by default.
+# MyAAC site. The Dockerfile builds from the MyAAC 2.x branch by default.
 MYAAC_HTTP_PORT=8080
 MYAAC_SITE_URL=http://localhost:8080
-MYAAC_REF=develop
+MYAAC_REF=2.x
 MYAAC_ADMIN_ACCOUNT=myaacadmin
 MYAAC_ADMIN_EMAIL=admin@localhost.local
 MYAAC_ADMIN_PASSWORD=admin123

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -7,7 +7,7 @@ The quickstart currently starts:
 
 - MariaDB
 - Canary server from the published runtime image
-- MyAAC from the `slawkens/myaac` `develop` branch
+- MyAAC from the `slawkens/myaac` `2.x` branch
 - `opentibiabr/login-server` for the client login webservice
 - Test accounts and characters, when enabled
 
@@ -257,7 +257,7 @@ For a first login, use account `@test1` with password `test`.
 ```env
 MYAAC_HTTP_PORT=8080
 MYAAC_SITE_URL=http://localhost:8080
-MYAAC_REF=develop
+MYAAC_REF=2.x
 MYAAC_ADMIN_ACCOUNT=myaacadmin
 MYAAC_ADMIN_EMAIL=admin@localhost.local
 MYAAC_ADMIN_PASSWORD=admin123
@@ -267,7 +267,7 @@ MYAAC_TIMEZONE=America/Fortaleza
 ```
 
 `MYAAC_REF` is the Git ref used when building the MyAAC image. The default is
-`develop`, which tracks the MyAAC branch compatible with Canary `main`. To test
+`2.x`, which tracks the MyAAC branch compatible with Canary `main`. To test
 a tag or another branch, change `MYAAC_REF` and rebuild:
 
 ```bash
@@ -338,7 +338,7 @@ Use `CANARY_IMAGE` only when testing another published or locally loaded Canary
 runtime image. The default quickstart should stay on the official image.
 
 The MyAAC image is built locally from `slawkens/myaac` because the quickstart
-tracks `MYAAC_REF=develop` by default. This build installs PHP dependencies with
+tracks `MYAAC_REF=2.x` by default. This build installs PHP dependencies with
 Composer, but it does not compile Canary.
 
 ## CI Coverage

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       context: .
       dockerfile: quickstart/myaac/Dockerfile
       args:
-        MYAAC_REF: "${MYAAC_REF:-develop}"
+        MYAAC_REF: "${MYAAC_REF:-2.x}"
     restart: unless-stopped
     environment:
       CANARY_DB_HOST: "${CANARY_DB_HOST:-db}"

--- a/docker/quickstart/myaac/Dockerfile
+++ b/docker/quickstart/myaac/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update \
 		libpng-dev \
 		libzip-dev \
 		unzip \
+		libfreetype6-dev \
+	&& docker-php-ext-configure gd --with-freetype \
 	&& docker-php-ext-install -j"$(nproc)" gd intl mysqli opcache pdo_mysql zip \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -45,6 +47,8 @@ RUN apt-get update \
 		libpng-dev \
 		libzip-dev \
 		unzip \
+		libfreetype6-dev \
+	&& docker-php-ext-configure gd --with-freetype \
 	&& docker-php-ext-install -j"$(nproc)" gd intl mysqli opcache pdo_mysql zip \
 	&& a2enmod headers rewrite \
 	&& rm -rf /var/lib/apt/lists/*

--- a/docker/quickstart/myaac/Dockerfile
+++ b/docker/quickstart/myaac/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3-apache AS builder
 
-ARG MYAAC_REF=develop
+ARG MYAAC_REF=2.x
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 RUN apt-get update \


### PR DESCRIPTION
Updates the Docker quickstart to follow MyAAC `2.x`, the branch selected by the upstream maintainer for Canary integrations, and enables FreeType support in PHP GD so Tibia.com template headline images render correctly.

## Fixes

- Change the default `MYAAC_REF` from `develop` to `2.x` in the Dockerfile, Compose configuration, and sample environment file.
- Build the PHP GD extension with FreeType support in both MyAAC image stages.

## Documentation

- Align Docker quickstart documentation and repository guidance with the new MyAAC default.
- Document that users can override `MYAAC_REF` with a tag or another branch when testing a different MyAAC revision.

## Tests/Validation

- `Build - Docker / Image Build` passed in GitHub Actions.
- `Docker Quickstart Smoke / Quickstart Smoke` passed with the default quickstart configuration.