### PR TITLE
ci: reduce Actions cache usage and fix cleanup

### DIFF
--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -1,30 +1,46 @@
 ---
-name: Cleanup caches by a branch
+name: Cleanup Actions caches
+
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
+  delete:
+
+permissions:
+  contents: read
 
 jobs:
-  cleanup:
+  cleanup-pull-request:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - name: Cleanup
-        run: |
-          gh extension install actions/gh-actions-cache
-
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )
-
-          ## Setting this to not fail the workflow while deleting cache keys.
-          set +e
-          echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
-          do
-              gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
-          done
-          echo "Done"
+      - name: Delete pull request caches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+          CACHE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: >-
+          gh cache delete --all
+          --ref "$CACHE_REF"
+          --repo "$GITHUB_REPOSITORY"
+          --succeed-on-no-caches
+
+  cleanup-branch:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete branch caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CACHE_REF: refs/heads/${{ github.event.ref }}
+        run: >-
+          gh cache delete --all
+          --ref "$CACHE_REF"
+          --repo "$GITHUB_REPOSITORY"
+          --succeed-on-no-caches

--- a/.github/workflows/reusable-build-docker.yml
+++ b/.github/workflows/reusable-build-docker.yml
@@ -92,7 +92,7 @@ jobs:
             ghcr.io/${{ steps.repo_lower.outputs.value }}:latest
             ghcr.io/${{ steps.repo_lower.outputs.value }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Build and export (PR)
         if: github.event_name != 'push' || github.ref != 'refs/heads/main'
@@ -111,7 +111,6 @@ jobs:
           tags: |
             ghcr.io/${{ steps.repo_lower.outputs.value }}:pr
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Validate Docker image (PR)
         if: github.event_name != 'push' || github.ref != 'refs/heads/main'


### PR DESCRIPTION
This change reduces GitHub Actions cache pressure by keeping one authoritative Docker BuildKit cache on `main` and making cache cleanup reliable for pull requests and deleted branches.

### Fixes

- Run closed pull request cleanup through `pull_request_target`, which provides the `actions: write` permission required to remove caches created by fork-owned PRs.
- Keep the privileged cleanup safe by avoiding checkout and execution of pull request code.
- Replace the extension/list loop with `gh cache delete --all` scoped to the exact pull request merge ref.
- Stop suppressing deletion errors, so permission or API failures are visible instead of producing a misleading successful run.

### Improvements

- Delete branch-scoped caches when a branch is removed, including temporary dependency-update branches.
- Make pull request Docker builds restore-only: they reuse the default branch BuildKit cache but no longer publish a separate full `mode=max` cache for every PR.
- Keep `main` responsible for publishing the complete reusable BuildKit cache, while treating cache-export backend/quota failures as non-blocking for the image build itself.

### Tests/Validation

- `actionlint .github/workflows/clean-cache.yaml .github/workflows/reusable-build-docker.yml`
- `git diff --check`
- GitHub Actions `yamllint`, fast checks, Lua checks, cppcheck, SonarCloud, Docker image build, and Docker quickstart smoke passed.
- The PR Docker build completed without creating any cache under `refs/pull/4123/merge`, confirming restore-only behavior.
- A one-time cleanup removed 178 legacy PR-scoped BuildKit caches (9.531 GiB) with no deletion failures. Repository cache usage dropped from 10.088 GiB to 0.557 GiB while preserving the default-branch BuildKit cache and the existing mise, ccache, map, and other non-BuildKit caches.
- The event-driven cleanup jobs can only execute from the default branch after merge; their syntax and command usage were validated statically in this PR.

Expected behavior before this change: fork PR cleanup could receive a read-only token and silently leave caches behind, deleted branches retained branch-scoped entries, and each Docker PR exported another full BuildKit cache.

Expected behavior after this change: closed PR and deleted-branch caches are removed with explicit failure reporting, PR Docker builds restore from the shared `main` cache without exporting their own cache, and `main` remains the single cache producer.