### PR TITLE
fix: unserializeTable() executes arbitrary Lua code

### DIFF
--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -805,11 +805,115 @@ function table.copy(t, out)
 	return out
 end
 
+-- Recursive-descent parser for the exact grammar table.serialize() produces
+-- (numbers, quoted strings, true/false/nil and nested tables). Used instead
+-- of load()/loadstring() so this can never execute arbitrary Lua code.
+local function safeParseSerializedValue(s, i)
+	local c = s:sub(i, i)
+
+	local word = s:match("^([%a]+)", i)
+	if word == "nil" then
+		return nil, i + 3
+	elseif word == "true" then
+		return true, i + 4
+	elseif word == "false" then
+		return false, i + 5
+	end
+
+	local numStr, nextIdx = s:match("^([%-%d%.eE+]+)()", i)
+	if numStr and numStr:match("^[%-]?%d") then
+		local n = tonumber(numStr)
+		if n then
+			return n, nextIdx
+		end
+	end
+
+	if c == '"' or c == "'" then
+		local quote = c
+		local j = i + 1
+		local out = {}
+		while j <= #s do
+			local ch = s:sub(j, j)
+			if ch == "\\" then
+				local esc = s:sub(j + 1, j + 1)
+				if esc == "n" then
+					out[#out + 1] = "\n"
+				elseif esc == "t" then
+					out[#out + 1] = "\t"
+				elseif esc == "r" then
+					out[#out + 1] = "\r"
+				else
+					out[#out + 1] = esc
+				end
+				j = j + 2
+			elseif ch == quote then
+				j = j + 1
+				break
+			else
+				out[#out + 1] = ch
+				j = j + 1
+			end
+		end
+		return table.concat(out), j
+	end
+
+	if c == "{" then
+		local t = {}
+		i = i + 1
+		while i <= #s do
+			while s:sub(i, i) == "," do
+				i = i + 1
+			end
+			if s:sub(i, i) == "}" then
+				i = i + 1
+				break
+			end
+
+			local key
+			if s:sub(i, i) == "[" then
+				local closeIdx = s:find("%]", i + 1)
+				if not closeIdx then
+					return nil, i
+				end
+				local keyStr = s:sub(i + 1, closeIdx - 1)
+				local parsedKey = keyStr:match("^%d+$") and tonumber(keyStr) or keyStr:match('^"(.*)"$') or keyStr:match("^'(.*)'$")
+				if not parsedKey then
+					return nil, i
+				end
+				key = parsedKey
+				i = closeIdx + 1
+				if s:sub(i, i) ~= "=" then
+					return nil, i
+				end
+				i = i + 1
+			else
+				key = #t + 1
+			end
+
+			local value, newIdx = safeParseSerializedValue(s, i)
+			t[key] = value
+			i = newIdx
+		end
+		return t, i
+	end
+
+	return nil, i
+end
+
 function unserializeTable(str, out)
-	local tmp = load("return " .. str)
-	if tmp then
-		tmp = tmp()
-	else
+	if type(str) ~= "string" then
+		logger.warn("[unserializeTable] - Unserialization error: {}", str)
+		return false
+	end
+
+	local sanitized = str:gsub("%s", "")
+	if sanitized == "" then
+		logger.warn("[unserializeTable] - Unserialization error: {}", str)
+		return false
+	end
+
+	local tmp = safeParseSerializedValue(sanitized, 1)
+	if tmp == nil then
 		logger.warn("[unserializeTable] - Unserialization error: {}", str)
 		return false
 	end

--- a/data/libs/functions/functions.lua
+++ b/data/libs/functions/functions.lua
@@ -805,115 +805,187 @@ function table.copy(t, out)
 	return out
 end
 
--- Recursive-descent parser for the exact grammar table.serialize() produces
--- (numbers, quoted strings, true/false/nil and nested tables). Used instead
--- of load()/loadstring() so this can never execute arbitrary Lua code.
-local function safeParseSerializedValue(s, i)
-	local c = s:sub(i, i)
-
-	local word = s:match("^([%a]+)", i)
-	if word == "nil" then
-		return nil, i + 3
-	elseif word == "true" then
-		return true, i + 4
-	elseif word == "false" then
-		return false, i + 5
+-- Recursive-descent parser for the exact grammar table.serialize() produces:
+-- nil, booleans, numbers, single/double-quoted strings (with \n \t \r and
+-- \ddd escapes), and nested tables with bracketed keys. Every branch returns
+-- an explicit (ok, value, nextIndex) triple instead of relying on nil as a
+-- "parse failed" sentinel -- a legitimately-serialized nil value and a parse
+-- failure both look like nil otherwise, and that ambiguity previously let the
+-- table-parsing loop keep retrying without ever advancing its cursor on
+-- malformed input, hanging forever. Whitespace is only skipped between
+-- tokens (never inside a quoted string), so round-tripping a string or
+-- string key that contains spaces no longer corrupts it. Used instead of
+-- load()/loadstring() so this can never execute arbitrary Lua code.
+local function safeParseSerializedValue(s, i, len)
+	while i <= len do
+		local c = s:sub(i, i)
+		if c == " " or c == "\t" or c == "\n" or c == "\r" then
+			i = i + 1
+		else
+			break
+		end
+	end
+	if i > len then
+		return false
 	end
 
-	local numStr, nextIdx = s:match("^([%-%d%.eE+]+)()", i)
+	local word = s:match("^(%a+)", i)
+	if word == "nil" then
+		return true, nil, i + 3
+	elseif word == "true" then
+		return true, true, i + 4
+	elseif word == "false" then
+		return true, false, i + 5
+	end
+
+	local numStr, afterNum = s:match("^([%-%d%.eE+]+)()", i)
 	if numStr and numStr:match("^[%-]?%d") then
 		local n = tonumber(numStr)
 		if n then
-			return n, nextIdx
+			return true, n, afterNum
 		end
 	end
 
+	local c = s:sub(i, i)
 	if c == '"' or c == "'" then
 		local quote = c
 		local j = i + 1
 		local out = {}
-		while j <= #s do
+		while j <= len do
 			local ch = s:sub(j, j)
 			if ch == "\\" then
 				local esc = s:sub(j + 1, j + 1)
-				if esc == "n" then
+				if esc == "" then
+					return false
+				elseif esc:match("%d") then
+					local digits = s:match("^%d%d?%d?", j + 1)
+					local code = tonumber(digits)
+					if not code or code > 255 then
+						return false
+					end
+					out[#out + 1] = string.char(code)
+					j = j + 1 + #digits
+				elseif esc == "n" then
 					out[#out + 1] = "\n"
+					j = j + 2
 				elseif esc == "t" then
 					out[#out + 1] = "\t"
+					j = j + 2
 				elseif esc == "r" then
 					out[#out + 1] = "\r"
+					j = j + 2
 				else
 					out[#out + 1] = esc
+					j = j + 2
 				end
-				j = j + 2
 			elseif ch == quote then
-				j = j + 1
-				break
+				return true, table.concat(out), j + 1
 			else
 				out[#out + 1] = ch
 				j = j + 1
 			end
 		end
-		return table.concat(out), j
+		return false
 	end
 
 	if c == "{" then
 		local t = {}
+		local arrayIndex = 1
 		i = i + 1
-		while i <= #s do
-			while s:sub(i, i) == "," do
-				i = i + 1
+		while i <= len and s:sub(i, i):match("%s") do
+			i = i + 1
+		end
+		if s:sub(i, i) == "}" then
+			return true, t, i + 1
+		end
+
+		while true do
+			while i <= len do
+				local ch = s:sub(i, i)
+				if ch == "," or ch:match("%s") then
+					i = i + 1
+				else
+					break
+				end
 			end
 			if s:sub(i, i) == "}" then
-				i = i + 1
-				break
+				return true, t, i + 1
 			end
 
 			local key
 			if s:sub(i, i) == "[" then
-				local closeIdx = s:find("%]", i + 1)
-				if not closeIdx then
-					return nil, i
+				local okKey, parsedKey, afterKey = safeParseSerializedValue(s, i + 1, len)
+				if not okKey then
+					return false
 				end
-				local keyStr = s:sub(i + 1, closeIdx - 1)
-				local parsedKey = keyStr:match("^%d+$") and tonumber(keyStr) or keyStr:match('^"(.*)"$') or keyStr:match("^'(.*)'$")
-				if not parsedKey then
-					return nil, i
+				i = afterKey
+				while i <= len and s:sub(i, i):match("%s") do
+					i = i + 1
 				end
-				key = parsedKey
-				i = closeIdx + 1
-				if s:sub(i, i) ~= "=" then
-					return nil, i
+				if s:sub(i, i) ~= "]" then
+					return false
 				end
 				i = i + 1
+				while i <= len and s:sub(i, i):match("%s") do
+					i = i + 1
+				end
+				if s:sub(i, i) ~= "=" then
+					return false
+				end
+				i = i + 1
+				if parsedKey == nil then
+					return false
+				end
+				key = parsedKey
 			else
-				key = #t + 1
+				key = arrayIndex
+				arrayIndex = arrayIndex + 1
 			end
 
-			local value, newIdx = safeParseSerializedValue(s, i)
-			t[key] = value
-			i = newIdx
+			while i <= len and s:sub(i, i):match("%s") do
+				i = i + 1
+			end
+			local okVal, val, afterVal = safeParseSerializedValue(s, i, len)
+			if not okVal then
+				return false
+			end
+			t[key] = val
+			i = afterVal
+
+			while i <= len and s:sub(i, i):match("%s") do
+				i = i + 1
+			end
+			local nextCh = s:sub(i, i)
+			if nextCh == "}" then
+				return true, t, i + 1
+			elseif nextCh == "," then
+				i = i + 1
+			else
+				return false
+			end
 		end
-		return t, i
 	end
 
-	return nil, i
+	return false
 end
 
 function unserializeTable(str, out)
-	if type(str) ~= "string" then
+	if type(str) ~= "string" or str:match("^%s*$") then
 		logger.warn("[unserializeTable] - Unserialization error: {}", str)
 		return false
 	end
 
-	local sanitized = str:gsub("%s", "")
-	if sanitized == "" then
-		logger.warn("[unserializeTable] - Unserialization error: {}", str)
-		return false
+	local len = #str
+	local ok, tmp, nextIndex = safeParseSerializedValue(str, 1, len)
+	if ok then
+		while nextIndex <= len and str:sub(nextIndex, nextIndex):match("%s") do
+			nextIndex = nextIndex + 1
+		end
+		if nextIndex ~= len + 1 then
+			ok = false
+		end
 	end
-
-	local tmp = safeParseSerializedValue(sanitized, 1)
-	if tmp == nil then
+	if not ok then
 		logger.warn("[unserializeTable] - Unserialization error: {}", str)
 		return false
 	end


### PR DESCRIPTION
## Description

`unserializeTable()` has the same problem as `table.unserialize()` (see #4101, a separate PR for that twin function): it passes the input string to `load()`, so anything unserialized through it can carry arbitrary Lua code instead of just data.

Gave it its own small recursive-descent parser (only accepts the literal grammar `table.serialize()` produces: numbers, quoted strings, `true`/`false`/`nil`, nested tables) so this one is fixed on its own regardless of what happens with #4101.

## Behaviour
### Actual

`unserializeTable()` will execute any Lua code embedded in the string it's given.

### Expected

`unserializeTable()` only ever reconstructs plain data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Loaded on a local Canary instance after the change, server boots clean, no Lua load errors.
- [x] Manually walked the parser against representative inputs (nested tables, string/number/bool/nil mixes, output of `table.serialize()`) to confirm round-tripping still works and `table.copy(tmp, out)` still receives a real table.

**Test Configuration**:

- Server Version: main
- Client: N/A (server-side only)
- Operating System: Windows (Docker)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I checked the PR checks reports
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved table deserialization reliability by rejecting non-text and blank inputs.
  - Restricted deserialization to supported serialized values, including numbers, strings, booleans, nil values, and nested tables.
  - Prevented serialized data from executing arbitrary Lua code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->