### PR TITLE
fix(imbuements): read configured shrine storage

### DIFF
--- a/src/creatures/players/imbuements/imbuements.cpp
+++ b/src/creatures/players/imbuements/imbuements.cpp
@@ -404,7 +404,7 @@ std::vector<Imbuement*> Imbuements::getImbuements(const std::shared_ptr<Player> 
 		// Parse the storages for each imbuement in imbuements.xml and config.lua (enable/disable storage)
 		if (g_configManager().getBoolean(TOGGLE_IMBUEMENT_SHRINE_STORAGE)
 		    && imbuement->getStorage() != 0
-		    && player->getStorageValue(imbuement->getStorage() == -1)
+		    && player->getStorageValue(imbuement->getStorage()) == -1
 		    && imbuement->getBaseID() >= 1 && imbuement->getBaseID() <= 3) {
 			continue;
 		}

--- a/tests/fixture/config/imbuements_test.lua
+++ b/tests/fixture/config/imbuements_test.lua
@@ -1,2 +1,2 @@
 coreDirectory = "tests/fixture/core"
-toggleImbuementShrineStorage = false
+toggleImbuementShrineStorage = true

--- a/tests/fixture/core/XML/imbuements.xml
+++ b/tests/fixture/core/XML/imbuements.xml
@@ -6,4 +6,8 @@
 		<attribute key="description" value="Boosts distance." />
 		<attribute key="effect" type="skill" value="distance" bonus="3" />
 	</imbuement>
+	<imbuement name="Storage Precision" base="1" category="15" iconid="2" premium="0" storage="12345">
+		<attribute key="description" value="Requires its configured storage." />
+		<attribute key="effect" type="skill" value="distance" bonus="1" />
+	</imbuement>
 </imbuements>

--- a/tests/unit/players/imbuements/imbuements_test.cpp
+++ b/tests/unit/players/imbuements/imbuements_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "creatures/players/imbuements/imbuements.hpp"
+#include "creatures/players/player.hpp"
 #include "../../../shared/imbuements/imbuements_test_fixture.hpp"
 
 namespace {
@@ -20,6 +21,16 @@ namespace {
 		EXPECT_EQ("Precision", imbuement->getName());
 		EXPECT_EQ("Boosts distance.", imbuement->getDescription());
 		EXPECT_EQ(3, imbuement->skills[SKILL_DISTANCE]);
+	}
+
+	TEST_F(ImbuementsUnitTest, UsesConfiguredStorageToFilterImbuements) {
+		auto player = std::make_shared<Player>();
+		player->addStorageValue(12345, 1);
+
+		auto imbuements = g_imbuements().getImbuements(player);
+		ASSERT_EQ(2u, imbuements.size());
+		EXPECT_EQ("Precision", imbuements[0]->getName());
+		EXPECT_EQ("Storage Precision", imbuements[1]->getName());
 	}
 
 } // namespace


### PR DESCRIPTION
Corrects shrine storage filtering so custom imbuements consult their declared storage key.

## Fixes

- Passes `Imbuement::getStorage()` itself to `Player::getStorageValue` instead of passing the boolean result of a comparison.
- Restores visibility of an imbuement once its own configured storage has been set while `toggleImbuementShrineStorage` is enabled.
- Adds a focused unit regression fixture for a storage-gated imbuement.

Fixes #3347

## Tests/Validation

- Parsed the changed imbuement XML fixture.
- Ran `git diff --check`.
- Ran `clang-format --dry-run --Werror` for the changed C++ sources.
- The unit test was not run because this task excludes compilation.