### PR TITLE
fix: select the correct death screenshot type

### DIFF
--- a/data/scripts/creaturescripts/player/death.lua
+++ b/data/scripts/creaturescripts/player/death.lua
@@ -74,7 +74,7 @@ local function saveDeathRecord(playerGuid, player, killerName, byPlayer, mostDam
 		mostDamageUnjustified and 1 or 0,
 		db.escapeString(participantsString)
 	)
-	db.query(query)
+	db.asyncQuery(query)
 end
 
 local function getDeathRecords(playerGuid)
@@ -194,7 +194,7 @@ function playerDeath.onDeath(player, corpse, killer, mostDamageKiller, unjustifi
 	local killerName, byPlayer = getKillerInfo(killer)
 	local mostDamageName, byPlayerMostDamage = getMostDamageInfo(mostDamageKiller)
 
-	player:takeScreenshot(byPlayer and SCREENSHOT_TYPE_DEATHPVP or SCREENSHOT_TYPE_DEATHPVE)
+	player:takeScreenshot(byPlayer == 1 and SCREENSHOT_TYPE_DEATHPVP or SCREENSHOT_TYPE_DEATHPVE)
 
 	if mostDamageKiller and mostDamageKiller:isPlayer() then
 		mostDamageKiller:takeScreenshot(SCREENSHOT_TYPE_PLAYERKILL)

--- a/data/scripts/creaturescripts/player/death.lua
+++ b/data/scripts/creaturescripts/player/death.lua
@@ -74,7 +74,12 @@ local function saveDeathRecord(playerGuid, player, killerName, byPlayer, mostDam
 		mostDamageUnjustified and 1 or 0,
 		db.escapeString(participantsString)
 	)
-	db.asyncQuery(query)
+	-- IronOT/CodeRabbit: this must stay synchronous. handleGuildWar(), called
+	-- right after this in onDeath, immediately does a synchronous
+	-- getDeathRecords() read against this same table -- with an async write,
+	-- that read can run before the INSERT lands, so a player's first-ever
+	-- death could read 0 records and skip the guild-war kill/score update.
+	db.query(query)
 end
 
 local function getDeathRecords(playerGuid)


### PR DESCRIPTION
Correct the screenshot category recorded for player deaths while preserving the synchronous death-record write required by the guild-war flow.

## Fixes

- Select `SCREENSHOT_TYPE_DEATHPVP` only when `byPlayer == 1`; Lua treats `0` as truthy, so the former truthiness check classified all deaths as PVP.
- Keep `saveDeathRecord()` synchronous because `handleGuildWar()` immediately queries the newly inserted death record in the same callback. Making the insert asynchronous can race that read and skip the guild-war update for the first relevant death.

## Tests/Validation

- Reviewed the `saveDeathRecord()` and `handleGuildWar()` call flow to confirm the ordering dependency.
- Reviewed the `byPlayer` flag assignment and the screenshot enum selection.
