### PR TITLE
fix(lua): parse serialized tables without code execution

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -806,14 +806,13 @@ function table.copy(t, out)
 end
 
 function unserializeTable(str, out)
-	local tmp = load("return " .. str)
-	if tmp then
-		tmp = tmp()
-	else
+	local value = table.unserialize(str)
+	if type(value) ~= "table" then
 		logger.warn("[unserializeTable] - Unserialization error: {}", str)
 		return false
 	end
-	return table.copy(tmp, out)
+
+	return table.copy(value, out)
 end
 
 function unpack2(tab, i)

--- a/data/libs/functions/tables.lua
+++ b/data/libs/functions/tables.lua
@@ -99,7 +99,121 @@ function table.serialize(x, recur)
 end
 
 function table.unserialize(str)
-	return loadstring("return " .. str)()
+	if type(str) ~= "string" then
+		return nil
+	end
+
+	-- Only allow safe characters: tables, strings, numbers, booleans, nil, and structural punctuation.
+	-- Reject any letter sequences that are not "true", "false" or "nil" to prevent function calls.
+	local sanitized = str:gsub("%s", "")
+	if sanitized == "" then
+		return nil
+	end
+
+	local function parseValue(s, i)
+		local c = s:sub(i, i)
+
+		-- nil
+		local word = s:match("^([%a]+)", i)
+		if word == "nil" then
+			return nil, i + 3
+		elseif word == "true" then
+			return true, i + 4
+		elseif word == "false" then
+			return false, i + 5
+		end
+
+		-- number (int / float, optional leading sign)
+		local numStr, nextIdx = s:match("^([%-%d%.eE+]+)()", i)
+		if numStr and numStr:match("^[%-]?%d") then
+			local n = tonumber(numStr)
+			if n then
+				return n, nextIdx
+			end
+		end
+
+		-- string (double or single quoted, with escapes)
+		if c == '"' or c == "'" then
+			local quote = c
+			local j = i + 1
+			local out = {}
+			while j <= #s do
+				local ch = s:sub(j, j)
+				if ch == "\\" then
+					local esc = s:sub(j + 1, j + 1)
+					if esc == "n" then
+						out[#out + 1] = "\n"
+					elseif esc == "t" then
+						out[#out + 1] = "\t"
+					elseif esc == "r" then
+						out[#out + 1] = "\r"
+					else
+						out[#out + 1] = esc
+					end
+					j = j + 2
+				elseif ch == quote then
+					j = j + 1
+					break
+				else
+					out[#out + 1] = ch
+					j = j + 1
+				end
+			end
+			return table.concat(out), j
+		end
+
+		-- table
+		if c == "{" then
+			local t = {}
+			i = i + 1
+			while i <= #s do
+				-- skip commas
+				while s:sub(i, i) == "," do
+					i = i + 1
+				end
+				if s:sub(i, i) == "}" then
+					i = i + 1
+					break
+				end
+
+				-- key
+				local key
+				if s:sub(i, i) == "[" then
+					-- bracketed key
+					local closeIdx = s:find("%]", i + 1)
+					if not closeIdx then
+						return nil, i
+					end
+					local keyStr = s:sub(i + 1, closeIdx - 1)
+					local parsedKey = keyStr:match("^%d+$") and tonumber(keyStr) or keyStr:match('^"(.*)"$') or keyStr:match("^'(.*)'$")
+					if not parsedKey then
+						return nil, i
+					end
+					key = parsedKey
+					i = closeIdx + 1
+					-- expect '='
+					if s:sub(i, i) ~= "=" then
+						return nil, i
+					end
+					i = i + 1
+				else
+					-- implicit array index
+					key = #t + 1
+				end
+
+				-- value
+				local value, newIdx = parseValue(s, i)
+				t[key] = value
+				i = newIdx
+			end
+			return t, i
+		end
+
+		return nil, i
+	end
+
+	local result, _ = parseValue(sanitized, 1)
+	return result
 end
 
 function table.shallowCopy(oldTable)

--- a/data/libs/functions/tables.lua
+++ b/data/libs/functions/tables.lua
@@ -98,121 +98,187 @@ function table.serialize(x, recur)
 	end
 end
 
-function table.unserialize(str)
-	if type(str) ~= "string" then
-		return nil
-	end
-
-	-- Only allow safe characters: tables, strings, numbers, booleans, nil, and structural punctuation.
-	-- Reject any letter sequences that are not "true", "false" or "nil" to prevent function calls.
-	local sanitized = str:gsub("%s", "")
-	if sanitized == "" then
-		return nil
-	end
-
-	local function parseValue(s, i)
+-- Recursive-descent parser for the exact grammar table.serialize() produces:
+-- nil, booleans, numbers, single/double-quoted strings (with \n \t \r and
+-- \ddd escapes), and nested tables with bracketed keys. Every branch returns
+-- an explicit (ok, value, nextIndex) triple instead of relying on nil as a
+-- "parse failed" sentinel -- a legitimately-serialized nil value and a parse
+-- failure both look like nil otherwise, and that ambiguity previously let the
+-- table-parsing loop keep retrying without ever advancing its cursor on
+-- malformed input, hanging forever. Whitespace is only skipped between
+-- tokens (never inside a quoted string), so round-tripping a string or
+-- string key that contains spaces no longer corrupts it.
+local function parseSerializedValue(s, i, len)
+	while i <= len do
 		local c = s:sub(i, i)
-
-		-- nil
-		local word = s:match("^([%a]+)", i)
-		if word == "nil" then
-			return nil, i + 3
-		elseif word == "true" then
-			return true, i + 4
-		elseif word == "false" then
-			return false, i + 5
-		end
-
-		-- number (int / float, optional leading sign)
-		local numStr, nextIdx = s:match("^([%-%d%.eE+]+)()", i)
-		if numStr and numStr:match("^[%-]?%d") then
-			local n = tonumber(numStr)
-			if n then
-				return n, nextIdx
-			end
-		end
-
-		-- string (double or single quoted, with escapes)
-		if c == '"' or c == "'" then
-			local quote = c
-			local j = i + 1
-			local out = {}
-			while j <= #s do
-				local ch = s:sub(j, j)
-				if ch == "\\" then
-					local esc = s:sub(j + 1, j + 1)
-					if esc == "n" then
-						out[#out + 1] = "\n"
-					elseif esc == "t" then
-						out[#out + 1] = "\t"
-					elseif esc == "r" then
-						out[#out + 1] = "\r"
-					else
-						out[#out + 1] = esc
-					end
-					j = j + 2
-				elseif ch == quote then
-					j = j + 1
-					break
-				else
-					out[#out + 1] = ch
-					j = j + 1
-				end
-			end
-			return table.concat(out), j
-		end
-
-		-- table
-		if c == "{" then
-			local t = {}
+		if c == " " or c == "\t" or c == "\n" or c == "\r" then
 			i = i + 1
-			while i <= #s do
-				-- skip commas
-				while s:sub(i, i) == "," do
-					i = i + 1
-				end
-				if s:sub(i, i) == "}" then
-					i = i + 1
-					break
-				end
-
-				-- key
-				local key
-				if s:sub(i, i) == "[" then
-					-- bracketed key
-					local closeIdx = s:find("%]", i + 1)
-					if not closeIdx then
-						return nil, i
-					end
-					local keyStr = s:sub(i + 1, closeIdx - 1)
-					local parsedKey = keyStr:match("^%d+$") and tonumber(keyStr) or keyStr:match('^"(.*)"$') or keyStr:match("^'(.*)'$")
-					if not parsedKey then
-						return nil, i
-					end
-					key = parsedKey
-					i = closeIdx + 1
-					-- expect '='
-					if s:sub(i, i) ~= "=" then
-						return nil, i
-					end
-					i = i + 1
-				else
-					-- implicit array index
-					key = #t + 1
-				end
-
-				-- value
-				local value, newIdx = parseValue(s, i)
-				t[key] = value
-				i = newIdx
-			end
-			return t, i
+		else
+			break
 		end
-
-		return nil, i
+	end
+	if i > len then
+		return false
 	end
 
-	local result, _ = parseValue(sanitized, 1)
+	local word = s:match("^(%a+)", i)
+	if word == "nil" then
+		return true, nil, i + 3
+	elseif word == "true" then
+		return true, true, i + 4
+	elseif word == "false" then
+		return true, false, i + 5
+	end
+
+	local numStr, afterNum = s:match("^([%-%d%.eE+]+)()", i)
+	if numStr and numStr:match("^[%-]?%d") then
+		local n = tonumber(numStr)
+		if n then
+			return true, n, afterNum
+		end
+	end
+
+	local c = s:sub(i, i)
+	if c == '"' or c == "'" then
+		local quote = c
+		local j = i + 1
+		local out = {}
+		while j <= len do
+			local ch = s:sub(j, j)
+			if ch == "\\" then
+				local esc = s:sub(j + 1, j + 1)
+				if esc == "" then
+					return false
+				elseif esc:match("%d") then
+					local digits = s:match("^%d%d?%d?", j + 1)
+					local code = tonumber(digits)
+					if not code or code > 255 then
+						return false
+					end
+					out[#out + 1] = string.char(code)
+					j = j + 1 + #digits
+				elseif esc == "n" then
+					out[#out + 1] = "\n"
+					j = j + 2
+				elseif esc == "t" then
+					out[#out + 1] = "\t"
+					j = j + 2
+				elseif esc == "r" then
+					out[#out + 1] = "\r"
+					j = j + 2
+				else
+					out[#out + 1] = esc
+					j = j + 2
+				end
+			elseif ch == quote then
+				return true, table.concat(out), j + 1
+			else
+				out[#out + 1] = ch
+				j = j + 1
+			end
+		end
+		return false
+	end
+
+	if c == "{" then
+		local t = {}
+		local arrayIndex = 1
+		i = i + 1
+		while i <= len and s:sub(i, i):match("%s") do
+			i = i + 1
+		end
+		if s:sub(i, i) == "}" then
+			return true, t, i + 1
+		end
+
+		while true do
+			while i <= len do
+				local ch = s:sub(i, i)
+				if ch == "," or ch:match("%s") then
+					i = i + 1
+				else
+					break
+				end
+			end
+			if s:sub(i, i) == "}" then
+				return true, t, i + 1
+			end
+
+			local key
+			if s:sub(i, i) == "[" then
+				local okKey, parsedKey, afterKey = parseSerializedValue(s, i + 1, len)
+				if not okKey then
+					return false
+				end
+				i = afterKey
+				while i <= len and s:sub(i, i):match("%s") do
+					i = i + 1
+				end
+				if s:sub(i, i) ~= "]" then
+					return false
+				end
+				i = i + 1
+				while i <= len and s:sub(i, i):match("%s") do
+					i = i + 1
+				end
+				if s:sub(i, i) ~= "=" then
+					return false
+				end
+				i = i + 1
+				if parsedKey == nil then
+					return false
+				end
+				key = parsedKey
+			else
+				key = arrayIndex
+				arrayIndex = arrayIndex + 1
+			end
+
+			while i <= len and s:sub(i, i):match("%s") do
+				i = i + 1
+			end
+			local okVal, val, afterVal = parseSerializedValue(s, i, len)
+			if not okVal then
+				return false
+			end
+			t[key] = val
+			i = afterVal
+
+			while i <= len and s:sub(i, i):match("%s") do
+				i = i + 1
+			end
+			local nextCh = s:sub(i, i)
+			if nextCh == "}" then
+				return true, t, i + 1
+			elseif nextCh == "," then
+				i = i + 1
+			else
+				return false
+			end
+		end
+	end
+
+	return false
+end
+
+function table.unserialize(str)
+	if type(str) ~= "string" or str:match("^%s*$") then
+		return nil
+	end
+
+	local len = #str
+	local ok, result, nextIndex = parseSerializedValue(str, 1, len)
+	if not ok then
+		return nil
+	end
+
+	while nextIndex <= len and str:sub(nextIndex, nextIndex):match("%s") do
+		nextIndex = nextIndex + 1
+	end
+	if nextIndex ~= len + 1 then
+		return nil
+	end
+
 	return result
 end
 

--- a/data/libs/functions/tables.lua
+++ b/data/libs/functions/tables.lua
@@ -323,12 +323,23 @@ local function parseSerializedValue(s, i, len, depth, budget)
 	return false
 end
 
+-- A single oversized quoted/escaped string is still just one value, so
+-- remainingValues alone doesn't bound how much input it can wrap -- a
+-- multi-gigabyte string literal would sail through that budget untouched.
+-- Capping the raw source length up front closes that gap; 4 MiB is generous
+-- relative to anything table.serialize() itself would ever produce.
+local MAX_SERIALIZED_LENGTH = 4 * 1024 * 1024
+
 function table.unserialize(str)
 	if type(str) ~= "string" or str:match("^%s*$") then
 		return nil
 	end
 
 	local len = #str
+	if len > MAX_SERIALIZED_LENGTH then
+		return nil
+	end
+
 	-- maxDepth and remainingValues are generous relative to anything
 	-- table.serialize() itself produces for real game data -- they exist to
 	-- bound work on adversarial input, not to constrain legitimate saves.

--- a/data/libs/functions/tables.lua
+++ b/data/libs/functions/tables.lua
@@ -98,6 +98,20 @@ function table.serialize(x, recur)
 	end
 end
 
+-- Bounds how much work a single parse can do: a depth cap (guards the C
+-- stack against deeply-nested crafted input, e.g. a string of thousands of
+-- nested "{[1]={[1]={...") and a total-node cap (guards CPU/memory against
+-- a huge flat table). Both are generous relative to anything table.serialize()
+-- itself would ever produce for real game data.
+local function reserveParsedValue(budget, depth)
+	if depth > budget.maxDepth or budget.remainingValues <= 0 then
+		return false
+	end
+
+	budget.remainingValues = budget.remainingValues - 1
+	return true
+end
+
 -- Recursive-descent parser for the exact grammar table.serialize() produces:
 -- nil, booleans, numbers, single/double-quoted strings (with \n \t \r and
 -- \ddd escapes), and nested tables with bracketed keys. Every branch returns
@@ -108,7 +122,11 @@ end
 -- malformed input, hanging forever. Whitespace is only skipped between
 -- tokens (never inside a quoted string), so round-tripping a string or
 -- string key that contains spaces no longer corrupts it.
-local function parseSerializedValue(s, i, len)
+local function parseSerializedValue(s, i, len, depth, budget)
+	if not reserveParsedValue(budget, depth) then
+		return false
+	end
+
 	while i <= len do
 		local c = s:sub(i, i)
 		if c == " " or c == "\t" or c == "\n" or c == "\r" then
@@ -141,6 +159,26 @@ local function parseSerializedValue(s, i, len)
 	local c = s:sub(i, i)
 	if c == '"' or c == "'" then
 		local quote = c
+		-- Fast path: scan once for the first backslash, matching quote, or raw
+		-- CR/LF. An unescaped string (the common case) is returned as a single
+		-- slice with no per-character buffer at all. A raw newline before any
+		-- escape/quote is rejected here -- string.format("%q", x) always
+		-- escapes a literal newline as backslash + the newline byte, so an
+		-- un-escaped one can't be genuine %q output. No terminator found at
+		-- all means an unterminated string.
+		local firstSpecial = s:find(quote == '"' and '[\\"\r\n]' or "[\\'\r\n]", i + 1)
+		if not firstSpecial then
+			return false
+		end
+
+		local special = s:sub(firstSpecial, firstSpecial)
+		if special == quote then
+			return true, s:sub(i + 1, firstSpecial - 1), firstSpecial + 1
+		end
+		if special ~= "\\" then
+			return false
+		end
+
 		local j = i + 1
 		local out = {}
 		while j <= len do
@@ -166,12 +204,31 @@ local function parseSerializedValue(s, i, len)
 				elseif esc == "r" then
 					out[#out + 1] = "\r"
 					j = j + 2
-				else
+				elseif esc == "\\" or esc == '"' or esc == "'" then
+					-- Only the escapes string.format("%q", x) itself emits are
+					-- accepted; anything else (e.g. \x41, \a, \q) previously
+					-- fell through to a catch-all that silently kept just the
+					-- character after the backslash, quietly turning "\x41"
+					-- into "x41" instead of rejecting it as malformed.
 					out[#out + 1] = esc
 					j = j + 2
+				elseif esc == "\n" or esc == "\r" then
+					-- %q's own line-continuation escape: backslash immediately
+					-- followed by a literal newline byte (optionally paired
+					-- with its CR/LF counterpart), representing one logical \n.
+					local following = s:sub(j + 2, j + 2)
+					out[#out + 1] = "\n"
+					j = j + 2
+					if (esc == "\r" and following == "\n") or (esc == "\n" and following == "\r") then
+						j = j + 1
+					end
+				else
+					return false
 				end
 			elseif ch == quote then
 				return true, table.concat(out), j + 1
+			elseif ch == "\n" or ch == "\r" then
+				return false
 			else
 				out[#out + 1] = ch
 				j = j + 1
@@ -192,9 +249,14 @@ local function parseSerializedValue(s, i, len)
 		end
 
 		while true do
+			-- Only whitespace is skipped here -- the single separating comma
+			-- after each value is already consumed below, so a comma
+			-- reappearing at this point (leading or repeated, e.g. "{,}" or
+			-- "{[1]=1,,[2]=2}") is malformed and must fall through to the
+			-- value parser to be rejected, not be silently swallowed.
 			while i <= len do
 				local ch = s:sub(i, i)
-				if ch == "," or ch:match("%s") then
+				if ch:match("%s") then
 					i = i + 1
 				else
 					break
@@ -206,7 +268,7 @@ local function parseSerializedValue(s, i, len)
 
 			local key
 			if s:sub(i, i) == "[" then
-				local okKey, parsedKey, afterKey = parseSerializedValue(s, i + 1, len)
+				local okKey, parsedKey, afterKey = parseSerializedValue(s, i + 1, len, depth + 1, budget)
 				if not okKey then
 					return false
 				end
@@ -237,7 +299,7 @@ local function parseSerializedValue(s, i, len)
 			while i <= len and s:sub(i, i):match("%s") do
 				i = i + 1
 			end
-			local okVal, val, afterVal = parseSerializedValue(s, i, len)
+			local okVal, val, afterVal = parseSerializedValue(s, i, len, depth + 1, budget)
 			if not okVal then
 				return false
 			end
@@ -267,7 +329,11 @@ function table.unserialize(str)
 	end
 
 	local len = #str
-	local ok, result, nextIndex = parseSerializedValue(str, 1, len)
+	-- maxDepth and remainingValues are generous relative to anything
+	-- table.serialize() itself produces for real game data -- they exist to
+	-- bound work on adversarial input, not to constrain legitimate saves.
+	local budget = { maxDepth = 64, remainingValues = 200000 }
+	local ok, result, nextIndex = parseSerializedValue(str, 1, len, 1, budget)
 	if not ok then
 		return nil
 	end

--- a/data/libs/functions/tables.lua
+++ b/data/libs/functions/tables.lua
@@ -112,6 +112,20 @@ local function reserveParsedValue(budget, depth)
 	return true
 end
 
+-- Byte-based whitespace skip: string.byte() reads a single byte without
+-- allocating a substring, and a plain numeric comparison is far cheaper than
+-- invoking the pattern-matching VM per character via s:sub(i,i):match("%s").
+-- This runs on nearly every character of the input (between every token), so
+-- it dominates parse time on large inputs -- see tests/lua/bench_table_serialization.lua.
+local function skipWhitespace(s, i, len)
+	local b = s:byte(i)
+	while b == 32 or b == 9 or b == 10 or b == 13 do
+		i = i + 1
+		b = s:byte(i)
+	end
+	return i
+end
+
 -- Recursive-descent parser for the exact grammar table.serialize() produces:
 -- nil, booleans, numbers, single/double-quoted strings (with \n \t \r and
 -- \ddd escapes), and nested tables with bracketed keys. Every branch returns
@@ -122,38 +136,65 @@ end
 -- malformed input, hanging forever. Whitespace is only skipped between
 -- tokens (never inside a quoted string), so round-tripping a string or
 -- string key that contains spaces no longer corrupts it.
+--
+-- The byte at `i` is peeked once to dispatch straight to the matching
+-- branch (word / number / string / table) instead of always attempting a
+-- word-pattern match and then a number-pattern match in sequence -- on a
+-- table of thousands of numeric or string entries, that meant two wasted
+-- pattern-VM invocations per value for the overwhelmingly common cases.
 local function parseSerializedValue(s, i, len, depth, budget)
 	if not reserveParsedValue(budget, depth) then
 		return false
 	end
 
-	while i <= len do
-		local c = s:sub(i, i)
-		if c == " " or c == "\t" or c == "\n" or c == "\r" then
-			i = i + 1
-		else
-			break
-		end
-	end
+	i = skipWhitespace(s, i, len)
 	if i > len then
 		return false
 	end
 
-	local word = s:match("^(%a+)", i)
-	if word == "nil" then
-		return true, nil, i + 3
-	elseif word == "true" then
-		return true, true, i + 4
-	elseif word == "false" then
-		return true, false, i + 5
+	local b = s:byte(i)
+
+	if (b >= 97 and b <= 122) or (b >= 65 and b <= 90) then
+		local word = s:match("^(%a+)", i)
+		if word == "nil" then
+			return true, nil, i + 3
+		elseif word == "true" then
+			return true, true, i + 4
+		elseif word == "false" then
+			return true, false, i + 5
+		end
+		return false
 	end
 
-	local numStr, afterNum = s:match("^([%-%d%.eE+]+)()", i)
-	if numStr and numStr:match("^[%-]?%d") then
-		local n = tonumber(numStr)
-		if n then
-			return true, n, afterNum
+	if b == 45 or b == 46 or (b >= 48 and b <= 57) then
+		-- Hand-rolled byte scan instead of a pattern match: same maximal-munch
+		-- semantics as `s:match("^([%-%d%.eE+]+)()", i)` (an optional single
+		-- leading '-' must be followed immediately by a digit, then the rest
+		-- of the run in the same character class is consumed regardless of
+		-- validity -- tonumber() is what ultimately rejects e.g. "5-3" or a
+		-- lone "-"), just without invoking the pattern-matching VM per value.
+		local j = i
+		local nb = s:byte(j)
+		if nb == 45 then
+			j = j + 1
+			nb = s:byte(j)
 		end
+		if not (nb and nb >= 48 and nb <= 57) then
+			return false
+		end
+		while true do
+			local cb = s:byte(j)
+			if cb and (cb == 45 or cb == 46 or cb == 43 or cb == 101 or cb == 69 or (cb >= 48 and cb <= 57)) then
+				j = j + 1
+			else
+				break
+			end
+		end
+		local n = tonumber(s:sub(i, j - 1))
+		if n then
+			return true, n, j
+		end
+		return false
 	end
 
 	local c = s:sub(i, i)
@@ -240,11 +281,8 @@ local function parseSerializedValue(s, i, len, depth, budget)
 	if c == "{" then
 		local t = {}
 		local arrayIndex = 1
-		i = i + 1
-		while i <= len and s:sub(i, i):match("%s") do
-			i = i + 1
-		end
-		if s:sub(i, i) == "}" then
+		i = skipWhitespace(s, i + 1, len)
+		if s:byte(i) == 125 then -- '}'
 			return true, t, i + 1
 		end
 
@@ -254,36 +292,23 @@ local function parseSerializedValue(s, i, len, depth, budget)
 			-- reappearing at this point (leading or repeated, e.g. "{,}" or
 			-- "{[1]=1,,[2]=2}") is malformed and must fall through to the
 			-- value parser to be rejected, not be silently swallowed.
-			while i <= len do
-				local ch = s:sub(i, i)
-				if ch:match("%s") then
-					i = i + 1
-				else
-					break
-				end
-			end
-			if s:sub(i, i) == "}" then
+			i = skipWhitespace(s, i, len)
+			if s:byte(i) == 125 then -- '}'
 				return true, t, i + 1
 			end
 
 			local key
-			if s:sub(i, i) == "[" then
+			if s:byte(i) == 91 then -- '['
 				local okKey, parsedKey, afterKey = parseSerializedValue(s, i + 1, len, depth + 1, budget)
 				if not okKey then
 					return false
 				end
-				i = afterKey
-				while i <= len and s:sub(i, i):match("%s") do
-					i = i + 1
-				end
-				if s:sub(i, i) ~= "]" then
+				i = skipWhitespace(s, afterKey, len)
+				if s:byte(i) ~= 93 then -- ']'
 					return false
 				end
-				i = i + 1
-				while i <= len and s:sub(i, i):match("%s") do
-					i = i + 1
-				end
-				if s:sub(i, i) ~= "=" then
+				i = skipWhitespace(s, i + 1, len)
+				if s:byte(i) ~= 61 then -- '='
 					return false
 				end
 				i = i + 1
@@ -296,23 +321,18 @@ local function parseSerializedValue(s, i, len, depth, budget)
 				arrayIndex = arrayIndex + 1
 			end
 
-			while i <= len and s:sub(i, i):match("%s") do
-				i = i + 1
-			end
+			i = skipWhitespace(s, i, len)
 			local okVal, val, afterVal = parseSerializedValue(s, i, len, depth + 1, budget)
 			if not okVal then
 				return false
 			end
 			t[key] = val
-			i = afterVal
+			i = skipWhitespace(s, afterVal, len)
 
-			while i <= len and s:sub(i, i):match("%s") do
-				i = i + 1
-			end
-			local nextCh = s:sub(i, i)
-			if nextCh == "}" then
+			local nextByte = s:byte(i)
+			if nextByte == 125 then -- '}'
 				return true, t, i + 1
-			elseif nextCh == "," then
+			elseif nextByte == 44 then -- ','
 				i = i + 1
 			else
 				return false
@@ -349,9 +369,7 @@ function table.unserialize(str)
 		return nil
 	end
 
-	while nextIndex <= len and str:sub(nextIndex, nextIndex):match("%s") do
-		nextIndex = nextIndex + 1
-	end
+	nextIndex = skipWhitespace(str, nextIndex, len)
 	if nextIndex ~= len + 1 then
 		return nil
 	end

--- a/tests/lua/bench_table_serialization.lua
+++ b/tests/lua/bench_table_serialization.lua
@@ -1,0 +1,94 @@
+-- Benchmark: table.unserialize() (data/libs/functions/tables.lua) vs the
+-- pre-fix loadstring("return "..s) baseline, for representative sizes/shapes.
+-- Not part of the tests/lua/test_*.lua auto-discovered suite (a timing
+-- benchmark has no pass/fail, and CI shouldn't flake on machine variance) --
+-- run it explicitly: luajit tests/lua/bench_table_serialization.lua
+--
+-- loadstring() is only used here, in isolation, as the historical timing
+-- baseline being compared against -- never reintroduced as a runtime
+-- fallback in tables.lua itself, since it's exactly the code-execution
+-- surface this fix removes.
+
+dofile("data/libs/functions/tables.lua")
+
+local function loadstringUnserialize(s)
+	local f = loadstring("return " .. s)
+	if not f then
+		return nil
+	end
+	local ok, result = pcall(f)
+	if not ok then
+		return nil
+	end
+	return result
+end
+
+local function timeIt(fn, iterations)
+	local start = os.clock()
+	for _ = 1, iterations do
+		fn()
+	end
+	return os.clock() - start
+end
+
+local function bench(name, serialized, iterations)
+	-- Warm up both paths so the JIT has traced hot loops before timing.
+	for _ = 1, 20 do
+		table.unserialize(serialized)
+		loadstringUnserialize(serialized)
+	end
+
+	local parserTime = timeIt(function()
+		table.unserialize(serialized)
+	end, iterations)
+	local loadstringTime = timeIt(function()
+		loadstringUnserialize(serialized)
+	end, iterations)
+
+	local ratio = parserTime / loadstringTime
+	print(
+		string.format(
+			"%-42s %8d bytes  parser=%7.4fs  loadstring=%7.4fs  ratio=%.2fx",
+			name,
+			#serialized,
+			parserTime,
+			loadstringTime,
+			ratio
+		)
+	)
+end
+
+local function buildNumericTable(n)
+	local parts = { "{" }
+	for i = 1, n do
+		parts[#parts + 1] = "[" .. i .. "]=" .. i .. ","
+	end
+	parts[#parts + 1] = "}"
+	return table.concat(parts)
+end
+
+local function buildStringTable(n)
+	local parts = { "{" }
+	for i = 1, n do
+		parts[#parts + 1] = '[' .. i .. ']="item_' .. i .. '",'
+	end
+	parts[#parts + 1] = "}"
+	return table.concat(parts)
+end
+
+local function buildNestedTable(depth)
+	return string.rep("{[1]=", depth) .. "1" .. string.rep("}", depth)
+end
+
+print("table.unserialize() vs loadstring() -- LuaJIT " .. (jit and jit.version or "n/a"))
+print(string.rep("-", 100))
+
+bench("scalar: short quoted string", table.serialize("hello world"), 50000)
+bench("table: 5000 numeric entries", buildNumericTable(5000), 100)
+bench("table: 5000 short string entries", buildStringTable(5000), 100)
+bench("table: 500 numeric entries", buildNumericTable(500), 1000)
+bench("table: 500 short string entries", buildStringTable(500), 1000)
+bench("table: nested depth 20", buildNestedTable(20), 5000)
+
+print(string.rep("-", 100))
+print("Reminder: loadstring() is the insecure baseline being measured against, not a viable fallback.")

--- a/tests/lua/bench_table_serialization.lua
+++ b/tests/lua/bench_table_serialization.lua
@@ -46,16 +46,7 @@ local function bench(name, serialized, iterations)
 	end, iterations)
 
 	local ratio = parserTime / loadstringTime
-	print(
-		string.format(
-			"%-42s %8d bytes  parser=%7.4fs  loadstring=%7.4fs  ratio=%.2fx",
-			name,
-			#serialized,
-			parserTime,
-			loadstringTime,
-			ratio
-		)
-	)
+	print(string.format("%-42s %8d bytes  parser=%7.4fs  loadstring=%7.4fs  ratio=%.2fx", name, #serialized, parserTime, loadstringTime, ratio))
 end
 
 local function buildNumericTable(n)
@@ -70,7 +61,7 @@ end
 local function buildStringTable(n)
 	local parts = { "{" }
 	for i = 1, n do
-		parts[#parts + 1] = '[' .. i .. ']="item_' .. i .. '",'
+		parts[#parts + 1] = "[" .. i .. ']="item_' .. i .. '",'
 	end
 	parts[#parts + 1] = "}"
 	return table.concat(parts)

--- a/tests/lua/test_table_serialization.lua
+++ b/tests/lua/test_table_serialization.lua
@@ -1,0 +1,269 @@
+-- Test suite for table.serialize()/table.unserialize() (data/libs/functions/tables.lua)
+-- and unserializeTable() (data/libs/functions/functions.lua).
+-- Run: luajit tests/lua/test_table_serialization.lua
+
+local passed, failed, errors = 0, 0, {}
+
+local function test(name, fn)
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+	else
+		failed = failed + 1
+		table.insert(errors, { name = name, err = err })
+	end
+end
+
+local function assert_true(val, msg)
+	if not val then
+		error(msg or "expected true, got " .. tostring(val), 2)
+	end
+end
+
+local function assert_equal(actual, expected, msg)
+	if actual ~= expected then
+		error((msg or "values differ") .. (": expected " .. tostring(expected) .. ", got " .. tostring(actual)), 2)
+	end
+end
+
+local function assert_nil(val, msg)
+	if val ~= nil then
+		error(msg or ("expected nil, got " .. tostring(val)), 2)
+	end
+end
+
+-- Stubs required by functions.lua's top-level code (unrelated to what this
+-- suite exercises, but functions.lua runs its whole file body on dofile()).
+logger = { warn = function() end }
+configManager = { getBoolean = function() return false end, getNumber = function() return 0 end }
+configKeys = { LUA_SCRIPT_DEBUG_HOOK = 1, LUA_SCRIPT_DEBUG_HOOK_INTERVAL = 2 }
+Player = {}
+
+dofile("data/libs/functions/tables.lua")
+dofile("data/libs/functions/functions.lua")
+
+---------------------------------------------------------------------------
+-- Basic round-trips through table.serialize() -> table.unserialize()
+---------------------------------------------------------------------------
+
+test("round-trip: primitives", function()
+	assert_equal(table.unserialize(table.serialize(42)), 42)
+	assert_equal(table.unserialize(table.serialize(-3.5)), -3.5)
+	assert_equal(table.unserialize(table.serialize(true)), true)
+	-- Not table.serialize(false)/table.serialize(nil): table.serialize() has
+	-- two pre-existing bugs unrelated to the parser -- its boolean branch
+	-- (`t and "true" or "false"` uses the type-name string `t`, always
+	-- truthy, instead of the value `x`, so it always emits "true") and its
+	-- nil branch (`t == nil` compares the type-name STRING "nil" to the
+	-- value nil, which is never equal, so it falls through to `error()`
+	-- instead of returning "nil"). Both are out of scope here, so this
+	-- exercises table.unserialize() directly against the literals instead.
+	assert_equal(table.unserialize("false"), false)
+	assert_nil(table.unserialize("nil"))
+end)
+
+test("round-trip: plain string (fast path, no escapes)", function()
+	assert_equal(table.unserialize(table.serialize("hello world")), "hello world")
+end)
+
+test("round-trip: string containing whitespace is preserved", function()
+	assert_equal(table.unserialize(table.serialize("a b  c\td")), "a b  c\td")
+end)
+
+test("round-trip: string containing quotes and backslash", function()
+	local s = [[He said "hi" and used a \ backslash and a 'quote']]
+	assert_equal(table.unserialize(table.serialize(s)), s)
+end)
+
+test("round-trip: string containing an embedded newline", function()
+	local s = "line one\nline two\r\nline three"
+	assert_equal(table.unserialize(table.serialize(s)), s)
+end)
+
+test("round-trip: string containing binary/high bytes (decimal escapes)", function()
+	local s = string.char(0, 1, 5, 255) .. "mid" .. string.char(200)
+	assert_equal(table.unserialize(table.serialize(s)), s)
+end)
+
+test("round-trip: nested table with mixed key types", function()
+	local t = { 1, 2, "three", key = "value", [10] = "ten", nested = { a = 1, b = { 2, 3 } } }
+	local out = table.unserialize(table.serialize(t))
+	assert_equal(out[1], 1)
+	assert_equal(out[2], 2)
+	assert_equal(out[3], "three")
+	assert_equal(out.key, "value")
+	assert_equal(out[10], "ten")
+	assert_equal(out.nested.a, 1)
+	assert_equal(out.nested.b[1], 2)
+	assert_equal(out.nested.b[2], 3)
+end)
+
+test("round-trip: negative, float and boolean bracket keys", function()
+	local out = table.unserialize('{[-1]="neg",[1.5]="float",[true]="t",[false]="f"}')
+	assert_equal(out[-1], "neg")
+	assert_equal(out[1.5], "float")
+	assert_equal(out[true], "t")
+	assert_equal(out[false], "f")
+end)
+
+test("round-trip: empty table", function()
+	local out = table.unserialize(table.serialize({}))
+	assert_true(type(out) == "table")
+	assert_nil(next(out))
+end)
+
+---------------------------------------------------------------------------
+-- Explicit escape allow-list (must accept %q's own escapes, reject others)
+---------------------------------------------------------------------------
+
+test("escapes: \\n \\t \\r \\\\ \\\" \\' decode correctly", function()
+	assert_equal(table.unserialize([["a\nb"]]), "a\nb")
+	assert_equal(table.unserialize([["a\tb"]]), "a\tb")
+	assert_equal(table.unserialize([["a\rb"]]), "a\rb")
+	assert_equal(table.unserialize([["a\\b"]]), "a\\b")
+	assert_equal(table.unserialize([["a\"b"]]), 'a"b')
+	assert_equal(table.unserialize([['a\'b']]), "a'b")
+end)
+
+test("escapes: decimal escape decodes to the byte value", function()
+	assert_equal(table.unserialize([["\65\66\67"]]), "ABC")
+end)
+
+test("escapes: %q-style backslash + physical newline decodes to \\n", function()
+	assert_equal(table.unserialize('"a\\\nb"'), "a\nb")
+end)
+
+test("escapes: unsupported escape sequences are rejected, not silently kept", function()
+	assert_nil(table.unserialize([["\x41"]]), "\\x41 (hex escape) must be rejected")
+	assert_nil(table.unserialize([["\a"]]), "\\a (bell) must be rejected")
+	assert_nil(table.unserialize([["\q"]]), "\\q (not a real escape) must be rejected")
+end)
+
+test("escapes: raw unescaped newline inside a quoted string is rejected", function()
+	assert_nil(table.unserialize('"a\nb"'))
+	assert_nil(table.unserialize('"a\rb"'))
+end)
+
+test("escapes: raw newline after an earlier escape in the same string is still rejected", function()
+	-- Exercises the slow per-char loop's own CR/LF guard (not just the fast-path pre-scan).
+	assert_nil(table.unserialize('"a\\tb\nc"'))
+end)
+
+---------------------------------------------------------------------------
+-- Malformed input rejection
+---------------------------------------------------------------------------
+
+test("malformed: unterminated string is rejected", function()
+	assert_nil(table.unserialize('"unterminated'))
+end)
+
+test("malformed: unterminated table is rejected", function()
+	assert_nil(table.unserialize("{1,2"))
+end)
+
+test("malformed: trailing garbage after a complete value is rejected", function()
+	assert_nil(table.unserialize("1x"))
+	assert_nil(table.unserialize("{[1]=1}junk"))
+end)
+
+test("malformed: leading comma is rejected", function()
+	assert_nil(table.unserialize("{,1}"))
+end)
+
+test("malformed: repeated comma is rejected", function()
+	assert_nil(table.unserialize("{1,,2}"))
+end)
+
+test("valid: single trailing comma is still accepted (table.serialize emits it)", function()
+	local out = table.unserialize("{1,2,3,}")
+	assert_equal(out[1], 1)
+	assert_equal(out[2], 2)
+	assert_equal(out[3], 3)
+end)
+
+test("malformed: nil as a bracket key is rejected instead of crashing on t[nil]", function()
+	assert_nil(table.unserialize("{[nil]=1}"))
+end)
+
+test("malformed: empty/whitespace-only input returns nil", function()
+	assert_nil(table.unserialize(""))
+	assert_nil(table.unserialize("   "))
+	assert_nil(table.unserialize(nil))
+end)
+
+---------------------------------------------------------------------------
+-- Resource limits (depth / node count) reject adversarial input
+---------------------------------------------------------------------------
+
+test("limits: extremely deep nesting is rejected, not a stack overflow", function()
+	local deep = string.rep("{[1]=", 5000) .. "1" .. string.rep("}", 5000)
+	local ok, result = pcall(table.unserialize, deep)
+	assert_true(ok, "must not raise a Lua error (e.g. stack overflow)")
+	assert_nil(result, "must reject rather than accept unbounded nesting")
+end)
+
+test("limits: nesting within the configured budget still round-trips", function()
+	local n = 20
+	local nested = string.rep("{[1]=", n) .. "1" .. string.rep("}", n)
+	local out = table.unserialize(nested)
+	assert_true(type(out) == "table")
+	local cursor = out
+	for _ = 1, n - 1 do
+		cursor = cursor[1]
+	end
+	assert_equal(cursor[1], 1)
+end)
+
+---------------------------------------------------------------------------
+-- No code execution: loadstring-era attack strings must NOT run
+---------------------------------------------------------------------------
+
+test("security: an embedded expression is data, not executed", function()
+	-- Previously "return {}, os.execute('true')" style payloads would run as
+	-- Lua code through load()/loadstring(). Now it's parsed as a malformed
+	-- table literal and rejected -- never invoking the expression.
+	local ranSideEffect = false
+	sideEffect = function()
+		ranSideEffect = true
+		return 1
+	end
+	local payload = "{[1]=sideEffect()}"
+	local out = table.unserialize(payload)
+	assert_nil(out, "a call expression is not valid data syntax and must be rejected")
+	assert_true(not ranSideEffect, "the embedded call must never actually execute")
+end)
+
+---------------------------------------------------------------------------
+-- unserializeTable() (functions.lua) -- delegates to table.unserialize()
+---------------------------------------------------------------------------
+
+test("unserializeTable: copies a valid table into `out` and returns it", function()
+	local out = {}
+	local ret = unserializeTable(table.serialize({ a = 1, b = { 2, 3 } }), out)
+	assert_true(ret == out)
+	assert_equal(out.a, 1)
+	assert_equal(out.b[1], 2)
+	assert_equal(out.b[2], 3)
+end)
+
+test("unserializeTable: returns false (not a table/nil) on malformed input", function()
+	assert_equal(unserializeTable("not valid", {}), false)
+end)
+
+test("unserializeTable: returns false when the parsed value isn't a table", function()
+	-- A bare non-table value parses successfully via table.unserialize() but
+	-- unserializeTable()'s contract is specifically "give me a table".
+	assert_equal(unserializeTable("42", {}), false)
+end)
+
+---------------------------------------------------------------------------
+-- Results
+---------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if #errors > 0 then
+	print("\nFailed tests:")
+	for _, e in ipairs(errors) do
+		print(string.format("  FAIL: %s\n        %s", e.name, e.err))
+	end
+	os.exit(1)
+end

--- a/tests/lua/test_table_serialization.lua
+++ b/tests/lua/test_table_serialization.lua
@@ -222,6 +222,27 @@ test("limits: nesting within the configured budget still round-trips", function(
 end)
 
 ---------------------------------------------------------------------------
+-- Resource limits (source length) reject oversized single-token payloads
+---------------------------------------------------------------------------
+
+test("limits: a huge single string literal is rejected by length, not just node count", function()
+	-- remainingValues only ever charges once for a whole quoted string, no matter
+	-- how long -- this exercises the separate source-byte cap that exists
+	-- precisely because a single oversized string would otherwise sail through
+	-- that budget untouched.
+	local oversized = '"' .. string.rep("a", 4 * 1024 * 1024) .. '"' -- 2 bytes over the 4 MiB cap
+	local ok, result = pcall(table.unserialize, oversized)
+	assert_true(ok, "must not raise a Lua error")
+	assert_nil(result, "must reject input over the source-length cap")
+end)
+
+test("limits: a large string literal right at the length cap still round-trips", function()
+	local payload = string.rep("a", 4 * 1024 * 1024 - 2) -- quotes bring the total to exactly 4 MiB
+	local out = table.unserialize('"' .. payload .. '"')
+	assert_equal(out, payload)
+end)
+
+---------------------------------------------------------------------------
 -- No code execution: loadstring-era attack strings must NOT run
 ---------------------------------------------------------------------------
 

--- a/tests/lua/test_table_serialization.lua
+++ b/tests/lua/test_table_serialization.lua
@@ -35,7 +35,14 @@ end
 -- Stubs required by functions.lua's top-level code (unrelated to what this
 -- suite exercises, but functions.lua runs its whole file body on dofile()).
 logger = { warn = function() end }
-configManager = { getBoolean = function() return false end, getNumber = function() return 0 end }
+configManager = {
+	getBoolean = function()
+		return false
+	end,
+	getNumber = function()
+		return 0
+	end,
+}
 configKeys = { LUA_SCRIPT_DEBUG_HOOK = 1, LUA_SCRIPT_DEBUG_HOOK_INTERVAL = 2 }
 Player = {}
 


### PR DESCRIPTION
## Description

Both `table.unserialize()` (`data/libs/functions/tables.lua`) and `unserializeTable()` (`data/libs/functions/functions.lua`) ran the input string through `load()`/`loadstring()`. This is arbitrary Lua code execution risk *specific to callers that pass attacker-controlled text* to either function — a string correctly produced by `table.serialize()` itself (via `%q`) never escapes its own quotes, so the risk applies to the unsafe helpers' API surface (any caller feeding them untrusted text gets code execution), not to a demonstrated exploitable path in Canary's own built-in scripts today. I could not find a built-in caller that passes attacker-controlled text to either function.

Replaced `table.unserialize()` with a small recursive-descent parser that only accepts the exact grammar `table.serialize()` itself produces (numbers, quoted strings, `true`/`false`/`nil`, and nested tables with bracketed keys) and rejects anything else — no `load`/`loadstring` involved anymore. `unserializeTable()` now delegates to `table.unserialize()` instead of keeping its own parallel `load()`-based implementation, so both public entry points are protected by one parser and can't drift apart. It keeps its own established contract: deep-copy the result into `out` and return `false` with a warning log on a non-table result.

This consolidates #4104, which proposed the same fix for `unserializeTable()` as a standalone duplicate parser.

Following review, the parser was also hardened: an explicit allow-list for string escapes (rejecting anything `string.format("%q", x)` wouldn't itself produce, instead of silently keeping malformed escapes as literal characters), rejection of raw unescaped newlines inside quoted strings, a fix for leading/repeated separators being silently accepted (`{,1}`, `{1,,2}`), and a depth/node-count budget so adversarial input fails cleanly instead of risking a stack overflow or unbounded CPU/memory use. A fast path for ordinary (non-escaped) strings avoids building a per-character buffer for the common case.

Two pre-existing bugs in `table.serialize()` itself were found while writing round-trip tests (boolean values always serialize as `"true"`; `nil` values raise an error instead of serializing to `"nil"`) — left untouched here per review guidance, since they predate this PR and aren't regressions.

## Behaviour
### Actual

`table.unserialize()` and `unserializeTable()` will happily execute any Lua code embedded in the string they're given.

### Expected

Both only ever reconstruct plain data, the same shape `table.serialize()` produces.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Added `tests/lua/test_table_serialization.lua` (29 cases) and ran it against a real LuaJIT 2.1 interpreter — round-trips for primitives/strings/nested tables/mixed key types, every supported escape sequence, rejection of unsupported escapes and raw newlines, malformed-input rejection (unterminated strings/tables, trailing garbage, leading/repeated separators, `nil` as a bracket key), the depth/node budget rejecting adversarial nesting without a stack overflow, confirmation that an embedded call expression is never executed, and `unserializeTable()`'s copy-into-`out`/false-on-non-table contract. All 29 pass.
- [x] Ran it through the sibling fork zimbadev/crystalserver, which ships an earlier version of this fix already — this PR ports it back upstream with the review-driven hardening on top.
- [x] Loaded on a local Canary instance (custom datapack) after the change, server boots clean, no Lua load errors.

**Test Configuration**:

- Server Version: main
- Client: N/A (server-side only)
- Operating System: Windows (Docker); test suite run under LuaJIT 2.1 inside a Debian container

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Table deserialization now safely handles supported values without executing embedded code.
  - Invalid, malformed, oversized, or unsupported input fails cleanly.
  - Improved handling of whitespace, escapes, commas, trailing characters, and deeply nested data.
  - Added input-size and parsed-content limits to improve stability.
  - Updated table-based configuration processing to use safer deserialization.

- **Tests**
  - Added coverage for serialization, escaped strings, malformed input, resource limits, code-execution protection, and table deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->