### PR TITLE
build(recompile): preserve executable history across rebuilds

### DIFF
--- a/.github/workflows/recompile.yml
+++ b/.github/workflows/recompile.yml
@@ -1,0 +1,44 @@
+---
+name: recompile script
+
+on:
+  pull_request:
+    paths:
+      - 'recompile.sh'
+      - 'tools/test_recompile.py'
+      - 'docs/building/recompile.md'
+      - '.github/workflows/recompile.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'recompile.sh'
+      - 'tools/test_recompile.py'
+      - '.github/workflows/recompile.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          persist-credentials: false
+      - name: Check shell syntax and lint
+        run: |
+          bash -n recompile.sh
+          shellcheck recompile.sh
+      - name: Verify test prerequisites
+        run: |
+          command -v cmake
+          command -v ninja
+          command -v readelf
+      - name: Test backups and build failures without compiling Canary
+        run: python3 tools/test_recompile.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -401,6 +401,7 @@ sftp-config.json
 # Binaries
 canary
 canary.old
+/backups/executables/
 
 # VCPKG
 .tools/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ environment variables, test account, and troubleshooting guide.
 
 ## Documentation
 
+- [Recompile on Linux with executable backups](docs/building/recompile.md).
+  Covers seven-day retention, crash analysis, optional restart and WSL tests.
 - [Hardware sizing and capacity planning](docs/hardware-sizing.md). Measure
   RAM and CPU, compare training and hunting workloads, and review capacity.
 - [Shared build cache for worktrees and forks](docs/development/shared-build-cache.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ references in the surrounding subdirectories:
 | [`architecture.md`](architecture.md)      | System design, components and technical architecture                 |
 | [`development.md`](development.md)        | Development environment, coding standards and contribution workflow  |
 | [`operations.md`](operations.md)          | Deployment, monitoring, security, backups and production operations  |
+| [`building/recompile.md`](building/recompile.md) | Linux recompilation, executable history, crash analysis and WSL validation |
 | [`hardware-sizing.md`](hardware-sizing.md) | RAM/CPU estimates, player activity and hardware capacity planning |
 | [`systems/content-reference-auditor.md`](systems/content-reference-auditor.md) | Profile-aware gameplay content and identifier auditing |
 

--- a/docs/building/recompile.md
+++ b/docs/building/recompile.md
@@ -1,0 +1,276 @@
+# Recompile on Linux with executable history
+
+[`recompile.sh`](../../recompile.sh) configures and builds Canary, installs the
+result at the checkout root, and keeps exact copies of previous executables.
+This lets an operator match a crash dump to the binary that actually produced
+it, even after another version has been installed.
+
+The default run **replaces the installed executable but does not restart the
+server**. A running Linux process continues using its previous executable.
+Restarting through the script requires `--restart-service`.
+
+- [Requirements](#requirements)
+- [Usage and options](#usage-and-options)
+- [Build and installation](#build-and-installation)
+- [Seven-day retention](#seven-day-retention)
+- [Investigating a crash](#investigating-a-crash)
+- [Windows and WSL](#windows-and-wsl)
+- [Validation without compiling Canary](#validation-without-compiling-canary)
+- [Troubleshooting](#troubleshooting)
+
+## Requirements
+
+Run this script in Linux, including Linux under WSL. It produces Linux ELF
+executables. For native Windows builds, use the
+[Windows CMake guide](<windows-(cmake).md>).
+
+Set up the compiler, Ninja and vcpkg using the [Ubuntu](ubuntu-24.04.md) or
+[Debian](debian.md) guide first. CMake must meet the minimum in
+[`CMakePresets.json`](../../CMakePresets.json), currently 3.24. The script also
+uses Bash, Git, GNU coreutils, `grep`, `sed`, `readelf` from binutils and `flock`
+from util-linux. Python 3 and ShellCheck are needed only for the tests below.
+
+Use an account that can read the relevant executables and write to this
+checkout. Reading a running executable through Linux `/proc` also requires
+appropriate process permissions. If a Canary process cannot be inspected, the
+script skips expired-backup cleanup for that invocation.
+
+The script reuses the selected CMake build tree and dependency caches. It does
+not install system packages, fetch source updates, switch branches, update the
+database or install a system service.
+
+On Linux ARM64 (`aarch64`), it retains vcpkg's system-binary selection through
+`VCPKG_FORCE_SYSTEM_BINARIES=1`. Build and dependency output is shown live and
+saved to logs; interactive terminals also show parsed progress percentages.
+
+## Usage and options
+
+Run these examples from the repository root:
+
+```bash
+# Inspect the options without creating files or building.
+bash ./recompile.sh --help
+
+# Configure, build and install, using at most two parallel jobs.
+bash ./recompile.sh --jobs 2
+
+# Use vcpkg/ under the parent directory and select a debug preset.
+bash ./recompile.sh .. linux-debug --jobs 1
+
+# Forward an additional CMake definition.
+bash ./recompile.sh --jobs 2 -- -DOPTIONS_ENABLE_OPENMP=OFF
+```
+
+The script locates its checkout from its own path, so it also works when called
+from another directory. Relative vcpkg paths are resolved from the caller's
+working directory.
+
+| Argument | Default | Meaning |
+| --- | --- | --- |
+| First positional argument | Environment, cache, then home | Directory **containing** `vcpkg/`, not the toolchain file or the vcpkg directory itself |
+| Second positional argument | `linux-release` | Linux configure preset from `CMakePresets.json`, using `build/<preset>` |
+| `--jobs N`, `-j N` | `CMAKE_BUILD_PARALLEL_LEVEL`, otherwise `2` | Limit both the build and vcpkg to a positive job count below 1000 |
+| `-- <cmake-options...>` | None | Forward CMake options as individual arguments; quote values containing spaces |
+| `--restart-service` | Disabled | Restart `canary.service` after installing a different executable |
+| `--help`, `-h` | — | Print help and exit without building or modifying files |
+
+Without the first positional argument, vcpkg is selected in this order:
+`VCPKG_ROOT`, the toolchain already recorded in this preset's cache, then
+`$HOME/vcpkg`. An explicit selection must match an existing cache's toolchain.
+The script also reuses the cache's `CMAKE_COMMAND`; a different CMake version
+earlier in `PATH` does not silently replace it.
+
+### Migrating an existing command
+
+The previous form still accepts CMake definitions after both positional
+arguments:
+
+```bash
+bash ./recompile.sh "$HOME" linux-release -DOPTIONS_ENABLE_OPENMP=OFF
+```
+
+Prefer `--` in new commands and put script options such as `--jobs` before
+the CMake options. Output management is now fixed: the script configures
+`TOGGLE_BIN_FOLDER=ON`, links inside `build/<preset>/bin`, and installs a
+verified copy at the checkout root. Overrides for the source/build directory,
+generator, preset, toolchain or `TOGGLE_BIN_FOLDER` are rejected.
+
+Older `canary.old` or `canary-debug.old` files are left untouched. Keep them if
+they are still needed for older crash dumps; the new retention process does
+not import or delete them.
+
+## Build and installation
+
+Each invocation follows this sequence:
+
+1. Acquire the checkout's build/output lock and validate existing paths,
+   CMake cache and toolchain.
+2. Back up installed executables, valid previous output from this preset and
+   matching running executables, including an older unlinked executable.
+3. Configure the existing preset and inspect pending work with a Ninja dry
+   run. Build its `canary` or `canary-debug` target with the requested
+   parallelism, or reuse the existing output when Ninja reports no work.
+4. Validate and archive the new ELF. Copy it to a temporary file beside the
+   installed executable, verify its SHA-256, then rename it into place.
+5. Refresh backups of running versions and remove eligible expired backups.
+6. Restart the service only if requested and a different binary was installed.
+
+If the new SHA-256 matches the installed file, the script preserves that file
+and skips the restart. Configure, link or staging-copy failures leave the
+installed executable intact. Existing dependencies and build intermediates
+can still change during a failed build.
+
+A failed build-plan inspection also stops the invocation. Reusing up-to-date
+output still requires a valid executable, verifies its hash and applies backup
+retention; an empty or unfamiliar dry-run response is treated as pending work.
+This entry point builds the server target. Use the standard
+[test workflow](../../tests/README.md) to build and run the full test suite.
+
+| Location | Contents |
+| --- | --- |
+| `build/<preset>/` | Reused CMake/Ninja state and build intermediates |
+| `build/<preset>/bin/canary` or `canary-debug` | Compiler output |
+| `canary` or `canary-debug` at the checkout root | Installed executable |
+| `backups/executables/` | Binary copies and their metadata, ignored by Git |
+| `build/cmake_log.txt` | Configure/vcpkg output from the latest invocation |
+| `build/build_plan_log.txt` | Latest Ninja dry-run output |
+| `build/build_log.txt` | Build output from the latest build step |
+| `build/.recompile.lock` | Lock shared by script invocations in this checkout |
+
+The lock covers all presets because they publish into the same checkout root.
+Manual CMake/Ninja commands do not acquire it: do not run them against the same
+build tree or installed output while this script is running.
+
+Run the server from the installed root executable. If the process runs directly
+from this preset's compiler output, the script refuses to relink over it.
+Use a separate checkout for compilation or move to the installed executable
+during a planned restart before adopting this workflow.
+
+### Optional systemd restart
+
+```bash
+bash ./recompile.sh --jobs 2 --restart-service
+```
+
+This invokes `sudo -n /usr/bin/systemctl restart canary.service`. It requires
+that unit to exist and the invoking account to have the corresponding
+non-interactive sudo permission. No permission or service is created by the
+script. Servers managed by a terminal, a launcher or another unit should use
+their existing restart procedure instead.
+
+A restart failure is reported after installation; it does not roll the binary
+back automatically. Likewise, the script does not test gameplay or revert data
+migrations. Executable recovery and database recovery are separate operations.
+
+## Seven-day retention
+
+Each distinct executable has a pair of files:
+
+```text
+backups/executables/
+  canary-<sha256>.bin
+  canary-<sha256>.meta
+  canary-debug-<sha256>.bin
+  canary-debug-<sha256>.meta
+```
+
+The binary is copied byte for byte; no compression or stripping is performed.
+Identical binaries share one backup. Metadata records the SHA-256, ELF Build
+ID when available, backup time and checkout commit observed at backup time.
+The `checkout_at_backup` field is **not proof of the commit that compiled an
+older binary**. Use binary identity when matching a dump.
+
+Retention is based on **last use or backup by this script**, not compilation
+time. An installed or running version has its timestamp refreshed and can be
+kept longer than a week. After a successful invocation, including one with no
+binary change, managed pairs unused for more than seven days are removed.
+
+Cleanup runs only when the script runs. It installs no timer or scheduled job,
+and failed builds do not prune backups. This is an age policy, not a disk-size
+quota; allow space for distinct binaries, the build output and installation
+staging. Preserve a needed binary/core pair separately before its retention
+period expires.
+
+Only recognized binary/metadata pairs in this directory are eligible for
+deletion. Unrelated files, old `.old` files, symlinks and core dumps are outside
+cleanup. Symlinked build/backup directories and compiler output hardlinked to
+the installed executable are rejected.
+
+## Investigating a crash
+
+A useful crash investigation needs the **core dump and its matching
+executable**. Core generation must already be enabled for the server's launch
+method. This script preserves executables; it does not configure kernel or
+systemd core-dump policy, attach GDB or archive shared libraries.
+
+Use metadata and `readelf -n` to select a backup. Replace `SHA256` and `PID`
+below with the actual backup hash and dump filename:
+
+```bash
+readelf -n backups/executables/canary-SHA256.bin
+gdb backups/executables/canary-SHA256.bin core.PID
+```
+
+Inside GDB, `thread apply all bt full` prints thread backtraces and available
+local variables. Default `linux-release` uses `RelWithDebInfo`; keep any
+separately stored debug symbols and required libraries with the incident
+artifacts. Copying a stripped binary preserves its identity but cannot restore
+debug information already removed from it.
+
+Building the same source commit again does not guarantee an identical
+executable: compiler, dependencies and build settings can differ. Prefer the
+original binary retained by the script.
+
+## Windows and WSL
+
+PowerShell does not interpret Bash scripts. With WSL installed and the current
+directory set to this repository, run:
+
+```powershell
+wsl --list --quiet
+wsl -d Ubuntu -- bash ./recompile.sh --help
+wsl -d Ubuntu -- python3 ./tools/test_recompile.py -v
+```
+
+Replace `Ubuntu` with the installed distribution's name if needed. The tests
+use temporary Linux fixtures and do not compile or start Canary. A normal
+build through WSL produces a Linux executable, even when launched from
+PowerShell. See the [WSL setup guide](wsl-ubuntu-24.04.md) for prerequisites.
+
+## Validation without compiling Canary
+
+Run from the repository root in Linux or WSL:
+
+```bash
+bash -n recompile.sh
+shellcheck recompile.sh
+python3 tools/test_recompile.py -v
+```
+
+The test suite invokes the real script in temporary directories. Most cases
+substitute inert CMake/sudo tools and use small existing ELF utilities as
+fixtures. A CMake/Ninja smoke test copies an existing ELF with no compiler
+enabled. Together they cover retention, hashes, deduplication, failed builds,
+interruption, cache reuse, command compatibility, output locks, optional
+restart requests, ARM64 environment selection and preservation of a running
+old executable. They also verify dry-run failure and up-to-date behavior.
+
+No game database or real service is used. The dedicated
+[`recompile script` workflow](../../.github/workflows/recompile.yml) runs these
+checks for relevant pull requests.
+
+## Troubleshooting
+
+| Symptom | Meaning and next step |
+| --- | --- |
+| PowerShell does not recognize the command | Invoke Bash through WSL as shown above |
+| Required command or toolchain missing | Complete the Linux prerequisites and check the selected vcpkg installation |
+| Cached CMake is unavailable | Restore the CMake recorded in this preset or repair the cache through the [local build workflow](local-validation.md#cache-recovery) |
+| Cache belongs to a different source directory | Use that checkout's maintained build tree; do not reuse another worktree's cache |
+| Build/output lock is occupied | Wait for the other invocation to finish; do not remove its lock |
+| Process runs from compiler output | Use a separate build checkout or switch the launcher to the installed root executable during planned maintenance |
+| Backup verification failed | Inspect disk space, access and the reported backup; the script stops before configuring |
+| Configuration/build failed | Inspect the corresponding log; the installed executable and older backups are retained |
+| Build-plan inspection failed | Inspect `build/build_plan_log.txt`; the script did not start the build |
+| Backup cleanup failed after installation | The new executable is already installed; inspect the reported path before retrying |
+| Service restart failed | The new executable is installed and backed up; inspect the unit and restart permissions |

--- a/recompile.sh
+++ b/recompile.sh
@@ -15,6 +15,7 @@ EXECUTABLE_UPDATED=0
 BACKUP_DIRECTORY="$WORKTREE_ROOT/backups/executables"
 RETENTION_SECONDS=$((7 * 24 * 60 * 60))
 PUBLISH_TEMP=""
+LOG_TEMP=""
 PRUNE_ALLOWED=1
 
 info() { printf '[INFO] %s\n' "$*"; }
@@ -108,11 +109,15 @@ parse_arguments() {
 			*TOGGLE_BIN_FOLDER*=* | *CMAKE_TOOLCHAIN_FILE*=*)
 				usage_error "This script manages TOGGLE_BIN_FOLDER and CMAKE_TOOLCHAIN_FILE; use the vcpkg positional argument."
 				;;
+			*) ;;
 		esac
 	done
 }
 
-check_command() { command -v "$1" >/dev/null || die "Required command not found: $1"; }
+check_command() {
+	local command_name=$1
+	command -v "$command_name" >/dev/null || die "Required command not found: $command_name"
+}
 
 cache_value() {
 	local key=$1 line
@@ -127,10 +132,14 @@ cache_value() {
 	return 1
 }
 
-digest() { sha256sum -- "$1" | cut -d ' ' -f 1; }
+digest() {
+	local path=$1
+	sha256sum -- "$path" | cut -d ' ' -f 1
+}
 
 is_executable_elf() {
-	LC_ALL=C readelf -h -- "$1" 2>/dev/null | grep -Eq '^[[:space:]]*Type:[[:space:]]+(EXEC|DYN)[[:space:]]'
+	local path=$1
+	LC_ALL=C readelf -h -- "$path" 2>/dev/null | grep -Eq '^[[:space:]]*Type:[[:space:]]+(EXEC|DYN)[[:space:]]'
 }
 
 # Backups have a dedicated, flat namespace. Never follow a directory symlink
@@ -142,6 +151,9 @@ check_directories() {
 		[[ ! -L $path ]] || die "Refusing a symlinked build/backup directory: $path"
 		[[ ! -e $path || -d $path ]] || die "Expected a directory: $path"
 	done
+	path="$BUILD_DIRECTORY/CMakeCache.txt"
+	[[ ! -L $path ]] || die "Refusing a symlinked CMake cache: $path"
+	[[ ! -e $path || -f $path ]] || die "Expected a regular CMake cache: $path"
 }
 
 archive_executable() {
@@ -182,7 +194,7 @@ archive_executable() {
 }
 
 archive_running_executables() {
-	local before_build=${1:-0} process target name comm
+	local before_build=${1:-0} process target name comm executable_fd stable_source stable_target
 	for process in /proc/[0-9]*; do
 		[[ -d $process ]] || continue
 		if ! target=$(readlink -- "$process/exe" 2>/dev/null); then
@@ -198,11 +210,31 @@ archive_running_executables() {
 			"$WORKTREE_ROOT/canary" | "$WORKTREE_ROOT/build/"*/bin/canary | "$BACKUP_DIRECTORY/canary-"*.bin) name=canary ;;
 			*) continue ;;
 		esac
-		if ! archive_executable "$process/exe" "$name"; then
+		# Hold the executable inode open while hashing and copying it. The process
+		# may exit after readlink, and Linux may immediately reuse its PID.
+		if ! exec {executable_fd}<"$process/exe"; then
+			[[ ! -e "$process/exe" ]] && continue
+			error "Could not open the running executable for PID ${process##*/}."
+			return 1
+		fi
+		stable_source="/proc/$$/fd/$executable_fd"
+		if ! stable_target=$(readlink -- "$stable_source" 2>/dev/null); then
+			exec {executable_fd}<&-
+			error "Could not inspect the running executable for PID ${process##*/}."
+			return 1
+		fi
+		stable_target=${stable_target% (deleted)}
+		if [[ $stable_target != "$target" ]]; then
+			exec {executable_fd}<&-
+			continue
+		fi
+		if ! archive_executable "$stable_source" "$name"; then
+			exec {executable_fd}<&-
 			error "Could not preserve the running executable for PID ${process##*/}."
 			return 1
 		fi
-		if ((before_build)) && [[ $target == "$BUILD_DIRECTORY/bin/$name" ]]; then
+		exec {executable_fd}<&-
+		if ((before_build)) && [[ $stable_target == "$BUILD_DIRECTORY/bin/$name" ]]; then
 			error "PID ${process##*/} runs from the compiler output. Build from a separate checkout or start the root executable first."
 			return 1
 		fi
@@ -235,12 +267,32 @@ prune_backups() {
 	done
 }
 
+# Logs are first written to a private file in build/. Renaming that file over
+# the public log path replaces a pre-existing symlink instead of following it.
+start_log() {
+	local log_file=$1
+	local log_directory=${log_file%/*}
+	[[ -d $log_directory && ! -L $log_directory ]] || return 1
+	LOG_TEMP=$(mktemp "$log_directory/.recompile-log.XXXXXX")
+}
+
+finish_log() {
+	local log_file=$1
+	if ! mv -fT -- "$LOG_TEMP" "$log_file"; then
+		rm -f -- "$LOG_TEMP"
+		LOG_TEMP=""
+		return 1
+	fi
+	LOG_TEMP=""
+}
+
 # tee keeps the complete log; pipefail retains command failures. No detached
 # tail process, temporary progress marker or lost stderr is involved.
 run_with_progress() {
-	local label=$1 log_file=$2 pattern=$3 line current total
+	local label=$1 log_file=$2 pattern=$3 line current total command_status=0
 	shift 3
-	"$@" 2>&1 | tee "$log_file" | while IFS= read -r line; do
+	start_log "$log_file" || { error "Could not create a safe temporary log for $log_file"; return 1; }
+	"$@" 2>&1 | tee "$LOG_TEMP" | while IFS= read -r line; do
 		if [[ -t 1 && $line =~ $pattern ]]; then
 			current=${BASH_REMATCH[1]}
 			total=${BASH_REMATCH[2]}
@@ -250,13 +302,18 @@ run_with_progress() {
 		else
 			printf '%s\n' "$line"
 		fi
-	done
+	done || command_status=$?
+	finish_log "$log_file" || { error "Could not publish log: $log_file"; return 1; }
+	return "$command_status"
 }
 
 build_has_pending_work() {
-	local cmake_command=$1 plan_log="$WORKTREE_ROOT/build/build_plan_log.txt"
-	if ! LC_ALL=C "$cmake_command" --build "$BUILD_DIRECTORY" --target "$EXECUTABLE_NAME" \
-		--parallel "$BUILD_JOBS" -- -n >"$plan_log" 2>&1; then
+	local cmake_command=$1 plan_log="$WORKTREE_ROOT/build/build_plan_log.txt" command_status=0
+	start_log "$plan_log" || { error "Could not create a safe temporary log for $plan_log"; return 2; }
+	LC_ALL=C "$cmake_command" --build "$BUILD_DIRECTORY" --target "$EXECUTABLE_NAME" \
+		--parallel "$BUILD_JOBS" -- -n >"$LOG_TEMP" 2>&1 || command_status=$?
+	finish_log "$plan_log" || { error "Could not publish log: $plan_log"; return 2; }
+	if ((command_status != 0)); then
 		cat -- "$plan_log" >&2
 		return 2
 	fi
@@ -276,7 +333,7 @@ publish_executable() {
 	is_executable_elf "$built" || die "Build output is not an ELF executable: $built"
 	checksum=$(digest "$built")
 	archive_executable "$built" "$EXECUTABLE_NAME" || die "Could not archive the new executable."
-	if [[ -f $installed && $(digest "$installed") == "$checksum" ]]; then
+	if [[ -f $installed && -x $installed && ! -L $installed && $(digest "$installed") == "$checksum" ]]; then
 		info "Executable unchanged; no replacement or service restart is needed."
 		return 0
 	fi
@@ -337,6 +394,7 @@ main() {
 	fi
 	export VCPKG_ROOT
 	export VCPKG_MAX_CONCURRENCY="$BUILD_JOBS"
+	export CMAKE_BUILD_PARALLEL_LEVEL="$BUILD_JOBS"
 	[[ $(uname -m) != aarch64* ]] || export VCPKG_FORCE_SYSTEM_BINARIES=1
 	(umask 077; mkdir -p -- "$BACKUP_DIRECTORY")
 	for name in canary canary-debug; do
@@ -388,6 +446,6 @@ main() {
 	info "Done. Backups: $BACKUP_DIRECTORY"
 }
 
-trap 'if [[ -n $PUBLISH_TEMP ]]; then rm -f -- "$PUBLISH_TEMP"; fi' EXIT
+trap 'if [[ -n $PUBLISH_TEMP ]]; then rm -f -- "$PUBLISH_TEMP"; fi; if [[ -n $LOG_TEMP ]]; then rm -f -- "$LOG_TEMP"; fi' EXIT
 parse_arguments "$@"
 main

--- a/recompile.sh
+++ b/recompile.sh
@@ -2,412 +2,392 @@
 
 set -euo pipefail
 
-# ============================================================================
-# Configuration
-# ============================================================================
+# Linux build and executable history. See docs/building/recompile.md.
+# The running server is restarted only with --restart-service.
 
-VCPKG_PATH=${1:-"$HOME"}
-VCPKG_PATH="$VCPKG_PATH/vcpkg/scripts/buildsystems/vcpkg.cmake"
-BUILD_TYPE=${2:-"linux-release"}
-ARCHITECTURE=$(uname -m)
-EXTRA_CMAKE_ARGS=("${@:3}")
-IS_ARM64=0
-WORKTREE_ROOT=$PWD
-BACKED_UP_EXECUTABLE=""
-BACKED_UP_EXECUTABLE_OLD=""
+WORKTREE_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+BUILD_TYPE=linux-release
+BUILD_JOBS=${CMAKE_BUILD_PARALLEL_LEVEL:-2}
+VCPKG_PARENT_DIRECTORY=""
+EXTRA_CMAKE_ARGS=()
+RESTART_SERVICE=0
+EXECUTABLE_UPDATED=0
+BACKUP_DIRECTORY="$WORKTREE_ROOT/backups/executables"
+RETENTION_SECONDS=$((7 * 24 * 60 * 60))
+PUBLISH_TEMP=""
+PRUNE_ALLOWED=1
 
-# ============================================================================
-# Logging helpers
-# ============================================================================
+info() { printf '[INFO] %s\n' "$*"; }
+error() { printf '[ERROR] %s\n' "$*" >&2; }
+die() { error "$*"; exit 1; }
 
-info() {
-	local message_info=$1
-	echo -e "\033[1;34m[INFO]\033[0m $message_info"
+usage() {
+	cat <<'EOF'
+Usage: ./recompile.sh [vcpkg-parent-directory] [configure-preset] [options]
+                      [-- <cmake-options...>]
+
+Linux/Bash entry point; Windows users can run help/tests through WSL.
+Defaults: existing VCPKG_ROOT (otherwise $HOME/vcpkg), linux-release, 2 jobs.
+An existing CMAKE_BUILD_PARALLEL_LEVEL overrides the default job count.
+
+Options:
+  -h, --help          Show this help without building or changing files.
+  -j, --jobs N        Limit both the build and vcpkg to N parallel jobs.
+  --restart-service   Restart canary.service only if a different executable
+                      was installed successfully.
+
+For compatibility, CMake -D options may also follow the two positional arguments
+without '--'. Script options such as --jobs must come before the CMake options.
+
+The existing build/<preset> tree, cached CMake and dependency caches are reused. The script
+sets TOGGLE_BIN_FOLDER=ON to link in build/<preset>/bin, then atomically installs
+canary (or canary-debug) at the repository root. CMake path/generator overrides
+and TOGGLE_BIN_FOLDER=OFF are not supported by this entry point.
+After configuration, a Ninja dry run checks for pending work. An up-to-date
+build reuses its output; SHA-256 comparison decides whether to install/restart.
+
+Exact ELF copies and metadata are kept in backups/executables for seven days
+after their last use/backup. Identical binaries share one backup. Cleanup runs
+after each successful invocation, including an up-to-date build; running
+versions are retained. Failed builds leave the installed executable intact.
+
+Examples:
+  ./recompile.sh
+  ./recompile.sh "$HOME" linux-debug --jobs 1
+  ./recompile.sh -- -DOPTIONS_ENABLE_OPENMP=OFF
+  ./recompile.sh --restart-service
+
+Guide: docs/building/recompile.md
+EOF
 }
 
-success() {
-	local message_success=$1
-	echo -e "\033[1;32m[OK]\033[0m $message_success"
+usage_error() { error "$*"; printf 'Use --help for usage.\n' >&2; exit 2; }
+
+parse_arguments() {
+	local positional_count=0 argument
+	while (($#)); do
+		argument=$1
+		shift
+		case "$argument" in
+			-h | --help) usage; exit 0 ;;
+			--restart-service) RESTART_SERVICE=1 ;;
+			-j | --jobs)
+				(($#)) || usage_error "$argument requires a positive job count."
+				BUILD_JOBS=$1
+				shift
+				;;
+			--jobs=*) BUILD_JOBS=${argument#*=} ;;
+			-D*)
+				((positional_count == 2)) || usage_error "Put CMake options after '--' or after both positional arguments."
+				EXTRA_CMAKE_ARGS=("$argument" "$@")
+				break
+				;;
+			--)
+				(($#)) || usage_error "The '--' separator requires CMake options."
+				EXTRA_CMAKE_ARGS=("$@")
+				break
+				;;
+			-*) usage_error "Unknown option: $argument" ;;
+			*)
+				case "$positional_count" in
+					0) VCPKG_PARENT_DIRECTORY=$argument ;;
+					1) BUILD_TYPE=$argument ;;
+					*) usage_error "Unexpected positional argument: $argument" ;;
+				esac
+				((positional_count += 1))
+				;;
+		esac
+	done
+	[[ $BUILD_JOBS =~ ^[1-9][0-9]{0,2}$ ]] || usage_error "Jobs must be a positive integer below 1000."
+	[[ $BUILD_TYPE =~ ^linux-[a-zA-Z0-9_-]+$ ]] || usage_error "Select an existing Linux configure preset."
+	for argument in "${EXTRA_CMAKE_ARGS[@]}"; do
+		case "$argument" in
+			-B* | -S* | -G* | --preset* | --build* | --install* | --workflow* | --toolchain*)
+				usage_error "CMake path/generator overrides are not supported: $argument"
+				;;
+			*TOGGLE_BIN_FOLDER*=* | *CMAKE_TOOLCHAIN_FILE*=*)
+				usage_error "This script manages TOGGLE_BIN_FOLDER and CMAKE_TOOLCHAIN_FILE; use the vcpkg positional argument."
+				;;
+		esac
+	done
 }
 
-error() {
-	local message_error=$1
-	echo -e "\033[1;31m[ERROR]\033[0m $message_error" >&2
-}
-
-# ============================================================================
-# Environment checks
-# ============================================================================
-
-check_command() {
-	local command_name=$1
-	if ! command -v "$command_name" >/dev/null; then
-		error "The command '$command_name' is not available. Please install it and try again."
-		exit 1
-	fi
-}
-
-check_architecture() {
-	if [[ $ARCHITECTURE == "aarch64"* ]]; then
-		info "Architecture detected: $ARCHITECTURE (ARM)"
-		IS_ARM64=1
-	else
-		info "Architecture detected: $ARCHITECTURE"
-	fi
-}
-
-check_vcpkg() {
-	if [[ ! -f "$VCPKG_PATH" ]]; then
-		error "vcpkg toolchain not found at: $VCPKG_PATH"
-		error "Pass the vcpkg parent directory as the first argument, or install vcpkg in \$HOME."
-		exit 1
-	fi
-}
-
-# ============================================================================
-# Generic progress runner
-# Runs a command in background, tails its log, and parses progress lines.
-# Args:
-#   $1 = display label (e.g. "vcpkg", "Build")
-#   $2 = log file path
-#   $3 = regex pattern (with capture groups for current and total)
-#   $4 = capture group index for "current" value
-#   $5 = capture group index for "total" value
-#   $6..$N = command and its arguments
-# ============================================================================
-
-run_with_progress() {
-	local label=$1
-	local log_file=$2
-	local pattern=$3
-	local current_idx=$4
-	local total_idx=$5
-	shift 5
-
-	# Truncate previous log
-	: >"$log_file"
-
-	local progress_marker
-	progress_marker=$(mktemp)
-	echo "0" >"$progress_marker"
-
-	# Launch command in background
-	"$@" >"$log_file" 2>&1 &
-	local cmd_pid=$!
-
-	# Tail the log in parallel; auto-exits when cmd_pid dies
-	(
-		# Small wait so the log file definitely exists
-		while [[ ! -s "$log_file" ]] && kill -0 "$cmd_pid" 2>/dev/null; do
-			sleep 0.1
-		done
-
-		tail -f "$log_file" --pid="$cmd_pid" 2>/dev/null | while IFS= read -r line; do
-			if [[ $line =~ $pattern ]]; then
-				local current=${BASH_REMATCH[$current_idx]}
-				local total=${BASH_REMATCH[$total_idx]}
-				# Guard against non-numeric matches (defensive: malformed regex)
-				if ! [[ $current =~ ^[0-9]+$ && $total =~ ^[0-9]+$ && $total -gt 0 ]]; then
-					continue
-				fi
-				local progress=$((current * 100 / total))
-				printf "\r\033[1;32m[INFO]\033[0m %s progress: [%3d%%] (%d/%d)   " \
-					"$label" "$progress" "$current" "$total"
-				echo "1" >"$progress_marker"
-			fi
-		done
-	)
-
-	local cmd_status=0
-	wait "$cmd_pid" || cmd_status=1
-
-	local had_progress
-	had_progress=$(cat "$progress_marker")
-	rm -f "$progress_marker"
-
-	# Newline only if we actually printed a progress bar
-	[[ $had_progress == 1 ]] && echo
-
-	return $cmd_status
-}
-
-# ============================================================================
-# Build steps
-# ============================================================================
-
-setup_canary() {
-	if [ -d "build" ]; then
-		info "Existing build directory found, reusing it."
-		cd build
-	else
-		info "Creating build directory..."
-		mkdir -p build && cd build
-	fi
-}
-
-absolute_path() {
-	local path=$1
-	case "$path" in
-		/* | [A-Za-z]:/* | [A-Za-z]:\\*)
-			printf '%s\n' "$path"
-			;;
-		*)
-			printf '%s\n' "${WORKTREE_ROOT}/${path}"
-			;;
-	esac
-}
+check_command() { command -v "$1" >/dev/null || die "Required command not found: $1"; }
 
 cache_value() {
-	local variable_name=$1
-	local cache_file="build/${BUILD_TYPE}/CMakeCache.txt"
-
-	if [[ ! -f "$cache_file" ]]; then
-		return 1
-	fi
-
-	local cache_line
-	while IFS= read -r cache_line || [[ -n "$cache_line" ]]; do
-		cache_line=${cache_line%$'\r'}
-		if [[ $cache_line == "$variable_name":*=* || $cache_line == "$variable_name="* ]]; then
-			printf '%s\n' "${cache_line#*=}"
+	local key=$1 line
+	[[ -f "$BUILD_DIRECTORY/CMakeCache.txt" ]] || return 1
+	while IFS= read -r line || [[ -n $line ]]; do
+		line=${line%$'\r'}
+		if [[ $line == "$key":*=* ]]; then
+			printf '%s\n' "${line#*=}"
 			return 0
 		fi
-	done <"$cache_file"
-
+	done <"$BUILD_DIRECTORY/CMakeCache.txt"
 	return 1
 }
 
-cmake_arg_value() {
-	local variable_name=$1
-	local index=0
-	local found=0
-	local value=""
+digest() { sha256sum -- "$1" | cut -d ' ' -f 1; }
 
-	while ((index < ${#EXTRA_CMAKE_ARGS[@]})); do
-		local arg="${EXTRA_CMAKE_ARGS[$index]}"
+is_executable_elf() {
+	LC_ALL=C readelf -h -- "$1" 2>/dev/null | grep -Eq '^[[:space:]]*Type:[[:space:]]+(EXEC|DYN)[[:space:]]'
+}
 
-		if [[ $arg == -D"$variable_name"=* || $arg == -D"$variable_name":*=* ]]; then
-			value=${arg#*=}
-			found=1
-		elif [[ $arg == "-D" ]]; then
-			((index += 1))
-			if ((index >= ${#EXTRA_CMAKE_ARGS[@]})); then
-				break
-			fi
-
-			arg="${EXTRA_CMAKE_ARGS[$index]}"
-			if [[ $arg == "$variable_name"=* || $arg == "$variable_name":*=* ]]; then
-				value=${arg#*=}
-				found=1
-			fi
-		fi
-
-		((index += 1))
+# Backups have a dedicated, flat namespace. Never follow a directory symlink
+# into another tree, and never recursively delete anything during retention.
+check_directories() {
+	local path
+	for path in "$WORKTREE_ROOT/build" "$BUILD_DIRECTORY" "$BUILD_DIRECTORY/bin" \
+		"$WORKTREE_ROOT/backups" "$BACKUP_DIRECTORY"; do
+		[[ ! -L $path ]] || die "Refusing a symlinked build/backup directory: $path"
+		[[ ! -e $path || -d $path ]] || die "Expected a directory: $path"
 	done
-
-	if [[ $found == 0 ]]; then
-		return 1
-	fi
-
-	printf '%s\n' "$value"
 }
 
-cmake_value() {
-	local variable_name=$1
-	local fallback=${2-}
-	local value
-
-	if value=$(cmake_arg_value "$variable_name"); then
-		printf '%s\n' "$value"
-	elif value=$(cache_value "$variable_name"); then
-		printf '%s\n' "$value"
-	elif [[ $# -ge 2 ]]; then
-		printf '%s\n' "$fallback"
-	else
-		return 1
-	fi
-}
-
-default_cmake_build_type() {
-	case "$BUILD_TYPE" in
-		*[Dd][Ee][Bb][Uu][Gg]*)
-			printf '%s\n' "Debug"
-			;;
-		*)
-			printf '%s\n' "RelWithDebInfo"
-			;;
-	esac
-}
-
-cmake_enabled() {
-	case "${1-}" in
-		1 | [Oo][Nn] | [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss])
-			return 0
-			;;
-		*)
+archive_executable() {
+	local source=$1 name=$2 checksum destination metadata saved_at build_id checkout temp
+	[[ -f $source ]] || return 0
+	checksum=$(digest "$source") || return 1
+	[[ $checksum =~ ^[a-f0-9]{64}$ ]] || return 1
+	destination="$BACKUP_DIRECTORY/$name-$checksum.bin"
+	metadata="$BACKUP_DIRECTORY/$name-$checksum.meta"
+	[[ ! -L $destination && ! -L $metadata ]] || { error "Refusing symlinked backup: $destination"; return 1; }
+	if [[ -e $destination ]]; then
+		[[ -f $destination && $(digest "$destination") == "$checksum" ]] || {
+			error "Existing backup failed its SHA-256 check: $destination"
 			return 1
-			;;
-	esac
-}
-
-executable_name() {
-	local build_type
-	build_type=$(cmake_value "CMAKE_BUILD_TYPE" "$(default_cmake_build_type)")
-
-	if [[ $build_type == "Debug" ]]; then
-		printf '%s\n' "canary-debug"
+		}
 	else
-		printf '%s\n' "canary"
-	fi
-}
-
-executable_suffix() {
-	local suffix
-	if suffix=$(cmake_value "CMAKE_EXECUTABLE_SUFFIX"); then
-		printf '%s\n' "$suffix"
-		return
-	fi
-
-	case "$(uname -s)" in
-		MINGW* | MSYS* | CYGWIN*)
-			printf '%s\n' ".exe"
-			;;
-		*)
-			printf '%s\n' ""
-			;;
-	esac
-}
-
-runtime_output_directory() {
-	local toggle_bin_folder
-	toggle_bin_folder=$(cmake_value "TOGGLE_BIN_FOLDER" "OFF")
-
-	if cmake_enabled "$toggle_bin_folder"; then
-		local cache_binary_dir
-		if cache_binary_dir=$(cache_value "CMAKE_CACHEFILE_DIR"); then
-			printf '%s\n' "${cache_binary_dir}/bin"
-		else
-			printf '%s\n' "build/${BUILD_TYPE}/bin"
+		is_executable_elf "$source" || { error "Expected an ELF executable: $source"; return 1; }
+		temp=$(mktemp "$BACKUP_DIRECTORY/.binary.XXXXXX") || return 1
+		if ! cp --preserve=mode -- "$source" "$temp" || [[ $(digest "$temp") != "$checksum" ]]; then
+			rm -f -- "$temp"
+			error "Could not verify a complete backup of $source"
+			return 1
 		fi
-	else
-		printf '%s\n' "."
+		mv -fT -- "$temp" "$destination" || return 1
+		info "Saved executable: $destination"
 	fi
-}
-
-executable_path() {
-	local output_directory
-	output_directory=$(runtime_output_directory)
-
-	local executable_file
-	executable_file="$(executable_name)$(executable_suffix)"
-
-	if [[ $output_directory == "." ]]; then
-		printf '%s\n' "$executable_file"
-	else
-		printf '%s\n' "${output_directory}/${executable_file}"
-	fi
-}
-
-move_executable() {
-	local current_executable
-	current_executable=$(executable_path)
-
-	if [[ -f "$current_executable" ]]; then
-		info "Saving previous build as ${current_executable}.old"
-		mv -f "$current_executable" "${current_executable}.old"
-		BACKED_UP_EXECUTABLE=$(absolute_path "$current_executable")
-		BACKED_UP_EXECUTABLE_OLD=$(absolute_path "${current_executable}.old")
-	fi
-}
-
-restore_executable_backup() {
-	if [[ -z $BACKED_UP_EXECUTABLE || -z $BACKED_UP_EXECUTABLE_OLD ]]; then
-		return 0
-	fi
-
-	if [[ ! -f $BACKED_UP_EXECUTABLE_OLD || -e $BACKED_UP_EXECUTABLE ]]; then
-		return 0
-	fi
-
-	info "Restoring previous build from ${BACKED_UP_EXECUTABLE_OLD}"
-	cp -p "$BACKED_UP_EXECUTABLE_OLD" "$BACKED_UP_EXECUTABLE"
-}
-
-fail_after_build_step() {
-	local message=$1
-	restore_executable_backup
-	error "$message"
-	exit 1
-}
-
-configure_or_restore() {
-	if ! configure_canary; then
-		fail_after_build_step "CMake configuration failed."
-	fi
-}
-
-compile_or_restore() {
-	if ! compile_canary; then
-		fail_after_build_step "Build failed."
-	fi
-}
-
-configure_canary() {
-	info "Configuring Canary (this includes vcpkg dependency install)..."
-
-	if [[ $IS_ARM64 == 1 ]]; then
-		export VCPKG_FORCE_SYSTEM_BINARIES=1
-	fi
-
-	# vcpkg emits lines like:
-	#   "Installing 1/16 openssl:arm64-linux@3.6.2..."
-	#   "Building 3/16 boost-asio:arm64-linux..."
-	#   "Restored 5/16 fmt:arm64-linux..."
-	# Group 1: action (discarded), Group 2: current, Group 3: total
-	local vcpkg_pattern='(Installing|Building|Restored)[[:space:]]+([0-9]+)/([0-9]+)'
-
-	if ! run_with_progress "vcpkg" "cmake_log.txt" "$vcpkg_pattern" 2 3 \
-		cmake -DCMAKE_TOOLCHAIN_FILE="$VCPKG_PATH" "${EXTRA_CMAKE_ARGS[@]}" .. \
-		--preset "$BUILD_TYPE"; then
-		error "CMake configuration failed. Full log:"
-		cat cmake_log.txt
+	# This is backup time, not the executable's old compilation mtime.
+	saved_at=$(date -u +%s)
+	build_id=$(LC_ALL=C readelf -n -- "$destination" | sed -n 's/.*Build ID: //p') || return 1
+	checkout=$(git -C "$WORKTREE_ROOT" rev-parse HEAD 2>/dev/null) || checkout=unknown
+	temp=$(mktemp "$BACKUP_DIRECTORY/.metadata.XXXXXX") || return 1
+	if ! printf 'format=canary-executable-backup-v1\nname=%s\nsha256=%s\nbuild_id=%s\nsaved_at_epoch=%s\nsaved_at_utc=%s\ncheckout_at_backup=%s\n' \
+		"$name" "$checksum" "${build_id:-unavailable}" "$saved_at" "$(date -u +%FT%TZ)" "$checkout" >"$temp"; then
+		rm -f -- "$temp"
 		return 1
 	fi
-
-	success "Configuration complete."
+	mv -fT -- "$temp" "$metadata"
 }
 
-compile_canary() {
-	info "Starting the build process..."
+archive_running_executables() {
+	local before_build=${1:-0} process target name comm
+	for process in /proc/[0-9]*; do
+		[[ -d $process ]] || continue
+		if ! target=$(readlink -- "$process/exe" 2>/dev/null); then
+			comm=$(cat "$process/comm" 2>/dev/null) || continue
+			if [[ $comm == canary* ]]; then
+				PRUNE_ALLOWED=0
+			fi
+			continue
+		fi
+		target=${target% (deleted)}
+		case "$target" in
+			"$WORKTREE_ROOT/canary-debug" | "$WORKTREE_ROOT/build/"*/bin/canary-debug | "$BACKUP_DIRECTORY/canary-debug-"*.bin) name=canary-debug ;;
+			"$WORKTREE_ROOT/canary" | "$WORKTREE_ROOT/build/"*/bin/canary | "$BACKUP_DIRECTORY/canary-"*.bin) name=canary ;;
+			*) continue ;;
+		esac
+		if ! archive_executable "$process/exe" "$name"; then
+			error "Could not preserve the running executable for PID ${process##*/}."
+			return 1
+		fi
+		if ((before_build)) && [[ $target == "$BUILD_DIRECTORY/bin/$name" ]]; then
+			error "PID ${process##*/} runs from the compiler output. Build from a separate checkout or start the root executable first."
+			return 1
+		fi
+	done
+}
 
-	# CMake/Ninja build emits lines like "[42/300] Building CXX object..."
-	# Group 1: current, Group 2: total
-	local build_pattern='^\[([0-9]+)/([0-9]+)\]'
+prune_backups() {
+	local metadata filename name checksum saved_at now binary
+	if ((PRUNE_ALLOWED == 0)); then
+		info "Cleanup skipped: a Canary process could not be inspected."
+		return 0
+	fi
+	now=$(date -u +%s)
+	for metadata in "$BACKUP_DIRECTORY"/*.meta; do
+		[[ -f $metadata && ! -L $metadata ]] || continue
+		filename=${metadata##*/}
+		[[ $filename =~ ^(canary|canary-debug)-([a-f0-9]{64})\.meta$ ]] || continue
+		name=${BASH_REMATCH[1]}
+		checksum=${BASH_REMATCH[2]}
+		grep -qx 'format=canary-executable-backup-v1' "$metadata" || continue
+		grep -qx "name=$name" "$metadata" || continue
+		grep -qx "sha256=$checksum" "$metadata" || continue
+		saved_at=$(sed -n 's/^saved_at_epoch=//p' "$metadata")
+		[[ $saved_at =~ ^[1-9][0-9]{0,10}$ ]] || continue
+		((now - saved_at > RETENTION_SECONDS)) || continue
+		binary="${metadata%.meta}.bin"
+		[[ -f $binary && ! -L $binary ]] || continue
+		rm -- "$binary" "$metadata" || return 1
+		info "Removed expired executable: ${binary##*/}"
+	done
+}
 
-	if ! run_with_progress "Build" "build_log.txt" "$build_pattern" 1 2 \
-		cmake --build "$BUILD_TYPE"; then
-		error "Build failed. Full log:"
-		cat build_log.txt
+# tee keeps the complete log; pipefail retains command failures. No detached
+# tail process, temporary progress marker or lost stderr is involved.
+run_with_progress() {
+	local label=$1 log_file=$2 pattern=$3 line current total
+	shift 3
+	"$@" 2>&1 | tee "$log_file" | while IFS= read -r line; do
+		if [[ -t 1 && $line =~ $pattern ]]; then
+			current=${BASH_REMATCH[1]}
+			total=${BASH_REMATCH[2]}
+			if ((total > 0)); then
+				printf '\r[%s] %3d%% (%d/%d)\033[K' "$label" "$((current * 100 / total))" "$current" "$total"
+			fi
+		else
+			printf '%s\n' "$line"
+		fi
+	done
+}
+
+build_has_pending_work() {
+	local cmake_command=$1 plan_log="$WORKTREE_ROOT/build/build_plan_log.txt"
+	if ! LC_ALL=C "$cmake_command" --build "$BUILD_DIRECTORY" --target "$EXECUTABLE_NAME" \
+		--parallel "$BUILD_JOBS" -- -n >"$plan_log" 2>&1; then
+		cat -- "$plan_log" >&2
+		return 2
+	fi
+	# These presets use Ninja. Unknown output is treated as pending work;
+	# an empty log or a command mentioning "up to date" is not proof of a no-op.
+	if grep -qx 'ninja: no work to do\.' "$plan_log"; then
 		return 1
 	fi
-
-	success "Build completed successfully!"
+	return 0
 }
 
-# ============================================================================
-# Main
-# ============================================================================
+publish_executable() {
+	local built="$BUILD_DIRECTORY/bin/$EXECUTABLE_NAME"
+	local installed="$WORKTREE_ROOT/$EXECUTABLE_NAME"
+	local checksum
+	[[ -f $built && -x $built && ! -L $built ]] || die "Build did not produce the expected executable: $built"
+	is_executable_elf "$built" || die "Build output is not an ELF executable: $built"
+	checksum=$(digest "$built")
+	archive_executable "$built" "$EXECUTABLE_NAME" || die "Could not archive the new executable."
+	if [[ -f $installed && $(digest "$installed") == "$checksum" ]]; then
+		info "Executable unchanged; no replacement or service restart is needed."
+		return 0
+	fi
+	[[ ! -e $installed || -f $installed ]] || die "Installed executable path is not a regular file: $installed"
+	[[ ! -L $installed ]] || die "Refusing to replace a symlinked executable: $installed"
+	# Copy into the destination filesystem, verify it, then rename. A running
+	# process keeps its old inode; a failed build/copy never truncates its binary.
+	PUBLISH_TEMP=$(mktemp "$WORKTREE_ROOT/.$EXECUTABLE_NAME.install.XXXXXX")
+	cp --preserve=mode -- "$built" "$PUBLISH_TEMP" || die "Could not stage the executable for installation."
+	[[ $(digest "$PUBLISH_TEMP") == "$checksum" ]] || die "Installed copy failed SHA-256 verification."
+	mv -fT -- "$PUBLISH_TEMP" "$installed" || die "Could not atomically install $installed"
+	PUBLISH_TEMP=""
+	EXECUTABLE_UPDATED=1
+	info "Installed executable: $installed"
+}
+
+restart_service_if_requested() {
+	((RESTART_SERVICE && EXECUTABLE_UPDATED)) || return 0
+	check_command sudo
+	[[ -x /usr/bin/systemctl ]] || die "systemctl not found at /usr/bin/systemctl"
+	sudo -n /usr/bin/systemctl restart canary.service || die "New executable is installed, but canary.service could not be restarted."
+	info "canary.service restarted."
+}
 
 main() {
-	check_command "cmake"
-	check_command "tail"
-	check_vcpkg
-	check_architecture
-	move_executable
-	setup_canary
-
-	configure_or_restore
-	compile_or_restore
+	local command name cached_root cached_toolchain cmake_command path plan_status=0
+	[[ $(uname -s) == Linux ]] || die "This entry point requires Linux."
+	for command in flock sha256sum readelf git tee cut sed grep date realpath readlink mktemp cp mv rm; do
+		check_command "$command"
+	done
+	BUILD_DIRECTORY="$WORKTREE_ROOT/build/$BUILD_TYPE"
+	check_directories
+	mkdir -p -- "$WORKTREE_ROOT/build"
+	# Every preset can publish at the same repository root. Serialize that shared
+	# output and the backup namespace, without locking other repositories.
+	[[ ! -L "$WORKTREE_ROOT/build/.recompile.lock" ]] || die "Refusing a symlinked build lock."
+	exec 9>>"$WORKTREE_ROOT/build/.recompile.lock"
+	flock -n 9 || die "Another recompile.sh owns this repository's build/output lock."
+	if cached_root=$(cache_value CMAKE_HOME_DIRECTORY); then
+		[[ $(realpath -m -- "$cached_root") == "$WORKTREE_ROOT" ]] || die "The existing CMake cache belongs to a different source directory."
+	fi
+	if cmake_command=$(cache_value CMAKE_COMMAND); then
+		[[ -f $cmake_command && -x $cmake_command ]] || die "The CMake recorded in this preset is unavailable: $cmake_command"
+	else
+		cmake_command=$(command -v cmake) || die "Required command not found: cmake"
+	fi
+	if [[ -n $VCPKG_PARENT_DIRECTORY ]]; then
+		VCPKG_ROOT="$VCPKG_PARENT_DIRECTORY/vcpkg"
+	elif [[ -z ${VCPKG_ROOT:-} ]] && cached_toolchain=$(cache_value CMAKE_TOOLCHAIN_FILE); then
+		VCPKG_ROOT=${cached_toolchain%/scripts/buildsystems/vcpkg.cmake}
+	else
+		VCPKG_ROOT=${VCPKG_ROOT:-"$HOME/vcpkg"}
+	fi
+	VCPKG_ROOT=$(realpath -m -- "$VCPKG_ROOT")
+	[[ -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" ]] || die "vcpkg toolchain not found under $VCPKG_ROOT"
+	if cached_toolchain=$(cache_value CMAKE_TOOLCHAIN_FILE); then
+		[[ $(realpath -m -- "$cached_toolchain") == "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" ]] || die "Use the vcpkg installation already configured in this preset."
+	fi
+	export VCPKG_ROOT
+	export VCPKG_MAX_CONCURRENCY="$BUILD_JOBS"
+	[[ $(uname -m) != aarch64* ]] || export VCPKG_FORCE_SYSTEM_BINARIES=1
+	(umask 077; mkdir -p -- "$BACKUP_DIRECTORY")
+	for name in canary canary-debug; do
+		for path in "$WORKTREE_ROOT/$name" "$BUILD_DIRECTORY/bin/$name"; do
+			[[ ! -L $path && ( ! -e $path || -f $path ) ]] || die "Expected a regular executable, not a link/directory: $path"
+		done
+		archive_executable "$WORKTREE_ROOT/$name" "$name" || die "Could not back up the installed executable."
+		path="$BUILD_DIRECTORY/bin/$name"
+		if [[ -f $path ]]; then
+			if is_executable_elf "$path"; then
+				archive_executable "$path" "$name" || die "Could not back up the previous build output."
+			else
+				info "Previous compiler output is incomplete; it will be rebuilt: $path"
+			fi
+		fi
+		[[ ! "$WORKTREE_ROOT/$name" -ef "$BUILD_DIRECTORY/bin/$name" ]] || die "Compiler output is a hardlink to the installed executable."
+	done
+	archive_running_executables 1 || die "Running executable backup/preflight failed."
+	cd -- "$WORKTREE_ROOT"
+	info "Configuring $BUILD_TYPE in its existing build tree ($BUILD_JOBS jobs)."
+	if ! run_with_progress vcpkg "$WORKTREE_ROOT/build/cmake_log.txt" '[[:space:]]([0-9]+)/([0-9]+)[[:space:]]' \
+		"$cmake_command" --preset "$BUILD_TYPE" "${EXTRA_CMAKE_ARGS[@]}" \
+		-DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" -DTOGGLE_BIN_FOLDER=ON; then
+		die "CMake configuration failed. Installed executable kept. Log: build/cmake_log.txt"
+	fi
+	check_directories
+	[[ $(cache_value CMAKE_CACHEFILE_DIR) == "$BUILD_DIRECTORY" ]] || die "Unexpected CMake binary directory."
+	[[ $(cache_value TOGGLE_BIN_FOLDER) == ON ]] || die "CMake did not select the staged bin output directory."
+	EXECUTABLE_NAME=$(cache_value CMAKE_PROJECT_NAME)
+	[[ $EXECUTABLE_NAME == canary || $EXECUTABLE_NAME == canary-debug ]] || die "Unexpected CMake target: $EXECUTABLE_NAME"
+	info "Checking for pending build work."
+	build_has_pending_work "$cmake_command" || plan_status=$?
+	case "$plan_status" in
+		0)
+			if ! run_with_progress Build "$WORKTREE_ROOT/build/build_log.txt" '^\[([0-9]+)/([0-9]+)\]' \
+				"$cmake_command" --build "$BUILD_DIRECTORY" --target "$EXECUTABLE_NAME" --parallel "$BUILD_JOBS"; then
+				die "Build failed. Installed executable kept. Log: build/build_log.txt"
+			fi
+			;;
+		1) info "Build is up to date; reusing the existing compiler output." ;;
+		*) die "Could not inspect pending build work. Installed executable kept. Log: build/build_plan_log.txt" ;;
+	esac
+	publish_executable
+	# A server can restart during a long build. Refresh the actually running
+	# version again immediately before considering any backup for expiry.
+	archive_running_executables || die "Could not preserve a running version; backup cleanup skipped."
+	prune_backups || die "Backup cleanup failed. The installed executable was kept."
+	restart_service_if_requested
+	info "Done. Backups: $BACKUP_DIRECTORY"
 }
 
+trap 'if [[ -n $PUBLISH_TEMP ]]; then rm -f -- "$PUBLISH_TEMP"; fi' EXIT
+parse_arguments "$@"
 main

--- a/tools/test_recompile.py
+++ b/tools/test_recompile.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Test recompile.sh with temporary ELF fixtures; never compile Canary or restart a service."""
+
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "recompile.sh"
+TRUE = Path("/bin/true").resolve()
+FALSE = Path("/bin/false").resolve()
+SLEEP = Path("/bin/sleep").resolve()
+REAL_CMAKE = shutil.which("cmake")
+REAL_NINJA = shutil.which("ninja")
+
+CMAKE_FIXTURE = r'''#!/usr/bin/python3
+import json, os, pathlib, shutil, sys, time
+root = pathlib.Path(os.environ['RECOMPILE_FIXTURE_ROOT'])
+assert (root / '.fixture').is_file()
+args = sys.argv[1:]
+with (root / 'calls.jsonl').open('a') as stream:
+    stream.write(json.dumps(dict(args=args, vcpkg_jobs=os.environ.get('VCPKG_MAX_CONCURRENCY'),
+                                system_binaries=os.environ.get('VCPKG_FORCE_SYSTEM_BINARIES'))) + '\n')
+mode = os.environ.get('FIXTURE_MODE', '')
+if args[0] == '--preset':
+    assert pathlib.Path.cwd() == root
+    if mode == 'configure-fail':
+        print('fixture configuration error', file=sys.stderr)
+        sys.exit(23)
+    preset = args[1]
+    binary = root / 'build' / preset
+    binary.mkdir(parents=True, exist_ok=True)
+    definitions = [arg[2:] for arg in args if arg.startswith('-D')]
+    toolchain = next(arg.split('=', 1)[1] for arg in definitions if arg.startswith('CMAKE_TOOLCHAIN_FILE='))
+    name = 'canary-debug' if 'debug' in preset else 'canary'
+    (binary / 'CMakeCache.txt').write_text(
+        f'CMAKE_HOME_DIRECTORY:INTERNAL={root}\n'
+        f'CMAKE_CACHEFILE_DIR:INTERNAL={binary}\n'
+        f'CMAKE_COMMAND:INTERNAL={pathlib.Path(sys.argv[0]).resolve()}\n'
+        f'CMAKE_TOOLCHAIN_FILE:FILEPATH={toolchain}\n'
+        f'CMAKE_PROJECT_NAME:STATIC={name}\n'
+        'TOGGLE_BIN_FOLDER:BOOL=ON\n')
+    print('Installing 1/2 fixture dependency')
+elif args[0] == '--build':
+    binary = pathlib.Path(args[1])
+    assert binary.parent == root / 'build'
+    if args[-2:] == ['--', '-n']:
+        if mode == 'plan-fail':
+            print('fixture build plan error', file=sys.stderr)
+            sys.exit(29)
+        if mode == 'no-work':
+            print('ninja: no work to do.')
+        elif mode != 'empty-plan':
+            print('[1/1] fixture pending build')
+        sys.exit(0)
+    target = args[args.index('--target') + 1]
+    output = binary / 'bin' / target
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if mode == 'slow':
+        (root / 'building').touch()
+        time.sleep(120)
+    if mode == 'missing':
+        sys.exit(0)
+    if mode in ('build-fail', 'invalid'):
+        output.write_text('incomplete fixture output')
+        output.chmod(0o755)
+        print('fixture build error', file=sys.stderr)
+        sys.exit(37 if mode == 'build-fail' else 0)
+    shutil.copy2(os.environ['FIXTURE_BINARY'], output)
+    print('[1/2] fixture build step')
+    print('[2/2] fixture link step')
+else:
+    raise AssertionError(args)
+'''
+
+SUDO_FIXTURE = r'''#!/usr/bin/python3
+import json, os, pathlib, sys
+root = pathlib.Path(os.environ['RECOMPILE_FIXTURE_ROOT'])
+assert (root / '.fixture').is_file()
+(root / 'restart.json').write_text(json.dumps(sys.argv[1:]))
+sys.exit(int(os.environ.get('FIXTURE_RESTART_STATUS', '0')))
+'''
+
+COPY_FIXTURE = r'''#!/usr/bin/python3
+import os, sys
+if '.install.' in sys.argv[-1]:
+    sys.exit(41)
+os.execv('/bin/cp', ['cp', *sys.argv[1:]])
+'''
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+class RecompileTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="recompile-fixture-")
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.root = self.directory / "source with spaces"
+        self.root.mkdir()
+        (self.root / ".fixture").touch()
+        self.script = self.root / "recompile.sh"
+        self.script.write_bytes(SCRIPT.read_bytes())
+        self.installed = self.root / "canary"
+        shutil.copy2(TRUE, self.installed)
+        self.backups = self.root / "backups" / "executables"
+        self.tools = self.directory / "fixture-tools"
+        self.tools.mkdir()
+        self.write_tool("cmake", CMAKE_FIXTURE)
+        self.write_tool("sudo", SUDO_FIXTURE)
+        self.vcpkg_parent = self.directory / "toolchain with spaces"
+        toolchain = self.vcpkg_parent / "vcpkg/scripts/buildsystems/vcpkg.cmake"
+        toolchain.parent.mkdir(parents=True)
+        toolchain.write_text("# Inert fixture; never included by a real CMake.\n")
+        self.environment = dict(os.environ)
+        for name in ("CMAKE_BUILD_PARALLEL_LEVEL", "VCPKG_ROOT", "VCPKG_FORCE_SYSTEM_BINARIES", "BASH_ENV", "ENV"):
+            self.environment.pop(name, None)
+        self.environment.update(
+            PATH=f"{self.tools}:/usr/bin:/bin",
+            RECOMPILE_FIXTURE_ROOT=str(self.root),
+            FIXTURE_BINARY=str(FALSE),
+            HOME=str(self.vcpkg_parent),
+        )
+
+    def write_tool(self, name, source):
+        path = self.tools / name
+        path.write_text(source)
+        path.chmod(0o755)
+
+    def run_script(self, *args, expected=0, **environment):
+        result = subprocess.run(
+            ["/bin/bash", str(self.script), *map(str, args)],
+            cwd=self.directory,
+            env=dict(self.environment, **environment),
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20,
+        )
+        if expected == 0:
+            self.assertEqual(0, result.returncode, result.stdout)
+        else:
+            self.assertNotEqual(0, result.returncode, result.stdout)
+        return result
+
+    def calls(self):
+        path = self.root / "calls.jsonl"
+        return [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+
+    def record(self, binary, name="canary"):
+        path = self.backups / f"{name}-{digest(binary)}.meta"
+        return dict(line.split("=", 1) for line in path.read_text().splitlines())
+
+    def old_backup(self, binary=SLEEP, days=8, managed=True):
+        self.backups.mkdir(parents=True, exist_ok=True)
+        checksum = digest(binary)
+        stem = self.backups / f"canary-{checksum}"
+        shutil.copy2(binary, Path(str(stem) + ".bin"))
+        Path(str(stem) + ".meta").write_text(
+            f"format={'canary-executable-backup-v1' if managed else 'operator-owned'}\n"
+            f"name=canary\nsha256={checksum}\nsaved_at_epoch={int(time.time()) - days * 86400}\n"
+        )
+        return Path(str(stem) + ".bin")
+
+    def start_sleep(self, path):
+        process = subprocess.Popen([str(path), "120"])
+
+        def stop():
+            if process.poll() is None:
+                process.terminate()
+            process.wait(timeout=5)
+
+        self.addCleanup(stop)
+        for _ in range(50):
+            if digest(f"/proc/{process.pid}/exe") == digest(SLEEP):
+                break
+            time.sleep(0.01)
+        return process
+
+    def test_help_and_invalid_arguments_do_not_build(self):
+        self.run_script("--help")
+        for args in (("--jobs", "0"), ("--",), ("--unknown",), ("--", "-B/tmp/elsewhere"),
+                     ("--", "-DTOGGLE_BIN_FOLDER=OFF"), ("--", "--preset=another")):
+            self.run_script(*args, expected=1)
+        self.assertFalse((self.root / "build").exists())
+        self.assertFalse(self.backups.exists())
+        self.assertFalse(self.calls())
+
+    def test_archives_exact_old_and_new_elf_and_installs_new_binary(self):
+        previous_inode = self.installed.stat().st_ino
+        self.run_script("--jobs", "1", "--", "-DOPTIONS_ENABLE_OPENMP=OFF")
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertNotEqual(previous_inode, self.installed.stat().st_ino)
+        for binary in (TRUE, FALSE):
+            record = self.record(binary)
+            self.assertEqual(digest(binary), record["sha256"])
+            self.assertNotEqual("unavailable", record["build_id"])
+            self.assertEqual(binary.read_bytes(), (self.backups / f"canary-{digest(binary)}.bin").read_bytes())
+        calls = self.calls()
+        self.assertEqual(["--preset", "linux-release"], calls[0]["args"][:2])
+        self.assertIn("-DTOGGLE_BIN_FOLDER=ON", calls[0]["args"])
+        self.assertIn("-DOPTIONS_ENABLE_OPENMP=OFF", calls[0]["args"])
+        self.assertEqual(["--", "-n"], calls[1]["args"][-2:])
+        self.assertEqual(["--parallel", "1"], calls[2]["args"][-2:])
+        self.assertEqual("1", calls[0]["vcpkg_jobs"])
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_no_change_deduplicates_and_does_not_restart_or_replace(self):
+        inode = self.installed.stat().st_ino
+        self.run_script("--restart-service", FIXTURE_BINARY=str(TRUE))
+        self.run_script("--restart-service", FIXTURE_BINARY=str(TRUE))
+        self.assertEqual(inode, self.installed.stat().st_ino)
+        self.assertEqual(1, len(list(self.backups.glob("*.bin"))))
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_compile_mtime_does_not_expire_a_new_backup(self):
+        os.utime(self.installed, (1, 1))
+        self.run_script()
+        self.assertGreater(int(self.record(TRUE)["saved_at_epoch"]), time.time() - 30)
+
+    def test_retention_deletes_only_expired_managed_pairs_even_on_noop(self):
+        expired = self.old_backup()
+        recent = self.old_backup(Path("/bin/echo"), days=6)
+        unknown = self.old_backup(Path("/bin/cat"), managed=False)
+        sentinel = self.backups / "operator-notes.txt"
+        sentinel.write_text("keep")
+        self.run_script(FIXTURE_BINARY=str(TRUE))
+        self.assertFalse(expired.exists())
+        self.assertFalse(expired.with_suffix(".meta").exists())
+        for path in (recent, unknown, sentinel):
+            self.assertTrue(path.exists())
+
+    def test_failure_preserves_runtime_and_does_not_prune_or_restart(self):
+        for mode in ("configure-fail", "plan-fail", "build-fail", "missing", "invalid"):
+            with self.subTest(mode=mode):
+                staged = self.root / "build/linux-release/bin/canary"
+                if staged.exists():
+                    staged.unlink()
+                expired = self.old_backup()
+                before = self.installed.read_bytes()
+                inode = self.installed.stat().st_ino
+                self.run_script("--restart-service", expected=1, FIXTURE_MODE=mode)
+                self.assertEqual(before, self.installed.read_bytes())
+                self.assertEqual(inode, self.installed.stat().st_ino)
+                self.assertTrue(expired.exists())
+                self.assertFalse((self.root / "restart.json").exists())
+        self.assertIn("fixture build error", (self.root / "build/build_log.txt").read_text())
+
+    def test_copy_failure_never_replaces_installed_file(self):
+        self.write_tool("cp", COPY_FIXTURE)
+        self.run_script("--restart-service", expected=1)
+        self.assertEqual(digest(TRUE), digest(self.installed))
+        self.assertFalse(list(self.root.glob(".canary.install.*")))
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_retry_after_failed_link_rebuilds_incomplete_staging_output(self):
+        self.run_script(expected=1, FIXTURE_MODE="build-fail")
+        self.run_script()
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertEqual(digest(TRUE), self.record(TRUE)["sha256"])
+
+    def test_cmake_arguments_are_forwarded_without_shell_expansion(self):
+        argument = "-DFIXTURE_TEXT=literal $(touch must-not-exist); with spaces"
+        self.run_script("--", argument)
+        self.assertIn(argument, self.calls()[0]["args"])
+        self.assertFalse((self.root / "must-not-exist").exists())
+
+    def test_existing_cache_toolchain_is_reused_when_environment_is_unset(self):
+        self.run_script()
+        self.environment["HOME"] = str(self.directory / "unused home")
+        self.run_script()
+        self.assertEqual(6, len(self.calls()))
+
+    def test_cached_cmake_is_reused_instead_of_a_different_path_version(self):
+        self.run_script()
+        maintained = self.directory / "maintained cmake" / "cmake"
+        maintained.parent.mkdir()
+        original = self.tools / "cmake"
+        original.rename(maintained)
+        cache = self.root / "build/linux-release/CMakeCache.txt"
+        cache.write_text(cache.read_text().replace(
+            f"CMAKE_COMMAND:INTERNAL={original}", f"CMAKE_COMMAND:INTERNAL={maintained}"))
+        self.write_tool("cmake", "#!/bin/sh\nexit 42\n")
+        self.run_script()
+        self.assertEqual(6, len(self.calls()))
+
+    def test_unavailable_cached_cmake_does_not_reconfigure_or_replace(self):
+        self.run_script()
+        inode = self.installed.stat().st_ino
+        (self.tools / "cmake").unlink()
+        result = self.run_script(expected=1)
+        self.assertIn("CMake recorded in this preset is unavailable", result.stdout)
+        self.assertEqual(3, len(self.calls()))
+        self.assertEqual(inode, self.installed.stat().st_ino)
+
+    def test_foreign_cache_or_toolchain_is_not_reconfigured(self):
+        build = self.root / "build/linux-release"
+        build.mkdir(parents=True)
+        cache = build / "CMakeCache.txt"
+        for content in (
+            f"CMAKE_HOME_DIRECTORY:INTERNAL={self.directory}\n",
+            f"CMAKE_HOME_DIRECTORY:INTERNAL={self.root}\nCMAKE_TOOLCHAIN_FILE:FILEPATH=/unrelated/toolchain.cmake\n",
+        ):
+            cache.write_text(content)
+            self.run_script(self.vcpkg_parent, expected=1)
+            self.assertFalse(self.calls())
+
+    def test_backup_failure_stops_before_configuration(self):
+        self.backups.mkdir(parents=True)
+        (self.backups / f"canary-{digest(TRUE)}.bin").write_text("corrupted")
+        self.run_script(expected=1)
+        self.assertFalse(self.calls())
+        self.assertEqual(digest(TRUE), digest(self.installed))
+
+    def test_restart_requires_flag_and_new_binary(self):
+        self.run_script("--restart-service")
+        self.assertEqual(["-n", "/usr/bin/systemctl", "restart", "canary.service"],
+                         json.loads((self.root / "restart.json").read_text()))
+
+    def test_restart_failure_reports_new_binary_without_rollback(self):
+        self.run_script("--restart-service", expected=1, FIXTURE_RESTART_STATUS="1")
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertEqual(digest(TRUE), self.record(TRUE)["sha256"])
+
+    def test_debug_preset_and_explicit_vcpkg_path_with_spaces(self):
+        self.run_script(self.vcpkg_parent, "linux-debug-asan", "--jobs=2")
+        self.assertEqual(digest(FALSE), digest(self.root / "canary-debug"))
+        self.assertEqual(digest(TRUE), digest(self.installed))
+        self.assertIn("canary-debug", self.calls()[1]["args"])
+        self.assertEqual(digest(FALSE), self.record(FALSE, "canary-debug")["sha256"])
+
+    def test_legacy_cmake_definitions_are_forwarded_and_managed_paths_still_rejected(self):
+        self.run_script(self.vcpkg_parent, "linux-release", "-DOPTIONS_ENABLE_OPENMP=OFF")
+        self.assertIn("-DOPTIONS_ENABLE_OPENMP=OFF", self.calls()[0]["args"])
+        previous_calls = len(self.calls())
+        self.run_script(self.vcpkg_parent, "linux-release", "-DTOGGLE_BIN_FOLDER=OFF", expected=1)
+        self.assertEqual(previous_calls, len(self.calls()))
+
+    def test_arm64_keeps_vcpkg_system_binary_selection(self):
+        self.write_tool("uname", '#!/bin/sh\ncase "$1" in -s) echo Linux;; -m) echo aarch64;; *) exit 1;; esac\n')
+        self.run_script()
+        self.assertEqual("1", self.calls()[0]["system_binaries"])
+
+    def test_no_pending_work_skips_build_and_still_prunes_expired_backups(self):
+        staged = self.root / "build/linux-release/bin/canary"
+        staged.parent.mkdir(parents=True)
+        shutil.copy2(TRUE, staged)
+        expired = self.old_backup()
+        inode = self.installed.stat().st_ino
+        self.run_script("--restart-service", FIXTURE_MODE="no-work")
+        self.assertEqual(2, len(self.calls()))
+        self.assertEqual(["--", "-n"], self.calls()[1]["args"][-2:])
+        self.assertEqual(inode, self.installed.stat().st_ino)
+        self.assertFalse(expired.exists())
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_no_pending_work_still_requires_a_valid_output(self):
+        self.run_script("--restart-service", expected=1, FIXTURE_MODE="no-work")
+        self.assertEqual(digest(TRUE), digest(self.installed))
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_empty_dry_run_output_is_not_assumed_to_mean_no_work(self):
+        self.run_script(FIXTURE_MODE="empty-plan")
+        self.assertEqual(3, len(self.calls()))
+        self.assertEqual(digest(FALSE), digest(self.installed))
+
+    @unittest.skipUnless(REAL_CMAKE and REAL_NINJA, "CMake and Ninja are needed for the copy-only smoke test")
+    def test_real_cmake_ninja_copy_only_success_noop_and_failed_build(self):
+        self.write_tool("cmake", '#!/bin/sh\nexec ' + shlex.quote(REAL_CMAKE) + ' "$@"\n')
+        self.write_tool("ninja", '#!/bin/sh\nexec ' + shlex.quote(REAL_NINJA) + ' "$@"\n')
+        shutil.copy2(FALSE, self.root / "fixture-binary")
+        (self.root / "CMakePresets.json").write_text(json.dumps({
+            "version": 3,
+            "configurePresets": [{"name": "linux-release", "generator": "Ninja",
+                                  "binaryDir": "${sourceDir}/build/${presetName}"}],
+        }))
+        (self.root / "CMakeLists.txt").write_text('''cmake_minimum_required(VERSION 3.24)
+project(canary LANGUAGES NONE)
+option(FIXTURE_FAIL "Fail the copy-only target" OFF)
+if(FIXTURE_FAIL)
+    add_custom_target(canary COMMAND "${CMAKE_COMMAND}" -E false)
+else()
+    add_custom_command(OUTPUT "${CMAKE_BINARY_DIR}/bin/canary"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/bin"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/fixture-binary" "${CMAKE_BINARY_DIR}/bin/canary"
+        DEPENDS "${CMAKE_SOURCE_DIR}/fixture-binary" VERBATIM)
+    add_custom_target(canary DEPENDS "${CMAKE_BINARY_DIR}/bin/canary")
+endif()
+''')
+        self.run_script()
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertEqual(digest(TRUE), self.record(TRUE)["sha256"])
+        inode = self.installed.stat().st_ino
+        first_build_log = (self.root / "build/build_log.txt").read_bytes()
+        result = self.run_script("--restart-service")
+        self.assertIn("Build is up to date", result.stdout)
+        self.assertEqual(first_build_log, (self.root / "build/build_log.txt").read_bytes())
+        self.assertEqual(inode, self.installed.stat().st_ino)
+        self.assertFalse((self.root / "restart.json").exists())
+        self.run_script("--restart-service", "--", "-DFIXTURE_FAIL=ON", expected=1)
+        self.assertEqual(inode, self.installed.stat().st_ino)
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertFalse((self.root / "restart.json").exists())
+
+    def test_lock_rejects_overlapping_scripts(self):
+        build = self.root / "build"
+        build.mkdir()
+        with (build / ".recompile.lock").open("a") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.run_script(expected=1)
+        self.assertFalse(self.calls())
+
+    def test_symlinked_backup_root_cannot_delete_external_files(self):
+        outside = self.directory / "outside"
+        outside.mkdir()
+        sentinel = outside / "keep"
+        sentinel.write_text("keep")
+        (self.root / "backups").symlink_to(outside, target_is_directory=True)
+        self.run_script(expected=1)
+        self.assertEqual([sentinel], list(outside.iterdir()))
+        self.assertFalse(self.calls())
+
+    def test_symlinked_or_hardlinked_output_is_rejected_before_build(self):
+        staged = self.root / "build/linux-release/bin/canary"
+        staged.parent.mkdir(parents=True)
+        staged.symlink_to(self.installed)
+        self.run_script(expected=1)
+        staged.unlink()
+        os.link(self.installed, staged)
+        self.run_script(expected=1)
+        self.assertEqual(digest(TRUE), digest(self.installed))
+        self.assertFalse(self.calls())
+
+    def test_expired_symlink_backup_is_kept_without_touching_target(self):
+        expired = self.old_backup()
+        outside = self.directory / "outside.bin"
+        outside.write_text("keep")
+        expired.unlink()
+        expired.symlink_to(outside)
+        self.run_script()
+        self.assertTrue(expired.is_symlink())
+        self.assertEqual("keep", outside.read_text())
+
+    def test_running_old_inode_is_preserved_and_kept_past_retention(self):
+        shutil.copy2(SLEEP, self.installed)
+        process = self.start_sleep(self.installed)
+        expired = self.old_backup()
+        replacement = self.root / "replacement"
+        shutil.copy2(TRUE, replacement)
+        replacement.replace(self.installed)
+        self.run_script()
+        self.assertIsNone(process.poll())
+        self.assertEqual(digest(SLEEP), digest(f"/proc/{process.pid}/exe"))
+        self.assertEqual(digest(FALSE), digest(self.installed))
+        self.assertTrue(expired.exists())
+        self.assertGreater(int(self.record(SLEEP)["saved_at_epoch"]), time.time() - 30)
+
+    def test_running_compiler_output_blocks_relink(self):
+        staged = self.root / "build/linux-release/bin/canary"
+        staged.parent.mkdir(parents=True)
+        shutil.copy2(SLEEP, staged)
+        process = self.start_sleep(staged)
+        self.run_script(expected=1)
+        self.assertFalse(self.calls())
+        self.assertIsNone(process.poll())
+
+    def test_interrupt_during_build_keeps_installed_binary(self):
+        process = subprocess.Popen(
+            ["/bin/bash", str(self.script)], cwd=self.directory,
+            env=dict(self.environment, FIXTURE_MODE="slow"), start_new_session=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            deadline = time.monotonic() + 10
+            while not (self.root / "building").exists() and time.monotonic() < deadline:
+                self.assertIsNone(process.poll())
+                time.sleep(0.02)
+            self.assertTrue((self.root / "building").exists())
+        finally:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=5)
+        self.assertEqual(digest(TRUE), digest(self.installed))
+        self.assertFalse((self.root / "restart.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_recompile.py
+++ b/tools/test_recompile.py
@@ -29,7 +29,8 @@ assert (root / '.fixture').is_file()
 args = sys.argv[1:]
 with (root / 'calls.jsonl').open('a') as stream:
     stream.write(json.dumps(dict(args=args, vcpkg_jobs=os.environ.get('VCPKG_MAX_CONCURRENCY'),
-                                system_binaries=os.environ.get('VCPKG_FORCE_SYSTEM_BINARIES'))) + '\n')
+                                 cmake_jobs=os.environ.get('CMAKE_BUILD_PARALLEL_LEVEL'),
+                                 system_binaries=os.environ.get('VCPKG_FORCE_SYSTEM_BINARIES'))) + '\n')
 mode = os.environ.get('FIXTURE_MODE', '')
 if args[0] == '--preset':
     assert pathlib.Path.cwd() == root
@@ -211,7 +212,20 @@ class RecompileTest(unittest.TestCase):
         self.assertEqual(["--", "-n"], calls[1]["args"][-2:])
         self.assertEqual(["--parallel", "1"], calls[2]["args"][-2:])
         self.assertEqual("1", calls[0]["vcpkg_jobs"])
+        self.assertEqual("1", calls[0]["cmake_jobs"])
         self.assertFalse((self.root / "restart.json").exists())
+
+    def test_explicit_jobs_override_inherited_cmake_parallelism(self):
+        self.run_script("--jobs", "1", CMAKE_BUILD_PARALLEL_LEVEL="17")
+        self.assertTrue(all(call["cmake_jobs"] == "1" for call in self.calls()))
+
+    def test_matching_nonexecutable_file_is_reinstalled_and_restarted(self):
+        inode = self.installed.stat().st_ino
+        self.installed.chmod(0o644)
+        self.run_script("--restart-service", FIXTURE_BINARY=str(TRUE))
+        self.assertNotEqual(inode, self.installed.stat().st_ino)
+        self.assertTrue(os.access(self.installed, os.X_OK))
+        self.assertTrue((self.root / "restart.json").exists())
 
     def test_no_change_deduplicates_and_does_not_restart_or_replace(self):
         inode = self.installed.stat().st_ino
@@ -427,6 +441,33 @@ endif()
         self.run_script(expected=1)
         self.assertEqual([sentinel], list(outside.iterdir()))
         self.assertFalse(self.calls())
+
+    def test_symlinked_cmake_cache_is_rejected_without_touching_its_target(self):
+        outside = self.directory / "outside-cache"
+        outside.write_text("keep")
+        build = self.root / "build/linux-release"
+        build.mkdir(parents=True)
+        (build / "CMakeCache.txt").symlink_to(outside)
+        self.run_script(expected=1)
+        self.assertEqual("keep", outside.read_text())
+        self.assertFalse(self.calls())
+
+    def test_log_symlinks_are_replaced_without_touching_their_targets(self):
+        build = self.root / "build"
+        build.mkdir()
+        sentinels = []
+        for name in ("cmake_log.txt", "build_plan_log.txt", "build_log.txt"):
+            outside = self.directory / f"outside-{name}"
+            outside.write_text("keep")
+            (build / name).symlink_to(outside)
+            sentinels.append(outside)
+        self.run_script()
+        for outside in sentinels:
+            self.assertEqual("keep", outside.read_text())
+        for name in ("cmake_log.txt", "build_plan_log.txt", "build_log.txt"):
+            log = build / name
+            self.assertTrue(log.is_file())
+            self.assertFalse(log.is_symlink())
 
     def test_symlinked_or_hardlinked_output_is_rejected_before_build(self):
         staged = self.root / "build/linux-release/bin/canary"


### PR DESCRIPTION
The recompile script previously kept one overwritten `.old` file and moved the current executable before building. This change preserves exact executable history and installs verified output with an atomic rename, so a failed build leaves the installed binary available and older crash dumps can be matched to their original executable.

## Features

- Keep SHA-256-addressed ELF copies and Build ID/backup-time metadata in the Git-ignored `backups/executables/` directory. Deduplicate identical binaries and remove managed pairs unused for more than seven days after successful runs.
- Retain installed and running versions, including a running executable whose original path has been replaced. Unrelated files, old `.old` backups and core dumps are outside cleanup.
- Add `--help`, bounded build/vcpkg parallelism and an opt-in `--restart-service`. Restart `canary.service` only after a different binary is installed.

## Fixes

- Link in `build/<preset>/bin`, verify a copy beside the installed executable, then rename it into place. Configure, build-plan, build and staging failures preserve the installed binary.
- Serialize script invocations across presets in the same checkout. Reject symlinked build/backup paths, output hardlinked to the installed binary, foreign caches and relinking over a running compiler output.
- Preserve complete command output and build failures without a detached log-tailing process.

## Improvements

- Reuse the maintained preset, its cached CMake executable and vcpkg toolchain. Keep ARM64 system-binary selection and interactive progress reporting.
- Inspect Ninja's build plan and skip the build when it reports no pending work. Still validate output, compare hashes and apply retention on up-to-date runs.
- Support quoted CMake options after `--` and preserve the existing `vcpkg-parent preset -D...` invocation. Reserve source/build/generator/toolchain and output-path control for the script.

## Documentation

- Add `docs/building/recompile.md`, linked from both documentation indexes, with Linux prerequisites, command migration, file locations, seven-day retention semantics, crash analysis, restart behavior and troubleshooting.
- Explain PowerShell/WSL usage, native Windows alternatives, the need for matching core/executable artifacts, and why rebuilding the same commit does not guarantee the same binary.
- Document operational boundaries: this entry point builds the Linux server target; it does not configure core dumps, manage database recovery or restart a server by default. A restart failure after installation does not automatically roll back the new binary.

## Tests/Validation

- `bash -n recompile.sh` and `shellcheck recompile.sh` passed.
- `python3 tools/test_recompile.py -v`: **30 tests passed** locally on Linux through WSL, including a real CMake/Ninja project that copies an existing ELF with no compiler enabled.
- Coverage includes retention/deduplication, exact hashes, configure/plan/build/copy failure, interrupted builds, cache/toolchain reuse, legacy arguments, ARM64 environment selection, locks, path aliases, optional restart requests and running old inodes.
- Python syntax, workflow structure, documentation links/anchors, portability and `git diff --check` passed.
- Add a focused Linux workflow for these checks. No full Canary build, gameplay replay, game database operation, real service restart or deployment was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reworked Linux recompilation with configurable parallel jobs, CMake options, optional service restart, atomic publishing, and safer failure handling.
  - Added executable history retention for crash analysis, including checksum verification and seven-day cleanup.

- **Documentation**
  - Added comprehensive recompilation guidance covering usage, troubleshooting, crash investigation, ARM64, WSL, and validation.
  - Added links to the new documentation from project documentation indexes.

- **Tests**
  - Added automated validation for recompilation, backups, locking, failures, restarts, and platform-specific behavior.

- **Chores**
  - Added automated checks for recompilation changes and excluded executable backups from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->