### PR TITLE
fix(wheel): clear destroyed active gems

### DIFF
--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1247,6 +1247,16 @@ void PlayerWheel::destroyGem(uint16_t index) {
 	}
 
 	m_destroyedGems.emplace_back(gem);
+	gem.remove(gemsKV());
+
+	for (const auto affinity : magic_enum::enum_values<WheelGemAffinity_t>()) {
+		auto &activeGem = m_activeGems[static_cast<uint8_t>(affinity)];
+		if (activeGem && activeGem.uuid == gem.uuid) {
+			activeGem = emptyGem;
+			gemsKV()->scoped("active")->remove(std::string(magic_enum::enum_name(affinity)));
+		}
+	}
+
 	m_revealedGems.erase(m_revealedGems.begin() + index);
 
 	const auto totalLesserFragment = m_player.getItemTypeCount(ITEM_LESSER_FRAGMENT) + m_player.getStashItemCount(ITEM_LESSER_FRAGMENT);

--- a/src/creatures/players/components/wheel/player_wheel.cpp
+++ b/src/creatures/players/components/wheel/player_wheel.cpp
@@ -1249,15 +1249,20 @@ void PlayerWheel::destroyGem(uint16_t index) {
 	m_destroyedGems.emplace_back(gem);
 	gem.remove(gemsKV());
 
+	bool removedActiveGem = false;
 	for (const auto affinity : magic_enum::enum_values<WheelGemAffinity_t>()) {
 		auto &activeGem = m_activeGems[static_cast<uint8_t>(affinity)];
 		if (activeGem && activeGem.uuid == gem.uuid) {
 			activeGem = emptyGem;
 			gemsKV()->scoped("active")->remove(std::string(magic_enum::enum_name(affinity)));
+			removedActiveGem = true;
 		}
 	}
 
 	m_revealedGems.erase(m_revealedGems.begin() + index);
+	if (removedActiveGem) {
+		loadPlayerBonusData();
+	}
 
 	const auto totalLesserFragment = m_player.getItemTypeCount(ITEM_LESSER_FRAGMENT) + m_player.getStashItemCount(ITEM_LESSER_FRAGMENT);
 	const auto totalGreaterFragment = m_player.getItemTypeCount(ITEM_GREATER_FRAGMENT) + m_player.getStashItemCount(ITEM_GREATER_FRAGMENT);


### PR DESCRIPTION
Keeps dismantled Wheel of Destiny gems from surviving through an active-vessel reference.

## Fixes

- Removes the destroyed gem's revealed KV entry as soon as dismantling has successfully awarded its fragments.
- Clears every active vessel that references the destroyed gem and removes the matching active KV key.
- Prevents the destroyed gem from returning after relogging or remaining active in the refreshed Wheel window.

Fixes #3724

## Tests/Validation

- Ran `git diff --check`.
- Ran `clang-format --dry-run --Werror src/creatures/players/components/wheel/player_wheel.cpp`.
- Did not run a build or test suite, as compilation was not requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Destroyed gems are now removed immediately from the revealed-gems collection.
  - Active gem slots are cleared promptly when their associated gem is destroyed, preventing stale gems from remaining active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->