### PR TITLE
feat: name runtime threads and document hardware sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ environment variables, test account, and troubleshooting guide.
 
 ## Documentation
 
+- [Hardware sizing and capacity planning](docs/hardware-sizing.md). Measure
+  RAM and CPU, compare training and hunting workloads, and review capacity.
 - [Shared build cache for worktrees and forks](docs/development/shared-build-cache.md).
 - [Docker beginner quickstart](docs/docker/quickstart-for-beginners.md).
 - [Multiprotocol runtime profiles](docs/systems/multiprotocol.md). Covers the

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ references in the surrounding subdirectories:
 | [`architecture.md`](architecture.md)      | System design, components and technical architecture                 |
 | [`development.md`](development.md)        | Development environment, coding standards and contribution workflow  |
 | [`operations.md`](operations.md)          | Deployment, monitoring, security, backups and production operations  |
+| [`hardware-sizing.md`](hardware-sizing.md) | RAM/CPU estimates, player activity and hardware capacity planning |
 | [`systems/content-reference-auditor.md`](systems/content-reference-auditor.md) | Profile-aware gameplay content and identifier auditing |
 
 ---

--- a/docs/hardware-sizing.md
+++ b/docs/hardware-sizing.md
@@ -1,0 +1,139 @@
+# Hardware Sizing and Capacity Planning
+
+Size a Canary server for its map, scripts, player activity and target response
+times. Estimate a range for that workload and build, with reserve for busy
+periods; online population alone does not determine RAM or CPU requirements.
+
+## Measure Player Activity
+
+The same number of connected players can generate very different workloads:
+
+| Activity | Work to account for |
+| --- | --- |
+| Idle or online training | Connected player state, periodic updates, training actions and any recurring spells or custom scripts. Training still consumes resources. |
+| Hunting | Movement, pathfinding, active monster AI, combat, loot, scripts and updates sent to nearby players. |
+| Crowded events or PvP | Interactions between nearby creatures, area effects and updates reaching many spectators. Concentrated activity can cost more than the same population spread across the map. |
+
+Compare similar activity mixes; a multiplier such as "one hunter equals five
+trainers" needs measurement. Count actual connected sessions consistently:
+website/status counters may apply filters, and offline training is not a
+connected session. Total spawned monsters also differ from active monsters.
+
+## Collect a Representative Baseline
+
+Start with a full weekly cycle, including busy hours, saves and events; two to
+four weeks can improve coverage. Even a long record with little load variation
+cannot establish the cost of growth.
+
+Record these measurements over aligned time windows:
+
+- **Population:** actual online sessions and available aggregate activity counters.
+- **CPU:** process, dispatcher and worker utilization, plus host contention and
+  VM limits. A saturated dispatcher can constrain the game while other cores idle.
+- **Memory:** resident memory (RSS), available host memory, swap and memory
+  pressure. Account for the database, website and other services on the machine.
+- **Service quality:** queue/scheduling delays, errors and rejected work where
+  exposed. Keep averages, p95/p99, maxima and overload duration, with the sampling
+  window stated. A p99 covers 99% of observations; it is not a maximum.
+- **Context:** build, configuration, map, hardware and uptime. Separate records
+  after substantial changes.
+
+On Linux and supported Windows versions, threads are named `canary-dispatch`
+for the dispatcher, `canary-wrk-N` for general pool workers, and `canary-ai`
+for dedicated monster compute workers. These labels help identify CPU activity
+in thread views of tools that display OS thread names, such as `htop`, `ps` and
+`perf` on Linux;
+use the process/thread IDs to distinguish workers sharing a label. Windows uses
+[`SetThreadDescription`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription),
+available from Windows 10 version 1607 and Windows Server 2016, with runtime
+detection so older systems retain their default names. Thread naming is
+best-effort and runs at startup, without per-task renaming. Other platforms
+currently keep their default names.
+Threads share process memory; do not sum RSS repeated in a thread view when
+estimating the server's RAM usage.
+
+Consider cheap OS counters every 5 seconds and population snapshots every
+30–60 seconds. Validate overhead, bound retention and analyze outside the game
+process. Five-second averages can hide shorter spikes. Avoid frequent scans of
+game entities, full memory-map scans, continuous profiling and per-player logging
+for this initial estimate. For optional application telemetry, see
+[Metrics](../metrics/README.md); check availability and overhead before enabling it.
+
+Utilization should be interpreted alongside latency and saturation, as described
+in [Google SRE's monitoring guidance](https://sre.google/sre-book/monitoring-distributed-systems/).
+Linux documents [RSS and available memory](https://docs.kernel.org/filesystems/proc.html)
+and [resource pressure (PSI)](https://docs.kernel.org/accounting/psi.html).
+RSS is approximate and does not represent total host memory demand.
+
+## Calculate Average and Incremental Resource Use
+
+Express process CPU in **core equivalents** so percentages have an explicit
+denominator:
+
+```text
+CPU core equivalents = change in process CPU seconds / elapsed wall seconds
+```
+
+For example, 0.40 core equivalents means 40% of one logical CPU, not 40% of the
+whole machine. A multithreaded process can exceed 1.0.
+
+For comparable, stable windows, let `N` be the average online session count,
+`R` the average RSS in MiB and `C` the CPU core equivalents:
+
+```text
+Average RAM per online session = R / N                         (N > 0)
+Average CPU per online session = C / N                         (N > 0)
+Estimated additional RAM per session = (R2 - R1) / (N2 - N1)   (N2 > N1)
+Estimated additional CPU per session = (C2 - C1) / (N2 - N1)   (N2 > N1)
+```
+
+**Illustrative numbers only; these are not measured Canary requirements:**
+
+| Comparable window | Average online sessions | Average RSS | CPU core equivalents |
+| --- | ---: | ---: | ---: |
+| A | 100 | 4,000 MiB | 0.40 |
+| B | 200 | 5,000 MiB | 0.65 |
+
+The average RAM per session falls from **40 MiB** to **25 MiB**, because shared
+memory is spread across more sessions. The estimated incremental use is
+**10 MiB** and **0.0025 core equivalents** per additional session. The implied
+RAM baseline is **3,000 MiB**: doubling population need not double total memory.
+
+Real estimates need more windows with comparable activity, world state and
+uptime. Map loading, items, Lua state, caches and allocator retention affect RAM;
+RSS may stay high after players leave. Investigate persistent growth at similar
+loads. Estimate peaks separately from averages, validate predictions on later
+days, and report uncertainty. Do not project far beyond the observed population
+or infer a player limit from average CPU alone: consumed CPU can plateau while
+queues and delays continue growing.
+
+## Choose Hardware and Review Capacity
+
+Compare machines using the same representative Canary workload in a test
+environment. Per-core performance, cache, memory latency/bandwidth, build options
+and VPS contention matter. DDR4/DDR5 describes performance characteristics, not
+a conversion of required RAM capacity. GHz and vCPU counts alone are insufficient;
+the [SPEC overview](https://www.spec.org/cpu2017/Docs/overview.html) explains why
+the actual application and workload are the best comparison.
+
+- **Increase capacity** before expected busy-period demand exhausts the limiting
+  resource. Check whether delays require more resources or a fix for a blocking
+  script/database operation.
+- **Keep capacity** when service targets and reserve are met, or evidence for a
+  smaller machine is insufficient.
+- **Consider reducing capacity** after sustained spare capacity across busy
+  periods, with a smaller candidate able to cover peaks, retained memory and
+  other services. An initial reserve of 25–30% unused capacity is a planning
+  example to validate, not a universal safe threshold. A quiet night or restart
+  is insufficient evidence.
+
+Use different thresholds and observation periods for increases and reductions,
+with a minimum interval between changes. Update recommendations as data arrives;
+schedule resizing around maintenance and provider constraints. A stop/start may
+be required, as documented for
+[Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/change-instance-type-of-ebs-backed-instance.html).
+
+State the workload, observed population range, limiting resource, uncertainty
+and reserve with each recommendation. For financial cost, divide the period's
+actual hosting cost by its total connected player-hours; an upgrade instead
+depends on plan price differences and migration costs.

--- a/src/game/scheduling/dispatcher.cpp
+++ b/src/game/scheduling/dispatcher.cpp
@@ -131,6 +131,8 @@ void Dispatcher::init() {
 	auto futureStarted = dispatcherStarted->get_future();
 
 	threadPool.detach_task([this, dispatcherStarted]() mutable {
+		ThreadPool::setCurrentThreadName("canary-dispatch");
+
 		std::unique_lock asyncLock(dummyMutex);
 
 		dispatcherStarted->set_value();

--- a/src/game/scheduling/monster_compute_service.cpp
+++ b/src/game/scheduling/monster_compute_service.cpp
@@ -10,6 +10,7 @@
 #include "game/scheduling/monster_compute_service.hpp"
 
 #include "lib/di/container.hpp"
+#include "lib/thread/thread_pool.hpp"
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <algorithm>
@@ -82,6 +83,7 @@ void MonsterComputeService::start(MonsterComputeConfig config) {
 		workers.reserve(workerCount);
 		for (size_t index = 0; index < workerCount; ++index) {
 			workers.emplace_back([this](std::stop_token stopToken) {
+				ThreadPool::setCurrentThreadName("canary-ai");
 				workerLoop(stopToken);
 			});
 		}

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -13,8 +13,11 @@
 #include "utils/tools.hpp"
 #include "lib/di/container.hpp"
 
-#include <cstdio>
 #include <csignal>
+
+#ifdef _WIN32
+	#include <Windows.h>
+#endif
 
 #ifdef __linux__
 	#include <pthread.h>
@@ -22,11 +25,9 @@
 
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <algorithm>
-	#include <iterator>
-
-	#ifdef _WIN32
-		#include <windows.h>
-	#endif
+	#include <array>
+	#include <charconv>
+	#include <system_error>
 #endif
 
 /**
@@ -39,6 +40,10 @@
 #ifndef DEFAULT_NUMBER_OF_THREADS
 	#define DEFAULT_NUMBER_OF_THREADS 4
 #endif
+
+namespace {
+	constexpr std::size_t ThreadNameCapacity = 16;
+}
 
 ThreadPool &ThreadPool::getInstance() {
 	return inject<ThreadPool>();
@@ -57,29 +62,28 @@ ThreadPool::ThreadPool(Logger &logger, uint32_t threadCount) :
 
 void ThreadPool::setCurrentThreadName(std::string_view name) noexcept {
 #if defined(__linux__) || defined(_WIN32)
-	char threadName[16] = {};
-	const auto length = std::min<std::size_t>(name.size(), sizeof(threadName) - 1);
-	for (std::size_t i = 0; i < length; ++i) {
-		threadName[i] = name[i];
-	}
+	std::array<char, ThreadNameCapacity> threadName {};
+	const auto length = std::min<std::size_t>(name.size(), threadName.size() - 1);
+	std::copy_n(name.begin(), length, threadName.begin());
 #endif
 
 #ifdef __linux__
-	(void)pthread_setname_np(pthread_self(), threadName);
+	(void)pthread_setname_np(pthread_self(), threadName.data());
 #elif defined(_WIN32)
 	using SetThreadDescriptionFunction = HRESULT(WINAPI*)(HANDLE, PCWSTR);
-	static const auto setThreadDescription = []() noexcept -> SetThreadDescriptionFunction {
+	static const auto setThreadDescription = []() noexcept {
 		// Runtime lookup also supports Windows 10 1607 and Windows Server 2016.
 		const auto kernelBase = GetModuleHandleW(L"KernelBase.dll");
-		return kernelBase ? reinterpret_cast<SetThreadDescriptionFunction>(GetProcAddress(kernelBase, "SetThreadDescription")) : nullptr;
+		const auto function = kernelBase ? GetProcAddress(kernelBase, "SetThreadDescription") : nullptr;
+		return function ? reinterpret_cast<SetThreadDescriptionFunction>(function) : nullptr; // NOSONAR: The Win32 API requires converting FARPROC to the typed function pointer.
 	}();
 	if (!setThreadDescription) {
 		return;
 	}
 
-	wchar_t wideName[16] = {};
-	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, threadName, -1, wideName, static_cast<int>(std::size(wideName))) > 0) {
-		(void)setThreadDescription(GetCurrentThread(), wideName);
+	std::array<wchar_t, ThreadNameCapacity> wideName {};
+	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, threadName.data(), -1, wideName.data(), static_cast<int>(wideName.size())) > 0) {
+		(void)setThreadDescription(GetCurrentThread(), wideName.data());
 	}
 #else
 	(void)name;
@@ -87,9 +91,17 @@ void ThreadPool::setCurrentThreadName(std::string_view name) noexcept {
 }
 
 void ThreadPool::setWorkerThreadName(const std::size_t index) noexcept {
-	char threadName[16] = {};
-	(void)std::snprintf(threadName, sizeof(threadName), "canary-wrk-%zu", index);
-	setCurrentThreadName(threadName);
+	constexpr std::string_view workerPrefix = "canary-wrk-";
+	std::array<char, ThreadNameCapacity> threadName {};
+	std::copy_n(workerPrefix.begin(), workerPrefix.size(), threadName.begin());
+
+	const auto [nameEnd, error] = std::to_chars(threadName.data() + workerPrefix.size(), threadName.data() + threadName.size() - 1, index);
+	if (error != std::errc {}) {
+		setCurrentThreadName("canary-wrk");
+		return;
+	}
+
+	setCurrentThreadName({ threadName.data(), static_cast<std::size_t>(nameEnd - threadName.data()) });
 }
 
 void ThreadPool::start() const {

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -13,7 +13,21 @@
 #include "utils/tools.hpp"
 #include "lib/di/container.hpp"
 
+#include <cstdio>
 #include <csignal>
+
+#ifdef __linux__
+	#include <pthread.h>
+#endif
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <algorithm>
+	#include <iterator>
+
+	#ifdef _WIN32
+		#include <windows.h>
+	#endif
+#endif
 
 /**
  * Regardless of how many cores your computer have, we want at least
@@ -33,9 +47,49 @@ ThreadPool &ThreadPool::getInstance() {
 ThreadPool::ThreadPool(Logger &logger, uint32_t threadCount) :
 	logger(logger),
 	pool { std::make_unique<BS::thread_pool<BS::tp::none>>(
-		threadCount > 0 ? threadCount : std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS)
+		threadCount > 0 ? threadCount : std::max<int>(getNumberOfCores(), DEFAULT_NUMBER_OF_THREADS),
+		[](const std::size_t index) noexcept {
+			ThreadPool::setWorkerThreadName(index);
+		}
 	) } {
 	start();
+}
+
+void ThreadPool::setCurrentThreadName(std::string_view name) noexcept {
+#if defined(__linux__) || defined(_WIN32)
+	char threadName[16] = {};
+	const auto length = std::min<std::size_t>(name.size(), sizeof(threadName) - 1);
+	for (std::size_t i = 0; i < length; ++i) {
+		threadName[i] = name[i];
+	}
+#endif
+
+#ifdef __linux__
+	(void)pthread_setname_np(pthread_self(), threadName);
+#elif defined(_WIN32)
+	using SetThreadDescriptionFunction = HRESULT(WINAPI*)(HANDLE, PCWSTR);
+	static const auto setThreadDescription = []() noexcept -> SetThreadDescriptionFunction {
+		// Runtime lookup also supports Windows 10 1607 and Windows Server 2016.
+		const auto kernelBase = GetModuleHandleW(L"KernelBase.dll");
+		return kernelBase ? reinterpret_cast<SetThreadDescriptionFunction>(GetProcAddress(kernelBase, "SetThreadDescription")) : nullptr;
+	}();
+	if (!setThreadDescription) {
+		return;
+	}
+
+	wchar_t wideName[16] = {};
+	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, threadName, -1, wideName, static_cast<int>(std::size(wideName))) > 0) {
+		(void)setThreadDescription(GetCurrentThread(), wideName);
+	}
+#else
+	(void)name;
+#endif
+}
+
+void ThreadPool::setWorkerThreadName(const std::size_t index) noexcept {
+	char threadName[16] = {};
+	(void)std::snprintf(threadName, sizeof(threadName), "canary-wrk-%zu", index);
+	setCurrentThreadName(threadName);
 }
 
 void ThreadPool::start() const {

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -64,7 +64,8 @@ void ThreadPool::setCurrentThreadName(std::string_view name) noexcept {
 #if defined(__linux__) || defined(_WIN32)
 	std::array<char, ThreadNameCapacity> threadName {};
 	const auto length = std::min<std::size_t>(name.size(), threadName.size() - 1);
-	std::copy_n(name.begin(), length, threadName.begin());
+	const auto threadNameEnd = std::copy_n(name.begin(), length, threadName.begin());
+	*threadNameEnd = '\0';
 #endif
 
 #ifdef __linux__
@@ -93,9 +94,9 @@ void ThreadPool::setCurrentThreadName(std::string_view name) noexcept {
 void ThreadPool::setWorkerThreadName(const std::size_t index) noexcept {
 	constexpr std::string_view workerPrefix = "canary-wrk-";
 	std::array<char, ThreadNameCapacity> threadName {};
-	std::copy_n(workerPrefix.begin(), workerPrefix.size(), threadName.begin());
+	const auto indexStart = std::copy_n(workerPrefix.begin(), workerPrefix.size(), threadName.begin());
 
-	const auto [nameEnd, error] = std::to_chars(threadName.data() + workerPrefix.size(), threadName.data() + threadName.size() - 1, index);
+	const auto [nameEnd, error] = std::to_chars(indexStart, threadName.data() + threadName.size() - 1, index);
 	if (error != std::errc {}) {
 		setCurrentThreadName("canary-wrk");
 		return;

--- a/src/lib/thread/thread_pool.cpp
+++ b/src/lib/thread/thread_pool.cpp
@@ -95,8 +95,9 @@ void ThreadPool::setWorkerThreadName(const std::size_t index) noexcept {
 	constexpr std::string_view workerPrefix = "canary-wrk-";
 	std::array<char, ThreadNameCapacity> threadName {};
 	const auto indexStart = std::copy_n(workerPrefix.begin(), workerPrefix.size(), threadName.begin());
+	const auto indexOffset = static_cast<std::size_t>(indexStart - threadName.begin());
 
-	const auto [nameEnd, error] = std::to_chars(indexStart, threadName.data() + threadName.size() - 1, index);
+	const auto [nameEnd, error] = std::to_chars(threadName.data() + indexOffset, threadName.data() + threadName.size() - 1, index);
 	if (error != std::errc {}) {
 		setCurrentThreadName("canary-wrk");
 		return;

--- a/src/lib/thread/thread_pool.hpp
+++ b/src/lib/thread/thread_pool.hpp
@@ -11,6 +11,8 @@
 
 #include "BS_thread_pool.hpp"
 
+#include <string_view>
+
 class ThreadPool {
 public:
 	explicit ThreadPool(Logger &logger, const uint32_t threadCount = std::thread::hardware_concurrency());
@@ -44,6 +46,8 @@ public:
 		return pool->get_thread_count();
 	}
 
+	static void setCurrentThreadName(std::string_view name) noexcept;
+
 	void start() const;
 	void shutdown();
 
@@ -64,6 +68,8 @@ public:
 	}
 
 private:
+	static void setWorkerThreadName(std::size_t index) noexcept;
+
 	std::mutex mutex;
 	std::condition_variable condition;
 


### PR DESCRIPTION
OS thread views make it difficult to distinguish dispatcher work from general pool and monster AI work. This PR adds runtime role labels on Linux and supported Windows versions, together with a guide for estimating CPU and RAM requirements from player activity and representative measurements.

## Features

Assign descriptive names when runtime threads initialize:

| Thread role | OS thread name | Naming point |
| --- | --- | --- |
| General pool worker | `canary-wrk-N` | Pool worker initialization callback |
| Game dispatcher | `canary-dispatch` | Before entering the dispatcher loop |
| Dedicated monster compute worker | `canary-ai` | Worker entry, before its compute loop |

- Use `pthread_setname_np` on Linux and dynamically resolve `SetThreadDescription` from the loaded `KernelBase.dll` on Windows. Runtime lookup supports the API available from Windows 10 version 1607 and Windows Server 2016 while allowing older systems to retain their existing names.
- Include the Win32 dependency independently of the precompiled-header setting. This keeps the Windows path self-contained in both PCH and non-PCH builds.
- Keep naming best effort and `noexcept`, with bounded `std::array` stack buffers. Worker indices use `std::to_chars` with a `char*` range derived from the copied prefix; Windows labels are converted from UTF-8 to UTF-16. Unavailable APIs, conversion failures and labels that cannot include an index retain a generic diagnostic name.
- Set labels during initialization, without per-task renaming or changes to scheduling, thread ownership or shutdown. Thread IDs distinguish workers that share a label.

## Documentation

- Add `docs/hardware-sizing.md`, linked from the root README and documentation index, so the detailed guidance lives in `docs/`.
- Explain how online training, hunting and crowded events generate different workloads, and why connected-player counts alone cannot determine server capacity.
- Describe representative observation periods, low-frequency OS sampling, average versus incremental RAM/CPU use, peak demand, dispatcher saturation and shared process memory. Include explicitly illustrative calculations and the limits of extrapolation.
- Cover hardware comparisons, uncertainty, reserve capacity and sustained observation criteria for increasing or reducing resources. Document the thread labels and link to the existing metrics documentation and public technical references.

## Fixes

- Address the Copilot finding that the Windows naming implementation depended on `<Windows.h>` only when precompiled headers were disabled.
- Replace raw character arrays and `snprintf` in the naming helper with bounded standard-library equivalents, retaining the iterators returned by `std::copy_n`.
- Pass a `char*` range to `std::to_chars`, because MSVC does not accept `std::array<char, N>::iterator` for that API.
- Keep the `GetProcAddress` conversion locally documented because the Win32 dynamic-linking API returns `FARPROC` and requires conversion to the typed function pointer.

## Tests/Validation

- **Passed:** changed-line clang-format 21.1.0 checks for all four C++ files and `git diff --check`.
- **Reviewed:** the BS thread-pool initializer contract, existing source registration and `Threads::Threads` linkage.
- **Passed:** a temporary local Windows Python process resolved the API from `KernelBase.dll`, converted and assigned all three role labels, read each back with `GetThreadDescription`, and restored its original name. This validates the OS API path; it does not validate the compiled C++ implementation.
- **Passed:** documentation relative-link resolution, balanced fenced blocks and portability checks.
- **CI context:** the first Windows CMake job failed because the hosted runner lost communication during CMake, with no compiler diagnostic. A later CI run exposed and localized an MSVC `std::to_chars` argument mismatch in both Windows variants; this PR now passes a character-pointer range and has started another CI run.
- **Not validated locally:** native Canary compilation, runtime name visibility, initialization/shutdown behavior, older-Windows fallback and startup overhead. No CPU/RAM improvement or measured player-capacity claim is made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic names for dispatcher, worker, and AI threads to make system activity easier to identify in monitoring tools.

* **Documentation**
  * Added a hardware-sizing guide covering RAM, CPU, player activity, workload measurement, and capacity planning.
  * Added links to the new guide in the main documentation indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->