### PR TITLE
fix(shutdown): release spectator cache before static teardown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ The global Git, commit, PR, C++ header, exception, and documentation policies ap
 - Removal, replacement, reload, or reinterpretation must cancel pending work or advance a checked generation. Callback-owning types are non-movable unless moving cancels or safely rebinds every event.
 - Use bounded arithmetic for intervals; stale work must become a no-op before gameplay, Lua, combat, movement, persistence, or client output. Cover destroyed/replaced owners, reused IDs, shutdown, and ownership transfer where practical.
 
+## Static Ownership Lifetime Safety
+
+- Never rely on cross-translation-unit static destruction order for caches, registries, or other global owners of gameplay objects. Prefer runtime-owned state; when global ownership is unavoidable, provide an explicit idempotent drain during controlled shutdown.
+- Stop and join every producer and consumer before draining global ownership, and release retained objects while all services their destructors may access are still alive. Validate shutdown with retained entries and lifetime instrumentation where practical.
+
 ## Canary build discipline
 
 - Before an authorized local build, read `docs/building/local-validation.md`; its maintained entry-point, environment, preset, cache, and MSVC Ninja workflow is mandatory.

--- a/src/canary_server.cpp
+++ b/src/canary_server.cpp
@@ -31,6 +31,7 @@
 #include "lua/modules/modules.hpp"
 #include "lua/scripts/lua_environment.hpp"
 #include "lua/scripts/scripts.hpp"
+#include "map/spectators.hpp"
 #include "server/network/protocol/protocollogin.hpp"
 #include "server/network/protocol/protocol_port_utils.hpp"
 #include "server/network/protocol/protocol_profile.hpp"
@@ -629,4 +630,7 @@ void CanaryServer::shutdown() {
 	g_dispatcher().shutdown();
 	g_metrics().shutdown();
 	g_threadPool().shutdown();
+
+	// Cached snapshots own creatures and must release them while gameplay services are still alive.
+	Spectators::clearCache();
 }


### PR DESCRIPTION
Cached spectator snapshots can retain the last strong reference to a creature until process-wide static destruction. This PR makes that ownership release deterministic after asynchronous execution has stopped and while DI-managed gameplay services are still alive.

## Fixes

- Drain `Spectators::spectatorsCache` after `ThreadPool::shutdown()` has stopped and joined task execution.
- Release cached `Player` instances before DI teardown so `Player::~Player()` can safely stop inventory decay through the live `Decay` service.
- Preserve the existing strong-reference spectator snapshot contract and normal tile-driven cache invalidation during gameplay.

## Documentation

- Add a repository lifecycle rule prohibiting reliance on cross-translation-unit static destruction order for global gameplay owners.
- Require explicit, idempotent draining after producers and consumers have stopped and before destructor dependencies are torn down.

## Tests/Validation

- `git diff --check origin/main...HEAD` completed successfully.
- The `AGENTS.md` instruction-chain audit completed successfully at 14,005 bytes, below the 24 KiB maintenance target and 32 KiB documented limit.
- Audited global strong ownership of `Creature` instances; the spectator cache is the confirmed global owner outside the DI-managed runtime.
- Expected behavior before: a non-empty spectator cache may release its final creature references during unordered static destruction, after gameplay services have been destroyed.
- Expected behavior after: the cache is emptied after task execution stops and before static teardown begins.
- Local compilation and runtime shutdown reproduction were not run under the repository build policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown safety by releasing cached spectator snapshot data before dependent gameplay services are stopped.
  * Helps prevent retained game entities from outliving the services that manage them.

* **Documentation**
  * Added guidance on safe shutdown ordering, producer and consumer coordination, and lifetime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->