### PR TITLE
fix(forge): match transfer candidates by classification

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -11556,6 +11556,11 @@ void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemI
 		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
 		return;
 	}
+	if (!convergence && donorItem->getTier() == 0) {
+		g_logger().error("[{}] Player {} tried to transfer a tier-0 donor item", __FUNCTION__, getName());
+		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
+		return;
+	}
 
 	const auto &receiveItem = getForgeItemFromId(receiveItemId, 0, donorItem);
 	if (!receiveItem) {

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -11563,6 +11563,11 @@ void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemI
 		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
 		return;
 	}
+	if (donorItem->getClassification() != receiveItem->getClassification()) {
+		g_logger().error("[{}] Player {} tried to transfer item classification {} to classification {}", __FUNCTION__, getName(), donorItem->getClassification(), receiveItem->getClassification());
+		sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
+		return;
+	}
 
 	// Pre-validate all resources before mutating player inventory.
 	auto configKey = convergence ? FORGE_CONVERGENCE_TRANSFER_DUST_COST : FORGE_TRANSFER_DUST_COST;
@@ -11581,15 +11586,17 @@ void Player::forgeTransferItemTier(ForgeAction_t actionType, uint16_t donorItemI
 			continue;
 		}
 		hasMatchingClassification = true;
-		const uint8_t toTier = convergence ? donorItem->getTier() : donorItem->getTier() - 1;
-		if (!itemClassification->tiers.contains(toTier)) {
-			g_logger().error("[{}] Failed to find tier {} for item {} in classification {}", __FUNCTION__, toTier, donorItem->getClassification(), itemClassification->id);
+		const uint8_t donorTier = donorItem->getTier();
+		const uint8_t toTier = convergence ? donorTier : donorTier - 1;
+		if (!itemClassification->tiers.contains(toTier) || !itemClassification->tiers.contains(donorTier)) {
+			g_logger().error("[{}] Failed to find donor tier {} or result tier {} for item {} in classification {}", __FUNCTION__, donorTier, toTier, donorItem->getClassification(), itemClassification->id);
 			sendForgeError(RETURNVALUE_CONTACTADMINISTRATOR);
 			return;
 		}
-		const auto &tierPrices = itemClassification->tiers.at(toTier);
-		cost = convergence ? tierPrices.convergenceTransferPrice : tierPrices.regularPrice;
-		coresAmount = tierPrices.corePrice;
+		const auto &resultTierPrices = itemClassification->tiers.at(toTier);
+		const auto &donorTierPrices = itemClassification->tiers.at(donorTier);
+		cost = convergence ? resultTierPrices.convergenceTransferPrice : donorTierPrices.regularPrice;
+		coresAmount = resultTierPrices.corePrice;
 		break;
 	}
 	if (!hasMatchingClassification) {

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7294,10 +7294,6 @@ void ProtocolGame::sendOpenForge() {
 			// Let's access the itemType to check the item's (donator of tier) classification level
 			// Must be the same as the item that will receive the tier
 			const ItemType &donorType = Item::items[itemId];
-			auto donorSlotPosition = donorType.slotPosition;
-			if ((donorSlotPosition & SLOTP_TWO_HAND) != 0) {
-				donorSlotPosition = SLOTP_HAND;
-			}
 
 			// Total count of item (donator of tier)
 			auto donorTierTotalItemsCount = tierAndCountMap.size();
@@ -7312,11 +7308,7 @@ void ProtocolGame::sendOpenForge() {
 			for (const auto &[iteratorItemId, unusedTierAndCountMap] : receiveTierItemMap) {
 				// Let's access the itemType to check the item's (receiver of tier) classification level
 				const ItemType &receiveType = Item::items[iteratorItemId];
-				auto receiveSlotPosition = receiveType.slotPosition;
-				if ((receiveSlotPosition & SLOTP_TWO_HAND) != 0) {
-					receiveSlotPosition = SLOTP_HAND;
-				}
-				if (donorType.upgradeClassification == receiveType.upgradeClassification && donorSlotPosition == receiveSlotPosition) {
+				if (donorType.upgradeClassification == receiveType.upgradeClassification) {
 					receiveTierTotalItemCount++;
 				}
 			}
@@ -7327,11 +7319,7 @@ void ProtocolGame::sendOpenForge() {
 				for (const auto &[receiveItemId, receiveTierAndCountMap] : receiveTierItemMap) {
 					// Let's access the itemType to check the item's (receiver of tier) classification level
 					const ItemType &receiveType = Item::items[receiveItemId];
-					auto receiveSlotPosition = receiveType.slotPosition;
-					if ((receiveSlotPosition & SLOTP_TWO_HAND) != 0) {
-						receiveSlotPosition = SLOTP_HAND;
-					}
-					if (donorType.upgradeClassification == receiveType.upgradeClassification && donorSlotPosition == receiveSlotPosition) {
+					if (donorType.upgradeClassification == receiveType.upgradeClassification) {
 						for (const auto &[receiveItemTier, receiveItemCount] : receiveTierAndCountMap) {
 							msg.add<uint16_t>(receiveItemId);
 							msg.add<uint16_t>(receiveItemCount);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7315,16 +7315,20 @@ void ProtocolGame::sendOpenForge() {
 
 			// Total count of item (receiver of tier)
 			msg.add<uint16_t>(receiveTierTotalItemCount);
-			if (receiveTierTotalItemCount > 0) {
-				for (const auto &[receiveItemId, receiveTierAndCountMap] : receiveTierItemMap) {
-					// Let's access the itemType to check the item's (receiver of tier) classification level
-					const ItemType &receiveType = Item::items[receiveItemId];
-					if (donorType.upgradeClassification == receiveType.upgradeClassification) {
-						for (const auto &[receiveItemTier, receiveItemCount] : receiveTierAndCountMap) {
-							msg.add<uint16_t>(receiveItemId);
-							msg.add<uint16_t>(receiveItemCount);
-						}
-					}
+			if (receiveTierTotalItemCount == 0) {
+				continue;
+			}
+
+			for (const auto &[receiveItemId, receiveTierAndCountMap] : receiveTierItemMap) {
+				// Let's access the itemType to check the item's (receiver of tier) classification level
+				const ItemType &receiveType = Item::items[receiveItemId];
+				if (donorType.upgradeClassification != receiveType.upgradeClassification) {
+					continue;
+				}
+
+				for (const auto &[receiveItemTier, receiveItemCount] : receiveTierAndCountMap) {
+					msg.add<uint16_t>(receiveItemId);
+					msg.add<uint16_t>(receiveItemCount);
 				}
 			}
 		}

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -7289,47 +7289,45 @@ void ProtocolGame::sendOpenForge() {
 
 	auto transferTotalCount = donorTierItemMap.size();
 	msg.addByte(transferTotalCount);
-	if (transferTotalCount > 0) {
-		for (const auto &[itemId, tierAndCountMap] : donorTierItemMap) {
-			// Let's access the itemType to check the item's (donator of tier) classification level
-			// Must be the same as the item that will receive the tier
-			const ItemType &donorType = Item::items[itemId];
+	for (const auto &[itemId, tierAndCountMap] : donorTierItemMap) {
+		// Let's access the itemType to check the item's (donator of tier) classification level
+		// Must be the same as the item that will receive the tier
+		const ItemType &donorType = Item::items[itemId];
 
-			// Total count of item (donator of tier)
-			auto donorTierTotalItemsCount = tierAndCountMap.size();
-			msg.add<uint16_t>(donorTierTotalItemsCount);
-			for (const auto &[donorItemTier, donorItemCount] : tierAndCountMap) {
-				msg.add<uint16_t>(itemId);
-				msg.addByte(donorItemTier);
-				msg.add<uint16_t>(donorItemCount);
+		// Total count of item (donator of tier)
+		auto donorTierTotalItemsCount = tierAndCountMap.size();
+		msg.add<uint16_t>(donorTierTotalItemsCount);
+		for (const auto &[donorItemTier, donorItemCount] : tierAndCountMap) {
+			msg.add<uint16_t>(itemId);
+			msg.addByte(donorItemTier);
+			msg.add<uint16_t>(donorItemCount);
+		}
+
+		uint16_t receiveTierTotalItemCount = 0;
+		for (const auto &[iteratorItemId, unusedTierAndCountMap] : receiveTierItemMap) {
+			// Let's access the itemType to check the item's (receiver of tier) classification level
+			const ItemType &receiveType = Item::items[iteratorItemId];
+			if (donorType.upgradeClassification == receiveType.upgradeClassification) {
+				receiveTierTotalItemCount++;
 			}
+		}
 
-			uint16_t receiveTierTotalItemCount = 0;
-			for (const auto &[iteratorItemId, unusedTierAndCountMap] : receiveTierItemMap) {
-				// Let's access the itemType to check the item's (receiver of tier) classification level
-				const ItemType &receiveType = Item::items[iteratorItemId];
-				if (donorType.upgradeClassification == receiveType.upgradeClassification) {
-					receiveTierTotalItemCount++;
-				}
-			}
+		// Total count of item (receiver of tier)
+		msg.add<uint16_t>(receiveTierTotalItemCount);
+		if (receiveTierTotalItemCount == 0) {
+			continue;
+		}
 
-			// Total count of item (receiver of tier)
-			msg.add<uint16_t>(receiveTierTotalItemCount);
-			if (receiveTierTotalItemCount == 0) {
+		for (const auto &[receiveItemId, receiveTierAndCountMap] : receiveTierItemMap) {
+			// Let's access the itemType to check the item's (receiver of tier) classification level
+			const ItemType &receiveType = Item::items[receiveItemId];
+			if (donorType.upgradeClassification != receiveType.upgradeClassification) {
 				continue;
 			}
 
-			for (const auto &[receiveItemId, receiveTierAndCountMap] : receiveTierItemMap) {
-				// Let's access the itemType to check the item's (receiver of tier) classification level
-				const ItemType &receiveType = Item::items[receiveItemId];
-				if (donorType.upgradeClassification != receiveType.upgradeClassification) {
-					continue;
-				}
-
-				for (const auto &[receiveItemTier, receiveItemCount] : receiveTierAndCountMap) {
-					msg.add<uint16_t>(receiveItemId);
-					msg.add<uint16_t>(receiveItemCount);
-				}
+			for (const auto &[receiveItemTier, receiveItemCount] : receiveTierAndCountMap) {
+				msg.add<uint16_t>(receiveItemId);
+				msg.add<uint16_t>(receiveItemCount);
 			}
 		}
 	}

--- a/tests/integration/game/forge_it.cpp
+++ b/tests/integration/game/forge_it.cpp
@@ -304,7 +304,7 @@ TEST_F(ForgeIntegrationTest, ForgeTransferItemTierViaGameFlowTransfersHigherTier
 	const auto* classification = fixture.getClassification();
 	ASSERT_NE(nullptr, classification);
 	const auto transferCoreCost = classification->tiers.contains(transferToTier) ? classification->tiers.at(transferToTier).corePrice : 0;
-	const auto transferGoldCost = fixture.fusionCostForTier(transferToTier);
+	const auto transferGoldCost = fixture.fusionCostForTier(transferFromTier);
 	const uint64_t dustCost = g_configManager().getNumber(FORGE_TRANSFER_DUST_COST);
 
 	setPlayerResources(dustCost, transferGoldCost + 7);
@@ -426,7 +426,7 @@ TEST_F(ForgeIntegrationTest, ForgeTransferItemTierWithIdenticalItemIdUsesDistinc
 	const auto* classification = fixture.getClassification();
 	ASSERT_NE(nullptr, classification);
 	const auto transferCoreCost = classification->tiers.contains(transferToTier) ? classification->tiers.at(transferToTier).corePrice : 0;
-	const auto transferGoldCost = fixture.fusionCostForTier(transferToTier);
+	const auto transferGoldCost = fixture.fusionCostForTier(transferFromTier);
 	const uint64_t dustCost = g_configManager().getNumber(FORGE_TRANSFER_DUST_COST);
 
 	setPlayerResources(dustCost, transferGoldCost + 7);


### PR DESCRIPTION
Restores the intended normal Forge transfer behavior and reconciles its debit with the client-visible donor-tier price.

## Fixes

- Lists normal-transfer receiver candidates by upgrade classification, regardless of equipment slot; convergence fusion remains slot-scoped and the packet shape/counts are unchanged.
- Charges normal transfers with the donor tier's regular gold price, while retaining the result tier's core requirement.
- Rejects direct cross-class transfer requests before any resource or inventory mutation.
- Updates Forge integration coverage so a tier-2-to-tier-1 transfer must deduct the tier-2 gold price.

Fixes #3251

## Tests/Validation

- Ran `git diff --check`.
- Ran `clang-format --dry-run --Werror` for the changed C++ sources and integration test.
- The integration test was not run because this task excludes compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Forge tier transfers now require compatible upgrade classifications and reject invalid non-convergence transfers from tier 0 items.
  - Non-convergence transfer costs are calculated from the donor tier.
  - Forge transfer displays now match eligible items by upgrade classification, including compatible equipment types.
  - Tier and transfer pricing validation has been improved.

- **Tests**
  - Updated forge transfer coverage to reflect donor-tier pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->