### PR TITLE
docs: update ubuntu build guides

### DIFF
--- a/docs/building/ubuntu.md
+++ b/docs/building/ubuntu.md
@@ -3,6 +3,7 @@
 ## Supported OS
 
 - Ubuntu 24.04
+- Ubuntu 26.04
 
 ## 1. Install the required software
 

--- a/docs/building/wsl-ubuntu.md
+++ b/docs/building/wsl-ubuntu.md
@@ -3,6 +3,7 @@
 ## Supported OS
 
 - Windows 11 + WSL2 with Ubuntu 24.04
+- Windows 11 + WSL2 with Ubuntu 26.04
 
 ## 1. Install the required software
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Ubuntu build documentation to list Ubuntu 26.04 as the supported operating system.
  - Updated the WSL Ubuntu build guide to list Ubuntu 26.04 as the supported WSL2 distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->