### PR TITLE
fix(actions): allow manual runes on players

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4868,7 +4868,7 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position &fromPos, uin
 
 	bool isHotkey = (fromPos.x == 0xFFFF && fromPos.y == 0 && fromPos.z == 0);
 	if (!g_configManager().getBoolean(AIMBOT_HOTKEY_ENABLED)) {
-		if (creature->getPlayer() || isHotkey) {
+		if (isHotkey) {
 			player->sendCancelMessage(RETURNVALUE_DIRECTPLAYERSHOOT);
 			return;
 		}


### PR DESCRIPTION
Restores manual rune and multi-use item targeting when only hotkey aimbot use is disabled.

## Fixes

- Limits the `hotkeyAimbotEnabled` gate in the use-with-creature path to requests marked as hotkeys.
- Allows a manually targeted player to reach the normal action/rune flow while retaining the block for hotkey-originated requests.
- Aligns the use-with-creature path with the existing item-use and item-use-ex hotkey checks.

Fixes #2542

## Tests/Validation

- Ran `git diff --check`.
- Ran `clang-format --dry-run --Werror src/game/game.cpp`.
- No build or runtime test was run because this task excludes compilation.