### PR TITLE
refactor: remove unreachable nil-player call in antiPush

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -49,7 +49,6 @@ local pushDelay = {}
 
 local function antiPush(player, item, count, fromPosition, toPosition, fromCylinder, toCylinder)
 	if not player then
-		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		return false
 	end
 


### PR DESCRIPTION
Remove an unreachable nil-player method call from the defensive guard in `antiPush()`.

## Refactors

- Remove `player:sendCancelMessage(...)` from the branch where `player` is already known to be nil.
- `antiPush()` is local to this file and is called only by `Player:onMoveItem()` with `self`. The C++ move-item event also receives and uses a valid `Player` before invoking Lua, so the nil branch is not reachable through the current game flow.
- Preserve the defensive `false` return should a future caller ever pass no player, without attempting to send a message to an unavailable object.

## Tests/Validation

- Reviewed the only Lua call site and the C++ `eventPlayerOnMoveItem()` dispatch path.
- GitHub CI checks for this Lua-only change passed.
