### PR TITLE
fix: avoid Lua errors when elevator items are missing

### DIFF
--- a/data-otservbr-global/scripts/actions/oramond/elevator.lua
+++ b/data-otservbr-global/scripts/actions/oramond/elevator.lua
@@ -26,6 +26,9 @@ function elevator.onUse(player, item, fromPosition, target, toPosition, isHotkey
 
 	local elevatorStructureItem = fromTile:getItemById(elevatorStructureItemId, -1)
 	local elevatorBaseItem = fromTile:getItemById(elevatorBaseItemId, -1)
+	if not elevatorStructureItem or not elevatorBaseItem then
+		return true
+	end
 
 	elevatorBaseItem:moveTo(toTile)
 	player:teleportTo(toTile:getPosition())
@@ -34,7 +37,9 @@ function elevator.onUse(player, item, fromPosition, target, toPosition, isHotkey
 	local elevatorPusherItem = toTile:getItemById(elevatorPusherItemId, -1)
 	if not elevatorPusherItem then
 		elevatorPusherItem = fromTile:getItemById(elevatorPusherItemId, -1)
-		elevatorPusherItem:moveTo(toTile)
+		if elevatorPusherItem then
+			elevatorPusherItem:moveTo(toTile)
+		end
 	else
 		elevatorPusherItem:moveTo(fromTile)
 	end


### PR DESCRIPTION
Prevents Lua errors in the Oramond elevator action when the structure, base, or pusher item expected by the script is absent. Action callbacks run through Canary's protected Lua-call path, so the failure is reported and that use attempt stops; it is not a server-process crash.

## Fixes

- Return before moving the elevator when its structure or base item is missing.
- Move the pusher item only when it can be found on either expected tile.
- Preserve the normal movement sequence when every required item is present.

## Tests/Validation

- The PR author reports loading a local Canary instance without Lua load errors.
- The PR author reports that the normal path keeps the existing sequence of calls.
- No automated regression test currently covers missing elevator items.
