### PR TITLE
fix(items): normalize active equipment on creation

### DIFF
--- a/data/scripts/talkactions/player/refill.lua
+++ b/data/scripts/talkactions/player/refill.lua
@@ -11,7 +11,7 @@ local chargeItem = {
 	["spiritthorn ring"] = { noChargeID = 39179, ChargeID = 39177, cost = 5 },
 	["alicorn ring"] = { noChargeID = 39182, ChargeID = 39180, cost = 5 },
 	["arcanomancer sigil"] = { noChargeID = 39185, ChargeID = 39183, cost = 5 },
-	["arboreal ring"] = { noChargeID = 39188, ChargeID = 39187, cost = 5 },
+	["arboreal ring"] = { noChargeID = 39188, ChargeID = 39186, cost = 5 },
 }
 local silverTokenID = 22516
 

--- a/src/items/functions/item/item_parse.cpp
+++ b/src/items/functions/item/item_parse.cpp
@@ -1023,6 +1023,9 @@ void ItemParse::createAndRegisterScript(ItemType &itemType, pugi::xml_node attri
 		moveevent = std::make_shared<MoveEvent>();
 		moveevent->setItemId(itemType.id);
 		moveevent->setEventType(eventType);
+		if (eventType == MOVE_EVENT_DEEQUIP) {
+			itemType.hasDeEquipEvent = true;
+		}
 
 		if (eventType == MOVE_EVENT_EQUIP) {
 			moveevent->equipFunction = moveevent->EquipItem;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -391,20 +391,6 @@ std::shared_ptr<Item> Item::createItemBatch(uint16_t itemId, uint32_t count, uin
 };
 
 std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/, Position* itemPosition /*= nullptr*/, bool createWrappableItem /* false*/, bool customCharges /* false */) {
-	// A map which contains items that, when on creating, should be transformed to the default type.
-	static const phmap::flat_hash_map<ItemID_t, ItemID_t> ItemTransformationMap = {
-		{ ITEM_SWORD_RING_ACTIVATED, ITEM_SWORD_RING },
-		{ ITEM_CLUB_RING_ACTIVATED, ITEM_CLUB_RING },
-		{ ITEM_DWARVEN_RING_ACTIVATED, ITEM_DWARVEN_RING },
-		{ ITEM_RING_HEALING_ACTIVATED, ITEM_RING_HEALING },
-		{ ITEM_STEALTH_RING_ACTIVATED, ITEM_STEALTH_RING },
-		{ ITEM_TIME_RING_ACTIVATED, ITEM_TIME_RING },
-		{ ITEM_PAIR_SOFT_BOOTS_ACTIVATED, ITEM_PAIR_SOFT_BOOTS },
-		{ ITEM_DEATH_RING_ACTIVATED, ITEM_DEATH_RING },
-		{ ITEM_PRISMATIC_RING_ACTIVATED, ITEM_PRISMATIC_RING },
-		{ ITEM_OLD_DIAMOND_ARROW, ITEM_DIAMOND_ARROW },
-	};
-
 	std::shared_ptr<Item> newItem = nullptr;
 
 	const ItemType &it = Item::items[type];
@@ -446,12 +432,12 @@ std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0
 		} else if (it.isBed()) {
 			newItem = std::make_shared<BedItem>(type);
 		} else {
-			const auto itemMap = ItemTransformationMap.find(static_cast<ItemID_t>(it.id));
-			if (itemMap != ItemTransformationMap.end()) {
-				newItem = std::make_shared<Item>(itemMap->second, count);
-			} else {
-				newItem = std::make_shared<Item>(type, count);
+			uint16_t creationType = it.transformDeEquipTo != 0 ? it.transformDeEquipTo : type;
+			// The old Diamond Arrow is a legacy asset alias, not an equipment state.
+			if (it.id == ITEM_OLD_DIAMOND_ARROW) {
+				creationType = ITEM_DIAMOND_ARROW;
 			}
+			newItem = std::make_shared<Item>(creationType, count);
 		}
 	} else if (type > 0 && itemPosition) {
 		const auto position = *itemPosition;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -432,7 +432,7 @@ std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0
 		} else if (it.isBed()) {
 			newItem = std::make_shared<BedItem>(type);
 		} else {
-			uint16_t creationType = it.transformDeEquipTo != 0 ? it.transformDeEquipTo : type;
+			uint16_t creationType = it.isActiveEquipment() ? it.transformDeEquipTo : type;
 			// The old Diamond Arrow is a legacy asset alias, not an equipment state.
 			if (it.id == ITEM_OLD_DIAMOND_ARROW) {
 				creationType = ITEM_DIAMOND_ARROW;

--- a/src/items/items.hpp
+++ b/src/items/items.hpp
@@ -188,6 +188,10 @@ public:
 	bool hasSubType() const {
 		return (isFluidContainer() || isSplash() || stackable || charges != 0);
 	}
+	[[nodiscard]] bool isActiveEquipment() const {
+		// Legacy timed equipment may omit a move event but decay directly to the same inactive state used on de-equip.
+		return transformDeEquipTo != 0 && (hasDeEquipEvent || (decayTime != 0 && decayTo == transformDeEquipTo));
+	}
 	bool isWeapon() const {
 		return weaponType != WEAPON_NONE && weaponType != WEAPON_SHIELD && weaponType != WEAPON_AMMO;
 	}
@@ -367,6 +371,7 @@ public:
 	bool allowDistRead = false;
 	bool lookThrough = false;
 	bool stopTime = false;
+	bool hasDeEquipEvent = false;
 	bool showCount = true;
 	bool stackable = false;
 	bool isPodium = false;

--- a/tests/unit/items/CMakeLists.txt
+++ b/tests/unit/items/CMakeLists.txt
@@ -1,5 +1,4 @@
 target_sources(
     canary_ut
-    PRIVATE containers/container_test.cpp
-            item_creation_test.cpp
+    PRIVATE containers/container_test.cpp item_creation_test.cpp
 )

--- a/tests/unit/items/CMakeLists.txt
+++ b/tests/unit/items/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(
     canary_ut
     PRIVATE containers/container_test.cpp
+            item_creation_test.cpp
 )

--- a/tests/unit/items/item_creation_test.cpp
+++ b/tests/unit/items/item_creation_test.cpp
@@ -8,6 +8,7 @@
  */
 
 #ifndef USE_PRECOMPILED_HEADERS
+	#include <array>
 	#include <optional>
 	#include <utility>
 #endif
@@ -18,8 +19,22 @@
 #include "items/items.hpp"
 
 namespace {
+	constexpr uint16_t TEST_RECIPROCAL_TRANSFORM_TARGET_ID = 64998;
+	constexpr uint16_t TEST_RECIPROCAL_NON_EQUIPMENT_ID = 64999;
+	constexpr uint16_t TEST_TIMED_TRANSFORM_TARGET_ID = 65000;
+	constexpr uint16_t TEST_TIMED_TARGET_NON_EQUIPMENT_ID = 65001;
 	constexpr uint16_t TEST_PAUSED_EQUIPMENT_ID = 65002;
 	constexpr uint16_t TEST_ACTIVE_EQUIPMENT_ID = 65003;
+	constexpr uint16_t TEST_TIMED_ACTIVE_EQUIPMENT_ID = 65004;
+	constexpr std::array TEST_ITEM_IDS = {
+		TEST_RECIPROCAL_TRANSFORM_TARGET_ID,
+		TEST_RECIPROCAL_NON_EQUIPMENT_ID,
+		TEST_TIMED_TRANSFORM_TARGET_ID,
+		TEST_TIMED_TARGET_NON_EQUIPMENT_ID,
+		TEST_PAUSED_EQUIPMENT_ID,
+		TEST_ACTIVE_EQUIPMENT_ID,
+		TEST_TIMED_ACTIVE_EQUIPMENT_ID,
+	};
 
 	class ItemCreationTest : public testing::Test {
 	protected:
@@ -27,15 +42,34 @@ namespace {
 			auto &items = Item::items.getItems();
 			originalItemsSize = items.size();
 
-			if (TEST_PAUSED_EQUIPMENT_ID < originalItemsSize) {
-				originalPausedItem.emplace(std::move(items[TEST_PAUSED_EQUIPMENT_ID]));
+			for (size_t index = 0; index < TEST_ITEM_IDS.size(); ++index) {
+				if (TEST_ITEM_IDS[index] < originalItemsSize) {
+					originalItems[index].emplace(std::move(items[TEST_ITEM_IDS[index]]));
+				}
 			}
-			if (TEST_ACTIVE_EQUIPMENT_ID < originalItemsSize) {
-				originalActiveItem.emplace(std::move(items[TEST_ACTIVE_EQUIPMENT_ID]));
+			if (items.size() <= TEST_TIMED_ACTIVE_EQUIPMENT_ID) {
+				items.resize(TEST_TIMED_ACTIVE_EQUIPMENT_ID + 1);
 			}
-			if (items.size() <= TEST_ACTIVE_EQUIPMENT_ID) {
-				items.resize(TEST_ACTIVE_EQUIPMENT_ID + 1);
-			}
+
+			auto &reciprocalTransformTarget = items[TEST_RECIPROCAL_TRANSFORM_TARGET_ID];
+			reciprocalTransformTarget = ItemType {};
+			reciprocalTransformTarget.id = TEST_RECIPROCAL_TRANSFORM_TARGET_ID;
+			reciprocalTransformTarget.transformEquipTo = TEST_RECIPROCAL_NON_EQUIPMENT_ID;
+
+			auto &reciprocalNonEquipmentType = items[TEST_RECIPROCAL_NON_EQUIPMENT_ID];
+			reciprocalNonEquipmentType = ItemType {};
+			reciprocalNonEquipmentType.id = TEST_RECIPROCAL_NON_EQUIPMENT_ID;
+			reciprocalNonEquipmentType.transformDeEquipTo = TEST_RECIPROCAL_TRANSFORM_TARGET_ID;
+
+			auto &timedTransformTarget = items[TEST_TIMED_TRANSFORM_TARGET_ID];
+			timedTransformTarget = ItemType {};
+			timedTransformTarget.id = TEST_TIMED_TRANSFORM_TARGET_ID;
+			timedTransformTarget.decayTime = 86400;
+
+			auto &timedTargetNonEquipmentType = items[TEST_TIMED_TARGET_NON_EQUIPMENT_ID];
+			timedTargetNonEquipmentType = ItemType {};
+			timedTargetNonEquipmentType.id = TEST_TIMED_TARGET_NON_EQUIPMENT_ID;
+			timedTargetNonEquipmentType.transformDeEquipTo = TEST_TIMED_TRANSFORM_TARGET_ID;
 
 			auto &pausedType = items[TEST_PAUSED_EQUIPMENT_ID];
 			pausedType = ItemType {};
@@ -47,15 +81,22 @@ namespace {
 			activeType.id = TEST_ACTIVE_EQUIPMENT_ID;
 			activeType.transformDeEquipTo = TEST_PAUSED_EQUIPMENT_ID;
 			activeType.decayTime = 3600;
+			activeType.hasDeEquipEvent = true;
+
+			auto &timedActiveType = items[TEST_TIMED_ACTIVE_EQUIPMENT_ID];
+			timedActiveType = ItemType {};
+			timedActiveType.id = TEST_TIMED_ACTIVE_EQUIPMENT_ID;
+			timedActiveType.transformDeEquipTo = TEST_PAUSED_EQUIPMENT_ID;
+			timedActiveType.decayTime = 3600;
+			timedActiveType.decayTo = TEST_PAUSED_EQUIPMENT_ID;
 		}
 
 		void TearDown() override {
 			auto &items = Item::items.getItems();
-			if (originalPausedItem) {
-				items[TEST_PAUSED_EQUIPMENT_ID] = std::move(*originalPausedItem);
-			}
-			if (originalActiveItem) {
-				items[TEST_ACTIVE_EQUIPMENT_ID] = std::move(*originalActiveItem);
+			for (size_t index = 0; index < TEST_ITEM_IDS.size(); ++index) {
+				if (originalItems[index]) {
+					items[TEST_ITEM_IDS[index]] = std::move(*originalItems[index]);
+				}
 			}
 			if (items.size() > originalItemsSize) {
 				items.resize(originalItemsSize);
@@ -63,8 +104,7 @@ namespace {
 		}
 
 		size_t originalItemsSize = 0;
-		std::optional<ItemType> originalPausedItem;
-		std::optional<ItemType> originalActiveItem;
+		std::array<std::optional<ItemType>, TEST_ITEM_IDS.size()> originalItems;
 	};
 } // namespace
 
@@ -73,5 +113,29 @@ TEST_F(ItemCreationTest, CreatesActiveEquipmentAsItsPausedXmlType) {
 
 	ASSERT_NE(item, nullptr);
 	EXPECT_EQ(TEST_PAUSED_EQUIPMENT_ID, item->getID());
+	EXPECT_EQ(0, item->getDuration());
+}
+
+TEST_F(ItemCreationTest, CreatesTimedActiveEquipmentWithoutMoveEventAsItsPausedXmlType) {
+	const auto item = Item::CreateItem(TEST_TIMED_ACTIVE_EQUIPMENT_ID);
+
+	ASSERT_NE(item, nullptr);
+	EXPECT_EQ(TEST_PAUSED_EQUIPMENT_ID, item->getID());
+	EXPECT_EQ(0, item->getDuration());
+}
+
+TEST_F(ItemCreationTest, PreservesNonEquipmentWithReciprocalTransformMetadata) {
+	const auto item = Item::CreateItem(TEST_RECIPROCAL_NON_EQUIPMENT_ID);
+
+	ASSERT_NE(item, nullptr);
+	EXPECT_EQ(TEST_RECIPROCAL_NON_EQUIPMENT_ID, item->getID());
+	EXPECT_EQ(0, item->getDuration());
+}
+
+TEST_F(ItemCreationTest, PreservesNonEquipmentWhenTransformTargetHasDuration) {
+	const auto item = Item::CreateItem(TEST_TIMED_TARGET_NON_EQUIPMENT_ID);
+
+	ASSERT_NE(item, nullptr);
+	EXPECT_EQ(TEST_TIMED_TARGET_NON_EQUIPMENT_ID, item->getID());
 	EXPECT_EQ(0, item->getDuration());
 }

--- a/tests/unit/items/item_creation_test.cpp
+++ b/tests/unit/items/item_creation_test.cpp
@@ -1,0 +1,77 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019–present OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#ifndef USE_PRECOMPILED_HEADERS
+	#include <optional>
+	#include <utility>
+#endif
+
+#include <gtest/gtest.h>
+
+#include "items/item.hpp"
+#include "items/items.hpp"
+
+namespace {
+	constexpr uint16_t TEST_PAUSED_EQUIPMENT_ID = 65002;
+	constexpr uint16_t TEST_ACTIVE_EQUIPMENT_ID = 65003;
+
+	class ItemCreationTest : public testing::Test {
+	protected:
+		void SetUp() override {
+			auto &items = Item::items.getItems();
+			originalItemsSize = items.size();
+
+			if (TEST_PAUSED_EQUIPMENT_ID < originalItemsSize) {
+				originalPausedItem.emplace(std::move(items[TEST_PAUSED_EQUIPMENT_ID]));
+			}
+			if (TEST_ACTIVE_EQUIPMENT_ID < originalItemsSize) {
+				originalActiveItem.emplace(std::move(items[TEST_ACTIVE_EQUIPMENT_ID]));
+			}
+			if (items.size() <= TEST_ACTIVE_EQUIPMENT_ID) {
+				items.resize(TEST_ACTIVE_EQUIPMENT_ID + 1);
+			}
+
+			auto &pausedType = items[TEST_PAUSED_EQUIPMENT_ID];
+			pausedType = ItemType {};
+			pausedType.id = TEST_PAUSED_EQUIPMENT_ID;
+			pausedType.stopTime = true;
+
+			auto &activeType = items[TEST_ACTIVE_EQUIPMENT_ID];
+			activeType = ItemType {};
+			activeType.id = TEST_ACTIVE_EQUIPMENT_ID;
+			activeType.transformDeEquipTo = TEST_PAUSED_EQUIPMENT_ID;
+			activeType.decayTime = 3600;
+		}
+
+		void TearDown() override {
+			auto &items = Item::items.getItems();
+			if (originalPausedItem) {
+				items[TEST_PAUSED_EQUIPMENT_ID] = std::move(*originalPausedItem);
+			}
+			if (originalActiveItem) {
+				items[TEST_ACTIVE_EQUIPMENT_ID] = std::move(*originalActiveItem);
+			}
+			if (items.size() > originalItemsSize) {
+				items.resize(originalItemsSize);
+			}
+		}
+
+		size_t originalItemsSize = 0;
+		std::optional<ItemType> originalPausedItem;
+		std::optional<ItemType> originalActiveItem;
+	};
+} // namespace
+
+TEST_F(ItemCreationTest, CreatesActiveEquipmentAsItsPausedXmlType) {
+	const auto item = Item::CreateItem(TEST_ACTIVE_EQUIPMENT_ID);
+
+	ASSERT_NE(item, nullptr);
+	EXPECT_EQ(TEST_PAUSED_EQUIPMENT_ID, item->getID());
+	EXPECT_EQ(0, item->getDuration());
+}


### PR DESCRIPTION
Creating timed equipment by its active item ID can place that active state in a backpack, causing its duration to expire before the item is equipped. This change normalizes only confirmed active-equipment relationships from `items.xml`: items with a configured de-equip event, plus legacy timed equipment whose decay and de-equip targets are the same inactive state.

## Fixes

- Replace the hard-coded active-equipment conversion table with validated item metadata.
- Preserve the requested ID and timing for legacy non-equipment metadata such as snow globe `20312` and claw `9397`.
- Preserve the old Diamond Arrow conversion as an explicit legacy asset alias.
- Correct `!refill` to grant the paused charged Arboreal Ring ID (`39186`) instead of its active ID (`39187`).

## Improvements

- Record whether an item type declares a de-equip move event so creation logic does not infer equipment state from `transformDeEquipTo` alone.
- Keep support for legacy timed equipment without a move event when its XML decay target confirms the same inactive state.

## Tests/Validation

- Added focused unit regressions for event-backed active equipment, timed legacy equipment without a move event, reciprocal non-equipment metadata, and a non-equipment transform target with a duration.
- Ran `luac -p data/scripts/talkactions/player/refill.lua`.
- Parsed all 43 `transformDeEquipTo` relationships: all targets exist, 41 active-equipment pairs qualify for normalization, and the two legacy metadata pairs remain unchanged.
- Ran clang-format comparisons for all changed C++ regions.
- Ran `git diff --check`.
- The C++ unit tests and full build were not run under the repository build policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refilling an Arboreal Ring now applies the correct charged item.
  - Creating active equipment now preserves the appropriate paused state without an incorrect remaining duration.
  - Item creation for activated rings, Soft Boots, and legacy Diamond Arrows now produces the correct item types.
  - Non-equipment items with transformation metadata are preserved correctly instead of being transformed unexpectedly.

- **Tests**
  - Added coverage for item creation, active equipment, and transformation scenarios to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
