### PR TITLE
fix: avoid Lua error when creating maze portal

### DIFF
--- a/data-otservbr-global/scripts/quests/the_pits_of_inferno_quest/actions_bazir_maze_lever.lua
+++ b/data-otservbr-global/scripts/quests/the_pits_of_inferno_quest/actions_bazir_maze_lever.lua
@@ -2,9 +2,9 @@ local pitsOfInfernoMazeLever = Action()
 function pitsOfInfernoMazeLever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local portal = Tile(Position(32816, 32345, 13)):getItemById(1949)
 	if not portal then
-		local item = Game.createItem(1949, 1, Position(32816, 32345, 13))
-		if item:isTeleport() then
-			item:setDestination(Position(32767, 32366, 15))
+		local newPortal = Game.createItem(1949, 1, Position(32816, 32345, 13))
+		if newPortal and newPortal:isTeleport() then
+			newPortal:setDestination(Position(32767, 32366, 15))
 		end
 	else
 		portal:remove()


### PR DESCRIPTION
Prevents a Lua error in the Bazir maze lever action when the portal item cannot be created. Action callbacks run through Canary's protected Lua-call path, so the failure is reported and that use attempt stops; it is not a server-process crash.

## Fixes

- Check the result of `Game.createItem()` before querying whether the created item is a teleport.
- Rename the inner portal variable so the final lever transformation remains clear.
- Preserve the existing portal destination setup when creation succeeds.

## Tests/Validation

- The PR author reports loading a local Canary instance without Lua load errors.
- The PR author reports that the final transformation continues to use the outer lever item.
- No automated regression test currently forces portal creation to fail.
