### PR TITLE
fix(wheel): preserve lower-grade spell effects

### DIFF
--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -307,11 +307,12 @@ namespace {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell area stage {}, grade {}", stage, size);
 			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				const auto &spellData = spellTable.grade[stage];
-				if (spellData.increase.area) {
-					g_logger().debug("[{}] spell with name {}, and stage {} has increase area", __FUNCTION__, spellName, stage);
+				for (auto grade = stage; grade > 0; --grade) {
+					if (spellTable.grade[grade].increase.area) {
+						g_logger().debug("[{}] spell with name {}, and stage {} has increase area", __FUNCTION__, spellName, stage);
 
-					return true;
+						return true;
+					}
 				}
 			}
 		}
@@ -325,9 +326,11 @@ namespace {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell target stage {}, grade {}", stage, size);
 			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				const auto &spellData = spellTable.grade[stage];
-				if (spellData.increase.additionalTarget) {
-					return spellData.increase.additionalTarget;
+				for (auto grade = stage; grade > 0; --grade) {
+					const auto additionalTarget = spellTable.grade[grade].increase.additionalTarget;
+					if (additionalTarget) {
+						return additionalTarget;
+					}
 				}
 			}
 		}
@@ -341,9 +344,11 @@ namespace {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell duration stage {}, grade {}", stage, size);
 			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				const auto &spellData = spellTable.grade[stage];
-				if (spellData.increase.duration > 0) {
-					return spellData.increase.duration;
+				for (auto grade = stage; grade > 0; --grade) {
+					const auto duration = spellTable.grade[grade].increase.duration;
+					if (duration > 0) {
+						return duration;
+					}
 				}
 			}
 		}

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -306,13 +306,15 @@ namespace {
 		for (const auto &spellTable : spellsTable) {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell area stage {}, grade {}", stage, size);
-			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				for (auto grade = stage; grade > 0; --grade) {
-					if (spellTable.grade[grade].increase.area) {
-						g_logger().debug("[{}] spell with name {}, and stage {} has increase area", __FUNCTION__, spellName, stage);
+			if (spellTable.name != spellName || stage >= static_cast<uint8_t>(size)) {
+				continue;
+			}
 
-						return true;
-					}
+			for (auto grade = stage; grade > 0; --grade) {
+				if (spellTable.grade[grade].increase.area) {
+					g_logger().debug("[{}] spell with name {}, and stage {} has increase area", __FUNCTION__, spellName, stage);
+
+					return true;
 				}
 			}
 		}
@@ -325,12 +327,14 @@ namespace {
 		for (const auto &spellTable : spellsTable) {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell target stage {}, grade {}", stage, size);
-			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				for (auto grade = stage; grade > 0; --grade) {
-					const auto additionalTarget = spellTable.grade[grade].increase.additionalTarget;
-					if (additionalTarget) {
-						return additionalTarget;
-					}
+			if (spellTable.name != spellName || stage >= static_cast<uint8_t>(size)) {
+				continue;
+			}
+
+			for (auto grade = stage; grade > 0; --grade) {
+				const auto additionalTarget = spellTable.grade[grade].increase.additionalTarget;
+				if (additionalTarget) {
+					return additionalTarget;
 				}
 			}
 		}
@@ -343,12 +347,14 @@ namespace {
 		for (const auto &spellTable : spellsTable) {
 			auto size = std::ssize(spellTable.grade);
 			g_logger().debug("spell duration stage {}, grade {}", stage, size);
-			if (spellTable.name == spellName && stage < static_cast<uint8_t>(size)) {
-				for (auto grade = stage; grade > 0; --grade) {
-					const auto duration = spellTable.grade[grade].increase.duration;
-					if (duration > 0) {
-						return duration;
-					}
+			if (spellTable.name != spellName || stage >= static_cast<uint8_t>(size)) {
+				continue;
+			}
+
+			for (auto grade = stage; grade > 0; --grade) {
+				const auto duration = spellTable.grade[grade].increase.duration;
+				if (duration > 0) {
+					return duration;
 				}
 			}
 		}

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -312,7 +312,7 @@ namespace {
 
 			for (auto grade = stage; grade > 0; --grade) {
 				if (spellTable.grade[grade].increase.area) {
-					g_logger().debug("[{}] spell with name {}, and stage {} has increase area", __FUNCTION__, spellName, stage);
+					g_logger().debug("[{}] spell with name {}, stage {}, and grade {} has increase area", __FUNCTION__, spellName, stage, grade);
 
 					return true;
 				}


### PR DESCRIPTION
Restores first-grade Wheel of Destiny effects after a spell reaches its second grade.

## Fixes

- Resolves #3288 by retaining Sap Strength's first-grade area increase when its second-grade damage-reduction upgrade is active.
- Preserves the confirmed equivalent Divine Dazzle extra-target effect at grade two, while retaining the higher-grade duration value.
- Uses the highest applicable non-zero numeric effect, so grade-specific target and duration values are not cumulatively over-applied.

Fixes #3288

## Tests/Validation

- Ran `git diff --check`.
- Ran `clang-format --dry-run --Werror src/creatures/players/components/wheel/player_wheel.cpp`.
- Did not run a build or test suite, as compilation was not requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spell bonuses defined at lower grades now apply when a spell reaches a higher stage.
  * Area effects, additional targets, and duration bonuses are now correctly carried forward when no matching bonus is defined at the current grade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->