### PR TITLE
fix: FS.mkdir() shell command injection, replaced with a native filesystem binding

### DIFF
--- a/data/libs/functions/fs.lua
+++ b/data/libs/functions/fs.lua
@@ -9,11 +9,36 @@ function FS.exists(path)
 	return false
 end
 
+-- Validates a path so it cannot be used for shell command injection.
+-- Only allows alphanumeric characters, underscores, dots, dashes,
+-- slashes and backslashes, and must not contain any quote character.
+function FS.isPathSafe(path)
+	if type(path) ~= "string" or path == "" then
+		return false
+	end
+	-- reject quotes, semicolons, pipes, ampersands, backticks, parentheses,
+	-- dollar, greater/less-than, newlines and other shell metacharacters.
+	if path:find("[%\"%';|&`$()<>%c]") then
+		return false
+	end
+	return true
+end
+
 function FS.mkdir(path)
 	if FS.exists(path) then
 		return true
 	end
-	local success, err = os.execute('mkdir "' .. path .. '"')
+	if not FS.isPathSafe(path) then
+		return false, "unsafe path"
+	end
+	local cmd
+	if package.config:sub(1, 1) == "\\" then
+		-- Windows: use quoted path and /C to avoid leaking shell state
+		cmd = 'cmd /c mkdir "' .. path .. '"'
+	else
+		cmd = 'mkdir "' .. path .. '"'
+	end
+	local success, err = os.execute(cmd)
 	if not success then
 		return false, err
 	end

--- a/data/libs/functions/fs.lua
+++ b/data/libs/functions/fs.lua
@@ -12,24 +12,27 @@ end
 -- Validates a path so it cannot be used for shell command injection.
 -- Only allows alphanumeric characters, underscores, dots, dashes,
 -- slashes and backslashes, and must not contain any quote character.
+-- "%" is also rejected: on Windows, cmd.exe expands "%VAR%" references at
+-- parse time even inside double quotes, so a path like "%TEMP%\x" would
+-- create a directory somewhere other than the literal path given.
 function FS.isPathSafe(path)
 	if type(path) ~= "string" or path == "" then
 		return false
 	end
 	-- reject quotes, semicolons, pipes, ampersands, backticks, parentheses,
-	-- dollar, greater/less-than, newlines and other shell metacharacters.
-	if path:find("[%\"%';|&`$()<>%c]") then
+	-- dollar, greater/less-than, percent, newlines and other shell metacharacters.
+	if path:find("[%\"%';|&`$()<>%%%c]") then
 		return false
 	end
 	return true
 end
 
 function FS.mkdir(path)
-	if FS.exists(path) then
-		return true
-	end
 	if not FS.isPathSafe(path) then
 		return false, "unsafe path"
+	end
+	if FS.exists(path) then
+		return true
 	end
 	local cmd
 	if package.config:sub(1, 1) == "\\" then

--- a/data/libs/functions/fs.lua
+++ b/data/libs/functions/fs.lua
@@ -41,9 +41,14 @@ function FS.mkdir(path)
 	else
 		cmd = 'mkdir "' .. path .. '"'
 	end
-	local success, err = os.execute(cmd)
-	if not success then
-		return false, err
+	-- os.execute() under LuaJIT/Lua 5.1 does not return a boolean: it returns
+	-- the process exit status as a number (0 on success), which is truthy in
+	-- Lua like any non-nil/non-false value -- `if not success` never caught a
+	-- failed mkdir. Handle both the LuaJIT/5.1 numeric convention and the
+	-- newer Lua (5.2+) `true/nil, "exit"/"signal", code` convention.
+	local result, reason, code = os.execute(cmd)
+	if result ~= true and result ~= 0 then
+		return false, code or reason or result
 	end
 	return true
 end

--- a/data/libs/functions/fs.lua
+++ b/data/libs/functions/fs.lua
@@ -9,75 +9,23 @@ function FS.exists(path)
 	return false
 end
 
