### PR TITLE
fix(login): allow modern client character lists

### DIFF
--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -45,9 +45,6 @@ void ProtocolLogin::getCharacterList(const std::string &accountDescriptor, const
 	if (oldProtocol && !g_configManager().getBoolean(OLD_PROTOCOL)) {
 		disconnectClient(ProtocolProfileRegistry::getUnsupportedClientProtocolMessage(false));
 		return;
-	} else if (!oldProtocol) {
-		disconnectClient(ProtocolProfileRegistry::getUnsupportedClientProtocolMessage(g_configManager().getBoolean(OLD_PROTOCOL)));
-		return;
 	}
 
 	if (account.load() != AccountErrors_t::Ok || !account.authenticate(password)) {
@@ -279,9 +276,6 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage &msg) {
 	if (accountDescriptor == "@livestream") {
 		if (oldProtocol && !g_configManager().getBoolean(OLD_PROTOCOL)) {
 			disconnectClient(ProtocolProfileRegistry::getUnsupportedClientProtocolMessage(false));
-			return;
-		} else if (!oldProtocol) {
-			disconnectClient(ProtocolProfileRegistry::getUnsupportedClientProtocolMessage(g_configManager().getBoolean(OLD_PROTOCOL)));
 			return;
 		}
 


### PR DESCRIPTION
Restores account-list delivery for a resolved and allowed modern client profile.

## Fixes

- Removes the obsolete guard that disconnected a modern client solely because it was not a legacy client after its profile had already been resolved and allowed.
- Applies the same correction to the livestream account-list path, so both entry points follow the same legacy-policy behavior.
- Preserves the configured rejection of legacy profiles when `allowOldProtocol` is disabled.
- Fixes #3430.

## Tests/Validation

- Ran `git diff --check` successfully.
- Traced the current profile from resolution and policy allowance through the login guard; the current profile has no legacy-compatibility feature and is allowed before this branch executes.
- Not run: build or compile-triggering checks, per the requested scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Modern clients can now complete authentication when legacy protocol support is disabled.
  - Legacy clients continue to be rejected when they are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->