### PR TITLE
fix: avoid Lua error when SayEvent cannot find an NPC

### DIFF
--- a/data/npclib/npc.lua
+++ b/data/npclib/npc.lua
@@ -75,7 +75,7 @@ end
 function SayEvent(npcId, playerId, messageDelayed, npcHandler, textType)
 	local npc = Npc(npcId)
 	if not npc then
-		return logger.error("[{} NpcHandler:say] - Npc parameter for npc '{}' is missing, nil or not found", npc:getName(), npc:getName())
+		return logger.error("[NpcHandler:say] - Npc parameter for npc id '{}' is missing, nil or not found", npcId)
 	end
 
 	local player = Player(playerId)


### PR DESCRIPTION
Prevent a Lua error in a delayed NPC dialogue callback when the NPC is no longer available.

## Fixes

- `SayEvent()` resolves its NPC from the id saved by `addEvent()`.
- When that NPC no longer exists, log the supplied `npcId` and return without trying to call `getName()` on a nil value.
- The previous error was a protected Lua callback failure that logged an error and aborted that callback; it was not a C++ null-pointer dereference or a server-process crash.

## Tests/Validation

- Reviewed the delayed callback flow from `NpcHandler:say()` through `addEvent()` and `SayEvent()`.
- Reviewed the timer execution path, which invokes Lua through the protected call boundary.
- GitHub CI checks for this Lua-only change passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging when an NPC cannot be resolved during a speech event.
  - Error messages now include the NPC identifier and a clearer context prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->