--- Validates a path so it cannot be used for shell command injection.
--- Only allows alphanumeric characters, underscores, dots, dashes,
--- slashes and backslashes, and must not contain any quote character.
--- "%" is also rejected: on Windows, cmd.exe expands "%VAR%" references at
--- parse time even inside double quotes, so a path like "%TEMP%\x" would
--- create a directory somewhere other than the literal path given.
-function FS.isPathSafe(path)
-	if type(path) ~= "string" or path == "" then
-		return false
-	end
-	-- reject quotes, semicolons, pipes, ampersands, backticks, parentheses,
-	-- dollar, greater/less-than, percent, newlines and other shell metacharacters.
-	if path:find("[%\"%';|&`$()<>%%%c]") then
-		return false
-	end
-	return true
-end
-
+-- Thin wrapper around the native fsCreateDirectories() binding
+-- (src/lua/functions/core/game/global_functions.cpp -> std::filesystem::create_directories).
+-- No shell is ever started, so there's no command-injection surface and no
+-- denylist of "unsafe" path characters -- any path std::filesystem accepts
+-- (including "%", quotes, parentheses, etc. in legitimate directory names)
+-- works correctly. Also creates any missing parent directories, so this
+-- alone now covers what FS.mkdir_p() used to do by walking components.
 function FS.mkdir(path)
-	if not FS.isPathSafe(path) then
-		return false, "unsafe path"
+	if type(path) ~= "string" or path == "" then
+		return false, "invalid path"
 	end
-	if FS.exists(path) then
-		return true
-	end
-	local cmd
-	if package.config:sub(1, 1) == "\\" then
-		-- Windows: use quoted path and /C to avoid leaking shell state
-		cmd = 'cmd /c mkdir "' .. path .. '"'
-	else
-		cmd = 'mkdir "' .. path .. '"'
-	end
-	-- os.execute() under LuaJIT/Lua 5.1 does not return a boolean: it returns
-	-- the process exit status as a number (0 on success), which is truthy in
-	-- Lua like any non-nil/non-false value -- `if not success` never caught a
-	-- failed mkdir. Handle both the LuaJIT/5.1 numeric convention and the
-	-- newer Lua (5.2+) `true/nil, "exit"/"signal", code` convention.
-	local result, reason, code = os.execute(cmd)
-	if result ~= true and result ~= 0 then
-		return false, code or reason or result
-	end
-	return true
+	return fsCreateDirectories(path)
 end
 
 function FS.mkdir_p(path)
 	if path == "" then
 		return true
 	end
-
-	local components = {}
-	for component in path:gmatch("[^/\\]+") do
-		table.insert(components, component)
-	end
-
-	local currentPath = ""
-	for i, component in ipairs(components) do
-		currentPath = currentPath .. component
-
-		if not FS.exists(currentPath) then
-			local success, err = FS.mkdir(currentPath)
-			if not success then
-				return false, err
-			end
-		end
-
-		if i < #components then
-			currentPath = currentPath .. "/"
-		end
-	end
-
-	return true
+	return FS.mkdir(path)
 end

--- a/data/libs/functions/fs.lua
+++ b/data/libs/functions/fs.lua
@@ -1,5 +1,18 @@
 FS = {}
 
+-- Private bridge to the native fsCreateDirectories() binding
+-- (src/lua/functions/core/game/global_functions.cpp -> std::filesystem::create_directories).
+-- lua_register() has no narrower scope than the global table, so it's
+-- captured into a local here and immediately removed from _G -- otherwise
+-- it would sit alongside FS.mkdir() as a second, undocumented global entry
+-- point (no Lua API docgen coverage, no path validation of its own) instead
+-- of being purely implementation plumbing for FS.mkdir()/FS.mkdir_p(). This
+-- file loads as part of the core library bootstrap (data/core.lua ->
+-- libs/libs.lua), before any datapack/custom script runs, so nothing else
+-- ever observes the global existing.
+local nativeCreateDirectories = fsCreateDirectories
+fsCreateDirectories = nil
+
 function FS.exists(path)
 	local file = io.open(path, "r")
 	if file then
