### PR TITLE
fix: require the mother state before Sister of Jack dialogue

### DIFF
--- a/data-otservbr-global/npc/sister_of_jack.lua
+++ b/data-otservbr-global/npc/sister_of_jack.lua
@@ -71,7 +71,7 @@ local function creatureSayCallback(npc, creature, type, message)
 
 	if MsgContains(message, "jack") then
 		if player:getStorageValue(Storage.Quest.U8_7.JackFutureQuest.QuestLine) == 5 then
-			if player:getStorageValue(Storage.Quest.U8_7.JackFutureQuest.Mother == 1) and (player:getStorageValue(Storage.Quest.U8_7.JackFutureQuest.Sister)) < 1 then
+			if player:getStorageValue(Storage.Quest.U8_7.JackFutureQuest.Mother) == 1 and (player:getStorageValue(Storage.Quest.U8_7.JackFutureQuest.Sister)) < 1 then
 				npcHandler:say("Why are you asking, he didn't get himself into something again did he?", npc, creature)
 				npcHandler:setTopic(playerId, 1)
 			end


### PR DESCRIPTION
Require the Jack to the Future mother state before Sister of Jack starts her quest dialogue.

## Fixes

- Compare the value returned by `getStorageValue(Storage.Quest.U8_7.JackFutureQuest.Mother)` with `1`, rather than comparing the storage key before the call.
- The previous expression evaluated `Mother == 1` first. Since `Mother` is storage `43306`, that produced `false`, which was coerced to storage key `0`. A missing storage returns `-1`, and `-1` is truthy in Lua, so the mother-state guard could be bypassed.
- Preserve the intended order: at quest line `5`, the sister dialogue is available only after the Mother storage is `1` and before the Sister storage is set.

## Tests/Validation

- Reviewed the storage definitions and the linked NPC flow: `mother_of_jack.lua` sets the Mother storage to `1`, and `sister_of_jack.lua` sets the Sister storage and advances the quest line after the dialogue.
- GitHub CI checks for this Lua-only change passed.
