### PR TITLE
fix(rookie-guard): handle energy barrier creation failure

### DIFF
--- a/data-otservbr-global/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
+++ b/data-otservbr-global/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
@@ -463,7 +463,9 @@ local function energyBarrierRestore(barrierUID)
 	local energyBarrier = Tile(energyBarriers[barrierUID].position):getItemById(12796)
 	if not energyBarrier then
 		energyBarrier = Game.createItem(12796, 1, energyBarriers[barrierUID].position)
-		energyBarrier:setAttribute(ITEM_ATTRIBUTE_UNIQUEID, barrierUID)
+		if energyBarrier then
+			energyBarrier:setAttribute(ITEM_ATTRIBUTE_UNIQUEID, barrierUID)
+		end
 	end
 end
 

--- a/data-otservbr-global/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
+++ b/data-otservbr-global/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
@@ -463,9 +463,13 @@ local function energyBarrierRestore(barrierUID)
 	local energyBarrier = Tile(energyBarriers[barrierUID].position):getItemById(12796)
 	if not energyBarrier then
 		energyBarrier = Game.createItem(12796, 1, energyBarriers[barrierUID].position)
-		if energyBarrier then
-			energyBarrier:setAttribute(ITEM_ATTRIBUTE_UNIQUEID, barrierUID)
+		if not energyBarrier then
+			local position = energyBarriers[barrierUID].position
+			logger.error("[The Rookie Guard] Failed to restore energy barrier {} at ({}, {}, {}).", barrierUID, position.x, position.y, position.z)
+			return
 		end
+
+		energyBarrier:setAttribute(ITEM_ATTRIBUTE_UNIQUEID, barrierUID)
 	end
 end
 


### PR DESCRIPTION
Prevent a Lua nil-value error in the delayed callback that restores the energy barrier when `Game.createItem()` cannot create item `12796`. The callback is executed by `addEvent` through Canary's protected Lua-call path, so the previous outcome is a reported script error and an aborted restoration attempt; it is not a server-process crash.

## Fixes

- Guard the `setAttribute()` call when `Game.createItem()` returns `nil`.
- Keep the scope limited to the delayed energy-barrier restoration callback.
- A failed creation still leaves the barrier absent and needs investigation; this change only prevents the nil-value Lua error.

## Tests/Validation

- Existing PR checks passed: Fast Checks, Lua Tests, and the Linux build.
- The callback path was reviewed through `addEvent`, `LuaEnvironment::executeTimerEvent()`, and the protected Lua call.
- No automated regression test currently forces `Game.createItem()` to fail for this quest item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an energy barrier cannot be recreated.
  * Added error logging and prevented further processing when barrier creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->