@@ -9,8 +22,6 @@ function FS.exists(path)
 	return false
 end
 
--- Thin wrapper around the native fsCreateDirectories() binding
--- (src/lua/functions/core/game/global_functions.cpp -> std::filesystem::create_directories).
 -- No shell is ever started, so there's no command-injection surface and no
 -- denylist of "unsafe" path characters -- any path std::filesystem accepts
 -- (including "%", quotes, parentheses, etc. in legitimate directory names)
@@ -20,7 +31,7 @@ function FS.mkdir(path)
 	if type(path) ~= "string" or path == "" then
 		return false, "invalid path"
 	end
-	return fsCreateDirectories(path)
+	return nativeCreateDirectories(path)
 end
 
 function FS.mkdir_p(path)

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -9,6 +9,8 @@
 
 #include "lua/functions/core/game/global_functions.hpp"
 
+#include <filesystem>
+
 #include "config/configmanager.hpp"
 #include "creatures/creature.hpp"
 #include "creatures/combat/condition.hpp"
@@ -42,6 +44,7 @@ void GlobalFunctions::init(lua_State* L) {
 	lua_register(L, "doTargetCombatDispel", GlobalFunctions::luaDoTargetCombatDispel);
 	lua_register(L, "doTargetCombatHealth", GlobalFunctions::luaDoTargetCombatHealth);
 	lua_register(L, "doTargetCombatMana", GlobalFunctions::luaDoTargetCombatMana);
+	lua_register(L, "fsCreateDirectories", GlobalFunctions::luaFsCreateDirectories);
 	lua_register(L, "getDepotId", GlobalFunctions::luaGetDepotId);
 	lua_register(L, "getWaypointPositionByName", GlobalFunctions::luaGetWaypointPositionByName);
 	lua_register(L, "getWorldLight", GlobalFunctions::luaGetWorldLight);
@@ -794,6 +797,26 @@ int GlobalFunctions::luaIsInWar(lua_State* L) {
 
 	Lua::pushBoolean(L, player->isInWar(targetPlayer));
 	return 1;
+}
+
+int GlobalFunctions::luaFsCreateDirectories(lua_State* L) {
+	// fsCreateDirectories(path)
+	// Creates path and any missing parent directories, matching std::filesystem::create_directories.
+	// No shell is ever started, so there is no command-injection surface and no denylist of
+	// "unsafe" characters needed -- any path std::filesystem accepts is valid here.
+	const std::string path = Lua::getString(L, 1);
+
+	std::error_code errorCode;
+	std::filesystem::create_directories(path, errorCode);
+	if (errorCode) {
+		Lua::pushBoolean(L, false);
+		Lua::pushString(L, errorCode.message());
+		return 2;
+	}
+
+	Lua::pushBoolean(L, true);
+	lua_pushnil(L);
+	return 2;
 }
 
 int GlobalFunctions::luaGetWaypointPositionByName(lua_State* L) {

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -9,8 +9,6 @@
 
 #include "lua/functions/core/game/global_functions.hpp"
 
-#include <filesystem>
-
 #include "config/configmanager.hpp"
 #include "creatures/creature.hpp"
 #include "creatures/combat/condition.hpp"
@@ -801,6 +799,10 @@ int GlobalFunctions::luaIsInWar(lua_State* L) {
 
 int GlobalFunctions::luaFsCreateDirectories(lua_State* L) {
 	// fsCreateDirectories(path)
+	// Private bridge for FS.mkdir()/FS.mkdir_p() (data/libs/functions/fs.lua) --
+	// lua_register() only reaches the global table, so fs.lua captures this
+	// into a local and clears the global immediately on load; it is not meant
+	// to be called directly by scripts, hence no Lua API docgen entry.
 	// Creates path and any missing parent directories, matching std::filesystem::create_directories.
 	// No shell is ever started, so there is no command-injection surface and no denylist of
 	// "unsafe" characters needed -- any path std::filesystem accepts is valid here.

--- a/src/lua/functions/core/game/global_functions.hpp
+++ b/src/lua/functions/core/game/global_functions.hpp
@@ -29,6 +29,7 @@ private:
 	static int luaDoTargetCombatDispel(lua_State* L);
 	static int luaDoTargetCombatHealth(lua_State* L);
 	static int luaDoTargetCombatMana(lua_State* L);
+	static int luaFsCreateDirectories(lua_State* L);
 	static int luaGetDepotId(lua_State* L);
 	static int luaGetWaypointPositionByName(lua_State* L);
 	static int luaGetWorldLight(lua_State* L);

--- a/tests/lua/test_fs.lua
+++ b/tests/lua/test_fs.lua
@@ -1,0 +1,126 @@
+-- Test suite for FS.mkdir()/FS.mkdir_p() (data/libs/functions/fs.lua).
+-- Run: luajit tests/lua/test_fs.lua
+--
+-- The native fsCreateDirectories() binding (src/lua/functions/core/game/global_functions.cpp)
+-- is stubbed below exactly as lua_register() would expose it before fs.lua loads --
+-- this suite runs standalone, without linking the real C++ binary.
+
+local passed, failed, errors = 0, 0, {}
+
+local function test(name, fn)
+	local ok, err = pcall(fn)
+	if ok then
+		passed = passed + 1
+	else
+		failed = failed + 1
+		table.insert(errors, { name = name, err = err })
+	end
+end
+
+local function assert_equal(actual, expected, msg)
+	if actual ~= expected then
+		error((msg or "values differ") .. (": expected " .. tostring(expected) .. ", got " .. tostring(actual)), 2)
+	end
+end
+
+local function assert_nil(val, msg)
+	if val ~= nil then
+		error(msg or ("expected nil, got " .. tostring(val)), 2)
+	end
+end
+
+local nativeCalls = {}
+fsCreateDirectories = function(path)
+	table.insert(nativeCalls, path)
+	if path == "trigger-native-failure" then
+		return false, "simulated filesystem error"
+	end
+	return true, nil
+end
+
+dofile("data/libs/functions/fs.lua")
+
+---------------------------------------------------------------------------
+-- The native binding must not survive as a bare global
+---------------------------------------------------------------------------
+
+test("fsCreateDirectories is removed from _G once fs.lua has loaded", function()
+	assert_nil(fsCreateDirectories, "must not be reachable as a second, undocumented entry point")
+end)
+
+---------------------------------------------------------------------------
+-- FS.mkdir()
+---------------------------------------------------------------------------
+
+test("FS.mkdir: delegates to the native binding and returns its result", function()
+	nativeCalls = {}
+	local ok, err = FS.mkdir("some/dir")
+	assert_equal(ok, true)
+	assert_nil(err)
+	assert_equal(#nativeCalls, 1)
+	assert_equal(nativeCalls[1], "some/dir")
+end)
+
+test("FS.mkdir: propagates a native failure instead of swallowing it", function()
+	nativeCalls = {}
+	local ok, err = FS.mkdir("trigger-native-failure")
+	assert_equal(ok, false)
+	assert_equal(err, "simulated filesystem error")
+end)
+
+test("FS.mkdir: rejects an empty path before calling the native binding", function()
+	nativeCalls = {}
+	local ok, err = FS.mkdir("")
+	assert_equal(ok, false)
+	assert_equal(err, "invalid path")
+	assert_equal(#nativeCalls, 0, "must not reach the native binding for an invalid path")
+end)
+
+test("FS.mkdir: rejects a non-string path before calling the native binding", function()
+	nativeCalls = {}
+	local ok, err = FS.mkdir(nil)
+	assert_equal(ok, false)
+	assert_equal(err, "invalid path")
+	assert_equal(#nativeCalls, 0)
+end)
+
+test("FS.mkdir: paths with characters a shell would have needed escaping just work", function()
+	-- No shell is involved anymore, so nothing here needs denylisting --
+	-- this is exactly the class of legitimate path the old shell-based
+	-- implementation used to reject.
+	nativeCalls = {}
+	local ok = FS.mkdir("reports/50% (final) & summary.txt's_folder")
+	assert_equal(ok, true)
+	assert_equal(nativeCalls[1], "reports/50% (final) & summary.txt's_folder")
+end)
+
+---------------------------------------------------------------------------
+-- FS.mkdir_p()
+---------------------------------------------------------------------------
+
+test("FS.mkdir_p: delegates a single call to FS.mkdir (native binding creates all parents)", function()
+	nativeCalls = {}
+	local ok = FS.mkdir_p("a/b/c")
+	assert_equal(ok, true)
+	assert_equal(#nativeCalls, 1, "must be one call, not one per path component")
+	assert_equal(nativeCalls[1], "a/b/c")
+end)
+
+test("FS.mkdir_p: empty path is a no-op success", function()
+	nativeCalls = {}
+	local ok = FS.mkdir_p("")
+	assert_equal(ok, true)
+	assert_equal(#nativeCalls, 0)
+end)
+
+---------------------------------------------------------------------------
+-- Results
+---------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if #errors > 0 then
+	print("\nFailed tests:")
+	for _, e in ipairs(errors) do
+		print(string.format("  FAIL: %s\n        %s", e.name, e.err))
+	end
+	os.exit(1)
+end


### PR DESCRIPTION
## Description

`FS.mkdir()` concatenated its `path` argument straight into `os.execute('mkdir "' .. path .. '"')`. A path containing a double quote, backtick, `;`, `|`, `&`, `$(...)` etc. broke out of the quoted argument and ran whatever came after it as a shell command.

The first fix here added a character denylist (`FS.isPathSafe()`). Following review, that approach was replaced entirely: shell escaping and a character denylist can't cleanly cover both POSIX and `cmd.exe`, and rejecting characters like `&`, `%`, apostrophes and parentheses also rejects legitimate directory names — `FS.mkdir_p()` takes a configured core directory, and `FS` is a global helper available to custom scripts.

Added `fsCreateDirectories(path)` (`src/lua/functions/core/game/global_functions.cpp`), a thin Lua binding over `std::filesystem::create_directories` with `std::error_code` — no shell is ever started, so there's no injection surface and no path characters need to be rejected. It also creates every missing parent directory in one call, so `FS.mkdir_p()` no longer needs to walk path components itself; both `FS.mkdir()`/`FS.mkdir_p()` now just delegate to it.

Also fixed along the way: `os.execute()` under LuaJIT/Lua 5.1 returns the process exit status as a *number* (0 on success), not a boolean — a failed `mkdir` returned a non-zero number, which is truthy in Lua, so the original fix's `if not success then` never actually caught a failure.

## Behaviour
### Actual

Any path with a shell metacharacter reached `os.execute()` unmodified, and even the denylisted version could report success on a failed `mkdir`.

### Expected

No shell is involved at all; any path `std::filesystem` accepts works correctly, and a failed creation is reported accurately.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Built Canary with this change (ninja build, full link, Docker toolchain) — compiles clean, no errors.
- [x] Loaded on a local Canary instance after the change, server boots clean, no Lua load errors.
- [x] Ran a standalone LuaJIT smoke test of `fs.lua`'s Lua-side logic (success path, propagated error path, empty-path rejection, `mkdir_p` delegation) against a stubbed `fsCreateDirectories`, since the real binding is C++-only and not exercisable from a plain Lua test.

**Test Configuration**:

- Server Version: main
- Client: N/A (server-side only)
- Operating System: Windows (Docker)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `FS.mkdir` and `FS.mkdir_p` now create missing parent directories automatically.
  - Paths containing shell-special characters are supported.
  - Empty paths passed to `FS.mkdir_p` are treated as a successful no-op.

- **Bug Fixes**
  - Directory creation reports clear failures for invalid or inaccessible paths.
  - Empty and non-string paths are rejected consistently by `FS.mkdir`.

- **Breaking Changes**
  - Removed the `FS.isPathSafe` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->